### PR TITLE
Use zle reset-prompt instead of replaying captured prompt bytes

### DIFF
--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -11,10 +11,7 @@ export class OutputParser {
   private currentOutputCapture = "";
   private lastCommand = "";
   private foregroundBusy = false;
-  private capturingPrompt = false;
-  private promptCaptureComplete = false;
-  private promptBuffer = "";
-  private lastPrompt = "";
+  private promptReady = false;
 
   constructor(bus: EventBus, initialCwd: string) {
     this.bus = bus;
@@ -24,22 +21,7 @@ export class OutputParser {
   /** Process a chunk of PTY output data. */
   processData(data: string): void {
     this.parseOSC7(data);
-
-    // Bracketed prompt capture: accumulate bytes between OSC 9999 and 9998.
-    // parsePromptMarker may start capture (setting promptBuffer to the tail
-    // of the current chunk), so we only append subsequent chunks here.
-    const wasCapturing = this.capturingPrompt;
     this.parsePromptMarker(data);
-
-    // If we were already capturing before this chunk (and still are), append
-    // the full chunk. If capture just started in parsePromptMarker above, the
-    // tail after the start marker is already in promptBuffer — don't double-add.
-    if (wasCapturing && this.capturingPrompt) {
-      this.promptBuffer += data;
-    }
-
-    // Check for end marker. Must run after the append above so that
-    // multi-chunk captures include this chunk's data before we finalize.
     this.parsePromptEnd(data);
   }
 
@@ -54,27 +36,9 @@ export class OutputParser {
     }
   }
 
-  /** Returns the full captured prompt bytes, or empty if incomplete. */
-  getLastPrompt(): string {
-    if (!this.promptCaptureComplete) return "";
-    return this.lastPrompt;
-  }
-
-  /**
-   * Returns just the last line of the captured prompt (e.g. p10k's "❯ " line).
-   * This is safe to replay with \r because it's linear text (colors + chars),
-   * not relative cursor positioning. Returns empty if no complete capture.
-   */
-  getLastPromptLine(): string {
-    if (!this.promptCaptureComplete) return "";
-    // Find the last \r\n or \n — everything after it is the final prompt line
-    const lastNewline = this.lastPrompt.lastIndexOf("\n");
-    if (lastNewline < 0) return this.lastPrompt;
-    return this.lastPrompt.slice(lastNewline + 1);
-  }
-
-  isPromptCaptureComplete(): boolean {
-    return this.promptCaptureComplete;
+  /** Whether the shell's prompt is fully rendered and ready for input. */
+  isPromptReady(): boolean {
+    return this.promptReady;
   }
 
   isForegroundBusy(): boolean {
@@ -104,6 +68,7 @@ export class OutputParser {
    */
   private parsePromptMarker(data: string): void {
     if (data.includes("\x1b]9999;PROMPT\x07")) {
+      this.promptReady = false;
       if (this.foregroundBusy) {
         this.foregroundBusy = false;
         this.bus.emit("shell:foreground-busy", { busy: false });
@@ -120,57 +85,19 @@ export class OutputParser {
       }
       this.lastCommand = "";
       this.currentOutputCapture = "";
-
-      // Start bracketed prompt capture: accumulate bytes until OSC 9998
-      this.capturingPrompt = true;
-      this.promptCaptureComplete = false;
-      this.promptBuffer = "";
-      const markerEnd = data.indexOf("\x1b]9999;PROMPT\x07") + "\x1b]9999;PROMPT\x07".length;
-      if (markerEnd < data.length) {
-        this.promptBuffer = data.slice(markerEnd);
-      }
     } else {
       this.currentOutputCapture += data;
     }
   }
 
-
   /**
-   * Detect end-of-prompt marker (OSC 9998). Finalizes the bracketed capture.
-   *
-   * By the time this runs, the current chunk has already been appended to
-   * promptBuffer (either by parsePromptMarker for the first chunk, or by
-   * the wasCapturing guard in processData for subsequent chunks). So we
-   * just need to trim everything from the end marker onward.
+   * Detect end-of-prompt marker (OSC 9998). The prompt is fully rendered
+   * and the shell is ready for input.
    */
   private parsePromptEnd(data: string): void {
-    if (!this.capturingPrompt) return;
-    if (!data.includes("\x1b]9998;READY\x07")) return;
-
-    // promptBuffer already contains this chunk's data. Find the end marker
-    // within the buffer and trim everything from it onward.
-    const endMarker = "\x1b]9998;READY\x07";
-    const bufEndIdx = this.promptBuffer.indexOf(endMarker);
-    if (bufEndIdx >= 0) {
-      this.promptBuffer = this.promptBuffer.slice(0, bufEndIdx);
+    if (data.includes("\x1b]9998;READY\x07")) {
+      this.promptReady = true;
     }
-
-    this.capturingPrompt = false;
-    this.promptCaptureComplete = true;
-    this.lastPrompt = this.sanitizePromptForReplay(this.promptBuffer);
-  }
-
-  /**
-   * Strip internal OSC markers from captured prompt so replay is clean.
-   * We intentionally strip all OSC 7 sequences — they're used for cwd
-   * reporting and have no visual effect, so replaying them would just
-   * cause duplicate cwd-change events.
-   */
-  private sanitizePromptForReplay(raw: string): string {
-    return raw
-      .replace(/\x1b\]7;[^\x07]*\x07/g, "")   // OSC 7 (cwd reporting)
-      .replace(/\x1b\]9999;PROMPT\x07/g, "")    // start marker
-      .replace(/\x1b\]9998;READY\x07/g, "");    // end marker
   }
 
   private removeEchoedCommand(output: string, command: string): string {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -13,6 +13,7 @@ export class Shell implements InputContext {
   private outputParser: OutputParser;
   private paused = false;
   private agentActive = false;
+  private isZsh = false;
   private tmpDir?: string;
 
   constructor(opts: {
@@ -53,6 +54,7 @@ export class Shell implements InputContext {
     const osc7Cmd = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
     const promptMarker = 'printf "\\e]9999;PROMPT\\a"';
 
+    this.isZsh = isZsh;
     if (isZsh) {
       // For zsh: use ZDOTDIR to source user's real config, then append
       // our hooks via precmd_functions (additive — doesn't clobber p10k/omz).
@@ -83,6 +85,14 @@ export class Shell implements InputContext {
         "  }",
         "fi",
         "zle -N zle-line-init __agent_sh_line_init",
+        "",
+        "# Hidden widget to trigger prompt redraw from Node.js side",
+        "# Bound to an unused escape sequence that no real key produces",
+        "__agent_sh_redraw() {",
+        "  zle reset-prompt",
+        "}",
+        "zle -N __agent_sh_redraw",
+        "bindkey '\\e[9999~' __agent_sh_redraw",
       ].join("\n") + "\n");
       env.ZDOTDIR = this.tmpDir;
       shellArgs = ["--no-globalrcs"];
@@ -153,10 +163,11 @@ export class Shell implements InputContext {
   }
 
   /**
-   * Lightweight redraw: replay just the last line of the shell's prompt
-   * (e.g. p10k's "❯ "). This works because agent input mode only overwrites
-   * the final prompt line — the path bar above is still intact. The last
-   * line is linear text (colors + chars + clear-to-end), no cursor positioning.
+   * Lightweight redraw: ask the shell to redraw its own prompt via a hidden
+   * ZLE widget (zsh) bound to \e[9999~. The shell knows how to draw its
+   * prompt correctly — we don't try to replay captured bytes.
+   *
+   * For bash, falls back to sending \n for a fresh prompt cycle.
    */
   redrawPrompt(): void {
     const result = this.bus.emitPipe("shell:redraw-prompt", {
@@ -164,11 +175,11 @@ export class Shell implements InputContext {
       handled: false,
     });
     if (!result.handled) {
-      const lastLine = this.outputParser.getLastPromptLine();
-      if (lastLine) {
-        process.stdout.write("\r" + lastLine);
+      if (this.isZsh) {
+        // Trigger the hidden ZLE widget — zle reset-prompt redraws cleanly
+        this.ptyProcess.write("\x1b[9999~");
       } else {
-        // Fallback: send \n for a fresh prompt cycle
+        // Bash: no zle reset-prompt equivalent, use fresh prompt cycle
         this.ptyProcess.write("\n");
       }
     }


### PR DESCRIPTION
## Summary

- Replace prompt byte capture/replay with a hidden ZLE widget (`__agent_sh_redraw`) that triggers `zle reset-prompt` — the same mechanism used by fzf and Atuin
- Remove all prompt capture/replay logic from `output-parser.ts` (60+ lines deleted), keep OSC markers for state tracking only
- Fixes prompt corruption in tmux and with complex prompts (p10k)

## Context

The old approach captured raw PTY bytes between OSC 9999/9998 markers and replayed them to restore the shell prompt on Escape. This broke because captured bytes contain relative cursor movements (`\r\n`, `\e[A`, `\e[J`) that are position-dependent — replaying from a different cursor position produces garbage, especially inside tmux.

After studying how fzf, Atuin, and Amazon Q CLI solve this, the lesson is clear: **let the shell redraw its own prompt**. All three projects avoid replaying captured bytes entirely. For zsh, `zle reset-prompt` is the canonical solution.

## How it works

1. Injected `.zshrc` now defines a hidden widget bound to unused escape sequence `\e[9999~`
2. On Escape from agent mode: clear agent prompt line (`\r\e[2K`), send `\e[9999~` to PTY
3. ZLE receives it → widget fires → `zle reset-prompt` → shell redraws its own prompt correctly
4. For bash: falls back to `\n` for a fresh prompt cycle (no `zle` equivalent)

## Test plan

- [ ] Enter agent mode (`>`), press Escape — prompt restores cleanly
- [ ] Same test with p10k two-line prompt
- [ ] Same test inside tmux
- [ ] Type text after `>`, then Escape — prompt restores, no leftover characters
- [ ] Agent response completes — fresh prompt appears after output
- [ ] Bash shell — fresh prompt via `\n` still works