### PR TITLE
Respect user's shell config and decouple core from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,17 +289,18 @@ This means you can run a failing command, then type `> fix this` and the agent k
 
 agent-shell is an ACP **client**. The agent is a subprocess launched with stdio transport.
 
-### Design philosophy: headless core + pluggable extensions
+### Design philosophy: headless core + pluggable frontends
 
-The core is a minimal, headless runtime — it manages the PTY, runs agent queries via ACP, tracks context, and executes tools. It has **zero opinions about rendering**. Everything else is an extension.
+The core (`createCore()`) is a frontend-agnostic kernel — it wires up the EventBus, ContextManager, and AcpClient with zero knowledge of terminals, PTYs, or rendering. The interactive terminal (Shell + TUI + extensions) is one frontend built on top.
 
 ```
-index.ts (wiring)
-  ├── Core infrastructure:
+createCore() — frontend-agnostic kernel:
   │     EventBus          — typed pub/sub + transform pipelines
-  │     Shell             — PTY lifecycle (delegates to InputHandler + OutputParser)
-  │     AcpClient         — ACP protocol, terminal execution
   │     ContextManager    — exchange recording, context assembly
+  │     AcpClient         — ACP protocol, terminal execution
+  │
+index.ts — interactive terminal frontend:
+  │     Shell             — PTY lifecycle (delegates to InputHandler + OutputParser)
   │
   └── Extensions (pluggable, loaded at startup):
         tuiRenderer       — bordered markdown rendering, spinner, tool display
@@ -309,11 +310,12 @@ index.ts (wiring)
         shellRecall       — __shell_recall terminal interception
 ```
 
-Extensions are factory functions that receive the EventBus and self-register. The core communicates exclusively through typed events — extensions subscribe to what they care about.
+All components communicate exclusively through typed bus events. AcpClient has no reference to Shell — it emits lifecycle events (`agent:processing-start`, `agent:processing-done`) and Shell subscribes to manage its own state. Input flows the same way: any frontend emits `agent:submit` and the core routes it to the agent.
 
-**Without any extensions loaded, agent-shell still works** — PTY passthrough, agent queries, tool execution, context management all function. Output is silently dropped. This enables:
+**The core works without any frontend.** This enables:
 
-- **Headless mode** — testing, CI, scripting, embedding as a library
+- **Library usage** — `import { createCore } from "agent-shell"` to build WebSocket servers, REST APIs, Electron apps, or test harnesses
+- **Headless mode** — CI, scripting, embedding — no terminal needed
 - **Alternative renderers** — web UI, logging backend, minimal TUI
 - **Custom features** — add commands, autocomplete providers, tool interceptors by writing an extension
 
@@ -352,7 +354,8 @@ Extensions are factory functions that receive the EventBus and self-register. Th
 ```
 agent-shell/
 ├── src/
-│   ├── index.ts            # Entry point, CLI args, wiring, extension loading
+│   ├── index.ts            # Interactive terminal entry point (CLI args, Shell, extensions)
+│   ├── core.ts             # createCore() — frontend-agnostic kernel, library entry point
 │   ├── event-bus.ts        # Typed EventBus: emit/on, emitPipe, emitPipeAsync
 │   ├── shell.ts            # PTY lifecycle + wiring (InputHandler + OutputParser)
 │   ├── input-handler.ts    # Keyboard input, agent mode, bus-driven autocomplete
@@ -402,7 +405,7 @@ npm run dev -- --agent pi-acp
 
 ## How it works
 
-1. agent-shell spawns a real PTY running bash and sets up raw stdin passthrough
+1. agent-shell spawns a real PTY running your shell (zsh or bash, with your full rc config — oh-my-zsh, p10k, aliases, plugins, PATH) and sets up raw stdin passthrough
 2. It launches the specified ACP agent as a subprocess with stdio transport
 3. All keyboard input goes directly to the PTY — zero latency, full terminal compatibility
 4. **Smart connection**: The agent connects asynchronously in the background while the shell starts immediately
@@ -457,8 +460,7 @@ The `ExtensionContext` provides:
 | Property | Type | Description |
 |---|---|---|
 | `bus` | `EventBus` | Subscribe to events, emit events, register pipe handlers |
-| `contextManager` | `ContextManager` | Access exchange history, search, expand |
-| `shell` | `Shell` | Shell state (cwd, foreground busy) |
+| `contextManager` | `ContextManager` | Access exchange history, cwd, search, expand |
 | `getAcpClient` | `() => AcpClient` | Lazy getter for the agent client |
 | `quit` | `() => void` | Exit agent-shell |
 
@@ -479,6 +481,31 @@ npm start  # extension is loaded automatically
 ```
 
 Extensions are loaded after all built-in extensions and core services are initialized. Errors in extension loading are non-fatal — a `ui:error` is emitted and the next extension continues loading.
+
+### Using as a library
+
+The core can be imported directly for building custom frontends — no terminal required:
+
+```typescript
+import { createCore } from "agent-shell";
+
+const core = createCore({ agentCommand: "pi-acp" });
+
+// Subscribe to events
+core.bus.on("agent:response-chunk", ({ text }) => process.stdout.write(text));
+core.bus.on("agent:processing-done", () => console.log("\n[done]"));
+
+// Handle permissions (auto-approve, or wire to your own UI)
+core.bus.onPipeAsync("permission:request", async (p) => {
+  return { ...p, decision: { approved: true } };
+});
+
+// Connect and send a query
+await core.start();
+core.bus.emit("agent:submit", { query: "explain this codebase" });
+```
+
+This works for WebSocket servers, REST APIs, Electron apps, test harnesses, or any environment where you want agent-shell's context management and ACP integration without the interactive terminal.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "0.1.0",
   "description": "A shell-first terminal where any ACP-compatible AI agent is one keystroke away",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/core.js",
   "bin": {
     "agent-shell": "dist/index.js"
+  },
+  "exports": {
+    ".": "./dist/core.js",
+    "./core": "./dist/core.js"
   },
   "scripts": {
     "dev": "tsx src/index.ts",

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -9,7 +9,6 @@ import * as path from "node:path";
 import { stripAnsi } from "./utils/ansi.js";
 import type { EventBus } from "./event-bus.js";
 import type { ContextManager } from "./context-manager.js";
-import type { Shell } from "./shell.js";
 import type { AgentShellConfig } from "./types.js";
 
 export class AcpClient {
@@ -18,7 +17,6 @@ export class AcpClient {
   private sessionId: string | null = null;
   private bus: EventBus;
   private contextManager: ContextManager;
-  private shell: Shell;
   private config: AgentShellConfig;
   private promptInProgress = false;
   private currentResponseText = "";
@@ -34,12 +32,10 @@ export class AcpClient {
   constructor(opts: {
     bus: EventBus;
     contextManager: ContextManager;
-    shell: Shell;
     config: AgentShellConfig;
   }) {
     this.bus = opts.bus;
     this.contextManager = opts.contextManager;
-    this.shell = opts.shell;
     this.config = opts.config;
     this.fileWatcher = new FileWatcher(process.cwd());
   }
@@ -138,8 +134,7 @@ export class AcpClient {
     }
 
     this.promptInProgress = true;
-    this.shell.setAgentActive(true);
-    this.shell.pauseOutput();
+    this.bus.emit("agent:processing-start", {});
     await this.fileWatcher.snapshot();
 
     this.currentResponseText = "";
@@ -189,9 +184,7 @@ export class AcpClient {
         await this.showPendingFileChanges();
       }
 
-      this.shell.resumeOutput();
-      this.shell.setAgentActive(false);
-      this.shell.freshPrompt();
+      this.bus.emit("agent:processing-done", {});
       this.promptInProgress = false;
     }
   }
@@ -216,9 +209,7 @@ export class AcpClient {
     if (this.promptInProgress) {
       this.bus.emit("agent:cancelled", {});
     }
-    this.shell.resumeOutput();
-    this.shell.setAgentActive(false);
-    this.shell.freshPrompt();
+    this.bus.emit("agent:processing-done", {});
     this.promptInProgress = false;
   }
 
@@ -375,7 +366,6 @@ export class AcpClient {
   ): Promise<acp.RequestPermissionResponse> {
     const title = params.toolCall.title ?? "Unknown action";
 
-    this.shell.resumeOutput();
     const result = await this.bus.emitPipeAsync("permission:request", {
       kind: "tool-call",
       title,
@@ -387,7 +377,6 @@ export class AcpClient {
       },
       decision: { outcome: "cancelled" }, // default if no handler
     });
-    this.shell.pauseOutput();
 
     return { outcome: result.decision as acp.RequestPermissionOutcome };
   }
@@ -549,14 +538,12 @@ export class AcpClient {
     if (diff.isIdentical) return {};
 
     // Ask for permission — extension decides whether to prompt or auto-approve
-    this.shell.resumeOutput();
     const result = await this.bus.emitPipeAsync("permission:request", {
       kind: "file-write",
       title: params.path,
       metadata: { path: params.path, diff, content: params.content },
       decision: { approved: false }, // default if no handler
     });
-    this.shell.pauseOutput();
 
     if (!(result.decision as { approved: boolean }).approved) {
       throw new Error(`User rejected modification: ${params.path}`);
@@ -585,8 +572,6 @@ export class AcpClient {
     const changes = await this.fileWatcher.detectChanges();
     if (changes.length === 0) return;
 
-    this.shell.resumeOutput();
-
     for (const change of changes) {
       const diff = computeDiff(change.before, change.after);
       if (diff.isIdentical) continue;
@@ -604,8 +589,6 @@ export class AcpClient {
         await this.fileWatcher.revert(change.path);
       }
     }
-
-    this.shell.pauseOutput();
   }
 
   // ── Cleanup ────────────────────────────────────────────────────

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -191,7 +191,7 @@ export class AcpClient {
 
       this.shell.resumeOutput();
       this.shell.setAgentActive(false);
-      this.shell.printPrompt();
+      this.shell.freshPrompt();
       this.promptInProgress = false;
     }
   }
@@ -218,7 +218,7 @@ export class AcpClient {
     }
     this.shell.resumeOutput();
     this.shell.setAgentActive(false);
-    this.shell.printPrompt();
+    this.shell.freshPrompt();
     this.promptInProgress = false;
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,97 @@
+/**
+ * Core kernel — the minimum viable agent-shell.
+ *
+ * Wires up EventBus + ContextManager + AcpClient without any frontend.
+ * Consumers attach their own I/O (Shell, WebSocket, REST, tests) by
+ * subscribing to bus events and calling client methods.
+ *
+ * The core listens for `agent:submit` and `agent:cancel-request` events
+ * from any frontend, routing them to the AcpClient. This means frontends
+ * never need a direct reference to AcpClient — they just emit events.
+ *
+ * Usage:
+ *   import { createCore } from "agent-shell";
+ *   const core = createCore({ agentCommand: "pi-acp" });
+ *   core.bus.on("agent:response-chunk", ({ text }) => ws.send(text));
+ *   await core.start();
+ *   core.bus.emit("agent:submit", { query: "hello" });
+ */
+import { EventBus } from "./event-bus.js";
+import { ContextManager } from "./context-manager.js";
+import { AcpClient } from "./acp-client.js";
+import type { AgentShellConfig, ExtensionContext } from "./types.js";
+
+// Re-export types that library consumers need
+export { EventBus } from "./event-bus.js";
+export type { ShellEvents } from "./event-bus.js";
+export type { AgentShellConfig, ExtensionContext } from "./types.js";
+
+export interface AgentShellCore {
+  bus: EventBus;
+  contextManager: ContextManager;
+  client: AcpClient;
+  /** Connect to the agent subprocess. Call after wiring up bus listeners. */
+  start(): Promise<void>;
+  /** Build an ExtensionContext for loading extensions against this core. */
+  extensionContext(opts: { quit: () => void }): ExtensionContext;
+  /** Tear down the agent process and clean up. */
+  kill(): void;
+}
+
+export function createCore(config: AgentShellConfig): AgentShellCore {
+  const bus = new EventBus();
+  const contextManager = new ContextManager(bus);
+  const client = new AcpClient({ bus, contextManager, config });
+
+  let connected = false;
+
+  // Route frontend events to the agent — any frontend (Shell, WebSocket,
+  // REST handler, test harness) can emit these without knowing about AcpClient.
+  bus.on("agent:submit", ({ query }) => {
+    (async () => {
+      // Wait briefly for agent connection if start() is still in progress
+      if (!connected) {
+        for (let i = 0; i < 30 && !connected; i++) {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+      }
+      if (!connected) {
+        bus.emit("ui:error", { message: "Agent not connected. Please wait a moment and try again." });
+        return;
+      }
+      await client.sendPrompt(query);
+    })().catch((err) => {
+      bus.emit("agent:error", {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    });
+  });
+
+  bus.on("agent:cancel-request", () => {
+    client.cancel().catch(() => {});
+  });
+
+  return {
+    bus,
+    contextManager,
+    client,
+
+    async start() {
+      await client.start();
+      connected = true;
+    },
+
+    extensionContext(opts) {
+      return {
+        bus,
+        contextManager,
+        getAcpClient: () => client,
+        quit: opts.quit,
+      };
+    },
+
+    kill() {
+      client.kill();
+    },
+  };
+}

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -15,6 +15,10 @@ export interface ShellEvents {
   "shell:cwd-change": { cwd: string };
   "shell:foreground-busy": { busy: boolean };
 
+  // Agent input (frontend → core: user submitted a query or wants to cancel)
+  "agent:submit": { query: string };
+  "agent:cancel-request": Record<string, never>;
+
   // Agent interaction
   "agent:query": { query: string };
   "agent:response-chunk": { text: string };

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -21,6 +21,8 @@ export interface ShellEvents {
   "agent:response-done": { response: string };
 
   // Agent lifecycle
+  "agent:processing-start": Record<string, never>;
+  "agent:processing-done": Record<string, never>;
   "agent:cancelled": Record<string, never>;
   "agent:error": { message: string };
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -65,6 +65,13 @@ export interface ShellEvents {
     output: string;
   };
 
+  // Prompt redraw (sync pipe: core sends \n to PTY as default fallback;
+  // extensions can set `handled: true` and write their own prompt to stdout)
+  "shell:redraw-prompt": {
+    cwd: string;
+    handled: boolean;
+  };
+
   // Autocomplete (sync pipe: extensions inspect buffer and append items)
   "autocomplete:request": {
     buffer: string;

--- a/src/extensions/file-autocomplete.ts
+++ b/src/extensions/file-autocomplete.ts
@@ -9,7 +9,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionContext } from "../types.js";
 
-export default function activate({ bus, shell }: ExtensionContext): void {
+export default function activate({ bus, contextManager }: ExtensionContext): void {
   bus.onPipe("autocomplete:request", (payload) => {
     const atPos = payload.buffer.lastIndexOf("@");
     if (atPos < 0 || (atPos > 0 && payload.buffer[atPos - 1] !== " ")) {
@@ -20,7 +20,7 @@ export default function activate({ bus, shell }: ExtensionContext): void {
       return payload;
     }
 
-    const files = listFiles(afterAt, shell.getCwd());
+    const files = listFiles(afterAt, contextManager.getCwd());
     if (files.length === 0) return payload;
     return { ...payload, items: [...payload.items, ...files] };
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,8 +101,6 @@ async function main(): Promise<void> {
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;
 
-  // Placeholder for agent — we'll create it after shell but before starting input
-  let acpClient: AcpClient | null = null;
   let agentConnected = false;
 
   // Signal handling
@@ -115,43 +113,13 @@ async function main(): Promise<void> {
     process.exit(0);
   };
 
-  // Create shell — emits events to bus, ContextManager listens
+  // Create shell — subscribes to bus events for lifecycle management
   const shell = new Shell({
     bus,
     cols,
     rows,
     shell: config.shell || process.env.SHELL || "/bin/bash",
     cwd: process.cwd(),
-    onAgentRequest: async (query: string) => {
-      if (!acpClient) {
-        bus.emit("ui:error", { message: "Agent not initialized" });
-        return;
-      }
-
-      // Wait for agent to be connected before sending prompt
-      let attempts = 0;
-      const maxAttempts = 30; // Wait up to 3 seconds (30 * 100ms)
-      while (!agentConnected && attempts < maxAttempts) {
-        await new Promise(resolve => setTimeout(resolve, 100));
-        attempts++;
-      }
-
-      if (!agentConnected) {
-        bus.emit("ui:error", { message: "Agent not connected. Please wait a moment and try again." });
-        return;
-      }
-
-      try {
-        await acpClient.sendPrompt(query);
-      } catch (err: any) {
-        bus.emit("ui:error", { message: err.message });
-      }
-    },
-    onAgentCancel: () => {
-      if (acpClient) {
-        acpClient.cancel().catch(() => {});
-      }
-    },
     onShowAgentInfo: () => {
       if (acpClient && acpClient.isConnected()) {
         const agentInfo = acpClient.getAgentInfo();
@@ -165,7 +133,29 @@ async function main(): Promise<void> {
   });
 
   // Create agent client — emits agent events, queries ContextManager for context
-  acpClient = new AcpClient({ bus, contextManager, config });
+  const acpClient = new AcpClient({ bus, contextManager, config });
+
+  // Route bus events to agent — InputHandler emits these, core handles them
+  bus.on("agent:submit", ({ query }) => {
+    (async () => {
+      if (!agentConnected) {
+        for (let i = 0; i < 30 && !agentConnected; i++) {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+      }
+      if (!agentConnected) {
+        bus.emit("ui:error", { message: "Agent not connected. Please wait a moment and try again." });
+        return;
+      }
+      await acpClient.sendPrompt(query);
+    })().catch((err: any) => {
+      bus.emit("ui:error", { message: err.message });
+    });
+  });
+
+  bus.on("agent:cancel-request", () => {
+    acpClient.cancel().catch(() => {});
+  });
 
   // Build extension context — shared by all extensions (built-in and user)
   const extCtx: ExtensionContext = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-import { EventBus } from "./event-bus.js";
-import { ContextManager } from "./context-manager.js";
 import { Shell } from "./shell.js";
-import { AcpClient } from "./acp-client.js";
+import { createCore } from "./core.js";
 import { DIM, GREEN, RESET } from "./utils/ansi.js";
 import tuiRenderer from "./extensions/tui-renderer.js";
 import interactivePrompts from "./extensions/interactive-prompts.js";
@@ -10,7 +8,7 @@ import slashCommands from "./extensions/slash-commands.js";
 import fileAutocomplete from "./extensions/file-autocomplete.js";
 import shellRecall from "./extensions/shell-recall.js";
 import { loadExtensions } from "./extension-loader.js";
-import type { AgentShellConfig, ExtensionContext } from "./types.js";
+import type { AgentShellConfig } from "./types.js";
 
 function parseArgs(argv: string[]): AgentShellConfig {
   // Priority: CLI args > Environment variables > Config file > Defaults
@@ -91,21 +89,18 @@ function formatAgentInfo(agentInfo: { name: string; version: string }, model?: s
 async function main(): Promise<void> {
   const config = parseArgs(process.argv.slice(2));
 
-  // Create foundational infrastructure
-  const bus = new EventBus();
-  const contextManager = new ContextManager(bus);
+  // ── Core (frontend-agnostic) ──────────────────────────────────
+  const core = createCore(config);
+  const { bus, client } = core;
 
-  // Set terminal title
+  // ── Interactive frontend ──────────────────────────────────────
   process.stdout.write(`\x1b]0;agent-shell\x07`);
 
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;
 
-  let agentConnected = false;
-
-  // Signal handling
   const cleanup = () => {
-    acpClient?.kill();
+    core.kill();
     shell.kill();
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(false);
@@ -113,7 +108,6 @@ async function main(): Promise<void> {
     process.exit(0);
   };
 
-  // Create shell — subscribes to bus events for lifecycle management
   const shell = new Shell({
     bus,
     cols,
@@ -121,9 +115,9 @@ async function main(): Promise<void> {
     shell: config.shell || process.env.SHELL || "/bin/bash",
     cwd: process.cwd(),
     onShowAgentInfo: () => {
-      if (acpClient && acpClient.isConnected()) {
-        const agentInfo = acpClient.getAgentInfo();
-        const model = acpClient.getModel();
+      if (client.isConnected()) {
+        const agentInfo = client.getAgentInfo();
+        const model = client.getModel();
         if (agentInfo) {
           return { info: formatAgentInfo(agentInfo, model) };
         }
@@ -132,82 +126,38 @@ async function main(): Promise<void> {
     },
   });
 
-  // Create agent client — emits agent events, queries ContextManager for context
-  const acpClient = new AcpClient({ bus, contextManager, config });
+  // ── Extensions ────────────────────────────────────────────────
+  const extCtx = core.extensionContext({ quit: cleanup });
 
-  // Route bus events to agent — InputHandler emits these, core handles them
-  bus.on("agent:submit", ({ query }) => {
-    (async () => {
-      if (!agentConnected) {
-        for (let i = 0; i < 30 && !agentConnected; i++) {
-          await new Promise((r) => setTimeout(r, 100));
-        }
-      }
-      if (!agentConnected) {
-        bus.emit("ui:error", { message: "Agent not connected. Please wait a moment and try again." });
-        return;
-      }
-      await acpClient.sendPrompt(query);
-    })().catch((err: any) => {
-      bus.emit("ui:error", { message: err.message });
-    });
-  });
-
-  bus.on("agent:cancel-request", () => {
-    acpClient.cancel().catch(() => {});
-  });
-
-  // Build extension context — shared by all extensions (built-in and user)
-  const extCtx: ExtensionContext = {
-    bus, contextManager,
-    getAcpClient: () => acpClient!,
-    quit: cleanup,
-  };
-
-  // Load built-in extensions
   tuiRenderer(extCtx);
   interactivePrompts(extCtx);
   slashCommands(extCtx);
   fileAutocomplete(extCtx);
   shellRecall(extCtx);
 
-  // Load user/third-party extensions (from --extensions flag and ~/.agent-shell/extensions/)
   await loadExtensions(extCtx, config.extensions);
 
-  // Connect to agent asynchronously (don't block shell startup)
-  const connectAgent = async () => {
-    try {
-      await acpClient!.start();
-      agentConnected = true;
-    } catch (err) {
-      console.error(`Failed to connect to ${config.agentCommand}:`, err);
-    }
-  };
+  // ── Agent connection (async — don't block shell startup) ──────
+  core.start().catch((err) => {
+    console.error(`Failed to connect to ${config.agentCommand}:`, err);
+  });
 
-  // Start agent connection in background
-  connectAgent();
-
-  // Set up event handlers
+  // ── Terminal lifecycle ────────────────────────────────────────
   process.on("SIGTERM", cleanup);
   process.on("SIGHUP", cleanup);
 
-  // Handle terminal resize
   process.stdout.on("resize", () => {
-    const newCols = process.stdout.columns || 80;
-    const newRows = process.stdout.rows || 24;
-    shell.resize(newCols, newRows);
+    shell.resize(process.stdout.columns || 80, process.stdout.rows || 24);
   });
 
-  // Handle shell exit
   shell.onExit((e) => {
-    acpClient?.kill();
+    core.kill();
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(false);
     }
     process.exit(e.exitCode);
   });
 
-  // Set stdin to raw mode for PTY passthrough
   if (process.stdin.isTTY) {
     process.stdin.setRawMode(true);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ async function main(): Promise<void> {
     bus,
     cols,
     rows,
-    shell: config.shell,
+    shell: config.shell || process.env.SHELL || "/bin/bash",
     cwd: process.cwd(),
     onAgentRequest: async (query: string) => {
       if (!acpClient) {
@@ -138,8 +138,6 @@ async function main(): Promise<void> {
 
       if (!agentConnected) {
         bus.emit("ui:error", { message: "Agent not connected. Please wait a moment and try again." });
-        shell.resumeOutput();
-        shell.setAgentActive(false);
         return;
       }
 
@@ -147,8 +145,6 @@ async function main(): Promise<void> {
         await acpClient.sendPrompt(query);
       } catch (err: any) {
         bus.emit("ui:error", { message: err.message });
-        shell.resumeOutput();
-        shell.setAgentActive(false);
       }
     },
     onAgentCancel: () => {
@@ -169,11 +165,11 @@ async function main(): Promise<void> {
   });
 
   // Create agent client — emits agent events, queries ContextManager for context
-  acpClient = new AcpClient({ bus, contextManager, shell, config });
+  acpClient = new AcpClient({ bus, contextManager, config });
 
   // Build extension context — shared by all extensions (built-in and user)
   const extCtx: ExtensionContext = {
-    bus, contextManager, shell,
+    bus, contextManager,
     getAcpClient: () => acpClient!,
     quit: cleanup,
   };

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -26,21 +26,15 @@ export class InputHandler {
   private autocompleteItems: { name: string; description: string }[] = [];
   private autocompleteLines = 0;
   private bus: EventBus;
-  private onAgentRequest: (query: string) => void;
-  private onAgentCancel: () => void;
   private onShowAgentInfo: () => { info: string; model?: string };
 
   constructor(opts: {
     ctx: InputContext;
     bus: EventBus;
-    onAgentRequest: (query: string) => void;
-    onAgentCancel: () => void;
     onShowAgentInfo: () => { info: string; model?: string };
   }) {
     this.ctx = opts.ctx;
     this.bus = opts.bus;
-    this.onAgentRequest = opts.onAgentRequest;
-    this.onAgentCancel = opts.onAgentCancel;
     this.onShowAgentInfo = opts.onShowAgentInfo;
   }
 
@@ -60,7 +54,7 @@ export class InputHandler {
     // If agent is running (processing a query), handle Ctrl-C as cancel
     if (this.ctx.isAgentActive()) {
       if (data === "\x03") {
-        this.onAgentCancel();
+        this.bus.emit("agent:cancel-request", {});
       }
       return;
     }
@@ -297,7 +291,7 @@ export class InputHandler {
           this.bus.emit("command:execute", { name, args });
           this.ctx.redrawPrompt();
         } else if (query) {
-          this.onAgentRequest(query);
+          this.bus.emit("agent:submit", { query });
         } else {
           this.exitAgentInputMode();
         }

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -295,7 +295,7 @@ export class InputHandler {
           const name = spaceIdx === -1 ? query : query.slice(0, spaceIdx);
           const args = spaceIdx === -1 ? "" : query.slice(spaceIdx + 1).trim();
           this.bus.emit("command:execute", { name, args });
-          this.ctx.freshPrompt();
+          this.ctx.redrawPrompt();
         } else if (query) {
           this.onAgentRequest(query);
         } else {

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -12,6 +12,8 @@ export interface InputContext {
   isAgentActive(): boolean;
   writeToPty(data: string): void;
   onCommandEntered(command: string, cwd: string): void;
+  redrawPrompt(): void;
+  freshPrompt(): void;
 }
 
 export class InputHandler {
@@ -118,13 +120,8 @@ export class InputHandler {
     this.printPrompt();
   }
 
-  /**
-   * Print the shell prompt to stdout. Used to restore the prompt
-   * after agent mode or agent response without sending anything to the PTY.
-   */
   printPrompt(): void {
-    const dir = this.ctx.getCwd().split("/").pop() || this.ctx.getCwd();
-    process.stdout.write(`\x1b[36m⚡\x1b[0m \x1b[1m${dir}\x1b[0m $ `);
+    this.ctx.redrawPrompt();
   }
 
   private renderAgentInput(): void {
@@ -298,7 +295,7 @@ export class InputHandler {
           const name = spaceIdx === -1 ? query : query.slice(0, spaceIdx);
           const args = spaceIdx === -1 ? "" : query.slice(spaceIdx + 1).trim();
           this.bus.emit("command:execute", { name, args });
-          this.printPrompt();
+          this.ctx.freshPrompt();
         } else if (query) {
           this.onAgentRequest(query);
         } else {

--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -30,13 +30,17 @@ export class OutputParser {
     // of the current chunk), so we only append subsequent chunks here.
     const wasCapturing = this.capturingPrompt;
     this.parsePromptMarker(data);
-    this.parsePromptEnd(data);
 
-    // If we were already capturing before this chunk, append it.
-    // (If capture just started in parsePromptMarker, the tail is already in promptBuffer.)
+    // If we were already capturing before this chunk (and still are), append
+    // the full chunk. If capture just started in parsePromptMarker above, the
+    // tail after the start marker is already in promptBuffer — don't double-add.
     if (wasCapturing && this.capturingPrompt) {
       this.promptBuffer += data;
     }
+
+    // Check for end marker. Must run after the append above so that
+    // multi-chunk captures include this chunk's data before we finalize.
+    this.parsePromptEnd(data);
   }
 
   /** Called when user presses Enter on a non-empty line. */
@@ -133,24 +137,38 @@ export class OutputParser {
 
   /**
    * Detect end-of-prompt marker (OSC 9998). Finalizes the bracketed capture.
+   *
+   * By the time this runs, the current chunk has already been appended to
+   * promptBuffer (either by parsePromptMarker for the first chunk, or by
+   * the wasCapturing guard in processData for subsequent chunks). So we
+   * just need to trim everything from the end marker onward.
    */
   private parsePromptEnd(data: string): void {
     if (!this.capturingPrompt) return;
     if (!data.includes("\x1b]9998;READY\x07")) return;
 
-    // Append the portion of this chunk before the end marker
-    const endIdx = data.indexOf("\x1b]9998;READY\x07");
-    this.promptBuffer += data.slice(0, endIdx);
+    // promptBuffer already contains this chunk's data. Find the end marker
+    // within the buffer and trim everything from it onward.
+    const endMarker = "\x1b]9998;READY\x07";
+    const bufEndIdx = this.promptBuffer.indexOf(endMarker);
+    if (bufEndIdx >= 0) {
+      this.promptBuffer = this.promptBuffer.slice(0, bufEndIdx);
+    }
 
     this.capturingPrompt = false;
     this.promptCaptureComplete = true;
     this.lastPrompt = this.sanitizePromptForReplay(this.promptBuffer);
   }
 
-  /** Strip internal OSC markers from captured prompt so replay is clean. */
+  /**
+   * Strip internal OSC markers from captured prompt so replay is clean.
+   * We intentionally strip all OSC 7 sequences — they're used for cwd
+   * reporting and have no visual effect, so replaying them would just
+   * cause duplicate cwd-change events.
+   */
   private sanitizePromptForReplay(raw: string): string {
     return raw
-      .replace(/\x1b\]7;[^\x07]*\x07/g, "")   // OSC 7 (cwd)
+      .replace(/\x1b\]7;[^\x07]*\x07/g, "")   // OSC 7 (cwd reporting)
       .replace(/\x1b\]9999;PROMPT\x07/g, "")    // start marker
       .replace(/\x1b\]9998;READY\x07/g, "");    // end marker
   }

--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -11,6 +11,10 @@ export class OutputParser {
   private currentOutputCapture = "";
   private lastCommand = "";
   private foregroundBusy = false;
+  private capturingPrompt = false;
+  private promptCaptureComplete = false;
+  private promptBuffer = "";
+  private lastPrompt = "";
 
   constructor(bus: EventBus, initialCwd: string) {
     this.bus = bus;
@@ -20,7 +24,19 @@ export class OutputParser {
   /** Process a chunk of PTY output data. */
   processData(data: string): void {
     this.parseOSC7(data);
+
+    // Bracketed prompt capture: accumulate bytes between OSC 9999 and 9998.
+    // parsePromptMarker may start capture (setting promptBuffer to the tail
+    // of the current chunk), so we only append subsequent chunks here.
+    const wasCapturing = this.capturingPrompt;
     this.parsePromptMarker(data);
+    this.parsePromptEnd(data);
+
+    // If we were already capturing before this chunk, append it.
+    // (If capture just started in parsePromptMarker, the tail is already in promptBuffer.)
+    if (wasCapturing && this.capturingPrompt) {
+      this.promptBuffer += data;
+    }
   }
 
   /** Called when user presses Enter on a non-empty line. */
@@ -32,6 +48,29 @@ export class OutputParser {
       this.foregroundBusy = true;
       this.bus.emit("shell:foreground-busy", { busy: true });
     }
+  }
+
+  /** Returns the full captured prompt bytes, or empty if incomplete. */
+  getLastPrompt(): string {
+    if (!this.promptCaptureComplete) return "";
+    return this.lastPrompt;
+  }
+
+  /**
+   * Returns just the last line of the captured prompt (e.g. p10k's "❯ " line).
+   * This is safe to replay with \r because it's linear text (colors + chars),
+   * not relative cursor positioning. Returns empty if no complete capture.
+   */
+  getLastPromptLine(): string {
+    if (!this.promptCaptureComplete) return "";
+    // Find the last \r\n or \n — everything after it is the final prompt line
+    const lastNewline = this.lastPrompt.lastIndexOf("\n");
+    if (lastNewline < 0) return this.lastPrompt;
+    return this.lastPrompt.slice(lastNewline + 1);
+  }
+
+  isPromptCaptureComplete(): boolean {
+    return this.promptCaptureComplete;
   }
 
   isForegroundBusy(): boolean {
@@ -77,11 +116,44 @@ export class OutputParser {
       }
       this.lastCommand = "";
       this.currentOutputCapture = "";
+
+      // Start bracketed prompt capture: accumulate bytes until OSC 9998
+      this.capturingPrompt = true;
+      this.promptCaptureComplete = false;
+      this.promptBuffer = "";
+      const markerEnd = data.indexOf("\x1b]9999;PROMPT\x07") + "\x1b]9999;PROMPT\x07".length;
+      if (markerEnd < data.length) {
+        this.promptBuffer = data.slice(markerEnd);
+      }
     } else {
       this.currentOutputCapture += data;
     }
   }
 
+
+  /**
+   * Detect end-of-prompt marker (OSC 9998). Finalizes the bracketed capture.
+   */
+  private parsePromptEnd(data: string): void {
+    if (!this.capturingPrompt) return;
+    if (!data.includes("\x1b]9998;READY\x07")) return;
+
+    // Append the portion of this chunk before the end marker
+    const endIdx = data.indexOf("\x1b]9998;READY\x07");
+    this.promptBuffer += data.slice(0, endIdx);
+
+    this.capturingPrompt = false;
+    this.promptCaptureComplete = true;
+    this.lastPrompt = this.sanitizePromptForReplay(this.promptBuffer);
+  }
+
+  /** Strip internal OSC markers from captured prompt so replay is clean. */
+  private sanitizePromptForReplay(raw: string): string {
+    return raw
+      .replace(/\x1b\]7;[^\x07]*\x07/g, "")   // OSC 7 (cwd)
+      .replace(/\x1b\]9999;PROMPT\x07/g, "")    // start marker
+      .replace(/\x1b\]9998;READY\x07/g, "");    // end marker
+  }
 
   private removeEchoedCommand(output: string, command: string): string {
     const lines = output.split("\n");

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -135,6 +135,7 @@ export class Shell implements InputContext {
 
     this.setupOutput();
     this.setupInput();
+    this.setupAgentLifecycle();
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──
@@ -209,23 +210,35 @@ export class Shell implements InputContext {
     });
   }
 
-  // ── Public API (used by acp-client, index.ts) ──
+  /**
+   * React to agent lifecycle events — Shell manages its own state
+   * rather than being driven by AcpClient. This means AcpClient has
+   * zero frontend knowledge; any frontend can subscribe to the same events.
+   */
+  private setupAgentLifecycle(): void {
+    this.bus.on("agent:processing-start", () => {
+      this.agentActive = true;
+      this.paused = true;
+    });
 
-  printPrompt(): void {
-    this.redrawPrompt();
+    this.bus.on("agent:processing-done", () => {
+      this.paused = false;
+      this.agentActive = false;
+      this.freshPrompt();
+    });
+
+    // Permission prompts need stdout unpaused so the interactive UI renders,
+    // then re-paused after the decision.
+    this.bus.on("permission:request", () => {
+      this.paused = false;
+    });
+    this.bus.onPipeAsync("permission:request", async (payload) => {
+      this.paused = true;
+      return payload;
+    });
   }
 
-  pauseOutput(): void {
-    this.paused = true;
-  }
-
-  resumeOutput(): void {
-    this.paused = false;
-  }
-
-  setAgentActive(active: boolean): void {
-    this.agentActive = active;
-  }
+  // ── Public API (used by index.ts) ──
 
   resize(cols: number, rows: number): void {
     this.ptyProcess.resize(cols, rows);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -17,8 +17,6 @@ export class Shell implements InputContext {
 
   constructor(opts: {
     bus: EventBus;
-    onAgentRequest: (query: string) => void;
-    onAgentCancel: () => void;
     onShowAgentInfo?: () => { info: string; model?: string };
     cols: number;
     rows: number;
@@ -128,8 +126,6 @@ export class Shell implements InputContext {
     this.inputHandler = new InputHandler({
       ctx: this,
       bus: opts.bus,
-      onAgentRequest: opts.onAgentRequest,
-      onAgentCancel: opts.onAgentCancel,
       onShowAgentInfo: opts.onShowAgentInfo ?? (() => ({ info: "" })),
     });
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -35,12 +35,21 @@ export class Shell implements InputContext {
     env.AGENT_SHELL = "1";
 
     // Spawn the user's shell with their full config (aliases, plugins, PATH,
-    // completions, etc.). The core only injects two invisible hooks:
+    // completions, etc.). The core injects three invisible OSC hooks:
     //   - OSC 7: cwd tracking (required by OutputParser)
-    //   - OSC 9999: prompt marker (required for command boundary detection)
+    //   - OSC 9999: prompt start marker (command boundary detection)
+    //   - OSC 9998: prompt end marker (bracketed prompt capture)
     // Prompt theming is left entirely to the user's shell config.
-    const shellBin = opts.shell;
-    const isZsh = path.basename(shellBin).includes("zsh");
+    const shellName = path.basename(opts.shell);
+    const isZsh = shellName.includes("zsh");
+    const isBash = shellName.includes("bash");
+    if (!isZsh && !isBash) {
+      console.warn(
+        `Warning: agent-shell only supports zsh and bash. ` +
+        `"${opts.shell}" may not work correctly — falling back to /bin/bash.`
+      );
+    }
+    const shellBin = (isZsh || isBash) ? opts.shell : "/bin/bash";
     let shellArgs: string[];
 
     const osc7Cmd = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
@@ -80,10 +89,12 @@ export class Shell implements InputContext {
       env.ZDOTDIR = this.tmpDir;
       shellArgs = ["--no-globalrcs"];
     } else {
-      // For bash: source user's bashrc, then append our hooks to PROMPT_COMMAND
+      // For bash: use --rcfile to source our wrapper, which sources the user's
+      // real bashrc then appends our hooks. No HOME override needed.
       this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-shell-"));
+      const userHome = env.HOME || os.homedir();
       fs.writeFileSync(path.join(this.tmpDir, ".bashrc"), [
-        '[ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"',
+        `[ -f "${userHome}/.bashrc" ] && source "${userHome}/.bashrc"`,
         "",
         "# agent-shell hooks (invisible OSC sequences for cwd + prompt detection)",
         `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}${osc7Cmd}; ${promptMarker}"`,
@@ -91,8 +102,6 @@ export class Shell implements InputContext {
         "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",
         'case "$PS1" in *9998*) ;; *) PS1="${PS1}\\[\\e]9998;READY\\a\\]";; esac',
       ].join("\n") + "\n");
-      env.HOME_ORIG = env.HOME || os.homedir();
-      env.HOME = this.tmpDir;
       shellArgs = ["--rcfile", path.join(this.tmpDir, ".bashrc")];
     }
 
@@ -106,6 +115,15 @@ export class Shell implements InputContext {
 
     this.bus = opts.bus;
     this.outputParser = new OutputParser(opts.bus, opts.cwd);
+
+    // Ensure temp dir cleanup on abnormal exit (SIGKILL won't fire this,
+    // but it covers uncaught exceptions and normal process.exit paths)
+    if (this.tmpDir) {
+      const dir = this.tmpDir;
+      process.on("exit", () => {
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+      });
+    }
 
     this.inputHandler = new InputHandler({
       ctx: this,

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import * as pty from "node-pty";
 import type { EventBus } from "./event-bus.js";
 import { InputHandler, type InputContext } from "./input-handler.js";
@@ -5,10 +8,12 @@ import { OutputParser } from "./output-parser.js";
 
 export class Shell implements InputContext {
   private ptyProcess: pty.IPty;
+  private bus: EventBus;
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
   private paused = false;
   private agentActive = false;
+  private tmpDir?: string;
 
   constructor(opts: {
     bus: EventBus;
@@ -29,18 +34,69 @@ export class Shell implements InputContext {
     }
     env.AGENT_SHELL = "1";
 
-    // Use bash with a minimal config to avoid p10k/oh-my-zsh terminal
-    // control that conflicts with our status bar. We set up a custom
-    // PS1 with the ⚡ indicator and OSC 7 cwd reporting via PROMPT_COMMAND.
-    const shellBin = "/bin/bash";
+    // Spawn the user's shell with their full config (aliases, plugins, PATH,
+    // completions, etc.). The core only injects two invisible hooks:
+    //   - OSC 7: cwd tracking (required by OutputParser)
+    //   - OSC 9999: prompt marker (required for command boundary detection)
+    // Prompt theming is left entirely to the user's shell config.
+    const shellBin = opts.shell;
+    const isZsh = path.basename(shellBin).includes("zsh");
+    let shellArgs: string[];
+
     const osc7Cmd = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
     const promptMarker = 'printf "\\e]9999;PROMPT\\a"';
-    const ps1 = "\\[\\033[36m\\]⚡\\[\\033[0m\\] \\[\\033[1m\\]\\W\\[\\033[0m\\] \\$ ";
 
-    env.PROMPT_COMMAND = `${osc7Cmd}; ${promptMarker}`;
-    env.PS1 = ps1;
+    if (isZsh) {
+      // For zsh: use ZDOTDIR to source user's real config, then append
+      // our hooks via precmd_functions (additive — doesn't clobber p10k/omz).
+      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-shell-"));
+      const userZdotdir = env.ZDOTDIR || env.HOME || os.homedir();
+      fs.writeFileSync(path.join(this.tmpDir, ".zshrc"), [
+        `ZDOTDIR="${userZdotdir}"`,
+        `[ -f "${userZdotdir}/.zshrc" ] && source "${userZdotdir}/.zshrc"`,
+        "",
+        "# agent-shell hooks (invisible OSC sequences for cwd + prompt detection)",
+        "__agent_shell_precmd() {",
+        `  ${osc7Cmd}`,
+        `  ${promptMarker}`,
+        "}",
+        "precmd_functions+=(__agent_shell_precmd)",
+        "",
+        "# End-of-prompt marker via zle-line-init (fires after prompt is rendered)",
+        "# Chain onto existing widget (p10k uses zle-line-init) rather than clobbering",
+        'if (( ${+widgets[zle-line-init]} )); then',
+        "  zle -A zle-line-init __agent_shell_orig_line_init",
+        "  __agent_shell_line_init() {",
+        "    zle __agent_shell_orig_line_init",
+        '    printf "\\e]9998;READY\\a"',
+        "  }",
+        "else",
+        "  __agent_shell_line_init() {",
+        '    printf "\\e]9998;READY\\a"',
+        "  }",
+        "fi",
+        "zle -N zle-line-init __agent_shell_line_init",
+      ].join("\n") + "\n");
+      env.ZDOTDIR = this.tmpDir;
+      shellArgs = ["--no-globalrcs"];
+    } else {
+      // For bash: source user's bashrc, then append our hooks to PROMPT_COMMAND
+      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-shell-"));
+      fs.writeFileSync(path.join(this.tmpDir, ".bashrc"), [
+        '[ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"',
+        "",
+        "# agent-shell hooks (invisible OSC sequences for cwd + prompt detection)",
+        `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}${osc7Cmd}; ${promptMarker}"`,
+        "",
+        "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",
+        'case "$PS1" in *9998*) ;; *) PS1="${PS1}\\[\\e]9998;READY\\a\\]";; esac',
+      ].join("\n") + "\n");
+      env.HOME_ORIG = env.HOME || os.homedir();
+      env.HOME = this.tmpDir;
+      shellArgs = ["--rcfile", path.join(this.tmpDir, ".bashrc")];
+    }
 
-    this.ptyProcess = pty.spawn(shellBin, ["--norc", "--noprofile"], {
+    this.ptyProcess = pty.spawn(shellBin, shellArgs, {
       name: "xterm-256color",
       cols: opts.cols,
       rows: opts.rows,
@@ -48,6 +104,7 @@ export class Shell implements InputContext {
       env,
     });
 
+    this.bus = opts.bus;
     this.outputParser = new OutputParser(opts.bus, opts.cwd);
 
     this.inputHandler = new InputHandler({
@@ -80,6 +137,37 @@ export class Shell implements InputContext {
     this.ptyProcess.write(data);
   }
 
+  /**
+   * Lightweight redraw: replay just the last line of the shell's prompt
+   * (e.g. p10k's "❯ "). This works because agent input mode only overwrites
+   * the final prompt line — the path bar above is still intact. The last
+   * line is linear text (colors + chars + clear-to-end), no cursor positioning.
+   */
+  redrawPrompt(): void {
+    const result = this.bus.emitPipe("shell:redraw-prompt", {
+      cwd: this.outputParser.getCwd(),
+      handled: false,
+    });
+    if (!result.handled) {
+      const lastLine = this.outputParser.getLastPromptLine();
+      if (lastLine) {
+        process.stdout.write("\r" + lastLine);
+      } else {
+        // Fallback: send \n for a fresh prompt cycle
+        this.ptyProcess.write("\n");
+      }
+    }
+  }
+
+  /**
+   * Heavy redraw: send \n to PTY to trigger a full precmd → prompt cycle.
+   * Use this after agent responses where stdout has moved far from where
+   * zle expects the cursor. The blank line is acceptable as a separator.
+   */
+  freshPrompt(): void {
+    this.ptyProcess.write("\n");
+  }
+
   onCommandEntered(command: string, cwd: string): void {
     this.outputParser.onCommandEntered(command, cwd);
   }
@@ -106,7 +194,7 @@ export class Shell implements InputContext {
   // ── Public API (used by acp-client, index.ts) ──
 
   printPrompt(): void {
-    this.inputHandler.printPrompt();
+    this.redrawPrompt();
   }
 
   pauseOutput(): void {
@@ -131,5 +219,8 @@ export class Shell implements InputContext {
 
   kill(): void {
     this.ptyProcess.kill();
+    if (this.tmpDir) {
+      fs.rmSync(this.tmpDir, { recursive: true, force: true });
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,24 +1,24 @@
 import type { EventBus } from "./event-bus.js";
 import type { ContextManager } from "./context-manager.js";
-import type { Shell } from "./shell.js";
 import type { AcpClient } from "./acp-client.js";
 
 export interface AgentShellConfig {
   agentCommand: string;
   agentArgs: string[];
-  shell: string;
+  shell?: string;
   model?: string;
   extensions?: string[];
 }
 
 /**
  * Context passed to user/third-party extensions.
- * Provides access to all core services via a single object.
+ * Extensions interact with the system through the event bus — no direct
+ * frontend (Shell/TUI) dependencies. This enables headless, web, or
+ * alternative frontends without changing extensions.
  */
 export interface ExtensionContext {
   bus: EventBus;
   contextManager: ContextManager;
-  shell: Shell;
   getAcpClient: () => AcpClient;
   quit: () => void;
 }


### PR DESCRIPTION
## Summary

### Shell & prompt support
- Spawn the user's actual shell (zsh/bash) instead of hardcoding `/bin/bash`, sourcing their full rc config (oh-my-zsh, p10k, aliases, plugins, completions, PATH)
- Core only injects invisible OSC hooks (cwd tracking + command boundary detection), leaving prompt theming to the user's shell
- Bracketed prompt capture (OSC 9999→9998) for reliable prompt detection and replay
- Two prompt redraw strategies: lightweight last-line replay for agent input exit, fresh `\n` cycle for post-agent response
- Fix single-chunk double-append bug in bracketed prompt capture
- Stop overriding HOME for bash; use hardcoded path in rcfile instead
- Validate shell binary and fall back to /bin/bash for unsupported shells
- Add process.on('exit') handler for temp dir cleanup on abnormal exit
- Use lightweight redrawPrompt for slash commands instead of freshPrompt

### Core decoupling
- AcpClient no longer holds a reference to Shell — emits `agent:processing-start/done` lifecycle events instead of calling shell methods directly
- Shell subscribes to bus events to manage its own pause/resume/prompt state
- InputHandler emits `agent:submit` / `agent:cancel-request` bus events instead of calling callbacks, removing Shell's dependency on AcpClient
- Remove `shell` from ExtensionContext — extensions interact through the bus only

### Library API
- New `createCore()` factory in `src/core.ts` wires up EventBus + ContextManager + AcpClient as a reusable kernel
- `index.ts` becomes a thin interactive driver on top of createCore
- `package.json` exports `./core` so external consumers can `import { createCore } from "agent-shell"` to build custom frontends (WebSocket, REST, Electron) without terminal dependencies

## Test plan

- [ ] Launch with zsh + powerlevel10k: verify full p10k prompt renders, aliases/plugins work
- [ ] Type `>` then Escape: prompt restores without blank line
- [ ] Send agent query, get response: fresh prompt appears after output
- [ ] Run slash command (`/help`): prompt appears after output
- [ ] Launch with bash: verify prompt and hooks work
- [ ] Verify `AGENT_SHELL=1` env var prevents recursion from `.zshrc`
- [ ] Verify agent lifecycle (pause/resume/prompt) works through bus events
- [ ] Verify permission prompts render correctly (unpause → prompt → re-pause)