### PR TITLE
Show rich tool call details in TUI

### DIFF
--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -334,23 +334,31 @@ export class AcpClient {
       }
 
       case "tool_call": {
-        // Use toolCallId if available, otherwise generate a simple ID
         const toolId = update.toolCallId || `tool-${this.pendingToolCounter++}`;
         this.pendingToolCalls.set(toolId, true);
-        this.bus.emit("agent:tool-started", { title: update.title, toolCallId: toolId });
+        this.bus.emit("agent:tool-started", {
+          title: update.title,
+          toolCallId: toolId,
+          kind: update.kind ?? undefined,
+          locations: update.locations?.map((l) => ({ path: l.path, line: l.line })),
+          rawInput: update.rawInput,
+        });
         break;
       }
 
       case "tool_call_update": {
-        // Only show result when the tool completes, don't show tool call again
         if (update.status === "completed" || update.status === "failed") {
           const toolId = update.toolCallId;
           const exitCode = update.status === "completed" ? 0 : 1;
           if (toolId && this.pendingToolCalls.has(toolId)) {
             this.pendingToolCalls.delete(toolId);
-            this.bus.emit("agent:tool-completed", { toolCallId: toolId, exitCode });
+            this.bus.emit("agent:tool-completed", {
+              toolCallId: toolId,
+              exitCode,
+              rawOutput: update.rawOutput,
+            });
           } else if (!toolId) {
-            this.bus.emit("agent:tool-completed", { exitCode });
+            this.bus.emit("agent:tool-completed", { exitCode, rawOutput: update.rawOutput });
           }
         }
         break;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -40,8 +40,18 @@ export interface ShellEvents {
   };
 
   // Tool rendering (used by TUI for display — distinct data shape from above)
-  "agent:tool-started": { title: string; toolCallId?: string };
-  "agent:tool-completed": { toolCallId?: string; exitCode: number | null };
+  "agent:tool-started": {
+    title: string;
+    toolCallId?: string;
+    kind?: string;
+    locations?: { path: string; line?: number | null }[];
+    rawInput?: unknown;
+  };
+  "agent:tool-completed": {
+    toolCallId?: string;
+    exitCode: number | null;
+    rawOutput?: unknown;
+  };
   "agent:tool-output-chunk": { chunk: string };
 
   // Permission request (async pipe — core emits with safe default, extensions override)

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -80,7 +80,7 @@ export default function activate({ bus }: ExtensionContext): void {
 
   bus.on("agent:tool-started", (e) => {
     stopCurrentSpinner();
-    showToolCall(e.title, lastCommand);
+    showToolCall(e.title, lastCommand, e);
     lastCommand = "";
   });
 
@@ -195,12 +195,26 @@ export default function activate({ bus }: ExtensionContext): void {
     flushOutput();
   }
 
-  function showToolCall(title: string, command?: string): void {
+  function showToolCall(
+    title: string,
+    command?: string,
+    extra?: {
+      kind?: string;
+      locations?: { path: string; line?: number | null }[];
+      rawInput?: unknown;
+    },
+  ): void {
     stopCurrentSpinner();
     if (!renderer) startAgentResponse();
     renderer!.flush();
     const termW = process.stdout.columns || 80;
-    const lines = renderToolCall({ title, command: command || undefined }, termW);
+    const lines = renderToolCall({
+      title,
+      command: command || undefined,
+      kind: extra?.kind,
+      locations: extra?.locations,
+      rawInput: extra?.rawInput,
+    }, termW);
     for (const line of lines) {
       renderer!.writeLine(line);
     }

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -16,6 +16,12 @@ export interface ToolCallRender {
   title: string;
   /** Optional command string for bash-like tools. */
   command?: string;
+  /** Tool kind from ACP (read, edit, execute, search, etc.). */
+  kind?: string;
+  /** File locations affected by the tool call. */
+  locations?: { path: string; line?: number | null }[];
+  /** Raw input parameters sent to the tool. */
+  rawInput?: unknown;
 }
 
 export interface ToolResultRender {
@@ -60,6 +66,24 @@ export function selectToolDisplayMode(width: number): ToolDisplayMode {
   return "summary";
 }
 
+// ── Kind icons ──────────────────────────────────────────────────
+
+const KIND_ICONS: Record<string, string> = {
+  read: "◆",
+  edit: "✎",
+  delete: "✕",
+  move: "↗",
+  search: "⌕",
+  execute: "▶",
+  think: "◇",
+  fetch: "↓",
+  switch_mode: "⇄",
+};
+
+function kindIcon(kind?: string): string {
+  return kind ? (KIND_ICONS[kind] ?? "▶") : "▶";
+}
+
 // ── Tool call rendering ──────────────────────────────────────────
 
 export function renderToolCall(
@@ -67,24 +91,64 @@ export function renderToolCall(
   width: number,
 ): string[] {
   const mode = selectToolDisplayMode(width);
+  const icon = kindIcon(tool.kind);
 
   if (mode === "summary") {
-    const text = truncateVisible(`▶ ${tool.title}`, width);
+    const text = truncateVisible(`${icon} ${tool.title}`, width);
     return [`${p.warning}${text}${p.reset}`];
   }
 
   const lines: string[] = [];
-  lines.push(`${p.warning}${p.bold}▶ ${tool.title}${p.reset}`);
+  lines.push(`${p.warning}${p.bold}${icon} ${tool.title}${p.reset}`);
 
-  if (tool.command && mode === "full") {
-    const maxCmdW = Math.max(1, width - 4);
-    const cmd = tool.command.length > maxCmdW
-      ? tool.command.slice(0, maxCmdW - 1) + "…"
-      : tool.command;
-    lines.push(`  ${p.dim}$ ${cmd}${p.reset}`);
+  if (mode === "full") {
+    // Show file locations if available
+    if (tool.locations && tool.locations.length > 0) {
+      for (const loc of tool.locations) {
+        const lineInfo = loc.line ? `:${loc.line}` : "";
+        lines.push(`  ${p.dim}${loc.path}${lineInfo}${p.reset}`);
+      }
+    }
+
+    // Show command string for terminal tools
+    if (tool.command) {
+      const maxCmdW = Math.max(1, width - 4);
+      const cmd = tool.command.length > maxCmdW
+        ? tool.command.slice(0, maxCmdW - 1) + "…"
+        : tool.command;
+      lines.push(`  ${p.dim}$ ${cmd}${p.reset}`);
+    }
+
+    // Show raw input args for non-terminal, non-file tools
+    if (!tool.command && !tool.locations?.length && tool.rawInput) {
+      const detail = formatRawInput(tool.rawInput, width - 4);
+      if (detail) lines.push(`  ${p.dim}${detail}${p.reset}`);
+    }
   }
 
   return lines;
+}
+
+/**
+ * Format raw input parameters into a compact single-line summary.
+ */
+function formatRawInput(raw: unknown, maxWidth: number): string {
+  if (raw == null) return "";
+  if (typeof raw === "string") {
+    return raw.length > maxWidth ? raw.slice(0, maxWidth - 1) + "…" : raw;
+  }
+  if (typeof raw !== "object") return String(raw);
+
+  // Show key=value pairs for objects
+  const obj = raw as Record<string, unknown>;
+  const parts: string[] = [];
+  for (const [key, val] of Object.entries(obj)) {
+    if (val == null) continue;
+    const valStr = typeof val === "string" ? val : JSON.stringify(val);
+    parts.push(`${key}=${valStr}`);
+  }
+  const joined = parts.join("  ");
+  return joined.length > maxWidth ? joined.slice(0, maxWidth - 1) + "…" : joined;
 }
 
 // ── Tool result rendering ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Pass through `kind`, `locations`, and `rawInput` from ACP tool call events to the TUI renderer
- Display kind-specific icons (◆ read, ✎ edit, ⌕ search, ▶ execute, ↓ fetch, etc.)
- Show file paths and line numbers for file-related tools
- Show compact `key=value` argument summaries for other tools

## Example output

```
◆ Read file
  src/shell.ts

✎ Edit file
  src/output-parser.ts:25

▶ Run command
  $ npm run build

⌕ Search
  pattern=TODO  path=src/
```

## Test plan

- [ ] Run agent query that triggers file reads — verify file path shown
- [ ] Run agent query that triggers command execution — verify command shown
- [ ] Run agent query that triggers search/other tools — verify args shown
- [ ] Verify compact/summary modes still work at narrow terminal widths