### PR TITLE
Refactor TUI rendering: composable line protocol

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ index.ts — interactive terminal frontend:
   │
   ├── Built-in extensions:
   │     tuiRenderer       — markdown rendering, inline diffs, thinking display, spinner
+  │                        (all output via OutputWriter; components return string[])
   │     slashCommands     — /help, /clear, /copy, /compact, /quit
   │     fileAutocomplete  — @ file path completion
   │     shellRecall       — shell_recall terminal interception
@@ -25,7 +26,9 @@ index.ts — interactive terminal frontend:
   │     palette           — semantic color system (accent, success, warning, error, muted)
   │     diff-renderer     — syntax-highlighted diffs (split/unified/summary)
   │     box-frame         — bordered TUI panels
-  │     tool-display      — width-adaptive tool call rendering
+  │     tool-display      — width-adaptive tool call rendering + pure spinner
+  │     output-writer     — OutputWriter interface (StdoutWriter, BufferWriter for tests)
+  │     frame-renderer    — differential line-level output (infrastructure for frame-based rendering)
   │
   └── User extensions (opt-in, loaded from -e flag / settings.json / extensions dir):
         e.g. interactive-prompts, solarized-theme
@@ -271,14 +274,16 @@ agent-sh/
 │   ├── utils/
 │   │   ├── palette.ts      # Semantic color palette (accent/success/warning/error/muted)
 │   │   ├── ansi.ts         # ANSI utility functions (visibleLen, stripAnsi)
+│   │   ├── output-writer.ts# OutputWriter interface + StdoutWriter/BufferWriter
+│   │   ├── frame-renderer.ts # Differential line-level frame renderer
 │   │   ├── diff.ts         # Line-level LCS diff for file change previews
 │   │   ├── diff-renderer.ts# Syntax-highlighted diff display (split/unified/summary)
 │   │   ├── box-frame.ts    # Bordered TUI panels (rounded/square/double/heavy)
-│   │   ├── tool-display.ts # Width-adaptive tool call/result rendering
+│   │   ├── tool-display.ts # Width-adaptive tool call/result + pure spinner line
 │   │   ├── line-editor.ts       # Readline-style line editor (pure logic, no I/O)
 │   │   ├── stream-transform.ts  # Block transform helper for content pipeline
 │   │   ├── file-watcher.ts      # File change detection for agent tool writes
-│   │   └── markdown.ts          # Streaming markdown → ANSI renderer
+│   │   └── markdown.ts          # Streaming markdown → line accumulator (drainLines)
 │   └── extensions/
 │       ├── tui-renderer.ts       # Terminal rendering (markdown, spinner, tools)
 │       ├── slash-commands.ts     # /help, /clear, /copy, /compact, /quit

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -321,6 +321,97 @@ export default function activate(ctx: ExtensionContext) {
 }
 ```
 
+## Rendering Architecture
+
+The tui-renderer is the built-in extension that turns events and content blocks into terminal output. Understanding its internals helps when writing extensions that advise rendering handlers or emit UI events.
+
+### How content reaches the screen
+
+```
+ContentBlock (from transform pipeline)
+    │
+    ├── text        → MarkdownRenderer.push(chunk)  → drainLines() → writer
+    ├── code-block  → ctx.call("render:code-block")  → drainLines() → writer
+    ├── image       → ctx.call("render:image")        → writer
+    └── raw         → writer.write(escape)
+```
+
+All output flows through an **OutputWriter** — an injectable interface with `write(text)` and `columns` (terminal width). The default `StdoutWriter` forwards to `process.stdout`. Extensions should never call `process.stdout.write` directly — use the render handlers or emit events instead.
+
+### The line protocol
+
+Rendering components follow a **return lines, don't write** convention:
+
+- `renderBoxFrame(content, opts)` → `string[]`
+- `renderDiff(diff, opts)` → `string[]`
+- `renderToolCall(tool, width)` → `string[]`
+- `renderSpinnerLine(state, label, opts)` → `string`
+- `MarkdownRenderer.drainLines()` → `string[]`
+
+The tui-renderer collects lines from these components and writes them through the OutputWriter. This makes every component testable in isolation — call it with arguments, assert on the returned strings.
+
+### MarkdownRenderer
+
+The `MarkdownRenderer` is a streaming line accumulator:
+
+```typescript
+const md = new MarkdownRenderer(width);  // width in columns
+md.push("Hello **world**\n");            // buffer text, process complete lines
+md.writeLine("arbitrary pre-formatted line");
+md.flush();                              // process any remaining buffered text
+const lines: string[] = md.drainLines(); // extract all accumulated lines
+```
+
+It handles heading formatting, inline styles (bold, italic, code, links), lists, blockquotes, and word-wrapping with ANSI code preservation. Lines include a 2-space left indent.
+
+`printTopBorder()` and `printBottomBorder()` add response box borders to the line buffer.
+
+### Writing a render handler
+
+The `render:code-block` and `render:image` handlers are the extension points for custom rendering. When you advise them, your handler runs inside the tui-renderer's rendering context — the `MarkdownRenderer` is active and you can push lines into it.
+
+**Replacing a code block with an image:**
+
+```typescript
+ctx.advise("render:code-block", (next, language, code, width) => {
+  if (language !== "mermaid") return next(language, code, width);
+
+  const png = renderMermaidToPng(code);
+  if (!png) return next(language, code, width);  // fallback to syntax highlight
+
+  // Use the image handler — it knows about iTerm2/Kitty/Ghostty protocols
+  ctx.call("render:image", png);
+});
+```
+
+**Replacing a code block with custom text:**
+
+```typescript
+ctx.advise("render:code-block", (next, language, code, width) => {
+  if (language !== "csv") return next(language, code, width);
+
+  // Emit formatted lines through the bus — they'll appear in the response box
+  const { bus } = ctx;
+  const table = formatCsvAsTable(code, width);
+  bus.emit("ui:info", { message: table });
+});
+```
+
+### Emitting UI events
+
+Extensions can show messages without touching the renderer directly:
+
+```typescript
+bus.emit("ui:info", { message: "Operation completed" });   // dimmed text
+bus.emit("ui:error", { message: "Something went wrong" }); // red error
+```
+
+These render outside the response box and work regardless of renderer state.
+
+### Render state
+
+The tui-renderer maintains a `RenderState` that tracks the current phase of rendering (idle, responding, tool-running), spinner state, tool output buffering, thinking display, and diff expansion. Extensions don't access this directly — they interact through the named handler system and bus events.
+
 ## Yolo Mode
 
 By default, agent-sh runs in **yolo mode** — all tool calls and file writes are auto-approved. This matches pi's design philosophy where the agent operates freely unless you explicitly add permission gates.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -93,17 +93,17 @@ Built-in extensions register named processing steps with `ctx.define`. User exte
 
 ```typescript
 // tui-renderer defines the default code block handler
-ctx.define("render:code-block", (language, code) => {
-  syntaxHighlight(language, code);
+ctx.define("render:code-block", (language, code, width) => {
+  syntaxHighlight(language, code, width);
 });
 
 // Your extension wraps it
-ctx.advise("render:code-block", (next, language, code) => {
+ctx.advise("render:code-block", (next, language, code, width) => {
   if (language === "latex") {
     renderLatexImage(code);     // handle it yourself
     return;                     // don't call next — you replaced the handler
   }
-  next(language, code);          // not yours — pass through to the original
+  next(language, code, width);   // not yours — pass through to the original
 });
 ```
 
@@ -111,26 +111,26 @@ The `next` parameter is the key. It's the previous handler (or the one before th
 
 ```typescript
 // AROUND — conditionally call the original
-ctx.advise("render:code-block", (next, lang, code) => {
+ctx.advise("render:code-block", (next, lang, code, width) => {
   if (lang === "mermaid") return renderMermaid(code);
-  return next(lang, code);
+  return next(lang, code, width);
 });
 
 // BEFORE — do something, then call the original
-ctx.advise("render:code-block", (next, lang, code) => {
+ctx.advise("render:code-block", (next, lang, code, width) => {
   console.log(`rendering: ${lang}`);
-  return next(lang, code);
+  return next(lang, code, width);
 });
 
 // AFTER — call the original, then do something
-ctx.advise("render:code-block", (next, lang, code) => {
-  const result = next(lang, code);
+ctx.advise("render:code-block", (next, lang, code, width) => {
+  const result = next(lang, code, width);
   logMetrics(lang, code.length);
   return result;
 });
 
 // OVERRIDE — replace entirely, never call next
-ctx.advise("render:code-block", (_next, lang, code) => {
+ctx.advise("render:code-block", (_next, lang, code, width) => {
   return myCustomRenderer(lang, code);
 });
 ```
@@ -141,7 +141,7 @@ The tui-renderer registers these named handlers that extensions can advise:
 
 | Handler | Arguments | Description |
 |---|---|---|
-| `render:code-block` | `(language: string, code: string)` | Render a fenced code block (default: syntax highlighting) |
+| `render:code-block` | `(language: string, code: string, width: number)` | Render a fenced code block (default: syntax highlighting) |
 | `render:image` | `(data: Buffer)` | Display an image in the terminal (default: iTerm2/Kitty protocol) |
 
 ### Multiple advisors chain

--- a/examples/extensions/latex-images.ts
+++ b/examples/extensions/latex-images.ts
@@ -127,11 +127,11 @@ export default function activate(ctx: ExtensionContext) {
   });
 
   // Advise the code block renderer — wrap the default syntax highlighter
-  ctx.advise("render:code-block", (next, language: string, code: string) => {
-    if (language !== "latex" && language !== "tex") return next(language, code);
+  ctx.advise("render:code-block", (next, language: string, code: string, width: number) => {
+    if (language !== "latex" && language !== "tex") return next(language, code, width);
     const png = renderEquation(code);
-    if (!png) return next(language, code); // render failed — fall through
-    process.stdout.write("\n  " + encodeImage(png) + "\n");
+    if (!png) return next(language, code, width); // render failed — fall through
+    ctx.call("render:image", png);
   });
 
   process.on("exit", () => {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -16,16 +16,17 @@ import { createFencedBlockTransform } from "../utils/stream-transform.js";
 import { palette as p } from "../utils/palette.js";
 import {
   renderToolCall,
-  renderToolResult,
-  startSpinner,
-  stopSpinner as stopToolSpinner,
+  createSpinner,
+  renderSpinnerLine,
   type SpinnerState,
+  type SpinnerOpts,
 } from "../utils/tool-display.js";
 import { renderDiff } from "../utils/diff-renderer.js";
 import { renderBoxFrame } from "../utils/box-frame.js";
 import type { DiffResult } from "../utils/diff.js";
 import { getSettings } from "../settings.js";
 import type { ExtensionContext } from "../types.js";
+import { StdoutWriter } from "../utils/output-writer.js";
 
 /** Encode a PNG buffer as a terminal inline image escape sequence. */
 function encodeImageForTerminal(data: Buffer): string | null {
@@ -47,26 +48,70 @@ function encodeImageForTerminal(data: Buffer): string | null {
   return null;
 }
 
+// ── Render state ─────────────────────────────────────────────────
+// All mutable TUI state in one place for clarity and future
+// migration to a frame-based rendering model.
+
+interface TruncatedDiff {
+  filePath: string;
+  diff: DiffResult;
+  expandedLines?: string[];
+  expanded: boolean;
+}
+
+interface RenderState {
+  // ── Response rendering ──
+  renderer: MarkdownRenderer | null;
+  hadToolCalls: boolean;
+
+  // ── Spinner ──
+  spinner: SpinnerState | null;
+  spinnerLabel: string;
+  spinnerOpts: SpinnerOpts;
+  spinnerInterval: ReturnType<typeof setInterval> | null;
+  spinnerStartTime: number;
+
+  // ── Tool output ──
+  lastCommand: string;
+  toolLineOpen: boolean;
+  currentToolKind: string | undefined;
+  commandOutputBuffer: string;
+  commandOutputLineCount: number;
+  commandOutputOverflow: number;
+
+  // ── Thinking ──
+  isThinking: boolean;
+  showThinkingText: boolean;
+
+  // ── Diff expansion ──
+  lastTruncatedDiff: TruncatedDiff | null;
+}
+
+function createRenderState(): RenderState {
+  return {
+    renderer: null,
+    hadToolCalls: false,
+    spinner: null,
+    spinnerLabel: "",
+    spinnerOpts: {},
+    spinnerInterval: null,
+    spinnerStartTime: 0,
+    lastCommand: "",
+    toolLineOpen: false,
+    currentToolKind: undefined,
+    commandOutputBuffer: "",
+    commandOutputLineCount: 0,
+    commandOutputOverflow: 0,
+    isThinking: false,
+    showThinkingText: false,
+    lastTruncatedDiff: null,
+  };
+}
+
 export default function activate(ctx: ExtensionContext): void {
   const { bus, getAcpClient, define } = ctx;
-  let spinner: SpinnerState | null = null;
-  let renderer: MarkdownRenderer | null = null;
-  let commandOutputBuffer = "";
-  let commandOutputLineCount = 0;
-  let commandOutputOverflow = 0;
-  let lastCommand = "";
-  let toolLineOpen = false; // true when tool header was written without \n
-  let hadToolCalls = false; // true after any tool call in current response
-  let currentToolKind: string | undefined; // kind of the currently executing tool
-  let isThinking = false;
-  let showThinkingText = false;
-  let spinnerStartTime = 0; // preserved across spinner restarts
-  let lastTruncatedDiff: {
-    filePath: string;
-    diff: DiffResult;
-    expandedLines?: string[]; // cached full render
-    expanded: boolean;
-  } | null = null;
+  const writer = new StdoutWriter();
+  const s = createRenderState();
 
   // ── Register fenced block transform (code blocks → ContentBlock) ──
   // Nobody is special — tui-renderer uses the same primitive as any extension.
@@ -81,28 +126,29 @@ export default function activate(ctx: ExtensionContext): void {
   // ── Event subscriptions ─────────────────────────────────────
 
   bus.on("agent:query", (e) => {
-    spinnerStartTime = 0;
+    s.spinnerStartTime = 0;
     showUserQuery(e.query);
     startAgentResponse();
     startThinkingSpinner();
   });
 
   bus.on("agent:thinking-chunk", (e) => {
-    if (!isThinking) {
-      isThinking = true;
-      if (showThinkingText) {
+    if (!s.isThinking) {
+      s.isThinking = true;
+      if (s.showThinkingText) {
         stopCurrentSpinner();
-        if (!renderer) startAgentResponse();
-        renderer!.writeLine(`${p.dim}Thinking (ctrl+t to collapse)${p.reset}`);
+        if (!s.renderer) startAgentResponse();
+        s.renderer!.writeLine(`${p.dim}Thinking (ctrl+t to collapse)${p.reset}`);
+        drain();
       } else {
         // Restart spinner with ctrl+t hint now that we know thinking is available
         startThinkingSpinner();
       }
     }
-    if (showThinkingText && e.text) {
-      if (!renderer) startAgentResponse();
-      renderer!.push(`${p.dim}${e.text}${p.reset}`);
-      flushOutput();
+    if (s.showThinkingText && e.text) {
+      if (!s.renderer) startAgentResponse();
+      s.renderer!.push(`${p.dim}${e.text}${p.reset}`);
+      drain();
     }
   });
 
@@ -130,7 +176,7 @@ export default function activate(ctx: ExtensionContext): void {
             break;
           case "raw":
             flushForRaw();
-            process.stdout.write(block.escape);
+            writer.write(block.escape);
             break;
         }
       }
@@ -139,69 +185,66 @@ export default function activate(ctx: ExtensionContext): void {
     }
   });
   bus.on("agent:response-done", () => {
-    isThinking = false;
+    s.isThinking = false;
     endAgentResponse();
   });
 
   bus.on("agent:tool-call", (e) => {
-    lastCommand = e.tool;
+    s.lastCommand = e.tool;
   });
 
   bus.on("agent:tool-started", (e) => {
     stopCurrentSpinner();
-    currentToolKind = e.kind;
+    s.currentToolKind = e.kind;
     if (e.title === "user_shell") {
-      // Minimal annotation — PTY echo will show the output
       closeToolLine();
-      if (!renderer) startAgentResponse();
-      renderer!.flush();
+      if (!s.renderer) startAgentResponse();
+      s.renderer!.flush();
       const cmd = (e.rawInput as any)?.command || "";
-      renderer!.writeLine(`${p.dim}▶ user_shell: ${cmd}${p.reset}`);
-      hadToolCalls = true;
+      s.renderer!.writeLine(`${p.dim}▶ user_shell: ${cmd}${p.reset}`);
+      drain();
+      s.hadToolCalls = true;
     } else {
-      showToolCall(e.title, lastCommand, e);
+      showToolCall(e.title, s.lastCommand, e);
     }
-    lastCommand = "";
+    s.lastCommand = "";
   });
 
   bus.on("agent:tool-completed", (e) => {
     showToolComplete(e.exitCode);
-    currentToolKind = undefined;
-    spinnerStartTime = 0;
+    s.currentToolKind = undefined;
+    s.spinnerStartTime = 0;
     startThinkingSpinner();
   });
   bus.on("agent:tool-output-chunk", (e) => writeCommandOutput(e.chunk));
   bus.on("agent:tool-output", () => flushCommandOutput());
 
   bus.on("agent:cancelled", () => {
-    isThinking = false;
+    s.isThinking = false;
     stopCurrentSpinner();
     showInfo("(cancelled)");
     endAgentResponse();
   });
 
   bus.on("agent:processing-done", () => {
-    isThinking = false;
+    s.isThinking = false;
     stopCurrentSpinner();
     endAgentResponse();
   });
 
   bus.on("agent:error", (e) => showError(e.message));
 
-  // Flush rendering state and show inline diff for file writes
   bus.on("permission:request", (e) => {
     stopCurrentSpinner();
     flushCommandOutput();
-    renderer?.flush();
+    if (s.renderer) {
+      s.renderer.flush();
+      drain();
+    }
 
     if (e.kind === "file-write" && e.metadata?.diff) {
-      showFileDiff(
-        e.title,
-        e.metadata.diff as DiffResult,
-      );
+      showFileDiff(e.title, e.metadata.diff as DiffResult);
     } else {
-      // Non-file permission (e.g. tool-call) — end response box
-      // so interactive extensions can render their own UI
       endAgentResponse();
     }
   });
@@ -215,39 +258,39 @@ export default function activate(ctx: ExtensionContext): void {
 
   // ── Rendering functions ─────────────────────────────────────
 
-  function flushOutput(): void {
-    if (process.stdout.writable) {
-      try { process.stdout.write(""); } catch {}
+  function drain(): void {
+    if (!s.renderer) return;
+    for (const line of s.renderer.drainLines()) {
+      writer.write(line + "\n");
     }
   }
 
   function startAgentResponse(): void {
-    renderer = new MarkdownRenderer();
-    hadToolCalls = false;
-    renderer.printTopBorder();
+    s.renderer = new MarkdownRenderer(writer.columns);
+    s.hadToolCalls = false;
+    s.renderer.printTopBorder();
+    drain();
   }
 
   function endAgentResponse(): void {
     closeToolLine();
-    if (renderer) {
-      renderer.flush();
-      renderer.printBottomBorder();
-      renderer = null;
+    if (s.renderer) {
+      s.renderer.flush();
+      s.renderer.printBottomBorder();
+      drain();
+      s.renderer = null;
     }
   }
 
   function showUserQuery(query: string): void {
-    const termW = process.stdout.columns || 80;
-    const boxW = Math.min(84, termW);
-    const contentW = boxW - 4; // inside box padding
+    const boxW = Math.min(84, writer.columns);
+    const contentW = boxW - 4;
 
-    // Wrap long queries to fit within box
     const lines: string[] = [];
     for (const raw of query.split("\n")) {
       if (raw.length <= contentW) {
         lines.push(`${p.accent}${raw}${p.reset}`);
       } else {
-        // Simple word wrap
         let remaining = raw;
         while (remaining.length > contentW) {
           let breakAt = remaining.lastIndexOf(" ", contentW);
@@ -265,38 +308,36 @@ export default function activate(ctx: ExtensionContext): void {
       borderColor: p.accent,
       title: `${p.accent}${p.bold}❯${p.reset}`,
     });
-    process.stdout.write("\n");
+    writer.write("\n");
     for (const line of framed) {
-      process.stdout.write(line + "\n");
+      writer.write(line + "\n");
     }
   }
 
   function writeAgentText(text: string): void {
     closeToolLine();
-    const needsGap = hadToolCalls;
-    hadToolCalls = false;
-    if (isThinking) {
-      isThinking = false;
-      if (showThinkingText && renderer) {
-        renderer.flush();
-        const termW = process.stdout.columns || 80;
-        const w = Math.min(80, termW);
-        renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
+    const needsGap = s.hadToolCalls;
+    s.hadToolCalls = false;
+    if (s.isThinking) {
+      s.isThinking = false;
+      if (s.showThinkingText && s.renderer) {
+        s.renderer.flush();
+        const w = Math.min(80, writer.columns);
+        s.renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
+        drain();
       }
     }
     stopCurrentSpinner();
-    if (!renderer) startAgentResponse();
-    if (needsGap) process.stdout.write("\n");
-    renderer!.push(text);
-    flushOutput();
+    if (!s.renderer) startAgentResponse();
+    if (needsGap) writer.write("\n");
+    s.renderer!.push(text);
+    drain();
   }
 
-  /** Render a code block with syntax highlighting (extracted from MarkdownRenderer). */
-  // Register named handler — extensions can advise this
-  define("render:code-block", (language: string, code: string) => {
+  define("render:code-block", (language: string, code: string, width: number) => {
     flushForRaw();
     if (language) {
-      renderer!.writeLine(`${p.dim}${language}${p.reset}`);
+      s.renderer!.writeLine(`${p.dim}${language}${p.reset}`);
     }
     let highlighted: string;
     try {
@@ -304,34 +345,34 @@ export default function activate(ctx: ExtensionContext): void {
     } catch {
       highlighted = `${p.success}${code}${p.reset}`;
     }
-    const termW = process.stdout.columns || 100;
-    const contentWidth = Math.min(90, termW - 2);
+    const contentWidth = Math.min(90, width - 2);
     for (const line of highlighted.split("\n")) {
       const indented = `  ${line}`;
       const wrapped = wrapLine(indented, contentWidth);
       for (const wl of wrapped) {
-        renderer!.writeLine(wl);
+        s.renderer!.writeLine(wl);
       }
     }
+    drain();
   });
 
   function writeCodeBlock(language: string, code: string): void {
-    ctx.call("render:code-block", language, code);
+    ctx.call("render:code-block", language, code, writer.columns);
   }
 
-  /** Flush markdown renderer and prepare for raw stdout writes. */
   function flushForRaw(): void {
     closeToolLine();
     stopCurrentSpinner();
-    if (!renderer) startAgentResponse();
-    renderer!.flush();
+    if (!s.renderer) startAgentResponse();
+    s.renderer!.flush();
+    drain();
   }
 
   define("render:image", (data: Buffer) => {
     flushForRaw();
     const escape = encodeImageForTerminal(data);
     if (escape) {
-      process.stdout.write("  " + escape + "\n");
+      writer.write("  " + escape + "\n");
     }
   });
 
@@ -350,46 +391,45 @@ export default function activate(ctx: ExtensionContext): void {
   ): void {
     closeToolLine();
     stopCurrentSpinner();
-    if (!renderer) startAgentResponse();
-    renderer!.flush();
-    const termW = process.stdout.columns || 80;
+    if (!s.renderer) startAgentResponse();
+    s.renderer!.flush();
+    drain();
     const lines = renderToolCall({
       title,
       command: command || undefined,
       kind: extra?.kind,
       locations: extra?.locations,
       rawInput: extra?.rawInput,
-    }, termW);
-    // Write all lines except the last normally, write last without \n
+    }, writer.columns);
     for (let i = 0; i < lines.length - 1; i++) {
-      renderer!.writeLine(lines[i]!);
+      s.renderer!.writeLine(lines[i]!);
     }
+    drain();
     if (lines.length > 0) {
-      process.stdout.write(`  ${lines[lines.length - 1]}`);
-      toolLineOpen = true;
+      writer.write(`  ${lines[lines.length - 1]}`);
+      s.toolLineOpen = true;
     }
-    hadToolCalls = true;
-    // Reset output tracking for the new tool
-    commandOutputLineCount = 0;
-    commandOutputOverflow = 0;
+    s.hadToolCalls = true;
+    s.commandOutputLineCount = 0;
+    s.commandOutputOverflow = 0;
   }
 
   function showToolComplete(exitCode: number | null): void {
-    if (!renderer) return;
+    if (!s.renderer) return;
     const mark = exitCode === null
       ? `${p.muted}(timed out)${p.reset}`
       : exitCode === 0
         ? `${p.success}✓${p.reset}`
         : `${p.error}✗ exit ${exitCode}${p.reset}`;
 
-    if (toolLineOpen && commandOutputLineCount === 0) {
-      // No output written — append mark on same line as tool header
-      process.stdout.write(` ${mark}\n`);
-      toolLineOpen = false;
+    if (s.toolLineOpen && s.commandOutputLineCount === 0) {
+      writer.write(` ${mark}\n`);
+      s.toolLineOpen = false;
     } else {
       closeToolLine();
       flushCommandOutput();
-      renderer.writeLine(`  ${mark}`);
+      s.renderer.writeLine(`  ${mark}`);
+      drain();
     }
   }
 
@@ -399,70 +439,81 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function startThinkingSpinner(): void {
-    // Preserve start time if restarting (e.g. toggle), otherwise reset
-    if (!spinnerStartTime) spinnerStartTime = Date.now();
+    if (!s.spinnerStartTime) s.spinnerStartTime = Date.now();
     stopCurrentSpinner();
     const thinking = hasThinkingMode();
-    const label = thinking ? "Thinking" : "Working";
+    s.spinnerLabel = thinking ? "Thinking" : "Working";
     const hint = thinking
-      ? (showThinkingText ? "(ctrl+t to collapse)" : "(ctrl+t to expand)")
+      ? (s.showThinkingText ? "(ctrl+t to collapse)" : "(ctrl+t to expand)")
       : "";
-    spinner = startSpinner(label, { hint: hint || undefined, startTime: spinnerStartTime });
+    s.spinnerOpts = { hint: hint || undefined, startTime: s.spinnerStartTime };
+    s.spinner = createSpinner({ startTime: s.spinnerStartTime });
+    s.spinnerInterval = setInterval(() => {
+      if (s.spinner) {
+        const line = renderSpinnerLine(s.spinner, s.spinnerLabel, s.spinnerOpts);
+        writer.write(`\r  ${line}\x1b[K`);
+      }
+    }, 80);
   }
 
   function stopCurrentSpinner(): void {
-    if (spinner) {
-      stopToolSpinner(spinner);
-      spinner = null;
+    if (s.spinnerInterval) {
+      clearInterval(s.spinnerInterval);
+      s.spinnerInterval = null;
+    }
+    if (s.spinner) {
+      writer.write("\r\x1b[2K");
+      s.spinner = null;
     }
   }
 
   function closeToolLine(): void {
-    if (toolLineOpen) {
-      process.stdout.write("\n");
-      toolLineOpen = false;
+    if (s.toolLineOpen) {
+      writer.write("\n");
+      s.toolLineOpen = false;
     }
   }
 
   function writeCommandOutput(chunk: string): void {
-    if (!renderer) return;
+    if (!s.renderer) return;
     closeToolLine();
-    const maxLines = currentToolKind === "read"
+    const maxLines = s.currentToolKind === "read"
       ? getSettings().readOutputMaxLines
       : getSettings().maxCommandOutputLines;
-    commandOutputBuffer += chunk;
-    const lines = commandOutputBuffer.split("\n");
-    commandOutputBuffer = lines.pop()!;
+    s.commandOutputBuffer += chunk;
+    const lines = s.commandOutputBuffer.split("\n");
+    s.commandOutputBuffer = lines.pop()!;
     for (const line of lines) {
-      if (commandOutputLineCount < maxLines) {
-        renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
-        commandOutputLineCount++;
+      if (s.commandOutputLineCount < maxLines) {
+        s.renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
+        s.commandOutputLineCount++;
       } else {
-        commandOutputOverflow++;
+        s.commandOutputOverflow++;
       }
     }
+    drain();
   }
 
   function flushCommandOutput(): void {
-    if (!renderer) return;
-    const maxLines = currentToolKind === "read"
+    if (!s.renderer) return;
+    const maxLines = s.currentToolKind === "read"
       ? getSettings().readOutputMaxLines
       : getSettings().maxCommandOutputLines;
-    if (commandOutputBuffer) {
-      if (commandOutputLineCount < maxLines) {
-        renderer.writeLine(`${p.dim}  ${commandOutputBuffer}${p.reset}`);
-        commandOutputLineCount++;
+    if (s.commandOutputBuffer) {
+      if (s.commandOutputLineCount < maxLines) {
+        s.renderer.writeLine(`${p.dim}  ${s.commandOutputBuffer}${p.reset}`);
+        s.commandOutputLineCount++;
       } else {
-        commandOutputOverflow++;
+        s.commandOutputOverflow++;
       }
-      commandOutputBuffer = "";
+      s.commandOutputBuffer = "";
     }
-    if (commandOutputOverflow > 0 && maxLines > 0) {
-      renderer.writeLine(`${p.dim}  … ${commandOutputOverflow} more lines${p.reset}`);
+    if (s.commandOutputOverflow > 0 && maxLines > 0) {
+      s.renderer.writeLine(`${p.dim}  … ${s.commandOutputOverflow} more lines${p.reset}`);
     }
-    commandOutputOverflow = 0;
+    s.commandOutputOverflow = 0;
+    drain();
   }
-
 
   function diffTitle(filePath: string, diff: DiffResult): string {
     const stats = diff.isNewFile
@@ -474,8 +525,7 @@ export default function activate(ctx: ExtensionContext): void {
   function showFileDiff(filePath: string, diff: DiffResult): void {
     if (diff.isIdentical) return;
 
-    const termW = process.stdout.columns || 80;
-    const boxW = Math.min(84, termW);
+    const boxW = Math.min(84, writer.columns);
     const contentW = boxW - 4;
 
     const diffLines = renderDiff(diff, {
@@ -490,9 +540,9 @@ export default function activate(ctx: ExtensionContext): void {
     const isTruncated = lastLine.includes("… ");
 
     if (isTruncated) {
-      lastTruncatedDiff = { filePath, diff, expanded: false };
+      s.lastTruncatedDiff = { filePath, diff, expanded: false };
     } else {
-      lastTruncatedDiff = null;
+      s.lastTruncatedDiff = null;
     }
 
     const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
@@ -509,16 +559,17 @@ export default function activate(ctx: ExtensionContext): void {
       footer,
     });
 
-    if (!renderer) startAgentResponse();
+    if (!s.renderer) startAgentResponse();
     for (const line of framed) {
-      renderer!.writeLine(line);
+      s.renderer!.writeLine(line);
     }
+    drain();
   }
 
   function expandLastDiff(): void {
-    if (!lastTruncatedDiff) return;
+    if (!s.lastTruncatedDiff) return;
 
-    const entry = lastTruncatedDiff;
+    const entry = s.lastTruncatedDiff;
     entry.expanded = !entry.expanded;
 
     if (!entry.expanded) {
@@ -528,8 +579,7 @@ export default function activate(ctx: ExtensionContext): void {
 
     if (!entry.expandedLines) {
       const { filePath, diff } = entry;
-      const termW = process.stdout.columns || 80;
-      const boxW = Math.min(120, termW);
+      const boxW = Math.min(120, writer.columns);
       const contentW = boxW - 4;
 
       const diffLines = renderDiff(diff, {
@@ -550,16 +600,15 @@ export default function activate(ctx: ExtensionContext): void {
       });
     }
 
-    process.stdout.write("\n");
+    writer.write("\n");
     for (const line of entry.expandedLines) {
-      process.stdout.write(line + "\n");
+      writer.write(line + "\n");
     }
   }
 
-  function showFileDiffCached(entry: NonNullable<typeof lastTruncatedDiff>): void {
+  function showFileDiffCached(entry: TruncatedDiff): void {
     const { filePath, diff } = entry;
-    const termW = process.stdout.columns || 80;
-    const boxW = Math.min(84, termW);
+    const boxW = Math.min(84, writer.columns);
     const contentW = boxW - 4;
 
     const diffLines = renderDiff(diff, {
@@ -580,46 +629,44 @@ export default function activate(ctx: ExtensionContext): void {
       footer: [`  ${p.dim}ctrl+o to expand${p.reset}`],
     });
 
-    process.stdout.write("\n");
+    writer.write("\n");
     for (const line of framed) {
-      process.stdout.write(line + "\n");
+      writer.write(line + "\n");
     }
   }
 
   function toggleThinkingDisplay(): void {
-    showThinkingText = !showThinkingText;
+    s.showThinkingText = !s.showThinkingText;
 
-    // Update spinner hint to reflect new state, even if not actively thinking
-    if (spinner) {
+    if (s.spinner) {
       stopCurrentSpinner();
       startThinkingSpinner();
       return;
     }
 
-    if (!isThinking) return;
+    if (!s.isThinking) return;
 
-    if (showThinkingText) {
-      // Switch from spinner to streaming text
+    if (s.showThinkingText) {
       stopCurrentSpinner();
-      if (!renderer) startAgentResponse();
-      renderer!.writeLine(`${p.dim}Thinking (ctrl+t to collapse)${p.reset}`);
+      if (!s.renderer) startAgentResponse();
+      s.renderer!.writeLine(`${p.dim}Thinking (ctrl+t to collapse)${p.reset}`);
+      drain();
     } else {
-      // Switch from streaming text to spinner
-      if (renderer) {
-        renderer.flush();
-        const termW = process.stdout.columns || 80;
-        const w = Math.min(80, termW);
-        renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
+      if (s.renderer) {
+        s.renderer.flush();
+        const w = Math.min(80, writer.columns);
+        s.renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
+        drain();
       }
       startThinkingSpinner();
     }
   }
 
   function showError(message: string): void {
-    process.stdout.write(`\n${p.error}Error: ${message}${p.reset}\n`);
+    writer.write(`\n${p.error}Error: ${message}${p.reset}\n`);
   }
 
   function showInfo(message: string): void {
-    process.stdout.write(`${p.muted}${message}${p.reset}\n`);
+    writer.write(`${p.muted}${message}${p.reset}\n`);
   }
 }

--- a/src/utils/frame-renderer.ts
+++ b/src/utils/frame-renderer.ts
@@ -1,0 +1,100 @@
+/**
+ * Differential frame renderer.
+ *
+ * Accepts a frame (string[]) and writes only the lines that changed
+ * compared to the previous frame.  Designed for scrolling content
+ * (not full-screen ownership like pi-tui).
+ *
+ * Fast paths:
+ *   1. First render → write everything
+ *   2. Append-only → write only new lines
+ *   3. Last line changed → \r overwrite (for spinner / partial streaming)
+ *   4. General diff → cursor-up, rewrite changed region, cursor-down
+ */
+import type { OutputWriter } from "./output-writer.js";
+
+export class FrameRenderer {
+  private prevLines: string[] = [];
+
+  constructor(private writer: OutputWriter) {}
+
+  /**
+   * Render a new frame, writing only the diff to the output.
+   * Each line in `lines` should NOT include a trailing newline.
+   */
+  update(lines: string[]): void {
+    const prev = this.prevLines;
+
+    if (prev.length === 0) {
+      // Fast path 1: first render
+      for (const line of lines) {
+        this.writer.write(line + "\n");
+      }
+      this.prevLines = lines.slice();
+      return;
+    }
+
+    // Find first and last changed indices
+    const minLen = Math.min(prev.length, lines.length);
+    let firstChanged = -1;
+    let lastChanged = -1;
+
+    for (let i = 0; i < minLen; i++) {
+      if (prev[i] !== lines[i]) {
+        if (firstChanged === -1) firstChanged = i;
+        lastChanged = i;
+      }
+    }
+
+    // Check for appended or removed lines
+    const appended = lines.length > prev.length;
+    const truncated = lines.length < prev.length;
+
+    if (firstChanged === -1 && !appended && !truncated) {
+      // No changes at all
+      this.prevLines = lines.slice();
+      return;
+    }
+
+    if (firstChanged === -1 && appended) {
+      // Fast path 2: only new lines appended, existing unchanged
+      for (let i = prev.length; i < lines.length; i++) {
+        this.writer.write(lines[i] + "\n");
+      }
+      this.prevLines = lines.slice();
+      return;
+    }
+
+    // General diff: move cursor up to first changed line, rewrite
+    const linesFromBottom = prev.length - (firstChanged === -1 ? prev.length : firstChanged);
+    if (linesFromBottom > 0) {
+      this.writer.write(`\x1b[${linesFromBottom}A`); // cursor up
+    }
+    this.writer.write("\r"); // start of line
+
+    // Rewrite from firstChanged to end of new frame
+    const start = firstChanged === -1 ? prev.length : firstChanged;
+    for (let i = start; i < lines.length; i++) {
+      this.writer.write(`\x1b[2K${lines[i]}\n`); // clear line + write + newline
+    }
+
+    // If new frame is shorter, clear remaining old lines
+    if (truncated) {
+      for (let i = lines.length; i < prev.length; i++) {
+        this.writer.write("\x1b[2K\n");
+      }
+      // Move cursor back up to end of new content
+      const extra = prev.length - lines.length;
+      if (extra > 0) {
+        this.writer.write(`\x1b[${extra}A`);
+      }
+    }
+
+    this.prevLines = lines.slice();
+  }
+
+  /** Reset state — next update will be treated as a first render. */
+  reset(): void {
+    this.prevLines = [];
+  }
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -77,25 +77,20 @@ export function wrapLine(text: string, maxWidth: number): string[] {
  * Streaming markdown renderer that processes chunks of text,
  * renders complete lines with ANSI formatting, and wraps output
  * in a bordered box.
+ *
+ * The renderer accumulates lines internally. Call `drainLines()` to
+ * extract them — this is the only way output leaves the renderer.
  */
-export interface MarkdownRendererOptions {
-  terminalWidth?: number;
-  /** Output function. Defaults to process.stdout.write. */
-  write?: (text: string) => void;
-}
-
 export class MarkdownRenderer {
   private buffer = "";
   private contentWidth: number;
   private firstLine = true;
-  private writeFn: (text: string) => void;
+  private pendingLines: string[] = [];
+  private width: number;
 
-  constructor(opts?: MarkdownRendererOptions | number) {
-    // Backward compat: accept bare number for terminalWidth
-    const options = typeof opts === "number" ? { terminalWidth: opts } : opts;
-    const termW = options?.terminalWidth ?? (process.stdout.columns || 100);
-    this.contentWidth = Math.min(MAX_CONTENT_WIDTH, termW - 2);
-    this.writeFn = options?.write ?? ((text: string) => process.stdout.write(text));
+  constructor(width: number) {
+    this.width = width;
+    this.contentWidth = Math.min(MAX_CONTENT_WIDTH, width - 2);
   }
 
   /**
@@ -118,14 +113,22 @@ export class MarkdownRenderer {
   }
 
   printTopBorder(): void {
-    const termW = process.stdout.columns || 80;
-    this.writeFn(`${p.dim}${p.accent}${"─".repeat(termW)}${p.reset}\n`);
+    this.pendingLines.push(`${p.dim}${p.accent}${"─".repeat(this.width)}${p.reset}`);
     this.firstLine = true;
   }
 
   printBottomBorder(): void {
-    const termW = process.stdout.columns || 80;
-    this.writeFn(`${p.dim}${p.accent}${"─".repeat(termW)}${p.reset}\n`);
+    this.pendingLines.push(`${p.dim}${p.accent}${"─".repeat(this.width)}${p.reset}`);
+  }
+
+  /**
+   * Extract and clear all accumulated lines.
+   * This is the only way output leaves the renderer.
+   */
+  drainLines(): string[] {
+    const lines = this.pendingLines;
+    this.pendingLines = [];
+    return lines;
   }
 
   private processBuffer(): void {
@@ -209,11 +212,12 @@ export class MarkdownRenderer {
   }
 
   /**
-   * Write a single line with a subtle left indent.
+   * Add a single line with a subtle left indent.
+   * The line is accumulated internally — call drainLines() to extract.
    */
   writeLine(text: string): void {
     if (this.firstLine && visibleLen(text) === 0) return;
     this.firstLine = false;
-    this.writeFn(`  ${text}\n`);
+    this.pendingLines.push(`  ${text}`);
   }
 }

--- a/src/utils/output-writer.ts
+++ b/src/utils/output-writer.ts
@@ -1,0 +1,33 @@
+/**
+ * Abstraction over terminal output.
+ *
+ * All TUI rendering goes through an OutputWriter instead of calling
+ * process.stdout.write directly.  This enables testing (BufferWriter),
+ * alternative frontends, and a single point of control for output.
+ */
+
+export interface OutputWriter {
+  write(text: string): void;
+  get columns(): number;
+}
+
+/** Default writer that forwards to process.stdout. */
+export class StdoutWriter implements OutputWriter {
+  write(text: string): void {
+    if (process.stdout.writable) {
+      try { process.stdout.write(text); } catch {}
+    }
+  }
+  get columns(): number {
+    return process.stdout.columns || 80;
+  }
+}
+
+/** Captures all output in memory. Useful for testing. */
+export class BufferWriter implements OutputWriter {
+  output: string[] = [];
+  columns = 80;
+  write(text: string): void {
+    this.output.push(text);
+  }
+}

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -232,43 +232,34 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 export interface SpinnerState {
   frame: number;
   startTime: number;
-  interval: ReturnType<typeof setInterval> | null;
 }
 
-export function createSpinner(): SpinnerState {
-  return { frame: 0, startTime: Date.now(), interval: null };
+export interface SpinnerOpts {
+  color?: string;
+  hint?: string;
+  startTime?: number;
+}
+
+export function createSpinner(opts?: { startTime?: number }): SpinnerState {
+  return { frame: 0, startTime: opts?.startTime || Date.now() };
 }
 
 /**
- * Start a spinner that writes to stdout on the current line.
- * Returns the SpinnerState for later stopping.
+ * Pure function: render the current spinner line and advance the frame.
+ * Does not write to stdout — the caller is responsible for output.
  */
-export function startSpinner(
+export function renderSpinnerLine(
+  state: SpinnerState,
   label: string,
-  opts?: { color?: string; hint?: string; startTime?: number },
-): SpinnerState {
-  const state = createSpinner();
-  if (opts?.startTime) state.startTime = opts.startTime;
+  opts?: SpinnerOpts,
+): string {
+  const frame = SPINNER_FRAMES[state.frame % SPINNER_FRAMES.length];
+  state.frame++;
   const color = opts?.color ?? p.accent;
-
+  const elapsed = formatElapsed(Date.now() - state.startTime);
+  const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
   const hint = opts?.hint ? ` ${p.dim}${opts.hint}${p.reset}` : "";
-  state.interval = setInterval(() => {
-    const frame = SPINNER_FRAMES[state.frame % SPINNER_FRAMES.length];
-    const elapsed = formatElapsed(Date.now() - state.startTime);
-    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
-    process.stdout.write(`\r  ${color}${frame} ${label}...${p.reset}${timer}${hint}\x1b[K`);
-    state.frame++;
-  }, 80);
-
-  return state;
-}
-
-export function stopSpinner(state: SpinnerState): void {
-  if (state.interval) {
-    clearInterval(state.interval);
-    state.interval = null;
-    process.stdout.write("\r\x1b[2K");
-  }
+  return `${color}${frame} ${label}...${p.reset}${timer}${hint}`;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **OutputWriter abstraction** — all TUI output goes through an injectable `OutputWriter` interface instead of `process.stdout.write` directly. `StdoutWriter` for production, `BufferWriter` for testing. Zero `process.stdout` references remain in tui-renderer.
- **MarkdownRenderer returns lines** — transformed from push-to-stdout to push-to-buffer. Constructor takes explicit `width`, `drainLines()` extracts accumulated lines. Fully testable without mocking globals.
- **Pure spinner function** — `renderSpinnerLine(state, label, opts): string` replaces the old `startSpinner`/`stopSpinner` that owned a `setInterval` and wrote to stdout. Interval now managed by the caller (tui-renderer).
- **Structured RenderState** — 14+ bare closure variables consolidated into a typed `RenderState` interface with `createRenderState()` factory. All accessed via `s.` prefix.
- **Width propagation** — `render:code-block` handler receives `width` as a parameter instead of reading `process.stdout.columns` internally.
- **FrameRenderer infrastructure** — `src/utils/frame-renderer.ts` provides differential line-level output with append-only fast path. Available for future incremental adoption.
- **latex-images example** — updated to use `ctx.call("render:image")` instead of direct `process.stdout.write`, and passes `width` through the advice chain.

Inspired by [pi-tui](https://github.com/badlogic/pi-mono/tree/main/packages/tui)'s `render(width): string[]` component model. Design analysis documented in `260410_tui_notes.org`.

## Test plan

- [ ] `npm run build` passes (verified)
- [ ] Manual test: agent query → streaming response renders identically
- [ ] Manual test: tool calls show with spinner, checkmark on completion
- [ ] Manual test: Ctrl+T toggles thinking display
- [ ] Manual test: file write shows inline diff, Ctrl+O expands
- [ ] Manual test: latex-images extension still renders LaTeX blocks