### PR TITLE
Persist agent query history and add settings module

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,35 +109,9 @@ When typing after `>`, full readline-style keybindings are available:
 
 ## Configuration
 
-agent-sh stores settings and history in `~/.agent-sh/`. Configure behavior via `~/.agent-sh/settings.json` — all fields are optional with sensible defaults:
+agent-sh stores settings and history in `~/.agent-sh/`. Behavior is configurable via `~/.agent-sh/settings.json` — context window size, truncation thresholds, display limits, and more. All fields are optional with sensible defaults.
 
-```json
-{
-  "extensions": [],
-  "historySize": 500,
-  "contextWindowSize": 20,
-  "contextBudget": 16384,
-  "shellTruncateThreshold": 10,
-  "shellHeadLines": 5,
-  "shellTailLines": 5,
-  "recallExpandMaxLines": 100,
-  "maxCommandOutputLines": 30,
-  "diffMaxLines": 20
-}
-```
-
-| Setting | Default | Description |
-|---|---|---|
-| `historySize` | `500` | Max agent query history entries (persisted across sessions) |
-| `contextWindowSize` | `20` | Recent exchanges included in agent context |
-| `contextBudget` | `16384` | Context budget in bytes (~4K tokens) |
-| `shellTruncateThreshold` | `10` | Shell output lines before truncation |
-| `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end of truncated output |
-| `recallExpandMaxLines` | `100` | Max lines for recall expand before requiring line ranges |
-| `maxCommandOutputLines` | `30` | Max command output lines shown inline |
-| `diffMaxLines` | `20` | Max diff lines before "ctrl+o to expand" |
-
-See the [Extensions guide](docs/extensions.md) for extension configuration.
+See the [Usage Guide](docs/usage.md#configuration) for the full settings reference.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ When typing after `>`, full readline-style keybindings are available:
 
 | Key | Action |
 |---|---|
+| `↑` / `↓` | Browse query history (persisted across sessions) |
 | `Ctrl-A` / `Home` | Move to start of line |
 | `Ctrl-E` / `End` | Move to end of line |
 | `Ctrl-B` / `←` | Move back one character |
@@ -105,6 +106,38 @@ When typing after `>`, full readline-style keybindings are available:
 | `/copy` | Copy last agent response to clipboard |
 | `/compact` | Ask agent to summarize the conversation |
 | `/quit` | Exit agent-sh |
+
+## Configuration
+
+agent-sh stores settings and history in `~/.agent-sh/`. Configure behavior via `~/.agent-sh/settings.json` — all fields are optional with sensible defaults:
+
+```json
+{
+  "extensions": [],
+  "historySize": 500,
+  "contextWindowSize": 20,
+  "contextBudget": 16384,
+  "shellTruncateThreshold": 10,
+  "shellHeadLines": 5,
+  "shellTailLines": 5,
+  "recallExpandMaxLines": 100,
+  "maxCommandOutputLines": 30,
+  "diffMaxLines": 20
+}
+```
+
+| Setting | Default | Description |
+|---|---|---|
+| `historySize` | `500` | Max agent query history entries (persisted across sessions) |
+| `contextWindowSize` | `20` | Recent exchanges included in agent context |
+| `contextBudget` | `16384` | Context budget in bytes (~4K tokens) |
+| `shellTruncateThreshold` | `10` | Shell output lines before truncation |
+| `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end of truncated output |
+| `recallExpandMaxLines` | `100` | Max lines for recall expand before requiring line ranges |
+| `maxCommandOutputLines` | `30` | Max command output lines shown inline |
+| `diffMaxLines` | `20` | Max diff lines before "ctrl+o to expand" |
+
+See the [Extensions guide](docs/extensions.md) for extension configuration.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ index.ts — interactive terminal frontend:
   │     tuiRenderer       — markdown rendering, inline diffs, thinking display, spinner
   │     slashCommands     — /help, /clear, /copy, /compact, /quit
   │     fileAutocomplete  — @ file path completion
-  │     shellRecall       — __shell_recall terminal interception
+  │     shellRecall       — shell_recall terminal interception
   │
   ├── Shared utilities:
   │     palette           — semantic color system (accent, success, warning, error, muted)
@@ -98,7 +98,7 @@ agent-sh exposes a Unix domain socket for external tools (MCP servers, pi extens
 | `shell/exec` | `{ command }` | `{ output, cwd }` | Execute command in the user's PTY, capture output |
 | `shell/cwd` | `{}` | `{ cwd }` | Get current working directory |
 | `shell/info` | `{}` | `{ shell, agentSh }` | Get shell metadata |
-| `shell/recall` | `{ operation, query?, ids? }` | `{ result }` | Search, expand, or browse session exchange history |
+| `shell/recall` | `{ operation, query?, ids?, start?, end? }` | `{ result }` | Search, expand, or browse session exchange history |
 
 ### Example
 
@@ -113,8 +113,8 @@ The socket path is available via the `AGENT_SH_SOCKET` environment variable. The
 
 Two paths, same backend:
 
-1. **MCP server** (universal) — the shell-exec extension registers an MCP server via the `session:configure` pipe. ACP agents that forward `mcpServers` (like claude-agent-acp) discover a `user_shell` tool automatically.
-2. **Agent extensions** (agent-specific) — extensions like pi-user-shell read `AGENT_SH_SOCKET` from the environment and connect directly. This is the path for pi-acp.
+1. **MCP server** (universal) — the shell-exec extension registers an MCP server via the `session:configure` pipe. ACP agents that forward `mcpServers` (like claude-agent-acp) discover `shell_cwd`, `user_shell`, and `shell_recall` tools automatically.
+2. **Agent extensions** (agent-specific) — the pi extension (`examples/pi-agent-sh.ts`, installed to `~/.pi/agent/extensions/pi-agent-sh/`) reads `AGENT_SH_SOCKET` from the environment and connects directly. This is the path for pi-acp.
 
 ## EventBus
 
@@ -137,9 +137,10 @@ agent-sh/
 │   ├── output-parser.ts    # OSC parsing, command boundary detection
 │   ├── acp-client.ts       # ACP protocol, terminal execution, session management
 │   ├── context-manager.ts  # Exchange log, context assembly, recall API
+│   ├── settings.ts         # User settings (~/.agent-sh/settings.json)
 │   ├── extension-loader.ts # Extension loading (-e, settings.json, extensions dir)
 │   ├── executor.ts         # Isolated child process execution
-│   ├── mcp-server.ts       # Standalone MCP server (user_shell tool via socket)
+│   ├── mcp-server.ts       # Standalone MCP server (shell_cwd, user_shell, shell_recall via socket)
 │   ├── types.ts            # Shared type definitions
 │   ├── utils/
 │   │   ├── palette.ts      # Semantic color palette (accent/success/warning/error/muted)
@@ -155,12 +156,13 @@ agent-sh/
 │       ├── tui-renderer.ts       # Terminal rendering (markdown, spinner, tools)
 │       ├── slash-commands.ts     # /help, /clear, /copy, /compact, /quit
 │       ├── file-autocomplete.ts  # @ file path completion
-│       ├── shell-recall.ts      # __shell_recall terminal interception
+│       ├── shell-recall.ts      # shell_recall terminal interception
 │       └── shell-exec.ts       # Unix socket server + MCP registration for PTY exec
 ├── examples/
+│   ├── pi-agent-sh.ts              # Pi extension: shell_cwd, user_shell, shell_recall tools
 │   └── extensions/
-│       ├── interactive-prompts.ts # Example: permission gates (opt-in)
-│       └── solarized-theme.ts    # Example: color theme via setPalette()
+│       ├── interactive-prompts.ts   # Example: permission gates (opt-in)
+│       └── solarized-theme.ts      # Example: color theme via setPalette()
 ├── package.json
 └── tsconfig.json
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ These tools are **not built into the agent** — they're registered externally a
 
 Two paths to the same socket backend — **both always active**:
 
-1. **MCP server** (automatic for MCP-capable agents) — the shell-exec extension registers an MCP server via the `session:configure` pipe when creating an ACP session. Any ACP agent that forwards `mcpServers` (like claude-agent-acp) discovers `shell_cwd`, `user_shell`, and `shell_recall` tools automatically. This is skipped for agents that don't support MCP (like pi-acp).
+1. **MCP server** (on by default) — the shell-exec extension registers an MCP server via the `session:configure` pipe when creating an ACP session. Any ACP agent that forwards `mcpServers` (like claude-agent-acp) discovers `shell_cwd`, `user_shell`, and `shell_recall` tools automatically. Agents that don't support MCP (like pi-acp) simply ignore it. Can be disabled via `"enableMcp": false` in settings.json.
 
 2. **Agent extensions** (agent-specific) — some agents don't support MCP but have their own extension system. For pi-acp, the pi extension (`examples/pi-agent-sh.ts`, installed to `~/.pi/agent/extensions/pi-agent-sh/`) reads `AGENT_SH_SOCKET` from the environment and connects to the same socket directly.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,9 +87,80 @@ All components communicate exclusively through typed bus events. AcpClient has n
 9. If the agent needs to run commands, it calls `terminal/create` and agent-sh executes them in isolated child processes, streaming output back
 10. When the agent finishes, normal shell operation resumes
 
+## Shell ↔ Agent Boundary
+
+The shell and the agent are **separate worlds** by default. The PTY runs your real shell; the agent runs as an isolated subprocess with its own tools (bash, file read/write, etc.). They don't directly interact — the agent's `bash` tool runs commands in an isolated child process, not your live shell. A `cd` by the agent doesn't change your shell's cwd.
+
+The connection between them is **context**: each time you send a query (`> ...`), agent-sh includes a `<shell_context>` block with your recent commands, their output, and your current working directory. The agent can see what you've been doing, but it can't touch your shell state.
+
+### Bridge tools
+
+For cases where the agent *should* affect the live shell (e.g., `cd`, `export`, `source`), agent-sh provides bridge tools via a Unix domain socket:
+
+| Tool | Purpose |
+|---|---|
+| `shell_cwd` | Query the user's real shell cwd (may differ from agent's internal cwd) |
+| `user_shell` | Execute a command in the user's live PTY — `cd`, `export`, etc. take effect |
+| `shell_recall` | Search, expand, or browse session history (commands, output, agent responses) |
+
+These tools are **not built into the agent** — they're registered externally and the agent discovers them at session start. This keeps the architecture clean: the agent doesn't need to know about agent-sh specifically.
+
+### How agents discover bridge tools
+
+Two paths to the same socket backend — **both always active**:
+
+1. **MCP server** (always on, universal) — the shell-exec extension automatically registers an MCP server via the `session:configure` pipe when creating an ACP session. Any ACP agent that forwards `mcpServers` (like claude-agent-acp) discovers `shell_cwd`, `user_shell`, and `shell_recall` tools automatically. No configuration needed.
+
+2. **Agent extensions** (agent-specific) — some agents don't support MCP but have their own extension system. For pi-acp, the pi extension (`examples/pi-agent-sh.ts`, installed to `~/.pi/agent/extensions/pi-agent-sh/`) reads `AGENT_SH_SOCKET` from the environment and connects to the same socket directly.
+
+Both paths connect to the same Unix socket (`$AGENT_SH_SOCKET`), which speaks JSON-RPC 2.0. The shell-exec extension handles requests by routing them through the EventBus — it never touches the PTY directly.
+
+```
+Agent (pi, claude, etc.)
+  │
+  ├── via MCP server (stdio) ──┐
+  │                             ├──→ Unix socket ($AGENT_SH_SOCKET)
+  └── via agent extension ─────┘         │
+                                    shell-exec extension
+                                         │ EventBus
+                                    Shell (PTY write + output capture)
+```
+
+### Pi extension example
+
+The reference implementation lives at `examples/pi-agent-sh.ts`. It registers all three bridge tools with pi's extension API and communicates with agent-sh via the socket:
+
+```typescript
+// Simplified — see examples/pi-agent-sh.ts for full source
+pi.registerTool({
+  name: "user_shell",
+  description: "Execute a command in the user's live terminal session...",
+  async execute(_id, params) {
+    const result = await callSocket("shell/exec", { command: params.command });
+    return { content: [{ type: "text", text: result.output }] };
+  },
+});
+```
+
+To install for pi:
+```bash
+mkdir -p ~/.pi/agent/extensions/pi-agent-sh
+cp examples/pi-agent-sh.ts ~/.pi/agent/extensions/pi-agent-sh/index.ts
+```
+
+### Writing your own bridge client
+
+Any process can connect to the socket. The protocol is JSON-RPC 2.0 (newline-delimited):
+
+```bash
+# Quick test (requires socat)
+echo '{"jsonrpc":"2.0","id":1,"method":"shell/cwd","params":{}}' | \
+  socat - UNIX-CONNECT:$AGENT_SH_SOCKET
+```
+
 ## Socket Protocol
 
-agent-sh exposes a Unix domain socket for external tools (MCP servers, pi extensions, etc.) to interact with the user's live shell. The socket speaks **JSON-RPC 2.0** (newline-delimited), the same protocol family as ACP and MCP.
+The Unix socket speaks **JSON-RPC 2.0** (newline-delimited).
 
 ### Methods
 
@@ -100,21 +171,7 @@ agent-sh exposes a Unix domain socket for external tools (MCP servers, pi extens
 | `shell/info` | `{}` | `{ shell, agentSh }` | Get shell metadata |
 | `shell/recall` | `{ operation, query?, ids?, start?, end? }` | `{ result }` | Search, expand, or browse session exchange history |
 
-### Example
-
-```
-→ {"jsonrpc":"2.0","id":1,"method":"shell/exec","params":{"command":"cd ~/Downloads && pwd"}}
-← {"jsonrpc":"2.0","id":1,"result":{"output":"/Users/me/Downloads","cwd":"/Users/me/Downloads"}}
-```
-
 The socket path is available via the `AGENT_SH_SOCKET` environment variable. The protocol is extensible — new methods can be added without breaking existing clients.
-
-### How agents discover the socket
-
-Two paths, same backend:
-
-1. **MCP server** (universal) — the shell-exec extension registers an MCP server via the `session:configure` pipe. ACP agents that forward `mcpServers` (like claude-agent-acp) discover `shell_cwd`, `user_shell`, and `shell_recall` tools automatically.
-2. **Agent extensions** (agent-specific) — the pi extension (`examples/pi-agent-sh.ts`, installed to `~/.pi/agent/extensions/pi-agent-sh/`) reads `AGENT_SH_SOCKET` from the environment and connects directly. This is the path for pi-acp.
 
 ## EventBus
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ These tools are **not built into the agent** — they're registered externally a
 
 Two paths to the same socket backend — **both always active**:
 
-1. **MCP server** (always on, universal) — the shell-exec extension automatically registers an MCP server via the `session:configure` pipe when creating an ACP session. Any ACP agent that forwards `mcpServers` (like claude-agent-acp) discovers `shell_cwd`, `user_shell`, and `shell_recall` tools automatically. No configuration needed.
+1. **MCP server** (automatic for MCP-capable agents) — the shell-exec extension registers an MCP server via the `session:configure` pipe when creating an ACP session. Any ACP agent that forwards `mcpServers` (like claude-agent-acp) discovers `shell_cwd`, `user_shell`, and `shell_recall` tools automatically. This is skipped for agents that don't support MCP (like pi-acp).
 
 2. **Agent extensions** (agent-specific) — some agents don't support MCP but have their own extension system. For pi-acp, the pi extension (`examples/pi-agent-sh.ts`, installed to `~/.pi/agent/extensions/pi-agent-sh/`) reads `AGENT_SH_SOCKET` from the environment and connects to the same socket directly.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -104,7 +104,7 @@ npm start -- -e my-ext-package -e ./local-ext.ts
 npm start -- -e my-ext-package,another-package   # comma-separated also works
 ```
 
-**2. Settings file** — `~/.agent-sh/settings.json`:
+**2. Settings file** — `~/.agent-sh/settings.json` (also supports other [configuration options](../README.md#configuration)):
 ```json
 {
   "extensions": [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -223,7 +223,8 @@ agent-sh stores settings and query history in `~/.agent-sh/`. Configure behavior
   "shellTailLines": 5,
   "recallExpandMaxLines": 100,
   "maxCommandOutputLines": 30,
-  "diffMaxLines": 20
+  "diffMaxLines": 20,
+  "enableMcp": true
 }
 ```
 
@@ -238,6 +239,7 @@ agent-sh stores settings and query history in `~/.agent-sh/`. Configure behavior
 | `recallExpandMaxLines` | `100` | Max lines for recall expand before requiring line ranges |
 | `maxCommandOutputLines` | `30` | Max command output lines shown inline in TUI |
 | `diffMaxLines` | `20` | Max diff lines shown before "ctrl+o to expand" |
+| `enableMcp` | `true` | Register MCP server for bridge tools (disable if agent doesn't use MCP) |
 
 The file doesn't need to exist — all defaults apply automatically. Settings are loaded once at startup.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -208,6 +208,39 @@ The socket speaks JSON-RPC 2.0 (newline-delimited). See [Architecture — Socket
 echo '{"jsonrpc":"2.0","id":1,"method":"shell/cwd","params":{}}' | socat - UNIX-CONNECT:$AGENT_SH_SOCKET
 ```
 
+## Configuration
+
+agent-sh stores settings and query history in `~/.agent-sh/`. Configure behavior via `~/.agent-sh/settings.json` — all fields are optional with sensible defaults:
+
+```json
+{
+  "extensions": [],
+  "historySize": 500,
+  "contextWindowSize": 20,
+  "contextBudget": 16384,
+  "shellTruncateThreshold": 10,
+  "shellHeadLines": 5,
+  "shellTailLines": 5,
+  "recallExpandMaxLines": 100,
+  "maxCommandOutputLines": 30,
+  "diffMaxLines": 20
+}
+```
+
+| Setting | Default | Description |
+|---|---|---|
+| `extensions` | `[]` | Extensions to load (npm packages or file paths) |
+| `historySize` | `500` | Max agent query history entries (persisted across sessions in `~/.agent-sh/history`) |
+| `contextWindowSize` | `20` | Recent exchanges included in agent context |
+| `contextBudget` | `16384` | Context budget in bytes (~4K tokens) |
+| `shellTruncateThreshold` | `10` | Shell output lines before truncation |
+| `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end of truncated output |
+| `recallExpandMaxLines` | `100` | Max lines for recall expand before requiring line ranges |
+| `maxCommandOutputLines` | `30` | Max command output lines shown inline in TUI |
+| `diffMaxLines` | `20` | Max diff lines shown before "ctrl+o to expand" |
+
+The file doesn't need to exist — all defaults apply automatically. Settings are loaded once at startup.
+
 ## Shell Context
 
 The agent automatically receives structured context about your shell session with each query, managed by the ContextManager:
@@ -218,14 +251,4 @@ The agent automatically receives structured context about your shell session wit
 
 This means you can run a failing command, then type `> fix this` and the agent knows exactly what happened. For long outputs, the agent sees a truncated summary and can recall the full content on demand.
 
-Context behavior is tunable via `~/.agent-sh/settings.json`:
-
-| Setting | Default | Description |
-|---|---|---|
-| `contextWindowSize` | `20` | How many recent exchanges to include |
-| `contextBudget` | `16384` | Max context size in bytes (~4K tokens) |
-| `shellTruncateThreshold` | `10` | Lines before shell output is truncated |
-| `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end after truncation |
-| `recallExpandMaxLines` | `100` | Max lines for recall expand |
-
-See the main [README](../README.md#configuration) for the full settings reference.
+Context behavior (window size, truncation thresholds) is tunable via `~/.agent-sh/settings.json` — see the [Configuration](#configuration) section above.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,12 +191,13 @@ agent-sh exposes a Unix socket that external tools connect to. Two discovery pat
 
 ### Pi extension setup
 
+Copy the pi extension to your pi extensions directory:
+
 ```bash
-# From wherever pi-user-shell lives
-pi install ./pi-user-shell
+cp examples/pi-agent-sh.ts ~/.pi/agent/extensions/pi-agent-sh/index.ts
 ```
 
-Once installed, the agent can use `user_shell` alongside its built-in tools. Ask it to `cd` somewhere and your shell prompt will reflect the change.
+This registers three tools for pi: `shell_cwd` (query real cwd), `user_shell` (execute in live PTY), and `shell_recall` (search/browse session history). Ask the agent to `cd` somewhere and your shell prompt will reflect the change.
 
 ### Writing your own socket client
 
@@ -216,3 +217,15 @@ The agent automatically receives structured context about your shell session wit
 - **Recall tool** — the agent can use the `shell_recall` MCP tool to search, expand, or browse session history (e.g., retrieve full output of a truncated exchange)
 
 This means you can run a failing command, then type `> fix this` and the agent knows exactly what happened. For long outputs, the agent sees a truncated summary and can recall the full content on demand.
+
+Context behavior is tunable via `~/.agent-sh/settings.json`:
+
+| Setting | Default | Description |
+|---|---|---|
+| `contextWindowSize` | `20` | How many recent exchanges to include |
+| `contextBudget` | `16384` | Max context size in bytes (~4K tokens) |
+| `shellTruncateThreshold` | `10` | Lines before shell output is truncated |
+| `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end after truncation |
+| `recallExpandMaxLines` | `100` | Max lines for recall expand |
+
+See the main [README](../README.md#configuration) for the full settings reference.

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -1,19 +1,13 @@
 import type { EventBus } from "./event-bus.js";
 import type { Exchange, ToolCallRecord } from "./types.js";
+import { getSettings } from "./settings.js";
 
-const DEFAULT_WINDOW_SIZE = 20;
-const DEFAULT_BUDGET = 16384; // ~4K tokens at ~4 chars/token
-
-// Truncation thresholds (in lines)
-const SHELL_TRUNCATE_THRESHOLD = 10;
-const SHELL_HEAD_LINES = 5;
-const SHELL_TAIL_LINES = 5;
+// Non-configurable thresholds (agent response and tool output follow shell settings)
 const AGENT_RESPONSE_TRUNCATE_THRESHOLD = 20;
 const AGENT_RESPONSE_HEAD_LINES = 15;
 const TOOL_TRUNCATE_THRESHOLD = 20;
 const TOOL_HEAD_LINES = 5;
 const TOOL_TAIL_LINES = 5;
-const RECALL_EXPAND_MAX_LINES = 100;
 
 export class ContextManager {
   private exchanges: Exchange[] = [];
@@ -101,7 +95,8 @@ export class ContextManager {
    * Build the <shell_context> block for the agent prompt.
    * Pipeline: window → truncate → format
    */
-  getContext(budget: number = DEFAULT_BUDGET): string {
+  getContext(budget?: number): string {
+    budget ??= getSettings().contextBudget;
     let exchanges = this.applyWindow(this.exchanges);
     exchanges = this.applyTruncation(exchanges, budget);
     return this.formatContext(exchanges);
@@ -187,7 +182,7 @@ export class ContextManager {
           lines.slice(s, e).join("\n") +
           `\n[showing lines ${s + 1}-${Math.min(e, total)} of ${total}]`,
         );
-      } else if (total > RECALL_EXPAND_MAX_LINES) {
+      } else if (total > getSettings().recallExpandMaxLines) {
         // Too large — tell the agent to narrow down
         results.push(
           `#${ex.id}: output is ${total} lines, too large to expand fully. ` +
@@ -265,8 +260,9 @@ export class ContextManager {
 
   private applyWindow(
     exchanges: Exchange[],
-    windowSize: number = DEFAULT_WINDOW_SIZE,
+    windowSize?: number,
   ): Exchange[] {
+    windowSize ??= getSettings().contextWindowSize;
     return exchanges.slice(-windowSize);
   }
 
@@ -280,11 +276,12 @@ export class ContextManager {
     // Pass 1: per-type truncation
     for (const ex of result) {
       if (ex.type === "shell_command") {
+        const s = getSettings();
         ex.output = truncateOutput(
           ex.output,
-          SHELL_TRUNCATE_THRESHOLD,
-          SHELL_HEAD_LINES,
-          SHELL_TAIL_LINES,
+          s.shellTruncateThreshold,
+          s.shellHeadLines,
+          s.shellTailLines,
           ex.id,
         );
       } else if (ex.type === "agent_response") {

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -1,11 +1,9 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import type { ExtensionContext } from "./types.js";
+import { CONFIG_DIR, getSettings } from "./settings.js";
 
-const CONFIG_DIR = path.join(os.homedir(), ".agent-sh");
 const EXT_DIR = path.join(CONFIG_DIR, "extensions");
-const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
 
 const TS_EXTS = [".ts", ".tsx", ".mts"];
 const SCRIPT_EXTS = [".js", ".mjs", ".ts", ".tsx", ".mts"];
@@ -23,18 +21,6 @@ async function ensureTsSupport(): Promise<void> {
   }
 }
 
-interface Settings {
-  extensions?: string[];
-}
-
-async function loadSettings(): Promise<Settings> {
-  try {
-    const raw = await fs.readFile(SETTINGS_PATH, "utf-8");
-    return JSON.parse(raw) as Settings;
-  } catch {
-    return {};
-  }
-}
 
 /**
  * Load extensions from three sources (merged, deduplicated):
@@ -62,8 +48,8 @@ export async function loadExtensions(
   }
 
   // 2. settings.json
-  const settings = await loadSettings();
-  if (settings.extensions) {
+  const settings = getSettings();
+  if (settings.extensions.length > 0) {
     specifiers.push(...settings.extensions);
   }
 

--- a/src/extensions/shell-exec.ts
+++ b/src/extensions/shell-exec.ts
@@ -23,20 +23,21 @@ import * as net from "node:net";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getSettings } from "../settings.js";
 import type { ExtensionContext } from "../types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default function activate(
   { bus, contextManager }: ExtensionContext,
-  opts: { socketPath: string; enableMcp?: boolean },
+  opts: { socketPath: string },
 ): void {
   const { socketPath } = opts;
 
   // Register MCP server so ACP agents discover the bridge tools.
-  // Skipped for agents that don't support MCP (e.g. pi-acp uses its own
-  // extension system instead — see examples/pi-agent-sh.ts).
-  if (opts.enableMcp !== false) {
+  // Agents that don't support MCP (e.g. pi-acp) simply ignore it.
+  // Can be disabled via settings.json if not needed.
+  if (getSettings().enableMcp) {
     bus.onPipe("session:configure", (payload) => {
       return {
         ...payload,

--- a/src/extensions/shell-exec.ts
+++ b/src/extensions/shell-exec.ts
@@ -29,27 +29,31 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default function activate(
   { bus, contextManager }: ExtensionContext,
-  opts: { socketPath: string },
+  opts: { socketPath: string; enableMcp?: boolean },
 ): void {
   const { socketPath } = opts;
 
-  // Register MCP server so ACP agents discover the user_shell tool
-  bus.onPipe("session:configure", (payload) => {
-    return {
-      ...payload,
-      mcpServers: [
-        ...payload.mcpServers,
-        {
-          name: "agent-sh",
-          command: process.execPath,
-          args: [path.join(__dirname, "..", "mcp-server.js")],
-          env: [{ name: "AGENT_SH_SOCKET", value: socketPath }],
-        },
-      ],
-    };
-  });
+  // Register MCP server so ACP agents discover the bridge tools.
+  // Skipped for agents that don't support MCP (e.g. pi-acp uses its own
+  // extension system instead — see examples/pi-agent-sh.ts).
+  if (opts.enableMcp !== false) {
+    bus.onPipe("session:configure", (payload) => {
+      return {
+        ...payload,
+        mcpServers: [
+          ...payload.mcpServers,
+          {
+            name: "agent-sh",
+            command: process.execPath,
+            args: [path.join(__dirname, "..", "mcp-server.js")],
+            env: [{ name: "AGENT_SH_SOCKET", value: socketPath }],
+          },
+        ],
+      };
+    });
+  }
 
-  // Also set AGENT_SH_SOCKET for pi extensions that connect directly
+  // Set AGENT_SH_SOCKET for agent extensions that connect directly
   process.env.AGENT_SH_SOCKET = socketPath;
 
   // Serialize shell/exec requests — only one PTY command at a time

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -22,9 +22,8 @@ import {
 import { renderDiff } from "../utils/diff-renderer.js";
 import { renderBoxFrame } from "../utils/box-frame.js";
 import type { DiffResult } from "../utils/diff.js";
+import { getSettings } from "../settings.js";
 import type { ExtensionContext } from "../types.js";
-
-const MAX_COMMAND_OUTPUT_LINES = 30;
 
 export default function activate({ bus }: ExtensionContext): void {
   let spinner: SpinnerState | null = null;
@@ -289,7 +288,7 @@ export default function activate({ bus }: ExtensionContext): void {
     const lines = commandOutputBuffer.split("\n");
     commandOutputBuffer = lines.pop()!;
     for (const line of lines) {
-      if (commandOutputLineCount < MAX_COMMAND_OUTPUT_LINES) {
+      if (commandOutputLineCount < getSettings().maxCommandOutputLines) {
         renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
         commandOutputLineCount++;
       } else {
@@ -301,7 +300,7 @@ export default function activate({ bus }: ExtensionContext): void {
   function flushCommandOutput(): void {
     if (!renderer) return;
     if (commandOutputBuffer) {
-      if (commandOutputLineCount < MAX_COMMAND_OUTPUT_LINES) {
+      if (commandOutputLineCount < getSettings().maxCommandOutputLines) {
         renderer.writeLine(`${p.dim}  ${commandOutputBuffer}${p.reset}`);
         commandOutputLineCount++;
       } else {
@@ -315,7 +314,6 @@ export default function activate({ bus }: ExtensionContext): void {
     }
   }
 
-  const DIFF_MAX_LINES = 20;
 
   function diffTitle(filePath: string, diff: DiffResult): string {
     const stats = diff.isNewFile
@@ -334,7 +332,7 @@ export default function activate({ bus }: ExtensionContext): void {
     const diffLines = renderDiff(diff, {
       width: contentW,
       filePath,
-      maxLines: DIFF_MAX_LINES,
+      maxLines: getSettings().diffMaxLines,
       trueColor: true,
       mode: "unified",
     });
@@ -418,7 +416,7 @@ export default function activate({ bus }: ExtensionContext): void {
     const diffLines = renderDiff(diff, {
       width: contentW,
       filePath,
-      maxLines: DIFF_MAX_LINES,
+      maxLines: getSettings().diffMaxLines,
       trueColor: true,
       mode: "unified",
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,10 +255,7 @@ async function main(): Promise<void> {
     if (process.env.DEBUG) {
       console.error('[agent-sh] Starting shell-exec socket server...');
     }
-    // pi-acp doesn't support MCP — it uses its own extension system.
-    // Only register the MCP server for agents that forward mcpServers.
-    const isPi = config.agentCommand.includes("pi");
-    shellExec(extCtx, { socketPath: `${tmpDir}/shell.sock`, enableMcp: !isPi });
+    shellExec(extCtx, { socketPath: `${tmpDir}/shell.sock` });
   }
 
   // Load extensions with timeout to prevent blocking startup

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,14 +248,17 @@ async function main(): Promise<void> {
   fileAutocomplete(extCtx);
   shellRecall(extCtx);
 
-  // Shell-exec: start the Unix domain socket bridge so the MCP server can
-  // route user_shell tool calls to the PTY via the EventBus.
+  // Shell-exec: start the Unix domain socket bridge so agent extensions
+  // and MCP servers can route tool calls to the PTY via the EventBus.
   const tmpDir = shell.getTmpDir();
   if (tmpDir) {
     if (process.env.DEBUG) {
       console.error('[agent-sh] Starting shell-exec socket server...');
     }
-    shellExec(extCtx, { socketPath: `${tmpDir}/shell.sock` });
+    // pi-acp doesn't support MCP — it uses its own extension system.
+    // Only register the MCP server for agents that forward mcpServers.
+    const isPi = config.agentCommand.includes("pi");
+    shellExec(extCtx, { socketPath: `${tmpDir}/shell.sock`, enableMcp: !isPi });
   }
 
   // Load extensions with timeout to prevent blocking startup

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -1,7 +1,12 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { visibleLen } from "./utils/ansi.js";
 import { palette as p } from "./utils/palette.js";
 import { LineEditor } from "./utils/line-editor.js";
+import { CONFIG_DIR, getSettings } from "./settings.js";
 import type { EventBus } from "./event-bus.js";
+
+const HISTORY_FILE = path.join(CONFIG_DIR, "history");
 
 /**
  * Narrow contract between InputHandler and its host (Shell).
@@ -42,6 +47,27 @@ export class InputHandler {
     this.ctx = opts.ctx;
     this.bus = opts.bus;
     this.onShowAgentInfo = opts.onShowAgentInfo;
+    this.loadHistory();
+  }
+
+  private loadHistory(): void {
+    try {
+      const data = fs.readFileSync(HISTORY_FILE, "utf-8");
+      this.history = data.split("\n").filter(Boolean);
+    } catch {
+      // No history file yet
+    }
+  }
+
+  private saveHistory(): void {
+    try {
+      const { historySize } = getSettings();
+      fs.mkdirSync(path.dirname(HISTORY_FILE), { recursive: true });
+      const lines = this.history.slice(-historySize);
+      fs.writeFileSync(HISTORY_FILE, lines.join("\n") + "\n");
+    } catch {
+      // Non-critical — ignore write failures
+    }
   }
 
   /** Write the agent prompt line with cursor at the correct position. */
@@ -279,6 +305,7 @@ export class InputHandler {
             // Add to history (avoid consecutive duplicates)
             if (this.history.length === 0 || this.history[this.history.length - 1] !== query) {
               this.history.push(query);
+              this.saveHistory();
             }
           }
           this.historyIndex = -1;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,44 @@
+/**
+ * User settings loaded from ~/.agent-sh/settings.json.
+ *
+ * Settings are loaded once at startup and available synchronously
+ * throughout the app. Unknown keys are preserved on write.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+export const CONFIG_DIR = path.join(os.homedir(), ".agent-sh");
+const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
+
+export interface Settings {
+  /** Extensions to load (npm packages or file paths). */
+  extensions?: string[];
+  /** Max agent query history entries to keep. Default 500. */
+  historySize?: number;
+}
+
+const DEFAULTS: Required<Settings> = {
+  extensions: [],
+  historySize: 500,
+};
+
+let cached: Settings | null = null;
+
+/** Load settings from disk (cached after first call). */
+export function getSettings(): Settings & typeof DEFAULTS {
+  if (!cached) {
+    try {
+      const raw = fs.readFileSync(SETTINGS_PATH, "utf-8");
+      cached = JSON.parse(raw) as Settings;
+    } catch {
+      cached = {};
+    }
+  }
+  return { ...DEFAULTS, ...cached };
+}
+
+/** Reset cached settings (for testing or after external edit). */
+export function reloadSettings(): void {
+  cached = null;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,13 +14,41 @@ const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
 export interface Settings {
   /** Extensions to load (npm packages or file paths). */
   extensions?: string[];
-  /** Max agent query history entries to keep. Default 500. */
+  /** Max agent query history entries to keep. */
   historySize?: number;
+
+  // ── Context & truncation ──────────────────────────────────
+  /** Recent exchanges included in agent context window. */
+  contextWindowSize?: number;
+  /** Context budget in bytes (~4 chars per token). */
+  contextBudget?: number;
+  /** Shell output lines before truncation kicks in. */
+  shellTruncateThreshold?: number;
+  /** Lines kept from start of truncated shell output. */
+  shellHeadLines?: number;
+  /** Lines kept from end of truncated shell output. */
+  shellTailLines?: number;
+  /** Max lines for recall expand before requiring line ranges. */
+  recallExpandMaxLines?: number;
+
+  // ── Display ───────────────────────────────────────────────
+  /** Max command output lines shown inline in TUI. */
+  maxCommandOutputLines?: number;
+  /** Max diff lines shown before "ctrl+o to expand". */
+  diffMaxLines?: number;
 }
 
 const DEFAULTS: Required<Settings> = {
   extensions: [],
   historySize: 500,
+  contextWindowSize: 20,
+  contextBudget: 16384,
+  shellTruncateThreshold: 10,
+  shellHeadLines: 5,
+  shellTailLines: 5,
+  recallExpandMaxLines: 100,
+  maxCommandOutputLines: 30,
+  diffMaxLines: 20,
 };
 
 let cached: Settings | null = null;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,6 +36,10 @@ export interface Settings {
   maxCommandOutputLines?: number;
   /** Max diff lines shown before "ctrl+o to expand". */
   diffMaxLines?: number;
+
+  // ── Agent integration ─────────────────────────────────────
+  /** Register MCP server for bridge tools (shell_cwd, user_shell, shell_recall). Default true. */
+  enableMcp?: boolean;
 }
 
 const DEFAULTS: Required<Settings> = {
@@ -49,6 +53,7 @@ const DEFAULTS: Required<Settings> = {
   recallExpandMaxLines: 100,
   maxCommandOutputLines: 30,
   diffMaxLines: 20,
+  enableMcp: true,
 };
 
 let cached: Settings | null = null;


### PR DESCRIPTION
## Summary

Add a shared settings module and make agent-sh configurable via `~/.agent-sh/settings.json`.

### Settings module (`src/settings.ts`)
- New shared module loads `~/.agent-sh/settings.json` with typed defaults
- Replaces the ad-hoc settings loading in extension-loader
- All fields optional — everything works without the file

### Persistent query history
- Agent input history persisted to `~/.agent-sh/history` across sessions
- Up/down arrows cycle through previous queries
- Size configurable via `historySize` setting (default 500)

### Configurable thresholds
Move hardcoded constants to settings so users can tune behavior:
- Context: `contextWindowSize`, `contextBudget`
- Truncation: `shellTruncateThreshold`, `shellHeadLines`, `shellTailLines`, `recallExpandMaxLines`
- Display: `maxCommandOutputLines`, `diffMaxLines`
- Integration: `enableMcp`

### MCP registration
- MCP server is on by default (agents that don't support it simply ignore it)
- Can be disabled via `"enableMcp": false` for users who don't need it
- No agent-specific logic in core — follows the agent-agnostic design principle

### Documentation
- **README**: Configuration section with link to usage guide, up/down history in keybindings
- **architecture.md**: New "Shell ↔ Agent Boundary" section explaining how the shell and agent are separate worlds connected by context, with bridge tools (`shell_cwd`, `user_shell`, `shell_recall`) for cases where the agent needs to affect the live shell. ASCII diagram of MCP + extension discovery paths. Pi extension example with install instructions.
- **usage.md**: Full settings reference with JSON example and table, updated pi extension setup
- **extensions.md**: Cross-link to settings reference
- General updates: `settings.ts` in project structure, `shell_recall` params, stale references fixed

## Settings reference

```json
{
  "extensions": [],
  "historySize": 500,
  "contextWindowSize": 20,
  "contextBudget": 16384,
  "shellTruncateThreshold": 10,
  "shellHeadLines": 5,
  "shellTailLines": 5,
  "recallExpandMaxLines": 100,
  "maxCommandOutputLines": 30,
  "diffMaxLines": 20,
  "enableMcp": true
}
```

## Test plan
- [ ] No settings file → all defaults work
- [ ] History persists across sessions (up arrow recalls previous queries)
- [ ] `"shellTruncateThreshold": 5` → long output truncates earlier
- [ ] `"diffMaxLines": 50` → larger diffs shown before collapse
- [ ] `"enableMcp": false` → MCP server not registered
- [ ] Extensions still load from settings.json
- [ ] Docs render correctly, links work