### PR TITLE
UI improvements and thinking level control

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See the [Usage Guide](docs/usage.md) for all options, model configuration, and e
 | `Ctrl-C` | Standard signal to shell, or cancels active agent response |
 | `Ctrl-O` | Expand/collapse truncated diff preview |
 | `Ctrl-T` | Toggle thinking/reasoning text display |
+| `Shift-Tab` | Cycle thinking level (off → minimal → low → medium → high → xhigh) |
 | `Escape` | Exit agent input mode (when typing after `>`) |
 
 ### Agent Input Keybindings
@@ -86,6 +87,9 @@ When typing after `>`, full readline-style keybindings are available:
 | Key | Action |
 |---|---|
 | `↑` / `↓` | Browse query history (persisted across sessions) |
+| `Shift-Enter` | Insert newline (multiline input) |
+| `Shift-Tab` | Cycle thinking level |
+| `Ctrl-D` | Exit agent input mode (on empty line) |
 | `Ctrl-A` / `Home` | Move to start of line |
 | `Ctrl-E` / `End` | Move to end of line |
 | `Ctrl-B` / `←` | Move back one character |
@@ -96,6 +100,16 @@ When typing after `>`, full readline-style keybindings are available:
 | `Ctrl-K` | Delete to end of line |
 | `Ctrl-W` / `Option-Backspace` | Delete word backward |
 | `Option-D` | Delete word forward |
+
+### Thinking Level
+
+The agent prompt shows the current thinking level next to the model name:
+
+```
+pi (claude-3.5-sonnet) [medium] ● ❯
+```
+
+Press **Shift-Tab** in agent input mode to cycle through levels. The levels are advertised by the agent via ACP session modes — different agents may offer different options. The spinner label reflects the mode: "Thinking" when thinking is enabled, "Working" when it's off.
 
 ### Slash Commands
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,9 +47,10 @@ All components communicate exclusively through typed bus events. AcpClient has n
 | Method | When |
 |---|---|
 | `initialize` | Startup: negotiate capabilities |
-| `session/new` | Create a conversation session |
+| `session/new` | Create a conversation session (returns available modes) |
 | `session/prompt` | User types `> query` — sent with shell context |
 | `session/cancel` | User hits Ctrl-C during agent response |
+| `session/set_mode` | Cycle thinking level (Shift-Tab) — e.g. off/low/medium/high |
 
 ### We handle from the agent
 
@@ -69,7 +70,8 @@ All components communicate exclusively through typed bus events. AcpClient has n
 | Update type | What we render |
 |---|---|
 | `agent_message_chunk` | Real-time streaming markdown with syntax highlighting in a bordered box |
-| `agent_thought_chunk` | Thinking spinner (default), or streaming text when toggled on with Ctrl+T |
+| `agent_thought_chunk` | Thinking spinner (default), or streaming text when toggled on with Ctrl+T. Spinner shows "Working" when thinking mode is off |
+| `current_mode_update` | Updates the thinking level indicator in the prompt |
 | `tool_call` | Kind icon (◆ read, ✎ edit, ▶ execute, ⌕ search, etc.) + title, file paths, arguments |
 | `tool_call_update` | Streaming output content + status indicator (checkmark or X with exit code) |
 | `file_write` | Inline diff preview in bordered box (Ctrl+O to expand/collapse) |
@@ -81,7 +83,7 @@ All components communicate exclusively through typed bus events. AcpClient has n
 3. All keyboard input goes directly to the PTY — zero latency, full terminal compatibility
 4. **Smart connection**: The agent connects asynchronously in the background while the shell starts immediately
 5. **Auto-wait**: If you send a query before the agent is fully connected, the system automatically waits for connection completion
-6. When you type `>` at the start of a line, agent-sh intercepts and enters agent input mode
+6. When you type `>` at the start of a line, agent-sh intercepts and enters agent input mode (with Shift-Enter for multiline, Shift-Tab to cycle thinking level)
 7. On Enter, the query (plus shell context) is sent to the agent via `session/prompt`
 8. The agent's streaming response renders inline in a bordered markdown box with real-time output
 9. If the agent needs to run commands, it calls `terminal/create` and agent-sh executes them in isolated child processes, streaming output back

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -222,7 +222,8 @@ agent-sh stores settings and query history in `~/.agent-sh/`. Configure behavior
   "shellHeadLines": 5,
   "shellTailLines": 5,
   "recallExpandMaxLines": 100,
-  "maxCommandOutputLines": 30,
+  "maxCommandOutputLines": 5,
+  "readOutputMaxLines": 0,
   "diffMaxLines": 20,
   "enableMcp": true
 }
@@ -237,7 +238,8 @@ agent-sh stores settings and query history in `~/.agent-sh/`. Configure behavior
 | `shellTruncateThreshold` | `10` | Shell output lines before truncation |
 | `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end of truncated output |
 | `recallExpandMaxLines` | `100` | Max lines for recall expand before requiring line ranges |
-| `maxCommandOutputLines` | `30` | Max command output lines shown inline in TUI |
+| `maxCommandOutputLines` | `5` | Max internal tool output lines shown inline in TUI |
+| `readOutputMaxLines` | `0` | Max read tool output lines shown inline (0 = hidden) |
 | `diffMaxLines` | `20` | Max diff lines shown before "ctrl+o to expand" |
 | `enableMcp` | `true` | Register MCP server for bridge tools (disable if agent doesn't use MCP) |
 

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -29,6 +29,8 @@ export class AcpClient {
   private autoCancelled = false;
   private pendingToolCounter = 0;
   private agentInfo: { name: string; version: string } | null = null;
+  private modes: { id: string; name: string }[] = [];
+  private currentModeId: string | null = null;
 
   constructor(opts: {
     bus: EventBus;
@@ -149,6 +151,12 @@ export class AcpClient {
 
     this.sessionId = sessionResponse.sessionId;
     this.log(`Session created: ${this.sessionId}`);
+
+    // Parse session modes (thinking level, etc.)
+    this.updateModes(sessionResponse);
+
+    // Listen for mode cycle requests from input handler
+    this.bus.on("config:cycle", () => this.cycleMode());
   }
 
   /**
@@ -277,6 +285,7 @@ export class AcpClient {
     this.sessionId = sessionResponse.sessionId;
     this.lastResponseText = "";
     this.currentResponseText = "";
+    this.updateModes(sessionResponse);
   }
 
   /**
@@ -298,12 +307,60 @@ export class AcpClient {
   }
 
   /**
+   * Get the current mode (e.g. thinking level).
+   */
+  getCurrentMode(): { id: string; name: string } | null {
+    if (!this.currentModeId) return null;
+    return this.modes.find((m) => m.id === this.currentModeId) ?? null;
+  }
+
+  /**
    * Check if agent is connected.
    */
   isConnected(): boolean {
     // Consider connected if we have a connection and agent info
     // Session ID may not be set yet if we're still initializing
     return this.connection !== null && this.agentInfo !== null;
+  }
+
+  /**
+   * Parse modes from a session response and notify listeners.
+   */
+  private updateModes(response: any): void {
+    const modes = response.modes;
+    if (!modes) return;
+    if (modes.availableModes) {
+      this.modes = modes.availableModes.map((m: any) => ({
+        id: m.id,
+        name: m.name || m.id,
+      }));
+    }
+    if (modes.currentModeId) {
+      this.currentModeId = modes.currentModeId;
+    }
+    this.bus.emit("config:changed", {});
+  }
+
+  /**
+   * Cycle to the next session mode.
+   */
+  private async cycleMode(): Promise<void> {
+    if (!this.connection || !this.sessionId || this.modes.length === 0) return;
+
+    const currentIdx = this.modes.findIndex((m) => m.id === this.currentModeId);
+    const nextIdx = (currentIdx + 1) % this.modes.length;
+    const nextMode = this.modes[nextIdx]!;
+
+    try {
+      await this.connection.setSessionMode({
+        sessionId: this.sessionId,
+        modeId: nextMode.id,
+      });
+      this.currentModeId = nextMode.id;
+      this.bus.emit("config:changed", {});
+    } catch (err) {
+      this.log(`Failed to set mode: ${err}`);
+    }
   }
 
   private log(msg: string): void {
@@ -432,6 +489,15 @@ export class AcpClient {
           if (toolTitle === "user_shell" && update.status === "completed") {
             this.autoCancel();
           }
+        }
+        break;
+      }
+
+      case "current_mode_update": {
+        const modeId = (update as any).currentModeId;
+        if (modeId) {
+          this.currentModeId = modeId;
+          this.bus.emit("config:changed", {});
         }
         break;
       }

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -404,9 +404,10 @@ export class AcpClient {
         const toolTitle = toolId ? this.pendingToolCalls.get(toolId) : undefined;
 
         if (update.status === "completed" || update.status === "failed") {
-          // Show content only on final status, and skip for informational
-          // tools like shell_recall (output is for the agent, not the user)
-          if (toolTitle !== "shell_recall" && update.content && Array.isArray(update.content)) {
+          // Show content only on final status. Skip tools whose output the
+          // user already sees (user_shell → PTY) or is agent-only (shell_recall).
+          const skipOutput = toolTitle === "user_shell" || toolTitle === "shell_recall";
+          if (!skipOutput && update.content && Array.isArray(update.content)) {
             for (const block of update.content) {
               if (block.type === "content" && block.content?.type === "text" && block.content.text) {
                 this.bus.emit("agent:tool-output-chunk", { chunk: block.content.text });

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -337,12 +337,14 @@ export class ContextManager {
     if (this.firstPrompt) {
       out += `You are an AI assistant living inside agent-sh, a shell-first terminal.\n`;
       out += `The user interacts with a real shell (PTY) and sends you queries inline. You are there to help them with their tasks.\n`;
-      out += `You can interact with the user's live shell using user_shell (cd, export, source, run commands — the user sees output instantly).\n`;
-      out += `You can also use your own isolated tools (bash, read, write) for internal work — these do NOT affect the user's shell.\n`;
-      out += `You can browse or search the user's session history with shell_recall.\n`;
-      out += `Your internal tool output (e.g. file reads) is not visible to the user.\n`;
-      out += `When the user wants to see something (a file, directory listing, command output), use user_shell (e.g. cat, ls) — they see the result directly in their terminal, no round-trip needed.\n`;
-      out += `Use your own internal tools (read, bash) when YOU need to reason about content to formulate a response.\n`;
+      out += `\n`;
+      out += `IMPORTANT tool usage rules:\n`;
+      out += `- user_shell runs commands in the user's live shell (PTY). The user sees output directly — no summary needed.\n`;
+      out += `- Your internal tools (bash, read, write, ls, etc.) run in an isolated subprocess. The user CANNOT see their output.\n`;
+      out += `- When the user asks to see, list, view, or display anything, ALWAYS use user_shell. NEVER use internal tools like ls/read/bash for display — the user won't see it.\n`;
+      out += `- Only use internal tools when YOU need to reason about content silently (e.g. reading a file to answer a question about it).\n`;
+      out += `- After a user_shell command, the user already saw the output. Do NOT repeat or summarize it.\n`;
+      out += `- You can browse or search session history with shell_recall.\n`;
       out += `\n`;
       this.firstPrompt = false;
     }

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -15,6 +15,7 @@ export class ContextManager {
   private currentCwd: string;
   private sessionStart: number;
   private pendingToolCalls: ToolCallRecord[] = [];
+  private firstPrompt = true;
 
   constructor(bus: EventBus) {
     this.currentCwd = process.cwd();
@@ -253,6 +254,7 @@ export class ContextManager {
   clear(): void {
     this.exchanges = [];
     this.pendingToolCalls = [];
+    this.firstPrompt = true;
     // Don't reset nextId — IDs should be globally unique within a session
   }
 
@@ -325,9 +327,22 @@ export class ContextManager {
     const totalCount = this.exchanges.length;
 
     let out = "<shell_context>\n";
+
+    if (this.firstPrompt) {
+      out += `You are an AI assistant living inside agent-sh, a shell-first terminal.\n`;
+      out += `The user interacts with a real shell (PTY) and sends you queries inline. You are there to help them with their tasks.\n`;
+      out += `You can interact with the user's live shell using user_shell (cd, export, source, run commands — the user sees output instantly).\n`;
+      out += `You can also use your own isolated tools (bash, read, write) for internal work — these do NOT affect the user's shell.\n`;
+      out += `You can browse or search the user's session history with shell_recall.\n`;
+      out += `Your internal tool output (e.g. file reads) is not visible to the user.\n`;
+      out += `When the user wants to see something (a file, directory listing, command output), use user_shell (e.g. cat, ls) — they see the result directly in their terminal, no round-trip needed.\n`;
+      out += `Use your own internal tools (read, bash) when YOU need to reason about content to formulate a response.\n`;
+      out += `\n`;
+      this.firstPrompt = false;
+    }
+
     out += `cwd: ${this.currentCwd}\n`;
     out += `session: ${totalCount} exchanges, ${elapsed}m elapsed\n`;
-    out += `[hint: use the shell_recall tool to retrieve truncated content — search(query) or expand(ids)]\n`;
 
     for (const ex of exchanges) {
       out += "\n" + this.formatExchangeTruncated(ex);

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -16,6 +16,7 @@ export class ContextManager {
   private sessionStart: number;
   private pendingToolCalls: ToolCallRecord[] = [];
   private firstPrompt = true;
+  private agentShellActive = false; // true while user_shell command is executing
 
   constructor(bus: EventBus) {
     this.currentCwd = process.cwd();
@@ -32,12 +33,17 @@ export class ContextManager {
         exitCode: e.exitCode,
         outputLines: lines.length,
         outputBytes: e.output.length,
+        source: this.agentShellActive ? "agent" : "user",
       });
     });
 
     bus.on("shell:cwd-change", (e) => {
       this.currentCwd = e.cwd;
     });
+
+    // Track agent-initiated shell commands (user_shell tool)
+    bus.on("shell:agent-exec-start", () => { this.agentShellActive = true; });
+    bus.on("shell:agent-exec-done", () => { this.agentShellActive = false; });
 
     // ── Subscribe to agent events ──
     bus.on("agent:query", (e) => {
@@ -366,7 +372,8 @@ export class ContextManager {
   private formatExchangeTruncated(ex: Exchange): string {
     switch (ex.type) {
       case "shell_command": {
-        let s = `#${ex.id} [shell cwd:${ex.cwd}] $ ${ex.command}\n`;
+        const label = ex.source === "agent" ? "agent → shell" : "shell";
+        let s = `#${ex.id} [${label} cwd:${ex.cwd}] $ ${ex.command}\n`;
         if (ex.output) s += indent(ex.output, "  ") + "\n";
         if (ex.exitCode !== null) s += `  exit ${ex.exitCode}\n`;
         return s;
@@ -394,8 +401,9 @@ export class ContextManager {
   private formatExchangeFull(ex: Exchange): string {
     switch (ex.type) {
       case "shell_command": {
+        const label = ex.source === "agent" ? "agent → shell" : "shell";
         const output = ex.output;
-        let s = `#${ex.id} [shell] $ ${ex.command} (${ex.outputLines} lines, ${ex.outputBytes} bytes)\n`;
+        let s = `#${ex.id} [${label}] $ ${ex.command} (${ex.outputLines} lines, ${ex.outputBytes} bytes)\n`;
         if (output) s += output + "\n";
         if (ex.exitCode !== null) s += `exit ${ex.exitCode}\n`;
         return s;
@@ -415,8 +423,10 @@ export class ContextManager {
 
   private exchangeOneLiner(ex: Exchange): string {
     switch (ex.type) {
-      case "shell_command":
-        return `#${ex.id} shell [cwd:${ex.cwd}]: ${ex.command} (${ex.outputLines} total lines, exit ${ex.exitCode ?? "?"})`;
+      case "shell_command": {
+        const label = ex.source === "agent" ? "agent → shell" : "shell";
+        return `#${ex.id} ${label} [cwd:${ex.cwd}]: ${ex.command} (${ex.outputLines} total lines, exit ${ex.exitCode ?? "?"})`;
+      }
       case "agent_query":
         return `#${ex.id} query: ${ex.query}`;
       case "agent_response": {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -108,6 +108,12 @@ export interface ShellEvents {
     mcpServers: { name: string; command: string; args: string[]; env: { name: string; value: string }[] }[];
   };
 
+  // Session mode/config updated (from ACP agent)
+  "config:changed": Record<string, never>;
+
+  // Cycle session mode (input-handler → core)
+  "config:cycle": Record<string, never>;
+
   // Autocomplete (sync pipe: extensions inspect buffer and append items)
   "autocomplete:request": {
     buffer: string;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -14,6 +14,8 @@ export interface ShellEvents {
   };
   "shell:cwd-change": { cwd: string };
   "shell:foreground-busy": { busy: boolean };
+  "shell:agent-exec-start": Record<string, never>;
+  "shell:agent-exec-done": Record<string, never>;
 
   // Agent input (frontend → core: user submitted a query or wants to cancel)
   "agent:submit": { query: string };

--- a/src/extensions/shell-exec.ts
+++ b/src/extensions/shell-exec.ts
@@ -77,22 +77,19 @@ export default function activate(
         return new Promise((resolve, reject) => {
           execPending = execPending.then(async () => {
             try {
+              bus.emit("shell:agent-exec-start", {});
               const result = await bus.emitPipeAsync("shell:exec-request", {
                 command,
                 output: "",
                 cwd: "",
                 done: false,
               });
-
-              // Show the command output in the TUI
-              if (result.output) {
-                bus.emit("agent:tool-output-chunk", { chunk: result.output });
-              }
+              bus.emit("shell:agent-exec-done", {});
 
               resolve({ output: result.output, cwd: result.cwd });
             } catch (err) {
+              bus.emit("shell:agent-exec-done", {});
               const message = err instanceof Error ? err.message : String(err);
-              bus.emit("agent:tool-output-chunk", { chunk: `Error: ${message}` });
               reject(rpcError(-32000, message));
             }
           });

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -37,6 +37,7 @@ export default function activate({ bus }: ExtensionContext): void {
   let currentToolKind: string | undefined; // kind of the currently executing tool
   let isThinking = false;
   let showThinkingText = false;
+  let spinnerStartTime = 0; // preserved across spinner restarts
   let lastTruncatedDiff: {
     filePath: string;
     diff: DiffResult;
@@ -47,6 +48,7 @@ export default function activate({ bus }: ExtensionContext): void {
   // ── Event subscriptions ─────────────────────────────────────
 
   bus.on("agent:query", (e) => {
+    spinnerStartTime = 0;
     showUserQuery(e.query);
     startAgentResponse();
     startThinkingSpinner();
@@ -55,12 +57,13 @@ export default function activate({ bus }: ExtensionContext): void {
   bus.on("agent:thinking-chunk", (e) => {
     if (!isThinking) {
       isThinking = true;
-      stopCurrentSpinner();
       if (showThinkingText) {
+        stopCurrentSpinner();
         if (!renderer) startAgentResponse();
-        renderer!.writeLine(`${p.dim}${p.bold}💭 Thinking${p.reset}`);
+        renderer!.writeLine(`${p.dim}Thinking (ctrl+t to collapse)${p.reset}`);
       } else {
-        startThinkingSpinner("Thinking");
+        // Restart spinner with ctrl+t hint now that we know thinking is available
+        startThinkingSpinner();
       }
     }
     if (showThinkingText && e.text) {
@@ -90,6 +93,7 @@ export default function activate({ bus }: ExtensionContext): void {
   bus.on("agent:tool-completed", (e) => {
     showToolComplete(e.exitCode);
     currentToolKind = undefined;
+    spinnerStartTime = 0;
     startThinkingSpinner();
   });
   bus.on("agent:tool-output-chunk", (e) => writeCommandOutput(e.chunk));
@@ -269,9 +273,11 @@ export default function activate({ bus }: ExtensionContext): void {
   }
 
   function startThinkingSpinner(label = "Thinking"): void {
+    // Preserve start time if restarting (e.g. toggle), otherwise reset
+    if (!spinnerStartTime) spinnerStartTime = Date.now();
     stopCurrentSpinner();
-    const hint = label === "Thinking" ? "(ctrl+t to expand)" : undefined;
-    spinner = startSpinner(label, { hint });
+    const hint = showThinkingText ? "(ctrl+t to collapse)" : "(ctrl+t to expand)";
+    spinner = startSpinner(label, { hint, startTime: spinnerStartTime });
   }
 
   function stopCurrentSpinner(): void {
@@ -452,8 +458,31 @@ export default function activate({ bus }: ExtensionContext): void {
 
   function toggleThinkingDisplay(): void {
     showThinkingText = !showThinkingText;
-    // No visible message — the spinner label change (or thinking text appearing)
-    // is sufficient feedback. The old "Thinking display: on/off" line polluted output.
+
+    // Update spinner hint to reflect new state, even if not actively thinking
+    if (spinner) {
+      stopCurrentSpinner();
+      startThinkingSpinner();
+      return;
+    }
+
+    if (!isThinking) return;
+
+    if (showThinkingText) {
+      // Switch from spinner to streaming text
+      stopCurrentSpinner();
+      if (!renderer) startAgentResponse();
+      renderer!.writeLine(`${p.dim}Thinking (ctrl+t to collapse)${p.reset}`);
+    } else {
+      // Switch from streaming text to spinner
+      if (renderer) {
+        renderer.flush();
+        const termW = process.stdout.columns || 80;
+        const w = Math.min(80, termW);
+        renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
+      }
+      startThinkingSpinner();
+    }
   }
 
   function showError(message: string): void {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -90,6 +90,7 @@ export default function activate({ bus }: ExtensionContext): void {
   bus.on("agent:tool-completed", (e) => {
     showToolComplete(e.exitCode);
     currentToolKind = undefined;
+    startThinkingSpinner();
   });
   bus.on("agent:tool-output-chunk", (e) => writeCommandOutput(e.chunk));
   bus.on("agent:tool-output", () => flushCommandOutput());
@@ -269,7 +270,8 @@ export default function activate({ bus }: ExtensionContext): void {
 
   function startThinkingSpinner(label = "Thinking"): void {
     stopCurrentSpinner();
-    spinner = startSpinner(label);
+    const hint = label === "Thinking" ? "(ctrl+t to expand)" : undefined;
+    spinner = startSpinner(label, { hint });
   }
 
   function stopCurrentSpinner(): void {
@@ -319,10 +321,10 @@ export default function activate({ bus }: ExtensionContext): void {
       }
       commandOutputBuffer = "";
     }
-    if (commandOutputOverflow > 0) {
+    if (commandOutputOverflow > 0 && maxLines > 0) {
       renderer.writeLine(`${p.dim}  … ${commandOutputOverflow} more lines${p.reset}`);
-      commandOutputOverflow = 0;
     }
+    commandOutputOverflow = 0;
   }
 
 
@@ -450,8 +452,8 @@ export default function activate({ bus }: ExtensionContext): void {
 
   function toggleThinkingDisplay(): void {
     showThinkingText = !showThinkingText;
-    const state = showThinkingText ? "on" : "off";
-    process.stdout.write(`\n${p.dim}Thinking display: ${state}${p.reset}\n`);
+    // No visible message — the spinner label change (or thinking text appearing)
+    // is sufficient feedback. The old "Thinking display: on/off" line polluted output.
   }
 
   function showError(message: string): void {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -34,6 +34,7 @@ export default function activate({ bus }: ExtensionContext): void {
   let lastCommand = "";
   let toolLineOpen = false; // true when tool header was written without \n
   let hadToolCalls = false; // true after any tool call in current response
+  let currentToolKind: string | undefined; // kind of the currently executing tool
   let isThinking = false;
   let showThinkingText = false;
   let lastTruncatedDiff: {
@@ -81,11 +82,15 @@ export default function activate({ bus }: ExtensionContext): void {
 
   bus.on("agent:tool-started", (e) => {
     stopCurrentSpinner();
+    currentToolKind = e.kind;
     showToolCall(e.title, lastCommand, e);
     lastCommand = "";
   });
 
-  bus.on("agent:tool-completed", (e) => showToolComplete(e.exitCode));
+  bus.on("agent:tool-completed", (e) => {
+    showToolComplete(e.exitCode);
+    currentToolKind = undefined;
+  });
   bus.on("agent:tool-output-chunk", (e) => writeCommandOutput(e.chunk));
   bus.on("agent:tool-output", () => flushCommandOutput());
 
@@ -284,11 +289,14 @@ export default function activate({ bus }: ExtensionContext): void {
   function writeCommandOutput(chunk: string): void {
     if (!renderer) return;
     closeToolLine();
+    const maxLines = currentToolKind === "read"
+      ? getSettings().readOutputMaxLines
+      : getSettings().maxCommandOutputLines;
     commandOutputBuffer += chunk;
     const lines = commandOutputBuffer.split("\n");
     commandOutputBuffer = lines.pop()!;
     for (const line of lines) {
-      if (commandOutputLineCount < getSettings().maxCommandOutputLines) {
+      if (commandOutputLineCount < maxLines) {
         renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
         commandOutputLineCount++;
       } else {
@@ -299,8 +307,11 @@ export default function activate({ bus }: ExtensionContext): void {
 
   function flushCommandOutput(): void {
     if (!renderer) return;
+    const maxLines = currentToolKind === "read"
+      ? getSettings().readOutputMaxLines
+      : getSettings().maxCommandOutputLines;
     if (commandOutputBuffer) {
-      if (commandOutputLineCount < getSettings().maxCommandOutputLines) {
+      if (commandOutputLineCount < maxLines) {
         renderer.writeLine(`${p.dim}  ${commandOutputBuffer}${p.reset}`);
         commandOutputLineCount++;
       } else {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -25,7 +25,7 @@ import type { DiffResult } from "../utils/diff.js";
 import { getSettings } from "../settings.js";
 import type { ExtensionContext } from "../types.js";
 
-export default function activate({ bus }: ExtensionContext): void {
+export default function activate({ bus, getAcpClient }: ExtensionContext): void {
   let spinner: SpinnerState | null = null;
   let renderer: MarkdownRenderer | null = null;
   let commandOutputBuffer = "";
@@ -160,7 +160,6 @@ export default function activate({ bus }: ExtensionContext): void {
   function startAgentResponse(): void {
     renderer = new MarkdownRenderer();
     hadToolCalls = false;
-    process.stdout.write("\n");
     renderer.printTopBorder();
   }
 
@@ -282,12 +281,21 @@ export default function activate({ bus }: ExtensionContext): void {
     }
   }
 
-  function startThinkingSpinner(label = "Thinking"): void {
+  function hasThinkingMode(): boolean {
+    const mode = getAcpClient().getCurrentMode();
+    return !mode || mode.id !== "off";
+  }
+
+  function startThinkingSpinner(): void {
     // Preserve start time if restarting (e.g. toggle), otherwise reset
     if (!spinnerStartTime) spinnerStartTime = Date.now();
     stopCurrentSpinner();
-    const hint = showThinkingText ? "(ctrl+t to collapse)" : "(ctrl+t to expand)";
-    spinner = startSpinner(label, { hint, startTime: spinnerStartTime });
+    const thinking = hasThinkingMode();
+    const label = thinking ? "Thinking" : "Working";
+    const hint = thinking
+      ? (showThinkingText ? "(ctrl+t to collapse)" : "(ctrl+t to expand)")
+      : "";
+    spinner = startSpinner(label, { hint: hint || undefined, startTime: spinnerStartTime });
   }
 
   function stopCurrentSpinner(): void {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -86,7 +86,17 @@ export default function activate({ bus }: ExtensionContext): void {
   bus.on("agent:tool-started", (e) => {
     stopCurrentSpinner();
     currentToolKind = e.kind;
-    showToolCall(e.title, lastCommand, e);
+    if (e.title === "user_shell") {
+      // Minimal annotation — PTY echo will show the output
+      closeToolLine();
+      if (!renderer) startAgentResponse();
+      renderer!.flush();
+      const cmd = (e.rawInput as any)?.command || "";
+      renderer!.writeLine(`${p.dim}▶ user_shell: ${cmd}${p.reset}`);
+      hadToolCalls = true;
+    } else {
+      showToolCall(e.title, lastCommand, e);
+    }
     lastCommand = "";
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,11 @@ Inside the shell:
   return { agentCommand, agentArgs, shell, model, extensions };
 }
 
-function formatAgentInfo(agentInfo: { name: string; version: string }, model?: string): string {
+function formatAgentInfo(
+  agentInfo: { name: string; version: string },
+  model?: string,
+  thoughtLevel?: string | null,
+): string {
   const name = agentInfo.name.replace(/-acp$/, "").replace(/-/g, " ");
   let infoStr = `${p.dim}${name}${p.reset}`;
   if (model) {
@@ -153,6 +157,11 @@ function formatAgentInfo(agentInfo: { name: string; version: string }, model?: s
       .replace(/^anthropic\//i, "")
       .replace(/^google\//i, "");
     infoStr += ` ${p.dim}(${cleanModel})${p.reset}`;
+  }
+  if (thoughtLevel) {
+    // Clean up verbose mode names like "Thinking: medium" → "medium"
+    const label = thoughtLevel.replace(/^Thinking:\s*/i, "");
+    infoStr += ` ${p.dim}[${label}]${p.reset}`;
   }
   return `${infoStr} ${p.success}●${p.reset}`;
 }
@@ -227,7 +236,8 @@ async function main(): Promise<void> {
         const agentInfo = client.getAgentInfo();
         const model = client.getModel();
         if (agentInfo) {
-          return { info: formatAgentInfo(agentInfo, model) };
+          const mode = client.getCurrentMode();
+          return { info: formatAgentInfo(agentInfo, model, mode?.name ?? null) };
         }
       }
       return { info: "" };

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -153,10 +153,15 @@ export class InputHandler {
       return;
     }
 
-    // Forward control chars that normal shell mode doesn't handle
+    // Intercept control chars for TUI (Ctrl+T, Ctrl+O) — don't pass to PTY
     if (data.length === 1 && data.charCodeAt(0) < 32 && !this.agentInputMode) {
       const code = data.charCodeAt(0);
-      // Don't intercept keys that shell mode handles: CR, Ctrl-C, Ctrl-D, Tab
+      // Keys consumed by TUI extensions
+      if (code === 0x14 || code === 0x0f) { // Ctrl+T, Ctrl+O
+        this.bus.emit("input:keypress", { key: data });
+        return;
+      }
+      // Forward other control chars that shell mode doesn't handle
       if (code !== 0x0d && code !== 0x03 && code !== 0x04 && code !== 0x09) {
         this.bus.emit("input:keypress", { key: data });
       }

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -35,6 +35,7 @@ export class InputHandler {
   private history: string[] = [];
   private historyIndex = -1; // -1 = not browsing history
   private savedBuffer = ""; // buffer saved when entering history
+  private promptWrappedLines = 0; // extra lines from terminal wrapping
   private escapeTimer: ReturnType<typeof setTimeout> | null = null;
   private bus: EventBus;
   private onShowAgentInfo: () => { info: string; model?: string };
@@ -72,17 +73,72 @@ export class InputHandler {
 
   /** Write the agent prompt line with cursor at the correct position. */
   private writeAgentPromptLine(showBuffer = true): void {
+    const termW = process.stdout.columns || 80;
+
+    // Move cursor to the start of the prompt area (first line of wrapped content)
+    if (this.promptWrappedLines > 0) {
+      process.stdout.write(`\x1b[${this.promptWrappedLines}A`);
+    }
+    // Clear from here to end of screen — removes current + all wrapped lines below
+    process.stdout.write("\r\x1b[J");
+
     const agentInfo = this.onShowAgentInfo();
     const infoPrefix = agentInfo.info ? `${agentInfo.info} ` : "";
     const promptPrefix = infoPrefix + p.warning + p.bold + "❯ " + p.reset;
-    const bufferText = showBuffer ? p.accent + this.editor.buffer + p.reset : "";
+    const promptVisLen = visibleLen(infoPrefix) + 2; // "❯ "
 
-    process.stdout.write("\r\x1b[2K" + promptPrefix + bufferText);
+    if (!showBuffer || !this.editor.buffer.includes("\n")) {
+      // Single-line: simple rendering
+      const bufferText = showBuffer ? p.accent + this.editor.buffer + p.reset : "";
+      process.stdout.write(promptPrefix + bufferText);
 
-    // Position cursor within the buffer (not always at end)
-    if (showBuffer && this.editor.cursor < this.editor.buffer.length) {
-      const charsAfterCursor = this.editor.buffer.length - this.editor.cursor;
-      process.stdout.write(`\x1b[${charsAfterCursor}D`);
+      const bufferVisLen = showBuffer ? this.editor.buffer.length : 0;
+      const totalVisLen = promptVisLen + bufferVisLen;
+      this.promptWrappedLines = totalVisLen > 0 ? Math.floor((totalVisLen - 1) / termW) : 0;
+
+      // Position cursor within the buffer
+      if (showBuffer && this.editor.cursor < this.editor.buffer.length) {
+        const charsAfterCursor = this.editor.buffer.length - this.editor.cursor;
+        process.stdout.write(`\x1b[${charsAfterCursor}D`);
+      }
+    } else {
+      // Multi-line: render each line with continuation indent
+      const lines = this.editor.buffer.split("\n");
+      const indent = " ".repeat(promptVisLen);
+      let totalTermLines = 0;
+
+      for (let li = 0; li < lines.length; li++) {
+        const prefix = li === 0 ? promptPrefix : indent;
+        const prefixVisLen = li === 0 ? promptVisLen : promptVisLen;
+        const lineText = lines[li]!;
+        process.stdout.write(prefix + p.accent + lineText + p.reset);
+        if (li < lines.length - 1) process.stdout.write("\n");
+
+        // Count terminal lines this logical line occupies
+        const lineVisLen = prefixVisLen + lineText.length;
+        totalTermLines += lineVisLen > 0 ? Math.ceil(lineVisLen / termW) : 1;
+      }
+      this.promptWrappedLines = totalTermLines - 1;
+
+      // Position cursor: find which line and column the cursor is on
+      let charsRemaining = this.editor.cursor;
+      let cursorLine = 0;
+      for (let li = 0; li < lines.length; li++) {
+        if (charsRemaining <= lines[li]!.length) {
+          cursorLine = li;
+          break;
+        }
+        charsRemaining -= lines[li]!.length + 1; // +1 for \n
+        cursorLine = li + 1;
+      }
+
+      // Move from end position to cursor position
+      const linesFromEnd = lines.length - 1 - cursorLine;
+      if (linesFromEnd > 0) {
+        process.stdout.write(`\x1b[${linesFromEnd}A`);
+      }
+      const cursorCol = (cursorLine === 0 ? promptVisLen : promptVisLen) + charsRemaining;
+      process.stdout.write(`\r\x1b[${cursorCol}C`);
     }
   }
 
@@ -150,6 +206,9 @@ export class InputHandler {
   private enterAgentInputMode(): void {
     this.agentInputMode = true;
     this.editor.clear();
+    // Enable kitty keyboard protocol (progressive enhancement flag 1)
+    // so Shift+Enter sends \x1b[13;2u instead of plain \r
+    process.stdout.write("\x1b[>1u");
     this.writeAgentPromptLine(false);
   }
 
@@ -157,8 +216,19 @@ export class InputHandler {
     this.dismissAutocomplete();
     this.agentInputMode = false;
     this.editor.clear();
-    process.stdout.write("\r\x1b[2K");
+    // Disable kitty keyboard protocol
+    process.stdout.write("\x1b[<u");
+    this.clearPromptArea();
     this.printPrompt();
+  }
+
+  /** Move to the start of the prompt area and clear everything below. */
+  private clearPromptArea(): void {
+    if (this.promptWrappedLines > 0) {
+      process.stdout.write(`\x1b[${this.promptWrappedLines}A`);
+    }
+    process.stdout.write("\r\x1b[J");
+    this.promptWrappedLines = 0;
   }
 
   printPrompt(): void {
@@ -311,7 +381,8 @@ export class InputHandler {
           this.historyIndex = -1;
           this.savedBuffer = "";
           this.clearAutocompleteLines();
-          process.stdout.write("\r\x1b[2K");
+          this.clearPromptArea();
+          process.stdout.write("\x1b[<u"); // disable kitty keyboard protocol
           this.agentInputMode = false;
           this.editor.clear();
           this.dismissAutocomplete();

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -49,6 +49,11 @@ export class InputHandler {
     this.bus = opts.bus;
     this.onShowAgentInfo = opts.onShowAgentInfo;
     this.loadHistory();
+
+    // Re-render prompt when config changes (e.g. thinking level cycled)
+    this.bus.on("config:changed", () => {
+      if (this.agentInputMode) this.writeAgentPromptLine();
+    });
   }
 
   private loadHistory(): void {
@@ -423,6 +428,10 @@ export class InputHandler {
           if (this.autocompleteActive) {
             this.applyAutocomplete();
           }
+          break;
+
+        case "shift+tab":
+          this.bus.emit("config:cycle", {});
           break;
 
         case "arrow-up":

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -53,7 +53,7 @@ const DEFAULTS: Required<Settings> = {
   shellHeadLines: 5,
   shellTailLines: 5,
   recallExpandMaxLines: 100,
-  maxCommandOutputLines: 30,
+  maxCommandOutputLines: 5,
   readOutputMaxLines: 0,
   diffMaxLines: 20,
   enableMcp: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,8 @@ export interface Settings {
   // ── Display ───────────────────────────────────────────────
   /** Max command output lines shown inline in TUI. */
   maxCommandOutputLines?: number;
+  /** Max read tool output lines shown inline in TUI (0 = hide). */
+  readOutputMaxLines?: number;
   /** Max diff lines shown before "ctrl+o to expand". */
   diffMaxLines?: number;
 
@@ -52,6 +54,7 @@ const DEFAULTS: Required<Settings> = {
   shellTailLines: 5,
   recallExpandMaxLines: 100,
   maxCommandOutputLines: 30,
+  readOutputMaxLines: 0,
   diffMaxLines: 20,
   enableMcp: true,
 };

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -242,6 +242,7 @@ export class Shell implements InputContext {
     this.bus.on("agent:processing-done", () => {
       this.paused = false;
       this.agentActive = false;
+      this.echoSkip = true;
       this.freshPrompt();
     });
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -248,10 +248,12 @@ export class Shell implements InputContext {
     // stdout is paused during agent processing, so PTY output flows through
     // OutputParser (for OSC detection) but never reaches the terminal.
     this.bus.onPipeAsync("shell:exec-request", async (payload) => {
+      // Unpause stdout so the user sees the command and output in their terminal
+      this.paused = false;
+
       const output = await new Promise<{ output: string; cwd: string }>((resolve, reject) => {
         const timeout = setTimeout(() => {
           this.bus.off("shell:command-done", handler);
-          // Kill any hung command
           this.ptyProcess.write("\x03");
           reject(new Error("Shell exec timed out after 30s"));
         }, 30_000);
@@ -263,10 +265,12 @@ export class Shell implements InputContext {
         };
         this.bus.on("shell:command-done", handler);
 
-        // Start capture and write to PTY
         this.outputParser.onCommandEntered(payload.command, this.outputParser.getCwd());
         this.ptyProcess.write(payload.command + "\r");
       });
+
+      // Re-pause for remaining agent output
+      this.paused = true;
 
       return { ...payload, output: output.output, cwd: output.cwd, done: true };
     });

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -12,6 +12,7 @@ export class Shell implements InputContext {
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
   private paused = false;
+  private echoSkip = false;
   private agentActive = false;
   private isZsh = false;
   private tmpDir?: string;
@@ -204,9 +205,19 @@ export class Shell implements InputContext {
     this.ptyProcess.onData((data: string) => {
       this.outputParser.processData(data);
 
-      if (!this.paused) {
-        process.stdout.write(data);
+      if (this.paused) return;
+
+      // During user_shell exec, skip the command echo (first line)
+      if (this.echoSkip) {
+        const nlIdx = data.indexOf("\n");
+        if (nlIdx === -1) return;
+        this.echoSkip = false;
+        const rest = data.slice(nlIdx + 1);
+        if (rest) process.stdout.write(rest);
+        return;
       }
+
+      process.stdout.write(data);
     });
   }
 
@@ -248,8 +259,9 @@ export class Shell implements InputContext {
     // stdout is paused during agent processing, so PTY output flows through
     // OutputParser (for OSC detection) but never reaches the terminal.
     this.bus.onPipeAsync("shell:exec-request", async (payload) => {
-      // Unpause stdout so the user sees the command and output in their terminal
+      this.echoSkip = true;
       this.paused = false;
+      process.stdout.write("\n");
 
       const output = await new Promise<{ output: string; cwd: string }>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -269,8 +281,8 @@ export class Shell implements InputContext {
         this.ptyProcess.write(payload.command + "\r");
       });
 
-      // Re-pause for remaining agent output
       this.paused = true;
+      this.echoSkip = false;
 
       return { ...payload, output: output.output, cwd: output.cwd, done: true };
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export type Exchange =
       exitCode: number | null;
       outputLines: number;
       outputBytes: number;
+      /** Who initiated this command: "user" (typed) or "agent" (via user_shell). */
+      source: "user" | "agent";
     }
   | {
       type: "agent_query";

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -6,6 +6,12 @@
  * cursor state are public for rendering.
  */
 
+// ── Kitty protocol keycode → readable name ──────────────────────
+
+const KITTY_KEY_NAMES: Record<number, string> = {
+  9: "tab", 13: "enter", 27: "escape", 127: "backspace",
+};
+
 // ── Action types returned by feed() ─────────────────────────────
 
 export type LineEditAction =
@@ -110,78 +116,11 @@ export class LineEditor {
       }
 
       // ── Control characters ──────────────────────────────
-      if (ch === "\r") {
-        actions.push({ action: "submit", buffer: this.buffer });
+      if (ch.charCodeAt(0) < 0x20 || ch === "\x7f") {
+        const action = this.handleControl(ch);
+        if (action) actions.push(action);
         i++;
         continue;
-      }
-      if (ch === "\x03") {
-        actions.push({ action: "cancel" });
-        i++;
-        continue;
-      }
-      if (ch === "\t") {
-        actions.push({ action: "tab" });
-        i++;
-        continue;
-      }
-      if (ch === "\x7f" || ch === "\b") {
-        // Backspace
-        if (this.buffer.length === 0) {
-          actions.push({ action: "delete-empty" });
-        } else if (this.cursor > 0) {
-          this.buffer = this.buffer.slice(0, this.cursor - 1) + this.buffer.slice(this.cursor);
-          this.cursor--;
-          actions.push({ action: "changed" });
-        }
-        i++;
-        continue;
-      }
-      // Ctrl-A: home
-      if (ch === "\x01") {
-        if (this.cursor > 0) { this.cursor = 0; actions.push({ action: "changed" }); }
-        i++; continue;
-      }
-      // Ctrl-E: end
-      if (ch === "\x05") {
-        if (this.cursor < this.buffer.length) { this.cursor = this.buffer.length; actions.push({ action: "changed" }); }
-        i++; continue;
-      }
-      // Ctrl-B: back one char
-      if (ch === "\x02") {
-        if (this.cursor > 0) { this.cursor--; actions.push({ action: "changed" }); }
-        i++; continue;
-      }
-      // Ctrl-F: forward one char
-      if (ch === "\x06") {
-        if (this.cursor < this.buffer.length) { this.cursor++; actions.push({ action: "changed" }); }
-        i++; continue;
-      }
-      // Ctrl-U: delete to start of line
-      if (ch === "\x15") {
-        if (this.cursor > 0) {
-          this.buffer = this.buffer.slice(this.cursor);
-          this.cursor = 0;
-          actions.push({ action: "changed" });
-        }
-        i++; continue;
-      }
-      // Ctrl-K: delete to end of line
-      if (ch === "\x0b") {
-        if (this.cursor < this.buffer.length) {
-          this.buffer = this.buffer.slice(0, this.cursor);
-          actions.push({ action: "changed" });
-        }
-        i++; continue;
-      }
-      // Ctrl-W: delete word backward
-      if (ch === "\x17") {
-        if (this.deleteWordBackward()) actions.push({ action: "changed" });
-        i++; continue;
-      }
-      // Other control chars — ignore
-      if (ch.charCodeAt(0) < 0x20) {
-        i++; continue;
       }
 
       // ── Printable character ─────────────────────────────
@@ -211,6 +150,110 @@ export class LineEditor {
     this.buffer = "";
     this.cursor = 0;
     this.pendingSeq = "";
+  }
+
+  // ── Key bindings ────────────────────────────────────────────
+  //
+  // Single source of truth for all keybindings. Both legacy control
+  // characters and kitty protocol sequences resolve to a key name
+  // and look it up here. To add a binding, add one entry.
+
+  private readonly bindings: Record<string, () => LineEditAction | null> = {
+    "enter":         () => ({ action: "submit", buffer: this.buffer }),
+    "ctrl+c":        () => ({ action: "cancel" }),
+    "tab":           () => ({ action: "tab" }),
+    "backspace":     () => this.deleteBackward(),
+    "ctrl+d":        () => this.buffer.length === 0 ? { action: "delete-empty" } : this.deleteForward(),
+    "ctrl+a":        () => this.moveTo(0),
+    "ctrl+e":        () => this.moveTo(this.buffer.length),
+    "ctrl+b":        () => this.moveTo(this.cursor - 1),
+    "ctrl+f":        () => this.moveTo(this.cursor + 1),
+    "ctrl+u":        () => this.deleteRange(0, this.cursor),
+    "ctrl+k":        () => this.deleteRange(this.cursor, this.buffer.length),
+    "ctrl+w":        () => this.deleteWordBackward() ? { action: "changed" } : null,
+    "shift+enter":   () => this.insertAt("\n"),
+  };
+
+  /** Resolve a key name from the bindings table and execute it. */
+  private dispatch(key: string): LineEditAction | null {
+    return this.bindings[key]?.() ?? null;
+  }
+
+  // ── Legacy control character mapping ───────────────────────
+
+  /** Map a legacy control character to a key name. */
+  private static readonly CTRL_MAP: Record<string, string> = {
+    "\r": "enter", "\x03": "ctrl+c", "\t": "tab",
+    "\x7f": "backspace", "\b": "backspace",
+    "\x01": "ctrl+a", "\x02": "ctrl+b", "\x04": "ctrl+d",
+    "\x05": "ctrl+e", "\x06": "ctrl+f", "\x0b": "ctrl+k",
+    "\x15": "ctrl+u", "\x17": "ctrl+w",
+  };
+
+  private handleControl(ch: string): LineEditAction | null {
+    const key = LineEditor.CTRL_MAP[ch];
+    return key ? this.dispatch(key) : null;
+  }
+
+  // ── Kitty keyboard protocol ────────────────────────────────
+
+  /** Handle a kitty protocol CSI u sequence. Params format: "keycode;modifier". */
+  private handleKittyKey(params: string): LineEditAction | null {
+    const [kc, mod] = params.split(";").map(Number);
+    const keycode = kc!;
+    const mods = (mod ?? 1) - 1; // kitty modifier bits
+
+    // Build key name from modifier + keycode
+    const modNames: string[] = [];
+    if (mods & 4) modNames.push("ctrl");
+    if (mods & 1) modNames.push("shift");
+    if (mods & 2) modNames.push("alt");
+
+    const keyName = KITTY_KEY_NAMES[keycode] ?? String.fromCharCode(keycode);
+    const fullName = [...modNames, keyName].join("+");
+
+    // Try exact binding first, then fall back to ctrl char mapping
+    return this.dispatch(fullName)
+      ?? ((mods & 4) && keycode >= 97 && keycode <= 122
+          ? this.dispatch(`ctrl+${String.fromCharCode(keycode)}`)
+          : null)
+      ?? (mods === 0 ? this.handleControl(String.fromCharCode(keycode)) : null);
+  }
+
+  // ── Editing primitives ─────────────────────────────────────
+
+  private insertAt(ch: string): LineEditAction {
+    this.buffer = this.buffer.slice(0, this.cursor) + ch + this.buffer.slice(this.cursor);
+    this.cursor++;
+    return { action: "changed" };
+  }
+
+  private moveTo(pos: number): LineEditAction | null {
+    const clamped = Math.max(0, Math.min(pos, this.buffer.length));
+    if (clamped === this.cursor) return null;
+    this.cursor = clamped;
+    return { action: "changed" };
+  }
+
+  private deleteBackward(): LineEditAction | null {
+    if (this.buffer.length === 0) return { action: "delete-empty" };
+    if (this.cursor <= 0) return null;
+    this.buffer = this.buffer.slice(0, this.cursor - 1) + this.buffer.slice(this.cursor);
+    this.cursor--;
+    return { action: "changed" };
+  }
+
+  private deleteForward(): LineEditAction | null {
+    if (this.cursor >= this.buffer.length) return null;
+    this.buffer = this.buffer.slice(0, this.cursor) + this.buffer.slice(this.cursor + 1);
+    return { action: "changed" };
+  }
+
+  private deleteRange(start: number, end: number): LineEditAction | null {
+    if (start >= end) return null;
+    this.buffer = this.buffer.slice(0, start) + this.buffer.slice(end);
+    this.cursor = start;
+    return { action: "changed" };
   }
 
   // ── CSI sequence handling ───────────────────────────────────
@@ -267,6 +310,11 @@ export class LineEditor {
       case "F": // End
         if (this.cursor < this.buffer.length) { this.cursor = this.buffer.length; actions.push({ action: "changed" }); }
         break;
+      case "u": { // Kitty keyboard protocol: \x1b[<keycode>;<modifier>u
+        const action = this.handleKittyKey(params);
+        if (action) actions.push(action);
+        break;
+      }
       case "~": // Extended keys: Delete (3~), etc.
         if (params === "3") {
           // Delete key: delete char under cursor

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -20,6 +20,7 @@ export type LineEditAction =
   | { action: "cancel" }
   | { action: "delete-empty" }
   | { action: "tab" }
+  | { action: "shift+tab" }
   | { action: "arrow-up" }
   | { action: "arrow-down" };
 
@@ -172,6 +173,7 @@ export class LineEditor {
     "ctrl+k":        () => this.deleteRange(this.cursor, this.buffer.length),
     "ctrl+w":        () => this.deleteWordBackward() ? { action: "changed" } : null,
     "shift+enter":   () => this.insertAt("\n"),
+    "shift+tab":     () => ({ action: "shift+tab" as const }),
   };
 
   /** Resolve a key name from the bindings table and execute it. */
@@ -309,6 +311,9 @@ export class LineEditor {
         break;
       case "F": // End
         if (this.cursor < this.buffer.length) { this.cursor = this.buffer.length; actions.push({ action: "changed" }); }
+        break;
+      case "Z": // Shift+Tab (legacy CSI sequence)
+        actions.push({ action: "shift+tab" });
         break;
       case "u": { // Kitty keyboard protocol: \x1b[<keycode>;<modifier>u
         const action = this.handleKittyKey(params);

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -116,14 +116,14 @@ export class MarkdownRenderer {
   }
 
   printTopBorder(): void {
-    const w = Math.min(this.contentWidth, 40);
-    process.stdout.write(`${p.dim}${p.accent}${"─".repeat(w)}${p.reset}\n`);
+    const termW = process.stdout.columns || 80;
+    process.stdout.write(`${p.dim}${p.accent}${"─".repeat(termW)}${p.reset}\n`);
     this.firstLine = true;
   }
 
   printBottomBorder(): void {
-    const w = Math.min(this.contentWidth, 40);
-    process.stdout.write(`${p.dim}${p.accent}${"─".repeat(w)}${p.reset}\n`);
+    const termW = process.stdout.columns || 80;
+    process.stdout.write(`${p.dim}${p.accent}${"─".repeat(termW)}${p.reset}\n`);
   }
 
   private processBuffer(): void {

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -245,16 +245,17 @@ export function createSpinner(): SpinnerState {
  */
 export function startSpinner(
   label: string,
-  opts?: { color?: string },
+  opts?: { color?: string; hint?: string },
 ): SpinnerState {
   const state = createSpinner();
   const color = opts?.color ?? p.accent;
 
+  const hint = opts?.hint ? ` ${p.dim}${opts.hint}${p.reset}` : "";
   state.interval = setInterval(() => {
     const frame = SPINNER_FRAMES[state.frame % SPINNER_FRAMES.length];
     const elapsed = formatElapsed(Date.now() - state.startTime);
     const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
-    process.stdout.write(`\r  ${color}${frame} ${label}...${p.reset}${timer}\x1b[K`);
+    process.stdout.write(`\r  ${color}${frame} ${label}...${p.reset}${timer}${hint}\x1b[K`);
     state.frame++;
   }, 80);
 

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -245,9 +245,10 @@ export function createSpinner(): SpinnerState {
  */
 export function startSpinner(
   label: string,
-  opts?: { color?: string; hint?: string },
+  opts?: { color?: string; hint?: string; startTime?: number },
 ): SpinnerState {
   const state = createSpinner();
+  if (opts?.startTime) state.startTime = opts.startTime;
   const color = opts?.color ?? p.accent;
 
   const hint = opts?.hint ? ` ${p.dim}${opts.hint}${p.reset}` : "";


### PR DESCRIPTION
## Summary
- Configurable read output max lines (default 0 — hidden)
- Full-width response borders, spinner timer after tool calls
- Ctrl+T to toggle thinking text display with timer preservation
- Agent context preamble explaining tool usage (user_shell vs internal tools)
- Agent input wrapping fix, Shift+Enter multiline, Ctrl+D to exit agent mode
- Unified keybindings architecture (bindings table + kitty protocol)
- user_shell PTY passthrough with rich output, echo skip, source tracking
- **Shift+Tab to cycle thinking level** via ACP session modes (off/minimal/low/medium/high/xhigh)
- Thinking-aware spinner: "Working" when thinking is off, "Thinking (ctrl+t)" otherwise
- Tighter vertical spacing: skip PTY echo on prompt recovery, remove extra newlines
- Lower default internal tool output to 5 lines

## Test plan
- [ ] Type `>` to enter agent mode, verify prompt shows model + thinking level
- [ ] Press Shift+Tab to cycle thinking levels, verify prompt updates
- [ ] Ask agent to list files — should use user_shell, output shown in PTY
- [ ] Verify no double prompt or missing prompt after user_shell
- [ ] Ctrl+T toggles thinking display during agent response
- [ ] Shift+Enter creates multiline input, Ctrl+D exits agent mode