### PR TITLE
Add input history for agent input mode

### DIFF
--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -30,6 +30,7 @@ export class InputHandler {
   private history: string[] = [];
   private historyIndex = -1; // -1 = not browsing history
   private savedBuffer = ""; // buffer saved when entering history
+  private escapeTimer: ReturnType<typeof setTimeout> | null = null;
   private bus: EventBus;
   private onShowAgentInfo: () => { info: string; model?: string };
 
@@ -238,7 +239,28 @@ export class InputHandler {
   }
 
   private handleAgentInput(data: string): void {
+    // Clear any pending escape timer — new data arrived
+    if (this.escapeTimer) {
+      clearTimeout(this.escapeTimer);
+      this.escapeTimer = null;
+    }
+
     const actions = this.editor.feed(data);
+
+    // If the editor is waiting for more escape sequence data, set a short
+    // timer — if nothing arrives, treat it as a bare Escape keypress
+    if (this.editor.hasPendingEscape()) {
+      this.escapeTimer = setTimeout(() => {
+        this.escapeTimer = null;
+        const flushed = this.editor.flushPendingEscape();
+        if (flushed.length > 0) this.processAgentActions(flushed);
+      }, 50);
+    }
+
+    this.processAgentActions(actions);
+  }
+
+  private processAgentActions(actions: ReturnType<typeof this.editor.feed>): void {
 
     for (const act of actions) {
       switch (act.action) {

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -27,6 +27,9 @@ export class InputHandler {
   private autocompleteIndex = 0;
   private autocompleteItems: { name: string; description: string }[] = [];
   private autocompleteLines = 0;
+  private history: string[] = [];
+  private historyIndex = -1; // -1 = not browsing history
+  private savedBuffer = ""; // buffer saved when entering history
   private bus: EventBus;
   private onShowAgentInfo: () => { info: string; model?: string };
 
@@ -240,6 +243,7 @@ export class InputHandler {
     for (const act of actions) {
       switch (act.action) {
         case "changed":
+          this.historyIndex = -1;
           this.autocompleteIndex = 0;
           this.renderAgentInput();
           break;
@@ -249,6 +253,14 @@ export class InputHandler {
             this.applyAutocomplete();
           }
           const query = act.buffer.trim();
+          if (query) {
+            // Add to history (avoid consecutive duplicates)
+            if (this.history.length === 0 || this.history[this.history.length - 1] !== query) {
+              this.history.push(query);
+            }
+          }
+          this.historyIndex = -1;
+          this.savedBuffer = "";
           this.clearAutocompleteLines();
           process.stdout.write("\r\x1b[2K");
           this.agentInputMode = false;
@@ -297,6 +309,16 @@ export class InputHandler {
             this.clearAutocompleteLines();
             this.writeAgentPromptLine();
             this.renderAutocomplete();
+          } else if (this.history.length > 0) {
+            if (this.historyIndex === -1) {
+              this.savedBuffer = this.editor.buffer;
+              this.historyIndex = this.history.length - 1;
+            } else if (this.historyIndex > 0) {
+              this.historyIndex--;
+            }
+            this.editor.buffer = this.history[this.historyIndex]!;
+            this.editor.cursor = this.editor.buffer.length;
+            this.renderAgentInput();
           }
           break;
 
@@ -309,6 +331,16 @@ export class InputHandler {
             this.clearAutocompleteLines();
             this.writeAgentPromptLine();
             this.renderAutocomplete();
+          } else if (this.historyIndex !== -1) {
+            if (this.historyIndex < this.history.length - 1) {
+              this.historyIndex++;
+              this.editor.buffer = this.history[this.historyIndex]!;
+            } else {
+              this.historyIndex = -1;
+              this.editor.buffer = this.savedBuffer;
+            }
+            this.editor.cursor = this.editor.buffer.length;
+            this.renderAgentInput();
           }
           break;
       }

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -22,14 +22,14 @@ export type LineEditAction =
 export class LineEditor {
   buffer = "";
   cursor = 0;
-  private pendingEscape = false;
+  private pendingSeq = ""; // buffered incomplete escape sequence
 
   /** Process raw terminal input, return actions for the consumer. */
   feed(data: string): LineEditAction[] {
-    // If we had a pending \x1b from a previous chunk, prepend it
-    if (this.pendingEscape) {
-      this.pendingEscape = false;
-      data = "\x1b" + data;
+    // If we had a pending incomplete escape sequence, prepend it
+    if (this.pendingSeq) {
+      data = this.pendingSeq + data;
+      this.pendingSeq = "";
     }
 
     const actions: LineEditAction[] = [];
@@ -42,18 +42,23 @@ export class LineEditor {
       if (ch === "\x1b") {
         const next = data[i + 1];
 
-        // Bare Escape (nothing follows in this chunk) — defer to next feed()
-        // in case the rest of the CSI sequence arrives in the next chunk
+        // Incomplete escape — buffer and wait for next feed()
         if (next == null) {
-          this.pendingEscape = true;
+          this.pendingSeq = "\x1b";
           i++;
           continue;
         }
 
         // CSI sequence: \x1b[...
         if (next === "[") {
-          const { consumed } = this.handleCSI(data, i, actions);
-          i += consumed;
+          const { consumed, incomplete } = this.handleCSI(data, i, actions);
+          if (incomplete) {
+            // Buffer the incomplete CSI sequence for next feed()
+            this.pendingSeq = data.slice(i, i + consumed);
+            i += consumed;
+          } else {
+            i += consumed;
+          }
           continue;
         }
 
@@ -161,35 +166,36 @@ export class LineEditor {
     return actions;
   }
 
-  /** Check if there's a pending escape waiting for more data. */
+  /** Check if there's a pending incomplete escape sequence. */
   hasPendingEscape(): boolean {
-    return this.pendingEscape;
+    return this.pendingSeq.length > 0;
   }
 
-  /** Flush a pending bare escape as a cancel action. */
+  /** Flush a pending sequence — treat bare \x1b as cancel, discard incomplete CSI. */
   flushPendingEscape(): LineEditAction[] {
-    if (!this.pendingEscape) return [];
-    this.pendingEscape = false;
-    return [{ action: "cancel" }];
+    if (!this.pendingSeq) return [];
+    const wasBarEscape = this.pendingSeq === "\x1b";
+    this.pendingSeq = "";
+    return wasBarEscape ? [{ action: "cancel" }] : [];
   }
 
   clear(): void {
     this.buffer = "";
     this.cursor = 0;
-    this.pendingEscape = false;
+    this.pendingSeq = "";
   }
 
   // ── CSI sequence handling ───────────────────────────────────
 
   /**
    * Parse and handle a CSI sequence (\x1b[...) starting at `start`.
-   * Returns the number of bytes consumed.
+   * Returns the number of bytes consumed and whether the sequence was incomplete.
    */
   private handleCSI(
     data: string,
     start: number,
     actions: LineEditAction[],
-  ): { consumed: number } {
+  ): { consumed: number; incomplete?: boolean } {
     // Skip \x1b[
     let j = start + 2;
     // Accumulate parameter bytes (0x20-0x3F: digits, semicolons, etc.)
@@ -198,8 +204,12 @@ export class LineEditor {
       params += data[j];
       j++;
     }
-    const final = j < data.length ? data[j]! : "";
-    const consumed = j - start + (final ? 1 : 0);
+    // If we ran out of data before the final byte, sequence is incomplete
+    if (j >= data.length) {
+      return { consumed: j - start, incomplete: true };
+    }
+    const final = data[j]!;
+    const consumed = j - start + 1;
 
     // Dispatch on final byte
     switch (final) {

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -22,9 +22,16 @@ export type LineEditAction =
 export class LineEditor {
   buffer = "";
   cursor = 0;
+  private pendingEscape = false;
 
   /** Process raw terminal input, return actions for the consumer. */
   feed(data: string): LineEditAction[] {
+    // If we had a pending \x1b from a previous chunk, prepend it
+    if (this.pendingEscape) {
+      this.pendingEscape = false;
+      data = "\x1b" + data;
+    }
+
     const actions: LineEditAction[] = [];
     let i = 0;
 
@@ -35,9 +42,10 @@ export class LineEditor {
       if (ch === "\x1b") {
         const next = data[i + 1];
 
-        // Bare Escape (nothing follows in this chunk)
+        // Bare Escape (nothing follows in this chunk) — defer to next feed()
+        // in case the rest of the CSI sequence arrives in the next chunk
         if (next == null) {
-          actions.push({ action: "cancel" });
+          this.pendingEscape = true;
           i++;
           continue;
         }
@@ -153,9 +161,22 @@ export class LineEditor {
     return actions;
   }
 
+  /** Check if there's a pending escape waiting for more data. */
+  hasPendingEscape(): boolean {
+    return this.pendingEscape;
+  }
+
+  /** Flush a pending bare escape as a cancel action. */
+  flushPendingEscape(): LineEditAction[] {
+    if (!this.pendingEscape) return [];
+    this.pendingEscape = false;
+    return [{ action: "cancel" }];
+  }
+
   clear(): void {
     this.buffer = "";
     this.cursor = 0;
+    this.pendingEscape = false;
   }
 
   // ── CSI sequence handling ───────────────────────────────────

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -53,11 +53,39 @@ export class LineEditor {
         if (next === "[") {
           const { consumed, incomplete } = this.handleCSI(data, i, actions);
           if (incomplete) {
-            // Buffer the incomplete CSI sequence for next feed()
             this.pendingSeq = data.slice(i, i + consumed);
             i += consumed;
           } else {
             i += consumed;
+          }
+          continue;
+        }
+
+        // SS3 sequence: \x1bO... (application cursor mode — arrow keys, Home, End)
+        if (next === "O") {
+          const ss3Final = data[i + 2];
+          if (ss3Final == null) {
+            // Incomplete — buffer for next feed()
+            this.pendingSeq = data.slice(i, i + 2);
+            i += 2;
+            continue;
+          }
+          i += 3; // consume \x1b O <final>
+          switch (ss3Final) {
+            case "A": actions.push({ action: "arrow-up" }); break;
+            case "B": actions.push({ action: "arrow-down" }); break;
+            case "C":
+              if (this.cursor < this.buffer.length) { this.cursor++; actions.push({ action: "changed" }); }
+              break;
+            case "D":
+              if (this.cursor > 0) { this.cursor--; actions.push({ action: "changed" }); }
+              break;
+            case "H": // Home
+              if (this.cursor > 0) { this.cursor = 0; actions.push({ action: "changed" }); }
+              break;
+            case "F": // End
+              if (this.cursor < this.buffer.length) { this.cursor = this.buffer.length; actions.push({ action: "changed" }); }
+              break;
           }
           continue;
         }


### PR DESCRIPTION
## Summary
- Add input history for agent queries (up/down arrows cycle through previous queries)
- Fix arrow keys in agent input mode — handle SS3 sequences (`\x1bOA/B/C/D`)
- Buffer incomplete escape/CSI sequences across stdin chunks

## Explanation

Terminals have two cursor key modes: **normal mode** sends CSI sequences (`\x1b[C` for right arrow), and **application mode** sends SS3 sequences (`\x1bOC`). Most shells (zsh via zle, bash via readline) switch to application mode on startup.

The line editor only handled CSI (`\x1b[`). When an SS3 sequence like `\x1bOC` arrived:

1. `\x1b` was recognized as an escape prefix
2. `O` didn't match `[` (CSI), so it fell through to the Alt+key handler
3. `O` didn't match any Alt binding (b/f/d/backspace), so it was silently ignored
4. `C` was then processed as a regular printable character and inserted into the buffer

This is why the user saw literal `C` and `D` characters when pressing right/left arrows. Shift+arrows were unaffected because modified keys always use CSI format (`\x1b[1;2C`), never SS3.

The fix adds an SS3 handler (`\x1bO` + final byte) alongside the existing CSI handler, covering arrow keys, Home, and End in application cursor mode.

Closes #29

## Test plan
- [x] Left/right arrows move cursor within agent input
- [x] Up/down arrows cycle through query history
- [x] Shift+arrows still work (word movement)
- [x] Escape still exits agent input mode
- [x] Autocomplete up/down navigation still works