### PR TITLE
Extract LineEditor for agent input mode

### DIFF
--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -1,5 +1,6 @@
 import { visibleLen } from "./utils/ansi.js";
 import { palette as p } from "./utils/palette.js";
+import { LineEditor } from "./utils/line-editor.js";
 import type { EventBus } from "./event-bus.js";
 
 /**
@@ -21,7 +22,7 @@ export class InputHandler {
   private ctx: InputContext;
   private lineBuffer = "";
   private agentInputMode = false;
-  private agentInputBuffer = "";
+  private editor = new LineEditor();
   private autocompleteActive = false;
   private autocompleteIndex = 0;
   private autocompleteItems: { name: string; description: string }[] = [];
@@ -39,16 +40,20 @@ export class InputHandler {
     this.onShowAgentInfo = opts.onShowAgentInfo;
   }
 
-  /** Write the agent prompt line (clear + info prefix + ❯ + buffer text). */
+  /** Write the agent prompt line with cursor at the correct position. */
   private writeAgentPromptLine(showBuffer = true): void {
     const agentInfo = this.onShowAgentInfo();
     const infoPrefix = agentInfo.info ? `${agentInfo.info} ` : "";
-    process.stdout.write(
-      "\r\x1b[2K" +
-      infoPrefix +
-      p.warning + p.bold + "❯ " + p.reset +
-      (showBuffer ? p.accent + this.agentInputBuffer + p.reset : "")
-    );
+    const promptPrefix = infoPrefix + p.warning + p.bold + "❯ " + p.reset;
+    const bufferText = showBuffer ? p.accent + this.editor.buffer + p.reset : "";
+
+    process.stdout.write("\r\x1b[2K" + promptPrefix + bufferText);
+
+    // Position cursor within the buffer (not always at end)
+    if (showBuffer && this.editor.cursor < this.editor.buffer.length) {
+      const charsAfterCursor = this.editor.buffer.length - this.editor.cursor;
+      process.stdout.write(`\x1b[${charsAfterCursor}D`);
+    }
   }
 
   handleInput(data: string): void {
@@ -114,14 +119,14 @@ export class InputHandler {
 
   private enterAgentInputMode(): void {
     this.agentInputMode = true;
-    this.agentInputBuffer = "";
+    this.editor.clear();
     this.writeAgentPromptLine(false);
   }
 
   private exitAgentInputMode(): void {
     this.dismissAutocomplete();
     this.agentInputMode = false;
-    this.agentInputBuffer = "";
+    this.editor.clear();
     process.stdout.write("\r\x1b[2K");
     this.printPrompt();
   }
@@ -138,7 +143,7 @@ export class InputHandler {
 
   private updateAutocomplete(): void {
     const { items } = this.bus.emitPipe("autocomplete:request", {
-      buffer: this.agentInputBuffer,
+      buffer: this.editor.buffer,
       items: [],
     });
     if (items.length > 0) {
@@ -179,19 +184,8 @@ export class InputHandler {
     }
     const agentInfo = this.onShowAgentInfo();
     const infoLength = visibleLen(agentInfo.info);
-    const col = infoLength + 2 + this.agentInputBuffer.length;
+    const col = infoLength + 2 + this.editor.cursor;
     process.stdout.write(`\r\x1b[${col}C`);
-  }
-
-  private clearAutocompleteLines(): void {
-    if (this.autocompleteLines <= 0) return;
-
-    process.stdout.write("\x1b7"); // save cursor
-    for (let i = 0; i < this.autocompleteLines; i++) {
-      process.stdout.write("\n\x1b[2K"); // move down, clear line
-    }
-    process.stdout.write("\x1b8"); // restore cursor
-    this.autocompleteLines = 0;
   }
 
   private applyAutocomplete(): void {
@@ -199,18 +193,19 @@ export class InputHandler {
     const selected = this.autocompleteItems[this.autocompleteIndex];
     if (!selected) return;
 
-    const atPos = this.agentInputBuffer.lastIndexOf("@");
+    const atPos = this.editor.buffer.lastIndexOf("@");
     const isFileAc =
       atPos >= 0 &&
-      (atPos === 0 || this.agentInputBuffer[atPos - 1] === " ") &&
-      !this.agentInputBuffer.slice(atPos + 1).includes(" ");
+      (atPos === 0 || this.editor.buffer[atPos - 1] === " ") &&
+      !this.editor.buffer.slice(atPos + 1).includes(" ");
 
     if (isFileAc) {
-      this.agentInputBuffer =
-        this.agentInputBuffer.slice(0, atPos) + "@" + selected.name;
+      this.editor.buffer =
+        this.editor.buffer.slice(0, atPos) + "@" + selected.name;
     } else {
-      this.agentInputBuffer = selected.name;
+      this.editor.buffer = selected.name;
     }
+    this.editor.cursor = this.editor.buffer.length;
 
     this.clearAutocompleteLines();
     this.autocompleteActive = false;
@@ -228,107 +223,94 @@ export class InputHandler {
     this.autocompleteIndex = 0;
   }
 
+  private clearAutocompleteLines(): void {
+    if (this.autocompleteLines <= 0) return;
+
+    process.stdout.write("\x1b7"); // save cursor
+    for (let i = 0; i < this.autocompleteLines; i++) {
+      process.stdout.write("\n\x1b[2K"); // move down, clear line
+    }
+    process.stdout.write("\x1b8"); // restore cursor
+    this.autocompleteLines = 0;
+  }
+
   private handleAgentInput(data: string): void {
-    for (let i = 0; i < data.length; i++) {
-      const ch = data[i]!;
+    const actions = this.editor.feed(data);
 
-      // Detect arrow key sequences: \x1b[A (up), \x1b[B (down)
-      if (ch === "\x1b" && data[i + 1] === "[") {
-        const arrow = data[i + 2];
-        if (arrow === "A" && this.autocompleteActive) {
-          // Arrow up
-          this.autocompleteIndex =
-            this.autocompleteIndex === 0
-              ? this.autocompleteItems.length - 1
-              : this.autocompleteIndex - 1;
-          this.clearAutocompleteLines();
-          this.writeAgentPromptLine();
-          this.renderAutocomplete();
-          i += 2;
-          continue;
-        } else if (arrow === "B" && this.autocompleteActive) {
-          this.autocompleteIndex =
-            this.autocompleteIndex === this.autocompleteItems.length - 1
-              ? 0
-              : this.autocompleteIndex + 1;
-          this.clearAutocompleteLines();
-          this.writeAgentPromptLine();
-          this.renderAutocomplete();
-          i += 2;
-          continue;
-        } else if (!this.autocompleteActive) {
-          // Escape without arrow: cancel agent input mode
-          this.dismissAutocomplete();
-          this.exitAgentInputMode();
-          return;
-        }
-        // Other escape sequences (e.g. left/right arrow) — ignore for now
-        i += 2;
-        continue;
-      }
-
-      if (ch === "\x1b") {
-        // Bare escape (no bracket follows)
-        if (this.autocompleteActive) {
-          this.dismissAutocomplete();
-          this.writeAgentPromptLine();
-        } else {
-          this.dismissAutocomplete();
-          this.exitAgentInputMode();
-        }
-        return;
-      }
-
-      if (ch === "\t") {
-        if (this.autocompleteActive) {
-          this.applyAutocomplete();
-        }
-        continue;
-      }
-
-      if (ch === "\r") {
-        if (this.autocompleteActive) {
-          this.applyAutocomplete();
-        }
-        const query = this.agentInputBuffer.trim();
-        this.clearAutocompleteLines();
-        process.stdout.write("\r\x1b[2K");
-        this.agentInputMode = false;
-        this.agentInputBuffer = "";
-        this.dismissAutocomplete();
-        if (query && query.startsWith("/")) {
-          const spaceIdx = query.indexOf(" ");
-          const name = spaceIdx === -1 ? query : query.slice(0, spaceIdx);
-          const args = spaceIdx === -1 ? "" : query.slice(spaceIdx + 1).trim();
-          this.bus.emit("command:execute", { name, args });
-          this.ctx.redrawPrompt();
-        } else if (query) {
-          this.bus.emit("agent:submit", { query });
-        } else {
-          this.exitAgentInputMode();
-        }
-        return;
-      } else if (ch === "\x03") {
-        // Ctrl-C: cancel
-        this.dismissAutocomplete();
-        this.exitAgentInputMode();
-        return;
-      } else if (ch === "\x7f" || ch === "\b") {
-        // Backspace
-        if (this.agentInputBuffer.length > 0) {
-          this.agentInputBuffer = this.agentInputBuffer.slice(0, -1);
+    for (const act of actions) {
+      switch (act.action) {
+        case "changed":
           this.autocompleteIndex = 0;
           this.renderAgentInput();
-        } else {
+          break;
+
+        case "submit": {
+          if (this.autocompleteActive) {
+            this.applyAutocomplete();
+          }
+          const query = act.buffer.trim();
+          this.clearAutocompleteLines();
+          process.stdout.write("\r\x1b[2K");
+          this.agentInputMode = false;
+          this.editor.clear();
+          this.dismissAutocomplete();
+          if (query && query.startsWith("/")) {
+            const spaceIdx = query.indexOf(" ");
+            const name = spaceIdx === -1 ? query : query.slice(0, spaceIdx);
+            const args = spaceIdx === -1 ? "" : query.slice(spaceIdx + 1).trim();
+            this.bus.emit("command:execute", { name, args });
+            this.ctx.redrawPrompt();
+          } else if (query) {
+            this.bus.emit("agent:submit", { query });
+          } else {
+            this.exitAgentInputMode();
+          }
+          return;
+        }
+
+        case "cancel":
+          if (this.autocompleteActive) {
+            this.dismissAutocomplete();
+            this.writeAgentPromptLine();
+          } else {
+            this.exitAgentInputMode();
+          }
+          return;
+
+        case "delete-empty":
           this.dismissAutocomplete();
           this.exitAgentInputMode();
           return;
-        }
-      } else if (ch.charCodeAt(0) >= 32) {
-        // Printable character
-        this.agentInputBuffer += ch;
-        this.autocompleteIndex = 0;
-        this.renderAgentInput();
+
+        case "tab":
+          if (this.autocompleteActive) {
+            this.applyAutocomplete();
+          }
+          break;
+
+        case "arrow-up":
+          if (this.autocompleteActive) {
+            this.autocompleteIndex =
+              this.autocompleteIndex === 0
+                ? this.autocompleteItems.length - 1
+                : this.autocompleteIndex - 1;
+            this.clearAutocompleteLines();
+            this.writeAgentPromptLine();
+            this.renderAutocomplete();
+          }
+          break;
+
+        case "arrow-down":
+          if (this.autocompleteActive) {
+            this.autocompleteIndex =
+              this.autocompleteIndex === this.autocompleteItems.length - 1
+                ? 0
+                : this.autocompleteIndex + 1;
+            this.clearAutocompleteLines();
+            this.writeAgentPromptLine();
+            this.renderAutocomplete();
+          }
+          break;
       }
     }
   }

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -1,0 +1,268 @@
+/**
+ * Minimal line editor with readline-style keybindings.
+ *
+ * Pure logic — no I/O, no rendering, no event bus. Consumers feed raw
+ * terminal input bytes and receive high-level actions back. Buffer and
+ * cursor state are public for rendering.
+ */
+
+// ── Action types returned by feed() ─────────────────────────────
+
+export type LineEditAction =
+  | { action: "changed" }
+  | { action: "submit"; buffer: string }
+  | { action: "cancel" }
+  | { action: "delete-empty" }
+  | { action: "tab" }
+  | { action: "arrow-up" }
+  | { action: "arrow-down" };
+
+// ── Line editor ─────────────────────────────────────────────────
+
+export class LineEditor {
+  buffer = "";
+  cursor = 0;
+
+  /** Process raw terminal input, return actions for the consumer. */
+  feed(data: string): LineEditAction[] {
+    const actions: LineEditAction[] = [];
+    let i = 0;
+
+    while (i < data.length) {
+      const ch = data[i]!;
+
+      // ── Escape sequences ────────────────────────────────
+      if (ch === "\x1b") {
+        const next = data[i + 1];
+
+        // Bare Escape (nothing follows in this chunk)
+        if (next == null) {
+          actions.push({ action: "cancel" });
+          i++;
+          continue;
+        }
+
+        // CSI sequence: \x1b[...
+        if (next === "[") {
+          const { consumed } = this.handleCSI(data, i, actions);
+          i += consumed;
+          continue;
+        }
+
+        // Alt/Option + key: \x1b followed by char
+        i += 2; // consume \x1b + next byte
+        if (next === "\x7f") {
+          // Option+Backspace: delete word backward
+          if (this.deleteWordBackward()) actions.push({ action: "changed" });
+        } else if (next === "b") {
+          // Alt+B: word backward
+          if (this.wordBackward()) actions.push({ action: "changed" });
+        } else if (next === "f") {
+          // Alt+F: word forward
+          if (this.wordForward()) actions.push({ action: "changed" });
+        } else if (next === "d") {
+          // Alt+D: delete word forward
+          if (this.deleteWordForward()) actions.push({ action: "changed" });
+        }
+        // Other Alt+key — ignore
+        continue;
+      }
+
+      // ── Control characters ──────────────────────────────
+      if (ch === "\r") {
+        actions.push({ action: "submit", buffer: this.buffer });
+        i++;
+        continue;
+      }
+      if (ch === "\x03") {
+        actions.push({ action: "cancel" });
+        i++;
+        continue;
+      }
+      if (ch === "\t") {
+        actions.push({ action: "tab" });
+        i++;
+        continue;
+      }
+      if (ch === "\x7f" || ch === "\b") {
+        // Backspace
+        if (this.buffer.length === 0) {
+          actions.push({ action: "delete-empty" });
+        } else if (this.cursor > 0) {
+          this.buffer = this.buffer.slice(0, this.cursor - 1) + this.buffer.slice(this.cursor);
+          this.cursor--;
+          actions.push({ action: "changed" });
+        }
+        i++;
+        continue;
+      }
+      // Ctrl-A: home
+      if (ch === "\x01") {
+        if (this.cursor > 0) { this.cursor = 0; actions.push({ action: "changed" }); }
+        i++; continue;
+      }
+      // Ctrl-E: end
+      if (ch === "\x05") {
+        if (this.cursor < this.buffer.length) { this.cursor = this.buffer.length; actions.push({ action: "changed" }); }
+        i++; continue;
+      }
+      // Ctrl-B: back one char
+      if (ch === "\x02") {
+        if (this.cursor > 0) { this.cursor--; actions.push({ action: "changed" }); }
+        i++; continue;
+      }
+      // Ctrl-F: forward one char
+      if (ch === "\x06") {
+        if (this.cursor < this.buffer.length) { this.cursor++; actions.push({ action: "changed" }); }
+        i++; continue;
+      }
+      // Ctrl-U: delete to start of line
+      if (ch === "\x15") {
+        if (this.cursor > 0) {
+          this.buffer = this.buffer.slice(this.cursor);
+          this.cursor = 0;
+          actions.push({ action: "changed" });
+        }
+        i++; continue;
+      }
+      // Ctrl-K: delete to end of line
+      if (ch === "\x0b") {
+        if (this.cursor < this.buffer.length) {
+          this.buffer = this.buffer.slice(0, this.cursor);
+          actions.push({ action: "changed" });
+        }
+        i++; continue;
+      }
+      // Ctrl-W: delete word backward
+      if (ch === "\x17") {
+        if (this.deleteWordBackward()) actions.push({ action: "changed" });
+        i++; continue;
+      }
+      // Other control chars — ignore
+      if (ch.charCodeAt(0) < 0x20) {
+        i++; continue;
+      }
+
+      // ── Printable character ─────────────────────────────
+      this.buffer = this.buffer.slice(0, this.cursor) + ch + this.buffer.slice(this.cursor);
+      this.cursor++;
+      actions.push({ action: "changed" });
+      i++;
+    }
+
+    return actions;
+  }
+
+  clear(): void {
+    this.buffer = "";
+    this.cursor = 0;
+  }
+
+  // ── CSI sequence handling ───────────────────────────────────
+
+  /**
+   * Parse and handle a CSI sequence (\x1b[...) starting at `start`.
+   * Returns the number of bytes consumed.
+   */
+  private handleCSI(
+    data: string,
+    start: number,
+    actions: LineEditAction[],
+  ): { consumed: number } {
+    // Skip \x1b[
+    let j = start + 2;
+    // Accumulate parameter bytes (0x20-0x3F: digits, semicolons, etc.)
+    let params = "";
+    while (j < data.length && data.charCodeAt(j) >= 0x20 && data.charCodeAt(j) < 0x40) {
+      params += data[j];
+      j++;
+    }
+    const final = j < data.length ? data[j]! : "";
+    const consumed = j - start + (final ? 1 : 0);
+
+    // Dispatch on final byte
+    switch (final) {
+      case "A": // Up arrow
+        actions.push({ action: "arrow-up" });
+        break;
+      case "B": // Down arrow
+        actions.push({ action: "arrow-down" });
+        break;
+      case "C": // Right (or modified right: 1;3C, 1;5C = word right)
+        if (params.includes(";")) {
+          if (this.wordForward()) actions.push({ action: "changed" });
+        } else {
+          if (this.cursor < this.buffer.length) { this.cursor++; actions.push({ action: "changed" }); }
+        }
+        break;
+      case "D": // Left (or modified left: 1;3D, 1;5D = word left)
+        if (params.includes(";")) {
+          if (this.wordBackward()) actions.push({ action: "changed" });
+        } else {
+          if (this.cursor > 0) { this.cursor--; actions.push({ action: "changed" }); }
+        }
+        break;
+      case "H": // Home
+        if (this.cursor > 0) { this.cursor = 0; actions.push({ action: "changed" }); }
+        break;
+      case "F": // End
+        if (this.cursor < this.buffer.length) { this.cursor = this.buffer.length; actions.push({ action: "changed" }); }
+        break;
+      case "~": // Extended keys: Delete (3~), etc.
+        if (params === "3") {
+          // Delete key: delete char under cursor
+          if (this.cursor < this.buffer.length) {
+            this.buffer = this.buffer.slice(0, this.cursor) + this.buffer.slice(this.cursor + 1);
+            actions.push({ action: "changed" });
+          }
+        }
+        break;
+      // All other CSI sequences — silently ignored
+    }
+
+    return { consumed };
+  }
+
+  // ── Word movement / deletion helpers ────────────────────────
+
+  private wordBackward(): boolean {
+    if (this.cursor === 0) return false;
+    let pos = this.cursor;
+    // Skip spaces
+    while (pos > 0 && this.buffer[pos - 1] === " ") pos--;
+    // Skip word chars
+    while (pos > 0 && this.buffer[pos - 1] !== " ") pos--;
+    if (pos === this.cursor) return false;
+    this.cursor = pos;
+    return true;
+  }
+
+  private wordForward(): boolean {
+    if (this.cursor >= this.buffer.length) return false;
+    let pos = this.cursor;
+    // Skip word chars
+    while (pos < this.buffer.length && this.buffer[pos] !== " ") pos++;
+    // Skip spaces
+    while (pos < this.buffer.length && this.buffer[pos] === " ") pos++;
+    if (pos === this.cursor) return false;
+    this.cursor = pos;
+    return true;
+  }
+
+  private deleteWordBackward(): boolean {
+    if (this.cursor === 0) return false;
+    const start = this.cursor;
+    this.wordBackward();
+    this.buffer = this.buffer.slice(0, this.cursor) + this.buffer.slice(start);
+    return true;
+  }
+
+  private deleteWordForward(): boolean {
+    if (this.cursor >= this.buffer.length) return false;
+    const start = this.cursor;
+    this.wordForward();
+    this.buffer = this.buffer.slice(0, start) + this.buffer.slice(this.cursor);
+    this.cursor = start;
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `LineEditor` utility (`src/utils/line-editor.ts`) — pure logic, no I/O, no event bus
- Rewrite `InputHandler.handleAgentInput` to consume `LineEditAction[]` instead of parsing escape sequences inline
- Support full readline keybindings: cursor movement, word jump, word/line deletion, Home/End, Delete

## Motivation

Option+Backspace was exiting agent mode because `\x1b\x7f` was treated as bare Escape + Backspace. Rather than special-casing each key combo, this extracts a proper terminal input parser that handles all `\x1b`-prefixed sequences as a unit.

## Architecture

Follows the headless core philosophy — `LineEditor` is a pure utility with no dependencies:

```
Raw terminal bytes → LineEditor.feed() → LineEditAction[]
                                              ↓
                              InputHandler switches on actions:
                              changed → re-render
                              submit  → dispatch to bus
                              cancel  → exit agent mode
                              arrow-* → autocomplete nav
```

## Keybindings supported

| Key | Action |
|---|---|
| Left/Right, Ctrl-B/F | Move cursor |
| Ctrl-A, Home | Start of line |
| Ctrl-E, End | End of line |
| Option+Left/Right | Word jump |
| Backspace, Ctrl-H | Delete char backward |
| Delete | Delete char forward |
| Ctrl-W, Option+Backspace | Delete word backward |
| Option+D | Delete word forward |
| Ctrl-U | Delete to start of line |
| Ctrl-K | Delete to end of line |

## Test plan

- [ ] Type in agent mode, cursor appears at end — normal typing works
- [ ] Left/Right arrows move cursor within buffer
- [ ] Ctrl-A / Ctrl-E jump to start/end
- [ ] Option+Backspace deletes word (previously exited agent mode)
- [ ] Option+Left/Right jumps by word
- [ ] Escape still exits agent mode
- [ ] Autocomplete still works (Tab, Up/Down, Enter)
- [ ] Backspace on empty buffer exits agent mode