### PR TITLE
rename package from agent-shell to agent-sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# agent-shell
+# agent-sh
 
 Not a shell that lives in an agent — an agent that lives in a shell.
 
-agent-shell is a real terminal first. Every keystroke goes to a real PTY. `cd`, pipes, vim, job control — they all just work. But type `>` at the start of a line, and you're talking to an AI agent that has full context of what you've been doing: your working directory, recent commands, their output.
+agent-sh is a real terminal first. Every keystroke goes to a real PTY. `cd`, pipes, vim, job control — they all just work. But type `>` at the start of a line, and you're talking to an AI agent that has full context of what you've been doing: your working directory, recent commands, their output.
 
 The agent connects via the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/), so you can plug in **any** ACP-compatible agent: [pi](https://github.com/svkozak/pi-acp), claude-code, codex, gemini-cli, goose, etc.
 
@@ -18,7 +18,7 @@ The agent connects via the [Agent Client Protocol (ACP)](https://agentclientprot
 
 Most AI coding tools are agent-first: the LLM drives the experience and the shell is bolted on. That means no real PTY, no job control, no interactive commands, and fragile `cd` tracking that reimplements what bash gives you for free.
 
-agent-shell starts from the opposite end. The shell is the primary interface — it's your terminal, not the agent's. The agent is a tool you reach for when you need it, not the other way around.
+agent-sh starts from the opposite end. The shell is the primary interface — it's your terminal, not the agent's. The agent is a tool you reach for when you need it, not the other way around.
 
 ### Why ACP?
 
@@ -46,17 +46,17 @@ The [Agent Client Protocol](https://agentclientprotocol.com/) decouples the shel
 ## Install
 
 ```bash
-git clone https://github.com/guanyilun/agent-shell.git
-cd agent-shell
+git clone https://github.com/guanyilun/agent-sh.git
+cd agent-sh
 npm install
 npm run build
 ```
 
 Requires Node.js 18+ and an ACP-compatible agent installed on your system.
 
-## Running agent-shell
+## Running agent-sh
 
-After building, you can run agent-shell in several ways:
+After building, you can run agent-sh in several ways:
 
 ```bash
 # Start with the default agent (pi-acp) - RECOMMENDED
@@ -73,7 +73,7 @@ node dist/index.js --agent <agent-name>
 npm start -- --agent <agent-name>
 
 # Using npx (if published to npm)
-npx agent-shell --agent <agent-name>
+npx agent-sh --agent <agent-name>
 
 # Make the built file executable and run directly
 chmod +x dist/index.js
@@ -85,7 +85,7 @@ AGENT_SHELL_AGENT=claude-agent-acp npm start
 
 ### Install ACP-compatible agents
 
-agent-shell requires an ACP-compatible agent. Here are some popular options:
+agent-sh requires an ACP-compatible agent. Here are some popular options:
 
 | Agent | Install Command | Notes |
 |-------|----------------|-------|
@@ -114,7 +114,7 @@ export ANTHROPIC_API_KEY="your-anthropic-api-key"
 # Or for OpenAI models with pi-acp:
 # export OPENAI_API_KEY="your-openai-api-key"
 
-# 3. Start agent-shell
+# 3. Start agent-sh
 npm start
 ```
 
@@ -174,16 +174,16 @@ npm start -- --agent pi-acp --agent-args "--provider anthropic --model claude-3-
 
 ### Agent environment configuration
 
-agent-shell can be configured via environment variables:
+agent-sh can be configured via environment variables:
 
 ```bash
 # Set the default agent to use
 export AGENT_SHELL_AGENT=pi-acp  # Default is pi-acp
 ```
 
-**Smart Connection**: agent-shell uses an intelligent connection system where the shell starts immediately and the agent connects in the background. If you send a query before the agent is fully connected, the system automatically waits for connection completion. This provides instant access to the shell while ensuring reliable agent communication.
+**Smart Connection**: agent-sh uses an intelligent connection system where the shell starts immediately and the agent connects in the background. If you send a query before the agent is fully connected, the system automatically waits for connection completion. This provides instant access to the shell while ensuring reliable agent communication.
 
-Many ACP agents also require API keys. Set these before starting agent-shell:
+Many ACP agents also require API keys. Set these before starting agent-sh:
 
 #### pi-acp configuration
 
@@ -260,7 +260,7 @@ export GOOGLE_API_KEY="your-key"
 | `Ctrl-T` | Toggle thinking/reasoning text display |
 | `Escape` | Exit agent input mode (when typing after `>`) |
 
-When you type `>` at the start of a line, agent-shell enters **agent input mode** — the prompt changes to show the agent and model information (e.g., `pi (gpt-4o) ● ❯`) and your text is sent to the agent on Enter. The agent's response streams inline in real-time in a bordered box with markdown rendering and syntax highlighting.
+When you type `>` at the start of a line, agent-sh enters **agent input mode** — the prompt changes to show the agent and model information (e.g., `pi (gpt-4o) ● ❯`) and your text is sent to the agent on Enter. The agent's response streams inline in real-time in a bordered box with markdown rendering and syntax highlighting.
 
 **Agent Info Display**: When entering agent mode, you'll see the current agent name and model (if specified) next to the prompt, followed by a green dot (●) indicating the connection status. For example:
 - `pi ● ❯` — pi agent without model specified
@@ -276,7 +276,7 @@ When you type `>` at the start of a line, agent-shell enters **agent input mode*
 | `/clear` | Start a new agent session |
 | `/copy` | Copy last agent response to clipboard |
 | `/compact` | Ask agent to summarize the conversation |
-| `/quit` | Exit agent-shell |
+| `/quit` | Exit agent-sh |
 
 Slash commands have tab-completion and arrow-key navigation in agent input mode.
 
@@ -292,7 +292,7 @@ This means you can run a failing command, then type `> fix this` and the agent k
 
 ## Architecture
 
-agent-shell is an ACP **client**. The agent is a subprocess launched with stdio transport.
+agent-sh is an ACP **client**. The agent is a subprocess launched with stdio transport.
 
 ### Design philosophy: headless core + pluggable frontends
 
@@ -327,7 +327,7 @@ All components communicate exclusively through typed bus events. AcpClient has n
 
 **The core works without any frontend.** This enables:
 
-- **Library usage** — `import { createCore } from "agent-shell"` to build WebSocket servers, REST APIs, Electron apps, or test harnesses
+- **Library usage** — `import { createCore } from "agent-sh"` to build WebSocket servers, REST APIs, Electron apps, or test harnesses
 - **Headless mode** — CI, scripting, embedding — no terminal needed
 - **Alternative renderers** — web UI, logging backend, minimal TUI
 - **Custom features** — add commands, autocomplete providers, tool interceptors by writing an extension
@@ -367,7 +367,7 @@ All components communicate exclusively through typed bus events. AcpClient has n
 ## Project structure
 
 ```
-agent-shell/
+agent-sh/
 ├── src/
 │   ├── index.ts            # Interactive terminal entry point (CLI args, Shell, extensions)
 │   ├── core.ts             # createCore() — frontend-agnostic kernel, library entry point
@@ -427,15 +427,15 @@ npm run dev -- --agent pi-acp
 
 ## How it works
 
-1. agent-shell spawns a real PTY running your shell (zsh or bash, with your full rc config — oh-my-zsh, p10k, aliases, plugins, PATH) and sets up raw stdin passthrough
+1. agent-sh spawns a real PTY running your shell (zsh or bash, with your full rc config — oh-my-zsh, p10k, aliases, plugins, PATH) and sets up raw stdin passthrough
 2. It launches the specified ACP agent as a subprocess with stdio transport
 3. All keyboard input goes directly to the PTY — zero latency, full terminal compatibility
 4. **Smart connection**: The agent connects asynchronously in the background while the shell starts immediately
 5. **Auto-wait**: If you send a query before the agent is fully connected, the system automatically waits for connection completion
-6. When you type `>` at the start of a line, agent-shell intercepts and enters agent input mode
+6. When you type `>` at the start of a line, agent-sh intercepts and enters agent input mode
 7. On Enter, the query (plus shell context) is sent to the agent via `session/prompt`
 8. The agent's streaming response renders inline in a bordered markdown box with real-time output
-9. If the agent needs to run commands, it calls `terminal/create` and agent-shell executes them in isolated child processes, streaming output back
+9. If the agent needs to run commands, it calls `terminal/create` and agent-sh executes them in isolated child processes, streaming output back
 10. When the agent finishes, normal shell operation resumes
 
 ### EventBus
@@ -484,12 +484,12 @@ The `ExtensionContext` provides:
 | `bus` | `EventBus` | Subscribe to events, emit events, register pipe handlers |
 | `contextManager` | `ContextManager` | Access exchange history, cwd, search, expand |
 | `getAcpClient` | `() => AcpClient` | Lazy getter for the agent client |
-| `quit` | `() => void` | Exit agent-shell |
+| `quit` | `() => void` | Exit agent-sh |
 | `setPalette` | `(overrides: Partial<ColorPalette>) => void` | Override color palette slots for theming |
 
 ### Yolo mode
 
-By default, agent-shell runs in **yolo mode** — all tool calls and file writes are auto-approved. This matches pi's design philosophy where the agent operates freely unless you explicitly add permission gates.
+By default, agent-sh runs in **yolo mode** — all tool calls and file writes are auto-approved. This matches pi's design philosophy where the agent operates freely unless you explicitly add permission gates.
 
 To add permission prompts, load the example extension:
 ```bash
@@ -497,15 +497,15 @@ To add permission prompts, load the example extension:
 npm start -- -e ./examples/extensions/interactive-prompts.ts
 
 # Permanent: copy to your extensions dir
-cp examples/extensions/interactive-prompts.ts ~/.agent-shell/extensions/
+cp examples/extensions/interactive-prompts.ts ~/.agent-sh/extensions/
 
 # Or add to settings.json
-echo '{ "extensions": ["./examples/extensions/interactive-prompts.ts"] }' > ~/.agent-shell/settings.json
+echo '{ "extensions": ["./examples/extensions/interactive-prompts.ts"] }' > ~/.agent-sh/settings.json
 ```
 
 ### Theming
 
-agent-shell uses a semantic color palette with ~10 base roles (`accent`, `success`, `warning`, `error`, `muted`, plus background variants and style modifiers). Extensions can override any slot via `setPalette()`:
+agent-sh uses a semantic color palette with ~10 base roles (`accent`, `success`, `warning`, `error`, `muted`, plus background variants and style modifiers). Extensions can override any slot via `setPalette()`:
 
 ```typescript
 // solarized-theme.ts
@@ -537,7 +537,7 @@ npm start -- -e my-ext-package -e ./local-ext.ts
 npm start -- -e my-ext-package,another-package   # comma-separated also works
 ```
 
-**2. Settings file** — `~/.agent-shell/settings.json`:
+**2. Settings file** — `~/.agent-sh/settings.json`:
 ```json
 {
   "extensions": [
@@ -548,9 +548,9 @@ npm start -- -e my-ext-package,another-package   # comma-separated also works
 }
 ```
 
-**3. Extensions directory** — files and directories in `~/.agent-shell/extensions/`:
+**3. Extensions directory** — files and directories in `~/.agent-sh/extensions/`:
 ```bash
-~/.agent-shell/extensions/
+~/.agent-sh/extensions/
 ├── my-extension.ts          # loaded directly
 ├── another.js               # JS works too
 └── complex-extension/       # directory with index file
@@ -569,7 +569,7 @@ Errors in extension loading are non-fatal — a `ui:error` is emitted and the ne
 The core can be imported directly for building custom frontends — no terminal required:
 
 ```typescript
-import { createCore } from "agent-shell";
+import { createCore } from "agent-sh";
 
 const core = createCore({ agentCommand: "pi-acp" });
 
@@ -587,7 +587,7 @@ await core.start();
 core.bus.emit("agent:submit", { query: "explain this codebase" });
 ```
 
-This works for WebSocket servers, REST APIs, Electron apps, test harnesses, or any environment where you want agent-shell's context management and ACP integration without the interactive terminal.
+This works for WebSocket servers, REST APIs, Electron apps, test harnesses, or any environment where you want agent-sh's context management and ACP integration without the interactive terminal.
 
 ## Troubleshooting
 

--- a/examples/extensions/interactive-prompts.ts
+++ b/examples/extensions/interactive-prompts.ts
@@ -2,22 +2,22 @@
  * Interactive permission prompts extension.
  *
  * Adds permission gates for tool calls and file writes.
- * Without this extension, agent-shell runs in yolo mode (auto-approve).
+ * Without this extension, agent-sh runs in yolo mode (auto-approve).
  *
  * Usage:
  *   # Load by short name (built-in):
- *   agent-shell --extensions interactive-prompts
+ *   agent-sh --extensions interactive-prompts
  *
- *   # Or copy to ~/.agent-shell/extensions/ for permanent use:
- *   cp examples/extensions/interactive-prompts.ts ~/.agent-shell/extensions/
+ *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
+ *   cp examples/extensions/interactive-prompts.ts ~/.agent-sh/extensions/
  *
  *   # Or install as an npm package and load by name:
- *   agent-shell --extensions my-prompts-package
+ *   agent-sh --extensions my-prompts-package
  */
-import { renderDiff } from "agent-shell/utils/diff-renderer.js";
-import { renderBoxFrame } from "agent-shell/utils/box-frame.js";
-import { palette as p } from "agent-shell/utils/palette.js";
-import type { ExtensionContext } from "agent-shell/types";
+import { renderDiff } from "agent-sh/utils/diff-renderer.js";
+import { renderBoxFrame } from "agent-sh/utils/box-frame.js";
+import { palette as p } from "agent-sh/utils/palette.js";
+import type { ExtensionContext } from "agent-sh/types";
 
 export default function activate({ bus }: ExtensionContext) {
   let autoApproveWrites = false;

--- a/examples/extensions/solarized-theme.ts
+++ b/examples/extensions/solarized-theme.ts
@@ -4,12 +4,12 @@
  * Overrides the default color palette with Solarized Dark colors.
  *
  * Usage:
- *   agent-shell -e ./examples/extensions/solarized-theme.ts
+ *   agent-sh -e ./examples/extensions/solarized-theme.ts
  *
- *   # Or copy to ~/.agent-shell/extensions/ for permanent use:
- *   cp examples/extensions/solarized-theme.ts ~/.agent-shell/extensions/
+ *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
+ *   cp examples/extensions/solarized-theme.ts ~/.agent-sh/extensions/
  */
-import type { ExtensionContext } from "agent-shell/types";
+import type { ExtensionContext } from "agent-sh/types";
 
 export default function activate({ setPalette }: ExtensionContext) {
   setPalette({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
-  "name": "agent-shell",
+  "name": "agent-sh",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-shell",
+      "name": "agent-sh",
       "version": "0.1.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.18.1",
         "cli-highlight": "^2.1.11",
         "marked": "^17.0.6",
-        "node-pty": "^1.2.0-beta.12"
+        "node-pty": "^1.2.0-beta.12",
+        "tsx": "^4.19.0"
       },
       "bin": {
-        "agent-shell": "dist/index.js"
+        "agent-sh": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "tsx": "^4.19.0",
         "typescript": "^5.7.0"
       }
     },
@@ -37,7 +37,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -53,7 +52,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -69,7 +67,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -85,7 +82,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -101,7 +97,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -117,7 +112,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -133,7 +127,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -149,7 +142,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -165,7 +157,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -181,7 +172,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -197,7 +187,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -213,7 +202,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -229,7 +217,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -245,7 +232,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -261,7 +247,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -277,7 +262,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -293,7 +277,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -309,7 +292,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -325,7 +307,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -341,7 +322,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -357,7 +337,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -373,7 +352,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -389,7 +367,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -405,7 +382,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -421,7 +397,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -437,7 +412,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -552,7 +526,6 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -601,7 +574,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -623,7 +595,6 @@
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
       "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -728,7 +699,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -791,7 +761,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "agent-shell",
+  "name": "agent-sh",
   "version": "0.1.0",
   "description": "A shell-first terminal where any ACP-compatible AI agent is one keystroke away",
   "type": "module",
   "main": "dist/core.js",
   "bin": {
-    "agent-shell": "dist/index.js"
+    "agent-sh": "dist/index.js"
   },
   "exports": {
     ".": "./dist/core.js",

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -91,7 +91,7 @@ export class AcpClient {
     this.log("Sending initialize request");
     const initResponse = await this.connection.initialize({
       protocolVersion: acp.PROTOCOL_VERSION,
-      clientInfo: { name: "agent-shell", version: "0.1.0" },
+      clientInfo: { name: "agent-sh", version: "0.1.0" },
       clientCapabilities: {
         terminal: true,
         fs: {
@@ -256,7 +256,7 @@ export class AcpClient {
 
   private log(msg: string): void {
     if (process.env.DEBUG) {
-      process.stderr.write(`[agent-shell] ${msg}\n`);
+      process.stderr.write(`[agent-sh] ${msg}\n`);
     }
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,5 @@
 /**
- * Core kernel — the minimum viable agent-shell.
+ * Core kernel — the minimum viable agent-sh.
  *
  * Wires up EventBus + ContextManager + AcpClient without any frontend.
  * Consumers attach their own I/O (Shell, WebSocket, REST, tests) by
@@ -10,7 +10,7 @@
  * never need a direct reference to AcpClient — they just emit events.
  *
  * Usage:
- *   import { createCore } from "agent-shell";
+ *   import { createCore } from "agent-sh";
  *   const core = createCore({ agentCommand: "pi-acp" });
  *   core.bus.on("agent:response-chunk", ({ text }) => ws.send(text));
  *   await core.start();

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import type { ExtensionContext } from "./types.js";
 
-const CONFIG_DIR = path.join(os.homedir(), ".agent-shell");
+const CONFIG_DIR = path.join(os.homedir(), ".agent-sh");
 const EXT_DIR = path.join(CONFIG_DIR, "extensions");
 const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
 
@@ -40,8 +40,8 @@ async function loadSettings(): Promise<Settings> {
  * Load extensions from three sources (merged, deduplicated):
  *
  * 1. CLI flags: -e / --extensions (npm packages or file paths)
- * 2. settings.json: ~/.agent-shell/settings.json → extensions[]
- * 3. Extensions dir: ~/.agent-shell/extensions/ (files and directories with index.{ts,js})
+ * 2. settings.json: ~/.agent-sh/settings.json → extensions[]
+ * 3. Extensions dir: ~/.agent-sh/extensions/ (files and directories with index.{ts,js})
  *
  * Extension specifiers resolve as:
  *   - File path (relative or absolute) → import directly
@@ -67,7 +67,7 @@ export async function loadExtensions(
     specifiers.push(...settings.extensions);
   }
 
-  // 3. ~/.agent-shell/extensions/ directory
+  // 3. ~/.agent-sh/extensions/ directory
   try {
     const entries = await fs.readdir(EXT_DIR, { withFileTypes: true });
     for (const entry of entries) {

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -74,7 +74,7 @@ export default function activate({ bus, getAcpClient, quit }: ExtensionContext):
     },
     {
       name: "/quit",
-      description: "Exit agent-shell",
+      description: "Exit agent-sh",
       handler: () => {
         quit();
       },

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -5,7 +5,7 @@
  * bordered markdown responses, spinner, tool call display, streaming
  * command output, error/info messages.
  *
- * Without this extension loaded, agent-shell runs headlessly — PTY
+ * Without this extension loaded, agent-sh runs headlessly — PTY
  * passthrough, agent queries, tool execution all function; output is
  * silently dropped. Alternative renderers (web UI, logging, minimal)
  * can subscribe to the same events.

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,9 @@ function parseArgs(argv: string[]): AgentShellConfig {
       const exts = argv[++i]!.split(",").map(s => s.trim());
       extensions = extensions ? [...extensions, ...exts] : exts;
     } else if (arg === "--help" || arg === "-h") {
-      console.log(`agent-shell — a shell-first terminal with ACP agent access
+      console.log(`agent-sh — a shell-first terminal with ACP agent access
 
-Usage: agent-shell [options]
+Usage: agent-sh [options]
 
 Quick Start:
   npm start           Start with default agent (pi-acp)
@@ -55,8 +55,8 @@ Options:
 Extensions:
   Extensions are loaded from (in order):
     1. -e flags:  npm packages or file paths
-    2. settings:  ~/.agent-shell/settings.json → "extensions": [...]
-    3. directory:  ~/.agent-shell/extensions/ (files or dirs with index.ts)
+    2. settings:  ~/.agent-sh/settings.json → "extensions": [...]
+    3. directory:  ~/.agent-sh/extensions/ (files or dirs with index.ts)
 
 Environment Variables:
   AGENT_SHELL_AGENT   Default agent to use (e.g., "pi-acp", "claude")
@@ -100,7 +100,7 @@ async function main(): Promise<void> {
   const { bus, client } = core;
 
   // ── Interactive frontend ──────────────────────────────────────
-  process.stdout.write(`\x1b]0;agent-shell\x07`);
+  process.stdout.write(`\x1b]0;agent-sh\x07`);
 
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -43,7 +43,7 @@ export class Shell implements InputContext {
     const isBash = shellName.includes("bash");
     if (!isZsh && !isBash) {
       console.warn(
-        `Warning: agent-shell only supports zsh and bash. ` +
+        `Warning: agent-sh only supports zsh and bash. ` +
         `"${opts.shell}" may not work correctly — falling back to /bin/bash.`
       );
     }
@@ -56,13 +56,13 @@ export class Shell implements InputContext {
     if (isZsh) {
       // For zsh: use ZDOTDIR to source user's real config, then append
       // our hooks via precmd_functions (additive — doesn't clobber p10k/omz).
-      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-shell-"));
+      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-"));
       const userZdotdir = env.ZDOTDIR || env.HOME || os.homedir();
       fs.writeFileSync(path.join(this.tmpDir, ".zshrc"), [
         `ZDOTDIR="${userZdotdir}"`,
         `[ -f "${userZdotdir}/.zshrc" ] && source "${userZdotdir}/.zshrc"`,
         "",
-        "# agent-shell hooks (invisible OSC sequences for cwd + prompt detection)",
+        "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
         "__agent_shell_precmd() {",
         `  ${osc7Cmd}`,
         `  ${promptMarker}`,
@@ -89,12 +89,12 @@ export class Shell implements InputContext {
     } else {
       // For bash: use --rcfile to source our wrapper, which sources the user's
       // real bashrc then appends our hooks. No HOME override needed.
-      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-shell-"));
+      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-"));
       const userHome = env.HOME || os.homedir();
       fs.writeFileSync(path.join(this.tmpDir, ".bashrc"), [
         `[ -f "${userHome}/.bashrc" ] && source "${userHome}/.bashrc"`,
         "",
-        "# agent-shell hooks (invisible OSC sequences for cwd + prompt detection)",
+        "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
         `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}${osc7Cmd}; ${promptMarker}"`,
         "",
         "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",


### PR DESCRIPTION
## Summary
- Rename npm package from `agent-shell` to `agent-sh` (available on npm)
- Update all references: package.json, bin entry, config dir (`~/.agent-sh`), source, docs, examples

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npx agent-sh` runs correctly
- [ ] Config dir resolves to `~/.agent-sh`