### PR TITLE
feat: add compact agent info display with model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The [Agent Client Protocol](https://agentclientprotocol.com/) decouples the shel
 - **⚡ Zero Latency** — Direct PTY access, full terminal compatibility
 - **🧠 Context Aware** — Agent sees your cwd, recent commands, and their output
 - **🎯 Multiple Agents** — Easy switching between pi-acp, claude, and other ACP agents
+- **🏷️ Agent Info Display** — Shows current agent and model next to the prompt (e.g., `pi (gpt-4o) ●`)
 
 ## Install
 
@@ -100,6 +101,7 @@ pi-acp --help  # Verify installation
 ```bash
 # Start with the default agent (pi-acp)
 npm start
+# Shows: pi ● ❯ when entering agent mode
 
 # Quick shortcuts
 npm run pi         # pi-acp
@@ -108,14 +110,19 @@ npm run claude     # Claude
 # Start with a specific agent
 npm start -- --agent pi-acp
 
-# Pass arguments to the agent
+# Pass arguments to the agent (including model)
 npm start -- --agent claude --agent-args "--model sonnet"
+# Shows: claude (sonnet) ● ❯ when entering agent mode
 
 # Use a different shell
 npm start -- --shell /bin/zsh
 
 # Set default agent via environment variable
 AGENT_SHELL_AGENT=claude npm start
+
+# Specify model for pi-acp
+npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
+# Shows: pi (gpt-4o) ● ❯ when entering agent mode
 ```
 
 ### Agent environment configuration
@@ -161,12 +168,16 @@ You can also configure pi-acp by passing arguments:
 # Use a specific model
 npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
 
+# The model will be displayed next to the prompt: pi (gpt-4o) ● ❯
+
 # Enable thinking mode
 npm start -- --agent pi-acp --agent-args "--thinking high"
 
 # Limit to read-only tools
 npm start -- --agent pi-acp --agent-args "--tools read,grep,find,ls"
 ```
+
+**Model Display**: When you specify a model using `--model`, it will be displayed in parentheses next to the agent name when you enter agent mode. This helps you quickly identify which model you're using.
 
 For more pi-acp options, run `pi --help` (pi-acp accepts the same arguments).
 
@@ -196,7 +207,12 @@ export GOOGLE_API_KEY="your-key"
 | `Ctrl-C` | Standard signal to shell, or cancels active agent response |
 | `Escape` | Exit agent input mode (when typing after `>`) |
 
-When you type `>` at the start of a line, agent-shell enters **agent input mode** — the prompt changes to a yellow `❯` and your text is sent to the agent on Enter. The agent's response streams inline in real-time in a bordered box with markdown rendering and syntax highlighting.
+When you type `>` at the start of a line, agent-shell enters **agent input mode** — the prompt changes to show the agent and model information (e.g., `pi (gpt-4o) ● ❯`) and your text is sent to the agent on Enter. The agent's response streams inline in real-time in a bordered box with markdown rendering and syntax highlighting.
+
+**Agent Info Display**: When entering agent mode, you'll see the current agent name and model (if specified) next to the prompt, followed by a green dot (●) indicating the connection status. For example:
+- `pi ● ❯` — pi agent without model specified
+- `pi (gpt-4o) ● ❯` — pi agent with gpt-4o model
+- `claude (sonnet) ● ❯` — claude agent with sonnet model
 
 ### Slash commands
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm start
 
 # Quick shortcuts
 npm run pi         # Start with pi-acp
-npm run claude     # Start with Claude agent
+npm run claude     # Start with claude-agent-acp (Anthropic's official Claude agent)
 
 # Using the built binary directly
 node dist/index.js --agent <agent-name>
@@ -77,7 +77,7 @@ chmod +x dist/index.js
 ./dist/index.js --agent <agent-name>
 
 # Using environment variable to set default agent
-AGENT_SHELL_AGENT=claude npm start
+AGENT_SHELL_AGENT=claude-agent-acp npm start
 ```
 
 ### Install ACP-compatible agents
@@ -87,8 +87,9 @@ agent-shell requires an ACP-compatible agent. Here are some popular options:
 | Agent | Install Command | Notes |
 |-------|----------------|-------|
 | **pi-acp** | `npm install -g pi-acp` | **Recommended default** - ACP adapter for pi coding agent |
-| **claude-code** | See [claude-code](https://github.com/anthropics/claude-code) | Anthropic's official ACP agent |
-| **gemini-cli** | See [gemini-cli](https://github.com/google-gemini/gemini-cli) | Google's Gemini ACP agent |
+| **claude-agent-acp** | `npm install -g @agentclientprotocol/claude-agent-acp` | Anthropic's official ACP Claude agent |
+
+**⚠️ Important**: The `claude` CLI tool (Claude Code) does **not** support the ACP protocol. You must use `claude-agent-acp` or `pi-acp` with Anthropic models.
 
 **Example: Installing pi-acp**
 ```bash
@@ -98,6 +99,24 @@ pi-acp --help  # Verify installation
 
 ## Usage
 
+### Quick Start
+
+```bash
+# 1. Install required agents (if not already installed)
+npm install -g pi-acp
+npm install -g @agentclientprotocol/claude-agent-acp
+
+# 2. Set required API keys
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+# Or for OpenAI models with pi-acp:
+# export OPENAI_API_KEY="your-openai-api-key"
+
+# 3. Start agent-shell
+npm start
+```
+
+### Common Usage Patterns
+
 ```bash
 # Start with the default agent (pi-acp)
 npm start
@@ -105,24 +124,49 @@ npm start
 
 # Quick shortcuts
 npm run pi         # pi-acp
-npm run claude     # Claude
+npm run claude     # claude-agent-acp (Anthropic's official Claude agent)
 
 # Start with a specific agent
 npm start -- --agent pi-acp
 
 # Pass arguments to the agent (including model)
-npm start -- --agent claude --agent-args "--model sonnet"
-# Shows: claude (sonnet) ● ❯ when entering agent mode
+npm start -- --agent claude-agent-acp --agent-args "--model claude-3-5-sonnet-20241022"
+# Shows: claude-agent-acp (claude-3-5-sonnet-20241022) ● ❯ when entering agent mode
+
+# Use pi-acp with Claude
+npm start -- --agent pi-acp --agent-args "--provider anthropic --model claude-3-5-sonnet-20241022"
+# Shows: pi (claude-3-5-sonnet-20241022) ● ❯
+
+# Use pi-acp with OpenAI GPT-4
+export OPENAI_API_KEY="your-openai-key"
+npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
+# Shows: pi (gpt-4o) ● ❯
 
 # Use a different shell
 npm start -- --shell /bin/zsh
 
 # Set default agent via environment variable
-AGENT_SHELL_AGENT=claude npm start
+AGENT_SHELL_AGENT=claude-agent-acp npm start
+```
 
-# Specify model for pi-acp
-npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
-# Shows: pi (gpt-4o) ● ❯ when entering agent mode
+### Common Claude Models
+
+**Valid Claude model names** (for use with `--model` parameter):
+- `claude-3-5-sonnet-20241022` (latest Sonnet)
+- `claude-3-5-haiku-20241022` (latest Haiku)
+- `claude-3-opus-20240229` (older Opus)
+- `claude-3-sonnet-20240229` (older Sonnet)
+
+**Example with claude-agent-acp**:
+```bash
+export ANTHROPIC_API_KEY="your-key"
+npm start -- --agent claude-agent-acp --agent-args "--model claude-3-5-sonnet-20241022"
+```
+
+**Example with pi-acp**:
+```bash
+export ANTHROPIC_API_KEY="your-key"
+npm start -- --agent pi-acp --agent-args "--provider anthropic --model claude-3-5-sonnet-20241022"
 ```
 
 ### Agent environment configuration
@@ -165,10 +209,14 @@ export OPENROUTER_API_KEY="your-openrouter-key"
 You can also configure pi-acp by passing arguments:
 
 ```bash
-# Use a specific model
-npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
+# Use Claude 3.5 Sonnet with pi-acp
+npm start -- --agent pi-acp --agent-args "--provider anthropic --model claude-3-5-sonnet-20241022"
+# Shows: pi (claude-3-5-sonnet-20241022) ● ❯
 
-# The model will be displayed next to the prompt: pi (gpt-4o) ● ❯
+# Use GPT-4o with pi-acp
+export OPENAI_API_KEY="your-openai-key"
+npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
+# Shows: pi (gpt-4o) ● ❯
 
 # Enable thinking mode
 npm start -- --agent pi-acp --agent-args "--thinking high"
@@ -186,10 +234,10 @@ For more pi-acp options, run `pi --help` (pi-acp accepts the same arguments).
 Refer to each agent's documentation for their specific environment variable requirements. Common patterns:
 
 ```bash
-# claude-code
+# claude-agent-acp (Anthropic's official Claude agent)
 export ANTHROPIC_API_KEY="your-key"
 
-# gemini-cli  
+# gemini-cli
 export GOOGLE_API_KEY="your-key"
 ```
 
@@ -212,7 +260,8 @@ When you type `>` at the start of a line, agent-shell enters **agent input mode*
 **Agent Info Display**: When entering agent mode, you'll see the current agent name and model (if specified) next to the prompt, followed by a green dot (●) indicating the connection status. For example:
 - `pi ● ❯` — pi agent without model specified
 - `pi (gpt-4o) ● ❯` — pi agent with gpt-4o model
-- `claude (sonnet) ● ❯` — claude agent with sonnet model
+- `pi (claude-3-5-sonnet-20241022) ● ❯` — pi agent with Claude Sonnet model
+- `claude-agent-acp (claude-3-5-sonnet-20241022) ● ❯` — Claude agent with Sonnet model
 
 ### Slash commands
 
@@ -327,7 +376,7 @@ npm start
 
 # Quick shortcuts for different agents
 npm run pi         # Start with pi-acp
-npm run claude     # Start with Claude agent
+npm run claude     # Start with claude-agent-acp (Anthropic's official Claude agent)
 
 # Debug mode — logs ACP protocol details to stderr
 DEBUG=1 npm start
@@ -348,6 +397,71 @@ npm run dev -- --agent pi-acp
 8. The agent's streaming response renders inline in a bordered markdown box with real-time output
 9. If the agent needs to run commands, it calls `terminal/create` and agent-shell executes them in isolated child processes, streaming output back
 10. When the agent finishes, normal shell operation resumes
+
+## Troubleshooting
+
+### Agent connection issues
+
+**Problem**: "Agent not connected. Please wait a moment and try again."
+
+**Solutions**:
+1. **Check agent installation**:
+   ```bash
+   which pi-acp
+   which claude-agent-acp
+   ```
+
+2. **Verify ACP compatibility**:
+   ```bash
+   # Test if agent supports ACP protocol
+   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientInfo":{"name":"test","version":"1.0.0"},"clientCapabilities":{"terminal":true,"fs":{"readTextFile":true,"writeTextFile":true}}}}' | pi-acp
+   ```
+
+3. **Install missing agents**:
+   ```bash
+   npm install -g pi-acp
+   npm install -g @agentclientprotocol/claude-agent-acp
+   ```
+
+4. **Check environment variables**:
+   ```bash
+   echo $ANTHROPIC_API_KEY
+   echo $OPENAI_API_KEY
+   echo $GEMINI_API_KEY
+   ```
+
+### Common errors
+
+**Error**: "claude: command not found"
+- **Cause**: Trying to use `claude` CLI tool which doesn't support ACP
+- **Solution**: Use `claude-agent-acp` or `pi-acp` instead
+
+**Error**: "API key not found"
+- **Cause**: Missing required API key environment variable
+- **Solution**: Set the appropriate API key (e.g., `export ANTHROPIC_API_KEY="your-key"`)
+
+**Error**: "Invalid model name"
+- **Cause**: Using incorrect model name
+- **Solution**: Use valid model names like `claude-3-5-sonnet-20241022` or `gpt-4o`
+
+**Error**: "Agent process exited with code X"
+- **Cause**: Agent crashed or failed to start
+- **Solution**: Check agent installation and API key validity
+
+### Debug mode
+
+Enable debug mode to see detailed ACP protocol information:
+```bash
+DEBUG=1 npm start -- --agent pi-acp
+```
+
+### Getting help
+
+If you encounter issues:
+1. Check the [ACP Protocol Documentation](https://agentclientprotocol.com/)
+2. Verify agent installation: `pi-acp --version` or `claude-agent-acp --version`
+3. Test with different agents to isolate the problem
+4. Check GitHub issues for known problems
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "pi": "node dist/index.js --agent pi-acp",
-    "claude": "node dist/index.js --agent claude"
+    "claude": "node dist/index.js --agent claude-agent-acp"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.18.1",

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -25,12 +25,16 @@ export class AcpClient {
   private terminalCounter = 0;
   private autoApproveWrites = false;
   private fileWatcher: FileWatcher;
+  private pendingToolCalls = new Map<string, boolean>(); // Track pending tool calls
+  private agentInfo: { name: string; version: string } | null = null; // Store agent info
+  private model: string | undefined; // Store model name from config
 
   constructor(shell: Shell, tui: TUI, config: AgentShellConfig) {
     this.shell = shell;
     this.tui = tui;
     this.config = config;
     this.fileWatcher = new FileWatcher(process.cwd());
+    this.model = config.model; // Store model from config
   }
 
   async start(): Promise<void> {
@@ -96,7 +100,14 @@ export class AcpClient {
 
     this.log("Initialize successful");
 
-    // Connection info available at initResponse.agentInfo if needed
+    // Store agent info for display
+    if (initResponse.agentInfo) {
+      this.agentInfo = {
+        name: initResponse.agentInfo.name || this.config.agentCommand,
+        version: initResponse.agentInfo.version || "unknown"
+      };
+      this.log(`Agent info: ${this.agentInfo.name} v${this.agentInfo.version}`);
+    }
 
     // Create a session
     const context = this.shell.getContext();
@@ -242,6 +253,29 @@ export class AcpClient {
     return this.lastResponseText;
   }
 
+  /**
+   * Get agent information for display.
+   */
+  getAgentInfo(): { name: string; version: string } | null {
+    return this.agentInfo;
+  }
+
+  /**
+   * Get model name for display.
+   */
+  getModel(): string | undefined {
+    return this.model;
+  }
+
+  /**
+   * Check if agent is connected.
+   */
+  isConnected(): boolean {
+    // Consider connected if we have a connection and agent info
+    // Session ID may not be set yet if we're still initializing
+    return this.connection !== null && this.agentInfo !== null;
+  }
+
   private log(msg: string): void {
     if (process.env.DEBUG) {
       process.stderr.write(`[agent-shell] ${msg}\n`);
@@ -321,18 +355,27 @@ export class AcpClient {
 
       case "tool_call": {
         this.tui.stopSpinner();
+        // Use toolCallId if available, otherwise generate a simple ID
+        const toolId = update.toolCallId || `tool-${this.pendingToolCalls.size}`;
+        this.pendingToolCalls.set(toolId, true);
         this.tui.showToolCall(update.title);
         break;
       }
 
       case "tool_call_update": {
-        if (update.title) {
-          this.tui.showToolCall(update.title);
-        }
-        if (update.status === "completed") {
-          this.tui.showToolResult(0);
-        } else if (update.status === "failed") {
-          this.tui.showToolResult(1);
+        // Only show result when the tool completes, don't show tool call again
+        if (update.status === "completed" || update.status === "failed") {
+          const toolId = update.toolCallId;
+          if (toolId && this.pendingToolCalls.has(toolId)) {
+            // Only show result if we haven't already
+            this.pendingToolCalls.delete(toolId);
+            const exitCode = update.status === "completed" ? 0 : 1;
+            this.tui.showToolResult(exitCode);
+          } else if (!toolId) {
+            // Fallback for tools without ID
+            const exitCode = update.status === "completed" ? 0 : 1;
+            this.tui.showToolResult(exitCode);
+          }
         }
         break;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ function parseArgs(argv: string[]): AgentShellConfig {
   const defaultAgent = process.env.AGENT_SHELL_AGENT || "pi-acp";
   let agentCommand = defaultAgent;
   let agentArgs: string[] = [];
+  let model: string | undefined;
   const shell = process.env.SHELL || "/bin/bash";
 
   for (let i = 0; i < argv.length; i++) {
@@ -17,9 +18,15 @@ function parseArgs(argv: string[]): AgentShellConfig {
     if (arg === "--agent" && argv[i + 1]) {
       agentCommand = argv[++i]!;
     } else if (arg === "--agent-args" && argv[i + 1]) {
-      agentArgs = argv[++i]!.split(" ");
+      const argsString = argv[++i]!;
+      agentArgs = argsString.split(" ");
+      // Extract model from agent args if provided
+      const modelArgIndex = agentArgs.findIndex(a => a === "--model" || a === "-m");
+      if (modelArgIndex !== -1 && agentArgs[modelArgIndex + 1]) {
+        model = agentArgs[modelArgIndex + 1];
+      }
     } else if (arg === "--shell" && argv[i + 1]) {
-      return { agentCommand, agentArgs, shell: argv[++i]! };
+      return { agentCommand, agentArgs, shell: argv[++i]!, model };
     } else if (arg === "--help" || arg === "-h") {
       console.log(`agent-shell — a shell-first terminal with ACP agent access
 
@@ -54,7 +61,7 @@ Inside the shell:
     }
   }
 
-  return { agentCommand, agentArgs, shell };
+  return { agentCommand, agentArgs, shell, model };
 }
 
 async function main(): Promise<void> {
@@ -132,6 +139,34 @@ async function main(): Promise<void> {
         });
       }
       shell.printPrompt();
+    },
+    onShowAgentInfo: () => {
+      // Return agent info string and model when entering agent input mode
+      if (acpClient && acpClient.isConnected()) {
+        const agentInfo = acpClient.getAgentInfo();
+        const model = acpClient.getModel();
+        if (agentInfo) {
+          return {
+            info: tui.getAgentInfoString(agentInfo, model),
+            model: model
+          };
+        } else {
+          // Debug: show why agent info is not available
+          if (process.env.DEBUG) {
+            process.stderr.write('[agent-shell] Agent info not available\n');
+          }
+        }
+      } else {
+        // Debug: show why we can't show agent info
+        if (process.env.DEBUG) {
+          if (!acpClient) {
+            process.stderr.write('[agent-shell] acpClient is null\n');
+          } else if (!acpClient.isConnected()) {
+            process.stderr.write('[agent-shell] Agent not connected\n');
+          }
+        }
+      }
+      return { info: "" };
     },
     slashCommandDefs: commands.map((c) => ({ name: c.name, description: c.description })),
     onPtyOutput: () => {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -5,6 +5,11 @@ import type { ShellContext, CommandRecord } from "./types.js";
 
 const MAX_HISTORY = 20;
 
+// Helper function to calculate visible string length (excluding ANSI codes)
+function visibleLen(str: string): number {
+  return str.replace(/\x1b\[[^m]*m/g, "").length;
+}
+
 export class Shell {
   private ptyProcess: pty.IPty;
   private lineBuffer = "";
@@ -27,12 +32,14 @@ export class Shell {
   private onAgentCancel: () => void;
   private onSlashCommand: (command: string) => void;
   private onPtyOutput: () => void;
+  private onShowAgentInfo: () => { info: string; model?: string }; // Callback to get agent info string and model
 
   constructor(opts: {
     onAgentRequest: (query: string) => void;
     onAgentCancel: () => void;
     onSlashCommand?: (command: string) => void;
     onPtyOutput?: () => void;
+    onShowAgentInfo?: () => { info: string; model?: string }; // Callback to get agent info string and model
     slashCommandDefs?: { name: string; description: string }[];
     cols: number;
     rows: number;
@@ -43,6 +50,7 @@ export class Shell {
     this.onAgentCancel = opts.onAgentCancel;
     this.onSlashCommand = opts.onSlashCommand ?? (() => {});
     this.onPtyOutput = opts.onPtyOutput ?? (() => {});
+    this.onShowAgentInfo = opts.onShowAgentInfo ?? (() => ({ info: "" }));
     this.slashCommandDefs = opts.slashCommandDefs ?? [];
     this.cwd = opts.cwd;
 
@@ -153,9 +161,12 @@ export class Shell {
     this.agentInputMode = true;
     this.agentInputBuffer = "";
     // Hide the shell's cursor line and show our agent prompt
-    // Move to start of line, clear it, show agent prompt
+    // Move to start of line, clear it, show agent prompt with info
+    const agentInfo = this.onShowAgentInfo();
+    const infoPrefix = agentInfo.info ? `${agentInfo.info} ` : "";
     process.stdout.write(
       "\r\x1b[2K" +
+      infoPrefix +
       "\x1b[33m\x1b[1m❯ \x1b[0m"  // yellow bold "❯ "
     );
   }
@@ -181,8 +192,13 @@ export class Shell {
     // Clear suggestion lines first, then redraw
     this.clearAutocompleteLines();
 
+    // Get agent info string
+    const agentInfo = this.onShowAgentInfo();
+    const infoPrefix = agentInfo.info ? `${agentInfo.info} ` : "";
+
     process.stdout.write(
       "\r\x1b[2K" +
+      infoPrefix +
       "\x1b[33m\x1b[1m❯ \x1b[0m" +
       "\x1b[36m" + this.agentInputBuffer + "\x1b[0m"
     );
@@ -307,8 +323,10 @@ export class Shell {
       process.stdout.write(`\x1b[${this.autocompleteLines}A`);
     }
     // Restore cursor to end of input on the prompt line
-    // "❯ " = 2 visible columns, then the typed text
-    const col = 2 + this.agentInputBuffer.length;
+    // Account for agent info length + "❯ " (2 visible columns) + typed text
+    const agentInfo = this.onShowAgentInfo();
+    const infoLength = visibleLen(agentInfo.info);
+    const col = infoLength + 2 + this.agentInputBuffer.length;
     process.stdout.write(`\r\x1b[${col}C`);
   }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -137,6 +137,29 @@ export class TUI {
     process.stdout.write(`${GRAY}${message}${RESET}\n`);
   }
 
+  /**
+   * Get agent info as a compact string for display next to the prompt.
+   */
+  getAgentInfoString(agentInfo: { name: string; version: string } | null, model?: string): string {
+    if (!agentInfo) return "";
+
+    // Compact format: "pi (gpt-4o) ●" (remove -acp suffix for cleaner display)
+    const name = agentInfo.name.replace(/-acp$/, '').replace(/-/g, ' '); // Clean up name
+    let infoStr = `${DIM}${name}${RESET}`;
+
+    // Add model if available
+    if (model) {
+      // Clean up model name - remove provider prefixes only
+      const cleanModel = model
+        .replace(/^openai\//i, '')
+        .replace(/^anthropic\//i, '')
+        .replace(/^google\//i, '');
+      infoStr += ` ${DIM}(${cleanModel})${RESET}`;
+    }
+
+    return `${infoStr} ${GREEN}●${RESET}`;
+  }
+
   async promptPermission(title: string, description?: string): Promise<string | null> {
     const desc = description ? `\n  ${DIM}${description}${RESET}` : "";
     process.stdout.write(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface AgentShellConfig {
   agentCommand: string;
   agentArgs: string[];
   shell: string;
+  model?: string; // Model name extracted from agent args
 }
 
 export type ConversationEntry =


### PR DESCRIPTION
- Add compact agent info display next to prompt (e.g., 'pi (gpt-4o) ● ❯')
- Display agent name, model (if specified), and connection status
- Remove agent version number for cleaner UI
- Add model parameter parsing from --agent-args
- Fix tool call marker alignment issue (▶ and ✓ now match correctly)
- Improve streaming output with proper flushing
- Maintain smart connection mechanism (async connection + auto-wait)

Display formats:
  - Without model: pi ● ❯
  - With model: pi (gpt-4o) ● ❯

Technical changes:
  - Add 'model' field to AgentShellConfig interface
  - Parse --model argument from --agent-args
  - Update TUI.getAgentInfoString() to include model name
  - Fix tool call tracking with pendingToolCalls Map
  - Modify onShowAgentInfo callback to return object with info and model
  - Update cursor position calculation for new display format