### PR TITLE
Forward user's shell environment to agent subprocess

### DIFF
--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -43,10 +43,12 @@ export class AcpClient {
   async start(): Promise<void> {
     this.log(`Starting agent: ${this.config.agentCommand} ${this.config.agentArgs.join(" ")}`);
 
-    // Spawn the agent subprocess
-    // Spawn the agent — wait briefly to catch ENOENT and other spawn errors
+    // Spawn the agent subprocess with the user's full shell environment
+    // (includes vars from .zshrc/.bashrc that process.env may not have)
+    const agentEnv = this.config.shellEnv ?? process.env;
     this.agentProcess = spawn(this.config.agentCommand, this.config.agentArgs, {
       stdio: ["pipe", "pipe", process.env.DEBUG ? "inherit" : "ignore"],
+      env: agentEnv as NodeJS.ProcessEnv,
     });
 
     // Catch spawn errors (ENOENT, EACCES, etc.) before proceeding
@@ -439,6 +441,7 @@ export class AcpClient {
     const { session, done } = executeCommand({
       command: fullCommand,
       cwd,
+      env: this.config.shellEnv,
       timeout: 60_000,
       maxOutputBytes: 256 * 1024,
       onOutput: (chunk) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execFileSync } from "node:child_process";
 import { Shell } from "./shell.js";
 import { createCore } from "./core.js";
 import { palette as p } from "./utils/palette.js";
@@ -8,6 +9,35 @@ import fileAutocomplete from "./extensions/file-autocomplete.js";
 import shellRecall from "./extensions/shell-recall.js";
 import { loadExtensions } from "./extension-loader.js";
 import type { AgentShellConfig } from "./types.js";
+
+/**
+ * Capture the user's full shell environment by running a quick interactive
+ * subshell. This picks up env vars exported in .zshrc/.bashrc that the
+ * Node.js process (which was spawned before the PTY sources rc files)
+ * doesn't have.
+ */
+function captureShellEnv(shell: string): Record<string, string> {
+  try {
+    const output = execFileSync(shell, ["-i", "-c", "env -0"], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"], // suppress interactive noise on stderr
+    });
+    const env: Record<string, string> = {};
+    for (const entry of output.split("\0")) {
+      const eq = entry.indexOf("=");
+      if (eq > 0) env[entry.slice(0, eq)] = entry.slice(eq + 1);
+    }
+    return env;
+  } catch {
+    // Fallback: use Node's own environment
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined) env[k] = v;
+    }
+    return env;
+  }
+}
 
 function parseArgs(argv: string[]): AgentShellConfig {
   // Priority: CLI args > Environment variables > Config file > Defaults
@@ -94,6 +124,10 @@ function formatAgentInfo(agentInfo: { name: string; version: string }, model?: s
 
 async function main(): Promise<void> {
   const config = parseArgs(process.argv.slice(2));
+
+  // Capture the user's shell environment (picks up vars from .zshrc/.bashrc
+  // that the Node process doesn't have)
+  config.shellEnv = captureShellEnv(config.shell || process.env.SHELL || "/bin/bash");
 
   // ── Core (frontend-agnostic) ──────────────────────────────────
   const core = createCore(config);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface AgentShellConfig {
   shell?: string;
   model?: string;
   extensions?: string[];
+  /** Full shell environment (from user's rc files) for agent subprocess. */
+  shellEnv?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Agent subprocess and its tool commands were inheriting `process.env` from the Node.js process, which misses env vars exported in the user's `.zshrc`/`.bashrc`
- Capture the full shell environment at startup by running `shell -i -c 'env -0'` and pass it through to agent spawn and tool execution
- Falls back to `process.env` if capture fails

## Test plan
- [ ] Add `export TEST_VAR=hello` to end of `.zshrc`, start agent-sh, verify agent can access `TEST_VAR`
- [ ] Verify agent starts normally when shell env capture times out (e.g. with an invalid shell path)