### PR TITLE
Content transform pipeline with composable stream primitives

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,11 +177,67 @@ The socket path is available via the `AGENT_SH_SOCKET` environment variable. The
 
 ## EventBus
 
-All communication between components flows through a typed EventBus. Components emit events (shell commands, agent responses, tool calls) and extensions subscribe to events they care about. The bus supports three modes:
+All communication between components flows through a typed EventBus. Components emit events (shell commands, agent responses, tool calls) and extensions subscribe to events they care about. The bus supports four modes:
 
-- **emit/on** — fire-and-forget notifications (e.g., `agent:response-chunk`)
+- **emit/on** — fire-and-forget notifications (e.g., `shell:command-done`)
 - **emitPipe/onPipe** — synchronous transform chains (e.g., `autocomplete:request` where extensions append completion items, `session:configure` where extensions add MCP servers)
 - **emitPipeAsync/onPipeAsync** — async transform chains (e.g., `permission:request` where extensions prompt the user and return a decision, `shell:exec-request` where Shell executes a command in the PTY)
+- **emitTransform** — transform-then-notify: runs pipe listeners to transform the payload, then emits the result to `on` listeners. Used for content streams where extensions can modify data before renderers see it.
+
+### Content Transform Pipeline
+
+Agent content streams (`agent:response-chunk`, `agent:thinking-chunk`, `agent:tool-output-chunk`) use `emitTransform`. This creates a two-phase flow:
+
+```
+AcpClient
+  → emitTransform("agent:response-chunk", { text })
+      Phase 1 (onPipe): transform extensions modify text
+        → latex-ext:    $E=mc^2$ → terminal image escape sequence
+        → diagram-ext:  ```mermaid → rendered diagram
+        → any extension can register here
+      Phase 2 (on): renderers see the final transformed text
+        → tui-renderer renders to terminal
+        → web-renderer renders to HTML
+        → logger captures for debugging
+```
+
+Transform extensions register with `bus.onPipe("agent:response-chunk", ...)` and modify the payload. Renderers register with `bus.on("agent:response-chunk", ...)` and consume the final result. Since `onPipe` runs first, transforms always complete before any renderer sees the content.
+
+This means the tui-renderer is just an extension — it has no privileged access to content. A LaTeX extension, a syntax highlighter, or a diagram renderer all compose through the same bus, and any renderer (terminal, web, log) sees the same transformed output.
+
+### Streaming Transforms
+
+Agent responses arrive as a stream of small chunks. A pattern like `$E=mc^2$` may span multiple chunks. Transform extensions handle this by **buffering** — holding back text until a pattern is complete, and releasing the safe portion:
+
+```
+chunk 1: "The energy is $E=mc"    → release "The energy is ", hold "$E=mc"
+chunk 2: "^2$ which means"        → transform "$E=mc^2$", release result + " which means"
+```
+
+The pipe supports this naturally — the extension returns only the ready-to-render portion and keeps a buffer internally. On `agent:response-done` (also piped via `emitTransform`), extensions flush any remaining buffered text.
+
+```typescript
+// Streaming transform skeleton
+let buf = "";
+
+bus.onPipe("agent:response-chunk", (e) => {
+  buf += e.text;
+  const { ready, pending } = splitAtSafeBoundary(buf, /\$[^$]*\$/);
+  buf = pending;
+  return { ...e, text: ready };
+});
+
+bus.onPipe("agent:response-done", (e) => {
+  if (buf) {
+    // Pattern never closed — flush raw text
+    bus.emitTransform("agent:response-chunk", { text: buf });
+    buf = "";
+  }
+  return e;
+});
+```
+
+Events using `emitTransform`: `agent:response-chunk`, `agent:thinking-chunk`, `agent:tool-output-chunk`, `agent:response-done`.
 
 ## Project Structure
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -54,6 +54,32 @@ export default function activate(ctx) {
 | `quit` | `() => void` | Exit agent-sh |
 | `setPalette` | `(overrides: Partial<ColorPalette>) => void` | Override color palette slots for theming |
 
+## Content Transforms
+
+Extensions can transform agent content before any renderer sees it. The content streams (`agent:response-chunk`, `agent:thinking-chunk`, `agent:tool-output-chunk`) flow through a transform pipeline: `onPipe` listeners modify the payload first, then `on` listeners (renderers) receive the transformed result.
+
+```typescript
+// latex-render.ts — render LaTeX equations as terminal images
+export default function activate({ bus }) {
+  bus.onPipe("agent:response-chunk", (e) => {
+    // Replace inline LaTeX with rendered terminal graphics
+    const transformed = e.text.replace(
+      /\$\$(.+?)\$\$/g,
+      (_, equation) => renderLatexToKittyGraphics(equation),
+    );
+    return { ...e, text: transformed };
+  });
+}
+```
+
+Since the tui-renderer is itself just an extension using `bus.on(...)`, transform extensions compose naturally — they sit in the pipe before any renderer without special privileges. Multiple transforms chain: each `onPipe` listener receives the output of the previous one.
+
+Use cases:
+- **LaTeX rendering** — detect `$...$` equations, render via `katex`/`latex`, emit kitty graphics escapes
+- **Diagram rendering** — detect mermaid/plantuml blocks, render to images
+- **Syntax transforms** — custom highlighting, annotation overlays
+- **Content filtering** — redact sensitive output, collapse verbose sections
+
 ## Yolo Mode
 
 By default, agent-sh runs in **yolo mode** — all tool calls and file writes are auto-approved. This matches pi's design philosophy where the agent operates freely unless you explicitly add permission gates.

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -216,7 +216,7 @@ export class AcpClient {
     } finally {
       this.log("restoring shell mode");
       if (!cancelled) {
-        this.bus.emit("agent:response-done", {
+        this.bus.emitTransform("agent:response-done", {
           response: this.currentResponseText,
         });
       }
@@ -430,7 +430,7 @@ export class AcpClient {
         const content = update.content;
         if (content.type === "text") {
           this.currentResponseText += content.text;
-          this.bus.emit("agent:response-chunk", { text: content.text });
+          this.bus.emitTransform("agent:response-chunk", { text: content.text });
         }
         break;
       }
@@ -438,7 +438,7 @@ export class AcpClient {
       case "agent_thought_chunk": {
         const thought = update.content;
         if (thought.type === "text" && thought.text) {
-          this.bus.emit("agent:thinking-chunk", { text: thought.text });
+          this.bus.emitTransform("agent:thinking-chunk", { text: thought.text });
         }
         break;
       }
@@ -467,7 +467,7 @@ export class AcpClient {
           if (!skipOutput && update.content && Array.isArray(update.content)) {
             for (const block of update.content) {
               if (block.type === "content" && block.content?.type === "text" && block.content.text) {
-                this.bus.emit("agent:tool-output-chunk", { chunk: block.content.text });
+                this.bus.emitTransform("agent:tool-output-chunk", { chunk: block.content.text });
               }
             }
           }

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -160,6 +160,20 @@ export class EventBus {
     this.emitter.emit(event, payload);
   }
 
+  /**
+   * Transform-then-notify: run the payload through any registered pipe
+   * listeners (transforms), then emit the final result to regular `on`
+   * listeners (renderers). This enables content pipelines where extensions
+   * modify data (e.g. render LaTeX → terminal image) before renderers see it.
+   */
+  emitTransform<K extends keyof ShellEvents>(
+    event: K,
+    payload: ShellEvents[K],
+  ): void {
+    const transformed = this.emitPipe(event, payload);
+    this.emitter.emit(event, transformed);
+  }
+
   /** Register a transform listener for a pipeline event. */
   onPipe<K extends keyof ShellEvents>(
     event: K,


### PR DESCRIPTION
## Summary

Adds a content transform pipeline that lets extensions modify agent responses before any renderer sees them. The core principle: **nobody is special** — built-in and user extensions compose through the same primitives.

### Layer 1 — `emitTransform` event bus method
- Two-phase emission: pipe listeners (transforms) run first, then `on` listeners (renderers) see the result
- Applied to `agent:response-chunk`, `agent:thinking-chunk`, `agent:tool-output-chunk`, `agent:response-done`

### Layer 2 — Typed `ContentBlock` system
- `text` → markdown renderer
- `code-block` → syntax highlighting (new)
- `image` → terminal image protocol (iTerm2/Kitty/Ghostty/WezTerm)
- `raw` → direct stdout bypass
- Extensions return content blocks; renderers dispatch by type. No `process.stdout` hacks.

### Layer 3 — Composable stream primitives
- **`createBlockTransform`** — inline delimiter detection (`$$...$$`) with streaming buffering
- **`createFencedBlockTransform`** — line-delimited fence detection (` ``` `, `:::`, `~~~`) with streaming buffering
- Each primitive operates on its own domain, passes everything else through — **order doesn't matter**
- tui-renderer uses `createFencedBlockTransform` for standard code fences (not special)

### Supporting infrastructure
- `ExtensionContext` provides all utilities via `ctx` — no package imports needed from extensions
- `getExtensionSettings(namespace, defaults)` — namespaced extension config from `settings.json`
- `MarkdownRenderer` simplified — code fence detection removed (moved to pipeline), `write` option added
- Package exports fixed for `./utils/*` and `./settings`

### Example: LaTeX image rendering
`examples/extensions/latex-images.ts` renders both `$$...$$` and ` ```latex ` blocks as inline terminal images using `latex` + `dvipng` (same pipeline as Emacs org-mode).

## Test plan
- [ ] Agent responses with code blocks render with syntax highlighting (unchanged)
- [ ] latex-images extension renders `$$...$$` as images
- [ ] latex-images extension renders ` ```latex ` blocks as images
- [ ] Normal text without patterns passes through unchanged
- [ ] Multiple extensions compose (e.g. latex + a hypothetical mermaid extension)
- [ ] Extensions loaded from `~/.agent-sh/extensions/` work without import issues