### PR TITLE
Expose recall as MCP tool via socket protocol

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,7 @@ agent-sh exposes a Unix domain socket for external tools (MCP servers, pi extens
 | `shell/exec` | `{ command }` | `{ output, cwd }` | Execute command in the user's PTY, capture output |
 | `shell/cwd` | `{}` | `{ cwd }` | Get current working directory |
 | `shell/info` | `{}` | `{ shell, agentSh }` | Get shell metadata |
+| `shell/recall` | `{ operation, query?, ids? }` | `{ result }` | Search, expand, or browse session exchange history |
 
 ### Example
 
@@ -106,7 +107,7 @@ agent-sh exposes a Unix domain socket for external tools (MCP servers, pi extens
 ← {"jsonrpc":"2.0","id":1,"result":{"output":"/Users/me/Downloads","cwd":"/Users/me/Downloads"}}
 ```
 
-The socket path is available via the `AGENT_SH_SOCKET` environment variable. The protocol is extensible — new methods (e.g. `shell/env`, `shell/recall`) can be added without breaking existing clients.
+The socket path is available via the `AGENT_SH_SOCKET` environment variable. The protocol is extensible — new methods can be added without breaking existing clients.
 
 ### How agents discover the socket
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -213,6 +213,6 @@ The agent automatically receives structured context about your shell session wit
 
 - **Current working directory** — tracked via OSC 7 escape sequences
 - **Recent commands and output** — truncated summaries of recent shell commands, agent queries, and tool executions
-- **Recall tool** — the agent can run `__shell_recall --search "query"` or `__shell_recall --expand 42` to retrieve full output of any past exchange
+- **Recall tool** — the agent can use the `shell_recall` MCP tool to search, expand, or browse session history (e.g., retrieve full output of a truncated exchange)
 
 This means you can run a failing command, then type `> fix this` and the agent knows exactly what happened. For long outputs, the agent sees a truncated summary and can recall the full content on demand.

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -190,22 +190,22 @@ export class ContextManager {
   }
 
   /**
-   * Parse and handle __shell_recall commands.
+   * Parse and handle shell_recall commands.
    */
   handleRecallCommand(command: string): string {
-    const args = command.replace(/^__shell_recall\s*/, "").trim();
+    const args = command.replace(/^_*shell_recall\s*/, "").trim();
 
     if (!args || args === "--help") {
       return [
         "Usage:",
-        "  __shell_recall                    Browse recent exchanges",
-        "  __shell_recall --search <query>   Search all exchanges",
-        "  __shell_recall --expand <id,...>   Show full content of exchanges",
+        "  shell_recall                    Browse recent exchanges",
+        "  shell_recall --search <query>   Search all exchanges",
+        "  shell_recall --expand <id,...>   Show full content of exchanges",
         "",
         "Examples:",
-        '  __shell_recall --search "test fail"',
-        "  __shell_recall --expand 41",
-        "  __shell_recall --expand 41,42,43",
+        '  shell_recall --search "test fail"',
+        "  shell_recall --expand 41",
+        "  shell_recall --expand 41,42,43",
       ].join("\n");
     }
 
@@ -289,11 +289,11 @@ export class ContextManager {
       const ex = result[i]!;
       const before = this.exchangeSize(ex);
       if (ex.type === "shell_command") {
-        ex.output = `[output omitted, use __shell_recall --expand ${ex.id}]`;
+        ex.output = `[output omitted, use shell_recall tool to expand id ${ex.id}]`;
       } else if (ex.type === "tool_execution") {
-        ex.output = `[output omitted, use __shell_recall --expand ${ex.id}]`;
+        ex.output = `[output omitted, use shell_recall tool to expand id ${ex.id}]`;
       } else if (ex.type === "agent_response") {
-        ex.response = `[response omitted, use __shell_recall --expand ${ex.id}]`;
+        ex.response = `[response omitted, use shell_recall tool to expand id ${ex.id}]`;
       }
       totalSize -= before - this.exchangeSize(ex);
     }
@@ -308,7 +308,7 @@ export class ContextManager {
     let out = "<shell_context>\n";
     out += `cwd: ${this.currentCwd}\n`;
     out += `session: ${totalCount} exchanges, ${elapsed}m elapsed\n`;
-    out += `[hint: run \`__shell_recall --search "query"\` or \`__shell_recall --expand ID\` to retrieve truncated content]\n`;
+    out += `[hint: use the shell_recall tool to retrieve truncated content — search(query) or expand(ids)]\n`;
 
     for (const ex of exchanges) {
       out += "\n" + this.formatExchangeTruncated(ex);
@@ -448,7 +448,7 @@ function truncateOutput(
   const omitted = lines.length - headLines - tailLines;
   return [
     ...lines.slice(0, headLines),
-    `[... ${omitted} lines truncated, use __shell_recall --expand ${id} to see full output ...]`,
+    `[... ${omitted} lines truncated, use shell_recall tool with expand and id ${id} to see full output ...]`,
     ...lines.slice(-tailLines),
   ].join("\n");
 }
@@ -464,7 +464,7 @@ function truncateHead(
 
   return [
     ...lines.slice(0, headLines),
-    `[... truncated, use __shell_recall --expand ${id} for full response ...]`,
+    `[... truncated, use shell_recall tool with expand and id ${id} for full response ...]`,
   ].join("\n");
 }
 

--- a/src/extensions/shell-exec.ts
+++ b/src/extensions/shell-exec.ts
@@ -13,9 +13,10 @@
  *
  * ## Socket protocol (JSON-RPC 2.0, newline-delimited)
  *
- *   shell/exec   { command: string }  → { output, cwd }
- *   shell/cwd    {}                   → { cwd }
- *   shell/info   {}                   → { busy, shell }
+ *   shell/exec    { command: string }  → { output, cwd }
+ *   shell/cwd     {}                   → { cwd }
+ *   shell/info    {}                   → { busy, shell }
+ *   shell/recall  { operation, ... }   → { result }
  */
 
 import * as net from "node:net";
@@ -101,6 +102,30 @@ export default function activate(
           shell: process.env.SHELL || "unknown",
           agentSh: true,
         };
+
+      case "shell/recall": {
+        const operation = (params?.operation as string) || "browse";
+        switch (operation) {
+          case "search": {
+            const query = params?.query;
+            if (typeof query !== "string" || !query) {
+              throw rpcError(-32602, "Missing required parameter: query");
+            }
+            return { result: contextManager.search(query) };
+          }
+          case "expand": {
+            const ids = params?.ids;
+            if (!Array.isArray(ids) || ids.length === 0) {
+              throw rpcError(-32602, "Missing required parameter: ids (array of numbers)");
+            }
+            return { result: contextManager.expand(ids.map(Number)) };
+          }
+          case "browse":
+            return { result: contextManager.getRecentSummary() };
+          default:
+            throw rpcError(-32602, `Unknown recall operation: ${operation}`);
+        }
+      }
 
       default:
         throw rpcError(-32601, `Method not found: ${method}`);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -52,6 +52,36 @@ const USER_SHELL_TOOL = {
   },
 };
 
+const SHELL_RECALL_TOOL = {
+  name: "shell_recall",
+  description:
+    "Retrieve past shell commands, agent responses, and tool executions from the session history. " +
+    "Use this to look up truncated output, search for previous commands or errors, " +
+    "or browse recent exchanges. Three operations: " +
+    '"search" finds exchanges matching a query, ' +
+    '"expand" retrieves full untruncated content by exchange ID, ' +
+    '"browse" lists recent exchange summaries.',
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      operation: {
+        type: "string",
+        enum: ["search", "expand", "browse"],
+        description: 'Operation to perform (default: "browse")',
+      },
+      query: {
+        type: "string",
+        description: 'Search query (required for "search" operation)',
+      },
+      ids: {
+        type: "array",
+        items: { type: "number" },
+        description: 'Exchange IDs to expand (required for "expand" operation)',
+      },
+    },
+  },
+};
+
 // ── agent-sh socket client (JSON-RPC 2.0) ──────────────────────
 
 let rpcId = 0;
@@ -119,31 +149,38 @@ async function handleRequest(id: unknown, method: string, params: any): Promise<
       break;
 
     case "tools/list":
-      sendResult(id, { tools: [USER_SHELL_TOOL] });
+      sendResult(id, { tools: [USER_SHELL_TOOL, SHELL_RECALL_TOOL] });
       break;
 
     case "tools/call": {
       const toolName = params?.name;
-      if (toolName !== "user_shell") {
-        sendError(id, -32602, `Unknown tool: ${toolName}`);
-        return;
-      }
-
-      const command = params?.arguments?.command;
-      if (!command || typeof command !== "string") {
-        sendError(id, -32602, "Missing required parameter: command");
-        return;
-      }
+      const args = params?.arguments ?? {};
 
       try {
-        const result = await callSocket("shell/exec", { command }) as { output: string; cwd: string };
+        let text: string;
+
+        if (toolName === "user_shell") {
+          const command = args.command;
+          if (!command || typeof command !== "string") {
+            sendError(id, -32602, "Missing required parameter: command");
+            return;
+          }
+          const result = await callSocket("shell/exec", { command }) as { output: string; cwd: string };
+          text = result.output || "(no output)";
+        } else if (toolName === "shell_recall") {
+          const result = await callSocket("shell/recall", {
+            operation: args.operation || "browse",
+            query: args.query,
+            ids: args.ids,
+          }) as { result: string };
+          text = result.result || "(no results)";
+        } else {
+          sendError(id, -32602, `Unknown tool: ${toolName}`);
+          return;
+        }
+
         sendResult(id, {
-          content: [
-            {
-              type: "text",
-              text: result.output || "(no output)",
-            },
-          ],
+          content: [{ type: "text", text }],
         });
       } catch (err) {
         sendResult(id, {


### PR DESCRIPTION
## Summary

- Add `shell/recall` method to the Unix socket protocol (search, expand, browse operations)
- Add `shell_recall` MCP tool to the MCP server, so agents discover it alongside `user_shell`
- Update context hints from `__shell_recall` (fake terminal command) to `shell_recall` (proper tool name)
- Keep terminal intercept fallback for backward compatibility

## Test plan

- [ ] Start agent-sh with claude-agent-acp, verify `shell_recall` tool appears in MCP discovery
- [ ] Run a command with long output, then ask the agent to recall it — should use `shell_recall` tool
- [ ] Verify `socat` test: `echo '{"jsonrpc":"2.0","id":1,"method":"shell/recall","params":{"operation":"browse"}}' | socat - UNIX-CONNECT:$AGENT_SH_SOCKET`