### PR TITLE
Prepare for npm publish and rename env vars

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ chmod +x dist/index.js
 ./dist/index.js --agent <agent-name>
 
 # Using environment variable to set default agent
-AGENT_SHELL_AGENT=claude-agent-acp npm start
+AGENT_SH_AGENT=claude-agent-acp npm start
 ```
 
 ### Install ACP-compatible agents
@@ -149,7 +149,7 @@ npm start -- --agent pi-acp --agent-args "--provider openai --model gpt-4o"
 npm start -- --shell /bin/zsh
 
 # Set default agent via environment variable
-AGENT_SHELL_AGENT=claude-agent-acp npm start
+AGENT_SH_AGENT=claude-agent-acp npm start
 ```
 
 ### Common Claude Models
@@ -178,7 +178,7 @@ agent-sh can be configured via environment variables:
 
 ```bash
 # Set the default agent to use
-export AGENT_SHELL_AGENT=pi-acp  # Default is pi-acp
+export AGENT_SH_AGENT=pi-acp  # Default is pi-acp
 ```
 
 **Smart Connection**: agent-sh uses an intelligent connection system where the shell starts immediately and the agent connects in the background. If you send a query before the agent is fully connected, the system automatically waits for connection completion. This provides instant access to the shell while ensuring reliable agent communication.

--- a/package.json
+++ b/package.json
@@ -4,21 +4,59 @@
   "description": "A shell-first terminal where any ACP-compatible AI agent is one keystroke away",
   "type": "module",
   "main": "dist/core.js",
+  "types": "dist/core.d.ts",
   "bin": {
     "agent-sh": "dist/index.js"
   },
   "exports": {
-    ".": "./dist/core.js",
-    "./core": "./dist/core.js",
+    ".": {
+      "types": "./dist/core.d.ts",
+      "default": "./dist/core.js"
+    },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "default": "./dist/core.js"
+    },
     "./utils/*": "./dist/utils/*",
-    "./types": "./dist/types.js"
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    }
   },
+  "files": [
+    "dist",
+    "examples"
+  ],
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "pi": "node dist/index.js --agent pi-acp",
-    "claude": "node dist/index.js --agent claude-agent-acp"
+    "claude": "node dist/index.js --agent claude-agent-acp",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "terminal",
+    "shell",
+    "agent",
+    "ai",
+    "acp",
+    "cli",
+    "pty",
+    "llm"
+  ],
+  "author": "Yilun Guan",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guanyilun/agent-sh.git"
+  },
+  "homepage": "https://github.com/guanyilun/agent-sh",
+  "bugs": {
+    "url": "https://github.com/guanyilun/agent-sh/issues"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.18.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import type { AgentShellConfig } from "./types.js";
 
 function parseArgs(argv: string[]): AgentShellConfig {
   // Priority: CLI args > Environment variables > Config file > Defaults
-  const defaultAgent = process.env.AGENT_SHELL_AGENT || "pi-acp";
+  const defaultAgent = process.env.AGENT_SH_AGENT || "pi-acp";
   let agentCommand = defaultAgent;
   let agentArgs: string[] = [];
   let model: string | undefined;
@@ -46,7 +46,7 @@ Quick Start:
   npm run claude      Start with Claude agent
 
 Options:
-  --agent <cmd>       Agent command to launch (default: $AGENT_SHELL_AGENT or "pi-acp")
+  --agent <cmd>       Agent command to launch (default: $AGENT_SH_AGENT or "pi-acp")
   --agent-args <args> Arguments for the agent (space-separated, quoted)
   --shell <path>      Shell to use (default: $SHELL or /bin/bash)
   -e, --extensions    Extensions to load (comma-separated, repeatable)
@@ -59,7 +59,7 @@ Extensions:
     3. directory:  ~/.agent-sh/extensions/ (files or dirs with index.ts)
 
 Environment Variables:
-  AGENT_SHELL_AGENT   Default agent to use (e.g., "pi-acp", "claude")
+  AGENT_SH_AGENT   Default agent to use (e.g., "pi-acp", "claude")
 
 Examples:
   npm start --agent pi-acp

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -30,7 +30,7 @@ export class Shell implements InputContext {
     for (const [k, v] of Object.entries(process.env)) {
       if (v !== undefined) env[k] = v;
     }
-    env.AGENT_SHELL = "1";
+    env.AGENT_SH = "1";
 
     // Spawn the user's shell with their full config (aliases, plugins, PATH,
     // completions, etc.). The core injects three invisible OSC hooks:
@@ -63,26 +63,26 @@ export class Shell implements InputContext {
         `[ -f "${userZdotdir}/.zshrc" ] && source "${userZdotdir}/.zshrc"`,
         "",
         "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
-        "__agent_shell_precmd() {",
+        "__agent_sh_precmd() {",
         `  ${osc7Cmd}`,
         `  ${promptMarker}`,
         "}",
-        "precmd_functions+=(__agent_shell_precmd)",
+        "precmd_functions+=(__agent_sh_precmd)",
         "",
         "# End-of-prompt marker via zle-line-init (fires after prompt is rendered)",
         "# Chain onto existing widget (p10k uses zle-line-init) rather than clobbering",
         'if (( ${+widgets[zle-line-init]} )); then',
-        "  zle -A zle-line-init __agent_shell_orig_line_init",
-        "  __agent_shell_line_init() {",
-        "    zle __agent_shell_orig_line_init",
+        "  zle -A zle-line-init __agent_sh_orig_line_init",
+        "  __agent_sh_line_init() {",
+        "    zle __agent_sh_orig_line_init",
         '    printf "\\e]9998;READY\\a"',
         "  }",
         "else",
-        "  __agent_shell_line_init() {",
+        "  __agent_sh_line_init() {",
         '    printf "\\e]9998;READY\\a"',
         "  }",
         "fi",
-        "zle -N zle-line-init __agent_shell_line_init",
+        "zle -N zle-line-init __agent_sh_line_init",
       ].join("\n") + "\n");
       env.ZDOTDIR = this.tmpDir;
       shellArgs = ["--no-globalrcs"];


### PR DESCRIPTION
## Summary
- Rename `AGENT_SHELL_AGENT` → `AGENT_SH_AGENT` and `AGENT_SHELL` → `AGENT_SH` env vars to match the package rename
- Rename internal `__agent_shell_*` zsh hooks to `__agent_sh_*`
- Add npm package metadata: `types`, `files`, `keywords`, `repository`, `license`, `engines`, proper `exports` with types conditions
- Add `prepublishOnly` script
- Add GitHub Actions workflow to auto-publish to npm on version tags (`v*`)

## Test plan
- [ ] Verify `npm run build` succeeds
- [ ] Verify `npm pack --dry-run` includes correct files
- [ ] After merge, tag `v0.1.0` and verify GitHub Action publishes to npm
- [ ] Verify `npx agent-sh` works after publish