### PR TITLE
Add user_shell tool for live PTY execution

### DIFF
--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -114,12 +114,16 @@ export class AcpClient {
       this.log(`Agent info: ${this.agentInfo.name} v${this.agentInfo.version}`);
     }
 
-    // Create a session
+    // Create a session — let extensions add MCP servers via pipe
     const cwd = this.contextManager.getCwd();
     this.log(`Creating new session with cwd: ${cwd}`);
-    const sessionResponse = await this.connection.newSession({
+    const sessionConfig = this.bus.emitPipe("session:configure", {
       cwd,
       mcpServers: [],
+    });
+    const sessionResponse = await this.connection.newSession({
+      cwd: sessionConfig.cwd,
+      mcpServers: sessionConfig.mcpServers as acp.McpServer[],
     });
 
     this.sessionId = sessionResponse.sessionId;
@@ -220,9 +224,13 @@ export class AcpClient {
    */
   async resetSession(): Promise<void> {
     if (!this.connection) return;
-    const sessionResponse = await this.connection.newSession({
+    const sessionConfig = this.bus.emitPipe("session:configure", {
       cwd: this.contextManager.getCwd(),
       mcpServers: [],
+    });
+    const sessionResponse = await this.connection.newSession({
+      cwd: sessionConfig.cwd,
+      mcpServers: sessionConfig.mcpServers as acp.McpServer[],
     });
     this.sessionId = sessionResponse.sessionId;
     this.lastResponseText = "";
@@ -261,6 +269,7 @@ export class AcpClient {
       process.stderr.write(`[agent-sh] ${msg}\n`);
     }
   }
+
 
   /**
    * Create the Client handler that responds to agent requests.
@@ -349,6 +358,15 @@ export class AcpClient {
       }
 
       case "tool_call_update": {
+        // Stream tool output content (text from pi's internal tool results)
+        if (update.content && Array.isArray(update.content)) {
+          for (const block of update.content) {
+            if (block.type === "content" && block.content?.type === "text" && block.content.text) {
+              this.bus.emit("agent:tool-output-chunk", { chunk: block.content.text });
+            }
+          }
+        }
+
         if (update.status === "completed" || update.status === "failed") {
           const toolId = update.toolCallId;
           const exitCode = update.status === "completed" ? 0 : 1;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -92,6 +92,20 @@ export interface ShellEvents {
     handled: boolean;
   };
 
+  // Shell exec (async pipe: extension requests command execution in user's PTY)
+  "shell:exec-request": {
+    command: string;
+    output: string;
+    cwd: string;
+    done: boolean;
+  };
+
+  // Session configure (sync pipe: extensions can add MCP servers before newSession)
+  "session:configure": {
+    cwd: string;
+    mcpServers: { name: string; command: string; args: string[]; env: { name: string; value: string }[] }[];
+  };
+
   // Autocomplete (sync pipe: extensions inspect buffer and append items)
   "autocomplete:request": {
     buffer: string;

--- a/src/extensions/shell-exec.ts
+++ b/src/extensions/shell-exec.ts
@@ -1,0 +1,188 @@
+/**
+ * Shell exec extension.
+ *
+ * Runs a Unix domain socket server speaking JSON-RPC 2.0 that external
+ * tools (MCP server, pi extensions, etc.) connect to for interacting
+ * with the user's live PTY shell.
+ *
+ * Also registers the MCP server via the `session:configure` pipe so
+ * ACP agents discover the `user_shell` tool automatically.
+ *
+ * This extension has no direct PTY or Shell knowledge — it communicates
+ * exclusively through the bus, following the headless-core philosophy.
+ *
+ * ## Socket protocol (JSON-RPC 2.0, newline-delimited)
+ *
+ *   shell/exec   { command: string }  → { output, cwd }
+ *   shell/cwd    {}                   → { cwd }
+ *   shell/info   {}                   → { busy, shell }
+ */
+
+import * as net from "node:net";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionContext } from "../types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default function activate(
+  { bus, contextManager }: ExtensionContext,
+  opts: { socketPath: string },
+): void {
+  const { socketPath } = opts;
+
+  // Register MCP server so ACP agents discover the user_shell tool
+  bus.onPipe("session:configure", (payload) => {
+    return {
+      ...payload,
+      mcpServers: [
+        ...payload.mcpServers,
+        {
+          name: "agent-sh",
+          command: process.execPath,
+          args: [path.join(__dirname, "..", "mcp-server.js")],
+          env: [{ name: "AGENT_SH_SOCKET", value: socketPath }],
+        },
+      ],
+    };
+  });
+
+  // Also set AGENT_SH_SOCKET for pi extensions that connect directly
+  process.env.AGENT_SH_SOCKET = socketPath;
+
+  // Serialize shell/exec requests — only one PTY command at a time
+  let execPending: Promise<void> = Promise.resolve();
+
+  // ── JSON-RPC handler ────────────────────────────────────────────
+
+  async function handleRequest(
+    method: string,
+    params: Record<string, unknown> | undefined,
+  ): Promise<unknown> {
+    switch (method) {
+      case "shell/exec": {
+        const command = params?.command;
+        if (typeof command !== "string" || !command) {
+          throw rpcError(-32602, "Missing required parameter: command");
+        }
+
+        // Serialize — one PTY command at a time
+        return new Promise((resolve, reject) => {
+          execPending = execPending.then(async () => {
+            try {
+              const result = await bus.emitPipeAsync("shell:exec-request", {
+                command,
+                output: "",
+                cwd: "",
+                done: false,
+              });
+
+              // Show the command output in the TUI
+              if (result.output) {
+                bus.emit("agent:tool-output-chunk", { chunk: result.output });
+              }
+
+              resolve({ output: result.output, cwd: result.cwd });
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              bus.emit("agent:tool-output-chunk", { chunk: `Error: ${message}` });
+              reject(rpcError(-32000, message));
+            }
+          });
+        });
+      }
+
+      case "shell/cwd":
+        return { cwd: contextManager.getCwd() };
+
+      case "shell/info":
+        return {
+          shell: process.env.SHELL || "unknown",
+          agentSh: true,
+        };
+
+      default:
+        throw rpcError(-32601, `Method not found: ${method}`);
+    }
+  }
+
+  // ── Socket server ───────────────────────────────────────────────
+
+  const server = net.createServer((conn) => {
+    let buffer = "";
+
+    conn.on("data", (chunk) => {
+      buffer += chunk.toString();
+
+      // Process complete lines (newline-delimited JSON-RPC)
+      let newlineIdx: number;
+      while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        if (!line) continue;
+
+        processMessage(conn, line);
+      }
+    });
+  });
+
+  function processMessage(conn: net.Socket, line: string): void {
+    let id: unknown = null;
+    try {
+      const msg = JSON.parse(line);
+      id = msg.id ?? null;
+      const method: string = msg.method;
+      if (!method) {
+        sendError(conn, id, -32600, "Invalid request: missing method");
+        return;
+      }
+
+      handleRequest(method, msg.params)
+        .then((result) => sendResult(conn, id, result))
+        .catch((err) => {
+          if (err && typeof err === "object" && "rpcCode" in err) {
+            sendError(conn, id, (err as any).rpcCode, (err as any).message);
+          } else {
+            sendError(conn, id, -32603, String(err));
+          }
+        });
+    } catch {
+      sendError(conn, id, -32700, "Parse error");
+    }
+  }
+
+  // Clean up stale socket file
+  try {
+    fs.unlinkSync(socketPath);
+  } catch {
+    // Doesn't exist — fine
+  }
+
+  server.listen(socketPath);
+
+  // Cleanup on exit
+  const cleanup = () => {
+    server.close();
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+  };
+  process.on("exit", cleanup);
+}
+
+// ── JSON-RPC helpers ──────────────────────────────────────────────
+
+function sendResult(conn: net.Socket, id: unknown, result: unknown): void {
+  conn.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+}
+
+function sendError(conn: net.Socket, id: unknown, code: number, message: string): void {
+  conn.write(JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } }) + "\n");
+}
+
+function rpcError(code: number, message: string): Error & { rpcCode: number } {
+  const err = new Error(message) as Error & { rpcCode: number };
+  err.rpcCode = code;
+  return err;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import tuiRenderer from "./extensions/tui-renderer.js";
 import slashCommands from "./extensions/slash-commands.js";
 import fileAutocomplete from "./extensions/file-autocomplete.js";
 import shellRecall from "./extensions/shell-recall.js";
+import shellExec from "./extensions/shell-exec.js";
 import { loadExtensions } from "./extension-loader.js";
 import type { AgentShellConfig } from "./types.js";
 
@@ -173,6 +174,13 @@ async function main(): Promise<void> {
   slashCommands(extCtx);
   fileAutocomplete(extCtx);
   shellRecall(extCtx);
+
+  // Shell-exec: start the Unix socket bridge so the MCP server can
+  // route user_shell tool calls to the PTY via the EventBus.
+  const tmpDir = shell.getTmpDir();
+  if (tmpDir) {
+    shellExec(extCtx, { socketPath: `${tmpDir}/shell.sock` });
+  }
 
   await loadExtensions(extCtx, config.extensions);
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Minimal MCP server exposing a `user_shell` tool.
+ *
+ * Spawned by the ACP agent (pi-acp, claude-agent-acp, etc.) as an MCP
+ * stdio server. When the LLM calls `user_shell`, this process connects
+ * to agent-sh's Unix socket to execute the command in the user's live
+ * PTY shell.
+ *
+ * Protocol: MCP over stdio (newline-delimited JSON-RPC 2.0).
+ * No SDK dependency — the protocol surface is tiny.
+ */
+
+import { createConnection } from "node:net";
+import { createInterface } from "node:readline";
+
+const SOCKET_PATH = process.env.AGENT_SH_SOCKET;
+
+// ── MCP protocol helpers ────────────────────────────────────────
+
+function send(msg: Record<string, unknown>): void {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...msg }) + "\n");
+}
+
+function sendResult(id: unknown, result: unknown): void {
+  send({ id, result });
+}
+
+function sendError(id: unknown, code: number, message: string): void {
+  send({ id, error: { code, message } });
+}
+
+// ── Tool definition ─────────────────────────────────────────────
+
+const USER_SHELL_TOOL = {
+  name: "user_shell",
+  description:
+    "Execute a command in the user's live terminal session. " +
+    "Use this for commands that should affect the user's shell state: " +
+    "cd, export, source, pushd/popd, alias, etc. " +
+    "The command runs in the user's actual shell with their full environment " +
+    "(aliases, functions, PATH), not an isolated subprocess.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      command: {
+        type: "string",
+        description: "Shell command to execute in the user's live terminal",
+      },
+    },
+    required: ["command"],
+  },
+};
+
+// ── agent-sh socket client (JSON-RPC 2.0) ──────────────────────
+
+let rpcId = 0;
+
+function callSocket(method: string, params?: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    if (!SOCKET_PATH) {
+      reject(new Error("AGENT_SH_SOCKET not set — not running inside agent-sh"));
+      return;
+    }
+
+    const conn = createConnection(SOCKET_PATH);
+    let buffer = "";
+
+    conn.on("connect", () => {
+      const msg = { jsonrpc: "2.0", id: ++rpcId, method, params: params ?? {} };
+      conn.write(JSON.stringify(msg) + "\n");
+    });
+
+    conn.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx === -1) return;
+
+      const line = buffer.slice(0, newlineIdx).trim();
+      conn.destroy();
+
+      try {
+        const response = JSON.parse(line);
+        if (response.error) {
+          reject(new Error(response.error.message || "RPC error"));
+        } else {
+          resolve(response.result);
+        }
+      } catch {
+        reject(new Error(`Invalid response from agent-sh: ${line}`));
+      }
+    });
+
+    conn.on("error", (err) => {
+      reject(new Error(`Failed to connect to agent-sh: ${err.message}`));
+    });
+
+    conn.setTimeout(35_000, () => {
+      conn.destroy();
+      reject(new Error("Connection to agent-sh timed out"));
+    });
+  });
+}
+
+// ── Request handler ─────────────────────────────────────────────
+
+async function handleRequest(id: unknown, method: string, params: any): Promise<void> {
+  switch (method) {
+    case "initialize":
+      sendResult(id, {
+        protocolVersion: params?.protocolVersion ?? "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: { name: "agent-sh-shell", version: "0.1.0" },
+      });
+      break;
+
+    case "notifications/initialized":
+      // Client acknowledgement — nothing to do
+      break;
+
+    case "tools/list":
+      sendResult(id, { tools: [USER_SHELL_TOOL] });
+      break;
+
+    case "tools/call": {
+      const toolName = params?.name;
+      if (toolName !== "user_shell") {
+        sendError(id, -32602, `Unknown tool: ${toolName}`);
+        return;
+      }
+
+      const command = params?.arguments?.command;
+      if (!command || typeof command !== "string") {
+        sendError(id, -32602, "Missing required parameter: command");
+        return;
+      }
+
+      try {
+        const result = await callSocket("shell/exec", { command }) as { output: string; cwd: string };
+        sendResult(id, {
+          content: [
+            {
+              type: "text",
+              text: result.output || "(no output)",
+            },
+          ],
+        });
+      } catch (err) {
+        sendResult(id, {
+          content: [
+            {
+              type: "text",
+              text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        });
+      }
+      break;
+    }
+
+    default:
+      // Unknown methods: return method-not-found for requests (those with id)
+      if (id !== undefined && id !== null) {
+        sendError(id, -32601, `Method not found: ${method}`);
+      }
+      break;
+  }
+}
+
+// ── Main loop ───────────────────────────────────────────────────
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  try {
+    const msg = JSON.parse(line);
+    const { id, method, params } = msg;
+    if (method) {
+      handleRequest(id, method, params).catch((err) => {
+        if (id !== undefined && id !== null) {
+          sendError(id, -32603, String(err));
+        }
+      });
+    }
+  } catch {
+    // Malformed JSON — ignore
+  }
+});
+
+rl.on("close", () => {
+  process.exit(0);
+});

--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -67,7 +67,13 @@ export class OutputParser {
    * Each time a prompt appears, we finalize the previous command's output.
    */
   private parsePromptMarker(data: string): void {
-    if (data.includes("\x1b]9999;PROMPT\x07")) {
+    const marker = "\x1b]9999;PROMPT\x07";
+    const markerIdx = data.indexOf(marker);
+    if (markerIdx !== -1) {
+      // Capture any output that arrived in the same chunk before the marker
+      if (markerIdx > 0) {
+        this.currentOutputCapture += data.slice(0, markerIdx);
+      }
       this.promptReady = false;
       if (this.foregroundBusy) {
         this.foregroundBusy = false;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -243,9 +243,41 @@ export class Shell implements InputContext {
       this.paused = true;
       return payload;
     });
+
+    // Shell exec: write a command to the live PTY and capture its output.
+    // stdout is paused during agent processing, so PTY output flows through
+    // OutputParser (for OSC detection) but never reaches the terminal.
+    this.bus.onPipeAsync("shell:exec-request", async (payload) => {
+      const output = await new Promise<{ output: string; cwd: string }>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          this.bus.off("shell:command-done", handler);
+          // Kill any hung command
+          this.ptyProcess.write("\x03");
+          reject(new Error("Shell exec timed out after 30s"));
+        }, 30_000);
+
+        const handler = (e: { command: string; output: string; cwd: string }) => {
+          clearTimeout(timeout);
+          this.bus.off("shell:command-done", handler);
+          resolve({ output: e.output, cwd: e.cwd });
+        };
+        this.bus.on("shell:command-done", handler);
+
+        // Start capture and write to PTY
+        this.outputParser.onCommandEntered(payload.command, this.outputParser.getCwd());
+        this.ptyProcess.write(payload.command + "\r");
+      });
+
+      return { ...payload, output: output.output, cwd: output.cwd, done: true };
+    });
   }
 
   // ── Public API (used by index.ts) ──
+
+  /** Temp directory used for shell config and sockets. */
+  getTmpDir(): string | undefined {
+    return this.tmpDir;
+  }
 
   resize(cols: number, rows: number): void {
     this.ptyProcess.resize(cols, rows);


### PR DESCRIPTION
## Summary
- Adds a `user_shell` tool that lets the agent execute commands directly in the user's live PTY shell (cd, export, source, etc.)
- Shell-exec extension runs a Unix socket server speaking **JSON-RPC 2.0**, routes requests through the EventBus
- MCP server (standalone process) wraps the socket for ACP agents that support `mcpServers`
- Generic `session:configure` pipe lets any extension register MCP servers — acp-client has zero shell-exec knowledge
- Agent-specific extensions (e.g. pi-user-shell) connect to the same socket and are maintained separately

## Socket protocol (JSON-RPC 2.0, newline-delimited)
```
shell/exec   { command }  → { output, cwd }
shell/cwd    {}           → { cwd }
shell/info   {}           → { shell, agentSh }
```
Extensible — new methods (e.g. shell/recall, shell/env) can be added without breaking existing clients.

## Also includes
- Fixes OutputParser dropping command output when it arrives in the same PTY chunk as the OSC 9999 marker
- Forwards tool result content from `tool_call_update` to the TUI

## Test plan
- [ ] `agent-sh` → `> cd into my downloads` → agent uses `user_shell`, prompt shows new cwd
- [ ] `pwd` in shell confirms directory changed
- [ ] Tool output appears in TUI response box
- [ ] MCP server responds correctly: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | node dist/mcp-server.js`