### PR TITLE
Polish shell tool UX: auto-cancel, recall line ranges, formatting

### DIFF
--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -25,7 +25,8 @@ export class AcpClient {
   private terminalDonePromises = new Map<string, Promise<void>>();
   private terminalCounter = 0;
   private fileWatcher: FileWatcher;
-  private pendingToolCalls = new Map<string, boolean>();
+  private pendingToolCalls = new Map<string, string>(); // toolCallId → title
+  private autoCancelled = false;
   private pendingToolCounter = 0;
   private agentInfo: { name: string; version: string } | null = null;
 
@@ -44,8 +45,16 @@ export class AcpClient {
     this.log(`Starting agent: ${this.config.agentCommand} ${this.config.agentArgs.join(" ")}`);
 
     // Spawn the agent subprocess with the user's full shell environment
-    // (includes vars from .zshrc/.bashrc that process.env may not have)
-    const agentEnv = this.config.shellEnv ?? process.env;
+    // (includes vars from .zshrc/.bashrc that process.env may not have).
+    // Merge in any runtime env vars set by extensions (e.g. AGENT_SH_SOCKET)
+    // that weren't present when shellEnv was captured at startup.
+    const baseEnv = this.config.shellEnv ?? process.env;
+    const agentEnv: Record<string, string> = { ...baseEnv } as Record<string, string>;
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && !(k in agentEnv)) {
+        agentEnv[k] = v;
+      }
+    }
     this.agentProcess = spawn(this.config.agentCommand, this.config.agentArgs, {
       stdio: ["pipe", "pipe", process.env.DEBUG ? "inherit" : "ignore"],
       env: agentEnv as NodeJS.ProcessEnv,
@@ -144,6 +153,7 @@ export class AcpClient {
     await this.fileWatcher.snapshot();
 
     this.currentResponseText = "";
+    this.autoCancelled = false;
     let cancelled = false;
 
     // Emit agent query event (TUI renders echo+spinner, ContextManager records it)
@@ -168,7 +178,9 @@ export class AcpClient {
 
       if (response.stopReason === "cancelled") {
         cancelled = true;
-        this.bus.emit("agent:cancelled", {});
+        if (!this.autoCancelled) {
+          this.bus.emit("agent:cancelled", {});
+        }
       }
     } catch (err) {
       this.log(`prompt error: ${err}`);
@@ -193,6 +205,18 @@ export class AcpClient {
       this.bus.emit("agent:processing-done", {});
       this.promptInProgress = false;
     }
+  }
+
+  /**
+   * Silently cancel the prompt after a shell tool completes.
+   * Unlike user-initiated cancel(), this doesn't show "(cancelled)" —
+   * the tool already ran, we just skip the unnecessary LLM follow-up.
+   */
+  private autoCancel(): void {
+    if (!this.connection || !this.sessionId || !this.promptInProgress) return;
+    this.log("auto-cancel: shell tool completed, skipping LLM follow-up");
+    this.autoCancelled = true;
+    this.connection.cancel({ sessionId: this.sessionId }).catch(() => {});
   }
 
   /**
@@ -346,7 +370,7 @@ export class AcpClient {
 
       case "tool_call": {
         const toolId = update.toolCallId || `tool-${this.pendingToolCounter++}`;
-        this.pendingToolCalls.set(toolId, true);
+        this.pendingToolCalls.set(toolId, update.title ?? "");
         this.bus.emit("agent:tool-started", {
           title: update.title,
           toolCallId: toolId,
@@ -358,17 +382,18 @@ export class AcpClient {
       }
 
       case "tool_call_update": {
-        // Stream tool output content (text from pi's internal tool results)
-        if (update.content && Array.isArray(update.content)) {
-          for (const block of update.content) {
-            if (block.type === "content" && block.content?.type === "text" && block.content.text) {
-              this.bus.emit("agent:tool-output-chunk", { chunk: block.content.text });
+        if (update.status === "completed" || update.status === "failed") {
+          // Show content only on final status — intermediate updates often
+          // contain stringified wrapper JSON (e.g. '{ "content": [] }')
+          if (update.content && Array.isArray(update.content)) {
+            for (const block of update.content) {
+              if (block.type === "content" && block.content?.type === "text" && block.content.text) {
+                this.bus.emit("agent:tool-output-chunk", { chunk: block.content.text });
+              }
             }
           }
-        }
-
-        if (update.status === "completed" || update.status === "failed") {
           const toolId = update.toolCallId;
+          const toolTitle = toolId ? this.pendingToolCalls.get(toolId) : undefined;
           const exitCode = update.status === "completed" ? 0 : 1;
           if (toolId && this.pendingToolCalls.has(toolId)) {
             this.pendingToolCalls.delete(toolId);
@@ -380,12 +405,18 @@ export class AcpClient {
           } else if (!toolId) {
             this.bus.emit("agent:tool-completed", { exitCode, rawOutput: update.rawOutput });
           }
+
+          // Auto-cancel after shell tools complete — the command already
+          // ran in the user's PTY, no need for a second LLM round trip.
+          // The result is captured in shell context / shell_recall.
+          if (toolTitle === "user_shell" && update.status === "completed") {
+            this.autoCancel();
+          }
         }
         break;
       }
 
       default:
-        // Ignore other update types for now
         break;
     }
   }

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -5,15 +5,15 @@ const DEFAULT_WINDOW_SIZE = 20;
 const DEFAULT_BUDGET = 16384; // ~4K tokens at ~4 chars/token
 
 // Truncation thresholds (in lines)
-const SHELL_TRUNCATE_THRESHOLD = 30;
-const SHELL_HEAD_LINES = 10;
-const SHELL_TAIL_LINES = 10;
+const SHELL_TRUNCATE_THRESHOLD = 10;
+const SHELL_HEAD_LINES = 5;
+const SHELL_TAIL_LINES = 5;
 const AGENT_RESPONSE_TRUNCATE_THRESHOLD = 20;
 const AGENT_RESPONSE_HEAD_LINES = 15;
 const TOOL_TRUNCATE_THRESHOLD = 20;
 const TOOL_HEAD_LINES = 5;
 const TOOL_TAIL_LINES = 5;
-const RECALL_EXPAND_MAX_LINES = 500;
+const RECALL_EXPAND_MAX_LINES = 100;
 
 export class ContextManager {
   private exchanges: Exchange[] = [];
@@ -164,9 +164,10 @@ export class ContextManager {
   }
 
   /**
-   * Return full untruncated content for specific exchange IDs.
+   * Return content for specific exchange IDs.
+   * Optional start/end restrict to a line range (1-indexed).
    */
-  expand(ids: number[]): string {
+  expand(ids: number[], start?: number, end?: number): string {
     const results: string[] = [];
     for (const id of ids) {
       const ex = this.exchanges.find((e) => e.id === id);
@@ -174,7 +175,28 @@ export class ContextManager {
         results.push(`#${id}: not found`);
         continue;
       }
-      results.push(this.formatExchangeFull(ex));
+      const text = this.formatExchangeFull(ex);
+      const lines = text.split("\n");
+      const total = lines.length;
+
+      if (start != null || end != null) {
+        // Line range requested
+        const s = Math.max(0, (start ?? 1) - 1);
+        const e = end ?? total;
+        results.push(
+          lines.slice(s, e).join("\n") +
+          `\n[showing lines ${s + 1}-${Math.min(e, total)} of ${total}]`,
+        );
+      } else if (total > RECALL_EXPAND_MAX_LINES) {
+        // Too large — tell the agent to narrow down
+        results.push(
+          `#${ex.id}: output is ${total} lines, too large to expand fully. ` +
+          `Use start/end params to select a line range (e.g. start=1, end=50), ` +
+          `or use search with a regex to find specific content.`,
+        );
+      } else {
+        results.push(text);
+      }
     }
     return results.join("\n\n");
   }
@@ -332,7 +354,7 @@ export class ContextManager {
   private formatExchangeTruncated(ex: Exchange): string {
     switch (ex.type) {
       case "shell_command": {
-        let s = `#${ex.id} [shell] $ ${ex.command}\n`;
+        let s = `#${ex.id} [shell cwd:${ex.cwd}] $ ${ex.command}\n`;
         if (ex.output) s += indent(ex.output, "  ") + "\n";
         if (ex.exitCode !== null) s += `  exit ${ex.exitCode}\n`;
         return s;
@@ -357,21 +379,10 @@ export class ContextManager {
     }
   }
 
-  private truncateForRecall(text: string): string {
-    const lines = text.split("\n");
-    if (lines.length <= RECALL_EXPAND_MAX_LINES) return text;
-    const half = RECALL_EXPAND_MAX_LINES / 2;
-    return (
-      lines.slice(0, half).join("\n") +
-      `\n[... ${lines.length - RECALL_EXPAND_MAX_LINES} more lines ...]\n` +
-      lines.slice(-half).join("\n")
-    );
-  }
-
   private formatExchangeFull(ex: Exchange): string {
     switch (ex.type) {
       case "shell_command": {
-        const output = this.truncateForRecall(ex.output);
+        const output = ex.output;
         let s = `#${ex.id} [shell] $ ${ex.command} (${ex.outputLines} lines, ${ex.outputBytes} bytes)\n`;
         if (output) s += output + "\n";
         if (ex.exitCode !== null) s += `exit ${ex.exitCode}\n`;
@@ -382,9 +393,8 @@ export class ContextManager {
       case "agent_response":
         return `#${ex.id} [agent]\n${ex.response}`;
       case "tool_execution": {
-        const output = this.truncateForRecall(ex.output);
         let s = `#${ex.id} [tool] ${ex.tool} (${ex.outputLines} lines, ${ex.outputBytes} bytes)\n`;
-        if (output) s += output + "\n";
+        if (ex.output) s += ex.output + "\n";
         if (ex.exitCode !== null) s += `exit ${ex.exitCode}\n`;
         return s;
       }
@@ -394,7 +404,7 @@ export class ContextManager {
   private exchangeOneLiner(ex: Exchange): string {
     switch (ex.type) {
       case "shell_command":
-        return `#${ex.id} shell: ${ex.command} (${ex.outputLines} lines, exit ${ex.exitCode ?? "?"})`;
+        return `#${ex.id} shell [cwd:${ex.cwd}]: ${ex.command} (${ex.outputLines} total lines, exit ${ex.exitCode ?? "?"})`;
       case "agent_query":
         return `#${ex.id} query: ${ex.query}`;
       case "agent_response": {

--- a/src/extensions/shell-exec.ts
+++ b/src/extensions/shell-exec.ts
@@ -118,7 +118,9 @@ export default function activate(
             if (!Array.isArray(ids) || ids.length === 0) {
               throw rpcError(-32602, "Missing required parameter: ids (array of numbers)");
             }
-            return { result: contextManager.expand(ids.map(Number)) };
+            const start = typeof params?.start === "number" ? params.start : undefined;
+            const end = typeof params?.end === "number" ? params.end : undefined;
+            return { result: contextManager.expand(ids.map(Number), start, end) };
           }
           case "browse":
             return { result: contextManager.getRecentSummary() };

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -95,6 +95,12 @@ export default function activate({ bus }: ExtensionContext): void {
     endAgentResponse();
   });
 
+  bus.on("agent:processing-done", () => {
+    isThinking = false;
+    stopCurrentSpinner();
+    endAgentResponse();
+  });
+
   bus.on("agent:error", (e) => showError(e.message));
 
   // Flush rendering state and show inline diff for file writes

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -57,10 +57,10 @@ const SHELL_RECALL_TOOL = {
   description:
     "Retrieve past shell commands, agent responses, and tool executions from the session history. " +
     "Use this to look up truncated output, search for previous commands or errors, " +
-    "or browse recent exchanges. Three operations: " +
-    '"search" finds exchanges matching a query, ' +
-    '"expand" retrieves full untruncated content by exchange ID, ' +
-    '"browse" lists recent exchange summaries.',
+    "or browse recent exchanges. Operations: " +
+    '"browse" lists recent exchange summaries with line counts, ' +
+    '"search" finds exchanges matching a regex query, ' +
+    '"expand" retrieves content by exchange ID (use start/end for specific line ranges).',
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -71,12 +71,20 @@ const SHELL_RECALL_TOOL = {
       },
       query: {
         type: "string",
-        description: 'Search query (required for "search" operation)',
+        description: 'Search query — supports regex (required for "search" operation)',
       },
       ids: {
         type: "array",
         items: { type: "number" },
         description: 'Exchange IDs to expand (required for "expand" operation)',
+      },
+      start: {
+        type: "number",
+        description: "Start line number, 1-indexed (optional, for expand)",
+      },
+      end: {
+        type: "number",
+        description: "End line number, inclusive (optional, for expand)",
       },
     },
   },
@@ -172,6 +180,8 @@ async function handleRequest(id: unknown, method: string, params: any): Promise<
             operation: args.operation || "browse",
             query: args.query,
             ids: args.ids,
+            start: args.start,
+            end: args.end,
           }) as { result: string };
           text = result.result || "(no results)";
         } else {

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -121,8 +121,34 @@ export function renderToolCall(
 
     // Show raw input args for non-terminal, non-file tools
     if (!tool.command && !tool.locations?.length && tool.rawInput) {
-      const detail = formatRawInput(tool.rawInput, width - 4);
-      if (detail) lines.push(`  ${p.dim}${detail}${p.reset}`);
+      const raw = tool.rawInput as Record<string, unknown>;
+      if (raw && typeof raw === "object") {
+        // command field → show as command line
+        if (typeof raw.command === "string") {
+          const maxCmdW = Math.max(1, width - 4);
+          const cmd = raw.command.length > maxCmdW
+            ? raw.command.slice(0, maxCmdW - 1) + "…"
+            : raw.command;
+          lines.push(`  ${p.dim}$ ${cmd}${p.reset}`);
+        }
+        // operation field → compact summary (e.g. "expand #1,2" or "search foo")
+        else if (typeof raw.operation === "string") {
+          let summary = raw.operation;
+          if (raw.ids && Array.isArray(raw.ids)) {
+            summary += ` #${(raw.ids as number[]).join(",")}`;
+          }
+          if (typeof raw.query === "string") {
+            summary += ` "${raw.query}"`;
+          }
+          lines.push(`  ${p.dim}${summary}${p.reset}`);
+        } else {
+          const detail = formatRawInput(tool.rawInput, width - 4);
+          if (detail) lines.push(`  ${p.dim}${detail}${p.reset}`);
+        }
+      } else {
+        const detail = formatRawInput(tool.rawInput, width - 4);
+        if (detail) lines.push(`  ${p.dim}${detail}${p.reset}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **Auto-cancel after user_shell** — skip the second LLM round trip when a command runs in the user's live PTY. The result is already visible and captured in shell context / `shell_recall`
- **Fix AGENT_SH_SOCKET not reaching agent** — runtime env vars set by extensions were missing from the agent subprocess because `shellEnv` was captured at startup before extensions ran
- **Recall line ranges** — `shell_recall` expand now accepts `start`/`end` params for specific line ranges. Large outputs (>100 lines) are rejected with guidance to use ranges or regex search
- **Clean up tool_call_update rendering** — only show content on completion status, filtering out intermediate JSON wrapper noise (`{ "content": [] }`)
- **Show cwd in shell context** — commands now display `[shell cwd:/path] $ cmd` so the agent knows where each command ran
- **Better tool display** — `command` fields render as `$ cmd`, operation fields as compact summaries (`expand #1`), tighter truncation (10 lines vs 30)

## Test plan

- [ ] `> help me cd into downloads` — should use `user_shell`, auto-cancel, no LLM follow-up
- [ ] Run `ls -al` then `> what was the output of my ls` — should use `shell_recall` with expand
- [ ] Generate large output (`find . -name "*.ts"`), then ask about it — should see "too large" guidance
- [ ] Verify response box closes properly after auto-cancel (bottom border renders)