### PR TITLE
Document socket protocol and user_shell setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ See the [Usage Guide](docs/usage.md) for all options, model configuration, and e
 | `Ctrl-T` | Toggle thinking/reasoning text display |
 | `Escape` | Exit agent input mode (when typing after `>`) |
 
+### Agent Input Keybindings
+
+When typing after `>`, full readline-style keybindings are available:
+
+| Key | Action |
+|---|---|
+| `Ctrl-A` / `Home` | Move to start of line |
+| `Ctrl-E` / `End` | Move to end of line |
+| `Ctrl-B` / `←` | Move back one character |
+| `Ctrl-F` / `→` | Move forward one character |
+| `Option-B` / `Option-←` | Move back one word |
+| `Option-F` / `Option-→` | Move forward one word |
+| `Ctrl-U` | Delete to start of line |
+| `Ctrl-K` | Delete to end of line |
+| `Ctrl-W` / `Option-Backspace` | Delete word backward |
+| `Option-D` | Delete word forward |
+
 ### Slash Commands
 
 | Command | Description |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,8 +70,8 @@ All components communicate exclusively through typed bus events. AcpClient has n
 |---|---|
 | `agent_message_chunk` | Real-time streaming markdown with syntax highlighting in a bordered box |
 | `agent_thought_chunk` | Thinking spinner (default), or streaming text when toggled on with Ctrl+T |
-| `tool_call` | Yellow header showing what the agent is invoking |
-| `tool_call_update` | Status indicator (checkmark or X with exit code) |
+| `tool_call` | Kind icon (◆ read, ✎ edit, ▶ execute, ⌕ search, etc.) + title, file paths, arguments |
+| `tool_call_update` | Streaming output content + status indicator (checkmark or X with exit code) |
 | `file_write` | Inline diff preview in bordered box (Ctrl+O to expand/collapse) |
 
 ## How It Works
@@ -87,13 +87,41 @@ All components communicate exclusively through typed bus events. AcpClient has n
 9. If the agent needs to run commands, it calls `terminal/create` and agent-sh executes them in isolated child processes, streaming output back
 10. When the agent finishes, normal shell operation resumes
 
+## Socket Protocol
+
+agent-sh exposes a Unix domain socket for external tools (MCP servers, pi extensions, etc.) to interact with the user's live shell. The socket speaks **JSON-RPC 2.0** (newline-delimited), the same protocol family as ACP and MCP.
+
+### Methods
+
+| Method | Params | Result | Description |
+|---|---|---|---|
+| `shell/exec` | `{ command }` | `{ output, cwd }` | Execute command in the user's PTY, capture output |
+| `shell/cwd` | `{}` | `{ cwd }` | Get current working directory |
+| `shell/info` | `{}` | `{ shell, agentSh }` | Get shell metadata |
+
+### Example
+
+```
+→ {"jsonrpc":"2.0","id":1,"method":"shell/exec","params":{"command":"cd ~/Downloads && pwd"}}
+← {"jsonrpc":"2.0","id":1,"result":{"output":"/Users/me/Downloads","cwd":"/Users/me/Downloads"}}
+```
+
+The socket path is available via the `AGENT_SH_SOCKET` environment variable. The protocol is extensible — new methods (e.g. `shell/env`, `shell/recall`) can be added without breaking existing clients.
+
+### How agents discover the socket
+
+Two paths, same backend:
+
+1. **MCP server** (universal) — the shell-exec extension registers an MCP server via the `session:configure` pipe. ACP agents that forward `mcpServers` (like claude-agent-acp) discover a `user_shell` tool automatically.
+2. **Agent extensions** (agent-specific) — extensions like pi-user-shell read `AGENT_SH_SOCKET` from the environment and connect directly. This is the path for pi-acp.
+
 ## EventBus
 
 All communication between components flows through a typed EventBus. Components emit events (shell commands, agent responses, tool calls) and extensions subscribe to events they care about. The bus supports three modes:
 
 - **emit/on** — fire-and-forget notifications (e.g., `agent:response-chunk`)
-- **emitPipe/onPipe** — synchronous transform chains (e.g., `autocomplete:request` where extensions append completion items)
-- **emitPipeAsync/onPipeAsync** — async transform chains (e.g., `permission:request` where extensions prompt the user and return a decision)
+- **emitPipe/onPipe** — synchronous transform chains (e.g., `autocomplete:request` where extensions append completion items, `session:configure` where extensions add MCP servers)
+- **emitPipeAsync/onPipeAsync** — async transform chains (e.g., `permission:request` where extensions prompt the user and return a decision, `shell:exec-request` where Shell executes a command in the PTY)
 
 ## Project Structure
 
@@ -110,6 +138,7 @@ agent-sh/
 │   ├── context-manager.ts  # Exchange log, context assembly, recall API
 │   ├── extension-loader.ts # Extension loading (-e, settings.json, extensions dir)
 │   ├── executor.ts         # Isolated child process execution
+│   ├── mcp-server.ts       # Standalone MCP server (user_shell tool via socket)
 │   ├── types.ts            # Shared type definitions
 │   ├── utils/
 │   │   ├── palette.ts      # Semantic color palette (accent/success/warning/error/muted)
@@ -118,13 +147,15 @@ agent-sh/
 │   │   ├── diff-renderer.ts# Syntax-highlighted diff display (split/unified/summary)
 │   │   ├── box-frame.ts    # Bordered TUI panels (rounded/square/double/heavy)
 │   │   ├── tool-display.ts # Width-adaptive tool call/result rendering
+│   │   ├── line-editor.ts  # Readline-style line editor (pure logic, no I/O)
 │   │   ├── file-watcher.ts # File change detection for agent tool writes
 │   │   └── markdown.ts     # Streaming markdown → ANSI renderer
 │   └── extensions/
 │       ├── tui-renderer.ts       # Terminal rendering (markdown, spinner, tools)
 │       ├── slash-commands.ts     # /help, /clear, /copy, /compact, /quit
 │       ├── file-autocomplete.ts  # @ file path completion
-│       └── shell-recall.ts      # __shell_recall terminal interception
+│       ├── shell-recall.ts      # __shell_recall terminal interception
+│       └── shell-exec.ts       # Unix socket server + MCP registration for PTY exec
 ├── examples/
 │   └── extensions/
 │       ├── interactive-prompts.ts # Example: permission gates (opt-in)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -28,6 +28,19 @@ export default function activate(ctx) {
     if (payload.command !== "my-tool") return payload;
     return { ...payload, intercepted: true, output: "custom output" };
   });
+
+  // Register an MCP server for the agent to discover
+  ctx.bus.onPipe("session:configure", (payload) => {
+    return {
+      ...payload,
+      mcpServers: [...payload.mcpServers, {
+        name: "my-tool",
+        command: "node",
+        args: ["/path/to/my-mcp-server.js"],
+        env: [{ name: "MY_VAR", value: "value" }],
+      }],
+    };
+  });
 }
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,6 +63,27 @@ npm start -- --shell /bin/zsh
 AGENT_SH_AGENT=claude-agent-acp npm start
 ```
 
+## Using agent-sh as Your Default Shell
+
+You can launch agent-sh automatically when you open a terminal by adding it to your `~/.zshrc` or `~/.bashrc`. The `AGENT_SH` guard prevents infinite recursion (agent-sh sets this when it starts):
+
+```bash
+# Add to the END of your ~/.zshrc or ~/.bashrc
+if [[ -z "$AGENT_SH" && $- == *i* && -t 0 ]]; then
+  exec agent-sh --agent pi-acp
+fi
+```
+
+The checks ensure agent-sh only launches for interactive terminal sessions (`$- == *i*` and `-t 0`), not for scripts or non-interactive subshells.
+
+If you installed via a local build instead of npm, point to the built file directly:
+
+```bash
+if [[ -z "$AGENT_SH" && $- == *i* && -t 0 ]]; then
+  exec node /path/to/agent-sh/dist/index.js --agent pi-acp
+fi
+```
+
 ## Common Claude Models
 
 **Valid Claude model names** (for use with `--model` parameter):
@@ -155,7 +176,36 @@ export ANTHROPIC_API_KEY="your-key"
 export GOOGLE_API_KEY="your-key"
 ```
 
-**Tip:** Add these to your `~/.zshrc` or `~/.bashrc` for persistent configuration.
+**Tip:** Add these to your `~/.zshrc` or `~/.bashrc` for persistent configuration. agent-sh captures your full shell environment at startup (by running an interactive subshell), so environment variables from your rc files are available to the agent and its tools — no restart needed after adding them.
+
+## Live Shell Execution
+
+By default, agent tool calls (bash, read, write) run in isolated subprocesses — they can't affect your shell's state. The `user_shell` tool lets the agent execute commands directly in your live PTY shell, so `cd`, `export`, `source`, and similar commands actually take effect.
+
+### How it works
+
+agent-sh exposes a Unix socket that external tools connect to. Two discovery paths:
+
+- **MCP server** — registered automatically via `session:configure`. Works with ACP agents that forward `mcpServers` (e.g. claude-agent-acp).
+- **Pi extension** — install pi-user-shell for pi-acp. It reads `AGENT_SH_SOCKET` from the environment and connects directly.
+
+### Pi extension setup
+
+```bash
+# From wherever pi-user-shell lives
+pi install ./pi-user-shell
+```
+
+Once installed, the agent can use `user_shell` alongside its built-in tools. Ask it to `cd` somewhere and your shell prompt will reflect the change.
+
+### Writing your own socket client
+
+The socket speaks JSON-RPC 2.0 (newline-delimited). See [Architecture — Socket Protocol](architecture.md#socket-protocol) for the full method reference.
+
+```bash
+# Quick test (requires socat)
+echo '{"jsonrpc":"2.0","id":1,"method":"shell/cwd","params":{}}' | socat - UNIX-CONNECT:$AGENT_SH_SOCKET
+```
 
 ## Shell Context
 


### PR DESCRIPTION
## Summary
- Architecture doc: socket protocol reference (JSON-RPC 2.0 methods), agent discovery paths, updated project structure
- Extensions doc: `session:configure` pipe example for registering MCP servers
- Usage doc: live shell execution section with pi extension setup

Docs companion to #21.