### PR TITLE
fix TUI streaming: interleave text with tool calls, prevent crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.tsbuildinfo
 *.org
+/.agent-shell/

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -7,7 +7,7 @@ import { computeDiff } from "./utils/diff.js";
 import { FileWatcher } from "./utils/file-watcher.js";
 import * as path from "node:path";
 import { stripAnsi } from "./utils/ansi.js";
-import type { EventBus } from "./event-bus.js";
+import type { EventBus, ShellEvents } from "./event-bus.js";
 import type { ContextManager } from "./context-manager.js";
 import type { AgentShellConfig } from "./types.js";
 
@@ -25,7 +25,10 @@ export class AcpClient {
   private terminalDonePromises = new Map<string, Promise<void>>();
   private terminalCounter = 0;
   private fileWatcher: FileWatcher;
-  private pendingToolCalls = new Map<string, string>(); // toolCallId → title
+  private pendingToolCalls = new Map<string, {
+    title: string;
+    deferredPayload?: ShellEvents["agent:tool-started"];
+  }>();
   private autoCancelled = false;
   private pendingToolCounter = 0;
   private agentInfo: { name: string; version: string } | null = null;
@@ -184,21 +187,15 @@ export class AcpClient {
 
     try {
       this.log("sending prompt...");
-      const promptTimeoutMs = 300000; // 5 minutes timeout for LLM response
-      const response = await Promise.race([
-        this.connection.prompt({
-          sessionId: this.sessionId,
-          prompt: [
-            {
-              type: "text",
-              text: contextBlock + "\n" + query,
-            },
-          ],
-        }),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`Prompt timeout after ${promptTimeoutMs}ms`)), promptTimeoutMs)
-        ),
-      ]);
+      const response = await this.connection.prompt({
+        sessionId: this.sessionId,
+        prompt: [
+          {
+            type: "text",
+            text: contextBlock + "\n" + query,
+          },
+        ],
+      });
 
       this.log(`prompt resolved: stopReason=${response.stopReason}`);
 
@@ -376,8 +373,14 @@ export class AcpClient {
   private createClientHandler(): acp.Client {
     return {
       // Required: handle session update notifications (streaming)
+      // Errors must not propagate — the ACP SDK returns them as error
+      // responses to the agent, which can stall the stream.
       sessionUpdate: async (params) => {
-        this.handleSessionUpdate(params);
+        try {
+          this.handleSessionUpdate(params);
+        } catch (err) {
+          this.log(`Error in sessionUpdate handler: ${err instanceof Error ? err.stack : err}`);
+        }
       },
 
       // Required: handle permission requests
@@ -445,22 +448,36 @@ export class AcpClient {
 
       case "tool_call": {
         const toolId = update.toolCallId || `tool-${this.pendingToolCounter++}`;
-        this.pendingToolCalls.set(toolId, update.title ?? "");
-        this.bus.emit("agent:tool-started", {
+        const payload: ShellEvents["agent:tool-started"] = {
           title: update.title,
           toolCallId: toolId,
           kind: update.kind ?? undefined,
           locations: update.locations?.map((l) => ({ path: l.path, line: l.line })),
           rawInput: update.rawInput,
+        };
+        const defer = this.pendingToolCalls.size > 0;
+        this.pendingToolCalls.set(toolId, {
+          title: update.title ?? "",
+          deferredPayload: defer ? payload : undefined,
         });
+        if (!defer) {
+          this.bus.emit("agent:tool-started", payload);
+        }
         break;
       }
 
       case "tool_call_update": {
         const toolId = update.toolCallId;
-        const toolTitle = toolId ? this.pendingToolCalls.get(toolId) : undefined;
+        const toolInfo = toolId ? this.pendingToolCalls.get(toolId) : undefined;
+        const toolTitle = toolInfo?.title;
 
         if (update.status === "completed" || update.status === "failed") {
+          // Emit deferred tool-started before output (parallel tools)
+          if (toolInfo?.deferredPayload) {
+            this.bus.emit("agent:tool-started", toolInfo.deferredPayload);
+            toolInfo.deferredPayload = undefined;
+          }
+
           // Show content only on final status. Skip tools whose output the
           // user already sees (user_shell → PTY) or is agent-only (shell_recall).
           const skipOutput = toolTitle === "user_shell" || toolTitle === "shell_recall";

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -355,10 +355,15 @@ export default function activate(ctx: ExtensionContext): void {
       s.renderer!.writeLine(`${p.dim}${language}${p.reset}`);
     }
     let highlighted: string;
-    try {
-      highlighted = highlight(code, { language: language || undefined });
-    } catch {
-      highlighted = `${p.success}${code}${p.reset}`;
+    if (!language) {
+      // No language specified — render as plain text to avoid false syntax detection
+      highlighted = code;
+    } else {
+      try {
+        highlighted = highlight(code, { language });
+      } catch {
+        highlighted = `${p.success}${code}${p.reset}`;
+      }
     }
     const contentWidth = Math.min(90, width - 2);
     for (const line of highlighted.split("\n")) {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -12,7 +12,7 @@
  */
 import { highlight } from "cli-highlight";
 import { MarkdownRenderer, wrapLine } from "../utils/markdown.js";
-import { createFencedBlockTransform } from "../utils/stream-transform.js";
+import { createFencedBlockTransform, type FencedBlockTransformHandle } from "../utils/stream-transform.js";
 import { palette as p } from "../utils/palette.js";
 import {
   renderToolCall,
@@ -82,6 +82,7 @@ interface RenderState {
   // ── Thinking ──
   isThinking: boolean;
   showThinkingText: boolean;
+  thinkingPending: boolean;
 
   // ── Diff expansion ──
   lastTruncatedDiff: TruncatedDiff | null;
@@ -104,6 +105,7 @@ function createRenderState(): RenderState {
     commandOutputOverflow: 0,
     isThinking: false,
     showThinkingText: false,
+    thinkingPending: false,
     lastTruncatedDiff: null,
   };
 }
@@ -115,7 +117,7 @@ export default function activate(ctx: ExtensionContext): void {
 
   // ── Register fenced block transform (code blocks → ContentBlock) ──
   // Nobody is special — tui-renderer uses the same primitive as any extension.
-  createFencedBlockTransform(bus, {
+  const fencedTransform = createFencedBlockTransform(bus, {
     open: /^```(\w*)\s*$/,
     close: /^```\s*$/,
     transform(match, content) {
@@ -133,6 +135,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:thinking-chunk", (e) => {
+    s.thinkingPending = true;
     if (!s.isThinking) {
       s.isThinking = true;
       if (s.showThinkingText) {
@@ -146,6 +149,7 @@ export default function activate(ctx: ExtensionContext): void {
       }
     }
     if (s.showThinkingText && e.text) {
+      s.thinkingPending = false;
       if (!s.renderer) startAgentResponse();
       s.renderer!.push(`${p.dim}${e.text}${p.reset}`);
       drain();
@@ -194,6 +198,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:tool-started", (e) => {
+    fencedTransform.flush();
     stopCurrentSpinner();
     s.currentToolKind = e.kind;
     if (e.title === "user_shell") {
@@ -272,8 +277,17 @@ export default function activate(ctx: ExtensionContext): void {
     drain();
   }
 
+  function showCollapsedThinking(): void {
+    if (s.thinkingPending && !s.showThinkingText) {
+      if (!s.renderer) startAgentResponse();
+      s.renderer!.writeLine(`${p.muted}… thinking${p.reset}`);
+      s.thinkingPending = false;
+    }
+  }
+
   function endAgentResponse(): void {
     closeToolLine();
+    stopCurrentSpinner();
     if (s.renderer) {
       s.renderer.flush();
       s.renderer.printBottomBorder();
@@ -327,6 +341,7 @@ export default function activate(ctx: ExtensionContext): void {
         drain();
       }
     }
+    showCollapsedThinking();
     stopCurrentSpinner();
     if (!s.renderer) startAgentResponse();
     if (needsGap) writer.write("\n");
@@ -392,6 +407,7 @@ export default function activate(ctx: ExtensionContext): void {
     closeToolLine();
     stopCurrentSpinner();
     if (!s.renderer) startAgentResponse();
+    showCollapsedThinking();
     s.renderer!.flush();
     drain();
     const lines = renderToolCall({

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -53,7 +53,7 @@ const DEFAULTS: Required<Settings> = {
   shellHeadLines: 5,
   shellTailLines: 5,
   recallExpandMaxLines: 100,
-  maxCommandOutputLines: 5,
+  maxCommandOutputLines: 3,
   readOutputMaxLines: 0,
   diffMaxLines: 20,
   enableMcp: true,

--- a/src/utils/box-frame.ts
+++ b/src/utils/box-frame.ts
@@ -53,7 +53,8 @@ export interface BoxFrameOptions {
  * @returns Array of terminal-ready lines with borders
  */
 export function renderBoxFrame(content: string[], opts: BoxFrameOptions): string[] {
-  const { width, borderColor = p.dim } = opts;
+  const { width: rawWidth, borderColor = p.dim } = opts;
+  const width = Math.max(6, rawWidth);
   const style = opts.style ?? "rounded";
   const b = BORDERS[style];
   const bc = borderColor;

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -410,7 +410,7 @@ function renderSplit(diff: DiffResult, opts: DiffRenderOptions): string[] {
   const lang = useSyntax ? detectLanguage(opts.filePath) : undefined;
   const totalWidth = opts.width;
   // 3 chars for " │ " separator
-  const colWidth = Math.floor((totalWidth - 3) / 2);
+  const colWidth = Math.max(1, Math.floor((totalWidth - 3) / 2));
 
   // Compute max line number width
   let maxNo = 0;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -8,6 +8,7 @@ const MAX_CONTENT_WIDTH = 90;
  * Returns an array of lines, each fitting within `maxWidth` visible characters.
  */
 export function wrapLine(text: string, maxWidth: number): string[] {
+  if (!(maxWidth > 0)) return [text]; // catches NaN, <=0, undefined
   if (visibleLen(text) <= maxWidth) return [text];
 
   const result: string[] = [];
@@ -89,8 +90,8 @@ export class MarkdownRenderer {
   private width: number;
 
   constructor(width: number) {
-    this.width = width;
-    this.contentWidth = Math.min(MAX_CONTENT_WIDTH, width - 2);
+    this.width = Math.max(10, width);
+    this.contentWidth = Math.min(MAX_CONTENT_WIDTH, this.width - 2);
   }
 
   /**

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -88,6 +88,7 @@ export class MarkdownRenderer {
   private firstLine = true;
   private pendingLines: string[] = [];
   private width: number;
+  private tableRows: string[][] = [];
 
   constructor(width: number) {
     this.width = Math.max(10, width);
@@ -111,6 +112,7 @@ export class MarkdownRenderer {
       this.processLine(this.buffer);
       this.buffer = "";
     }
+    this.flushTable();
   }
 
   printTopBorder(): void {
@@ -142,10 +144,87 @@ export class MarkdownRenderer {
   }
 
   private processLine(line: string): void {
+    // Table row detection: lines with | separators
+    if (/^\s*\|/.test(line)) {
+      const cells = parseTableRow(line);
+      if (cells) {
+        this.tableRows.push(cells);
+        return;
+      }
+    }
+
+    // Non-table line — flush any buffered table first
+    this.flushTable();
+
     const rendered = this.renderLine(line);
     const wrapped = wrapLine(rendered, this.contentWidth);
     for (const wl of wrapped) {
       this.writeLine(wl);
+    }
+  }
+
+  private flushTable(): void {
+    if (this.tableRows.length === 0) return;
+
+    const rows = this.tableRows;
+    this.tableRows = [];
+
+    // Filter out separator rows (|---|---|)
+    const sepIdx: number[] = [];
+    const dataRows: string[][] = [];
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i]!.every((c) => /^[-:]+$/.test(c.trim()) || c.trim() === "")) {
+        sepIdx.push(i);
+      } else {
+        dataRows.push(rows[i]!);
+      }
+    }
+
+    if (dataRows.length === 0) return;
+
+    // Normalize column count
+    const numCols = Math.max(...dataRows.map((r) => r.length));
+    for (const row of dataRows) {
+      while (row.length < numCols) row.push("");
+    }
+
+    // Calculate column widths from content
+    const colWidths: number[] = new Array(numCols).fill(0);
+    for (const row of dataRows) {
+      for (let c = 0; c < numCols; c++) {
+        colWidths[c] = Math.max(colWidths[c]!, row[c]!.length);
+      }
+    }
+
+    // Shrink columns proportionally if total exceeds content width
+    // Account for separators: " │ " between cols (3 chars each) + 2 outer padding
+    const separatorWidth = (numCols - 1) * 3;
+    const availableWidth = this.contentWidth - separatorWidth;
+    const totalWidth = colWidths.reduce((a, b) => a + b, 0);
+    if (totalWidth > availableWidth && availableWidth > numCols) {
+      const scale = availableWidth / totalWidth;
+      for (let c = 0; c < numCols; c++) {
+        colWidths[c] = Math.max(1, Math.floor(colWidths[c]! * scale));
+      }
+    }
+
+    // Render rows
+    const hasHeader = sepIdx.includes(1) && dataRows.length > 1;
+    for (let i = 0; i < dataRows.length; i++) {
+      const row = dataRows[i]!;
+      const isHeader = hasHeader && i === 0;
+      const cells = row.map((cell, c) => {
+        const w = colWidths[c]!;
+        const text = cell.length > w ? cell.slice(0, w - 1) + "…" : cell.padEnd(w);
+        return isHeader ? `${p.bold}${text}${p.reset}` : text;
+      });
+      this.writeLine(`${p.dim}│${p.reset} ${cells.join(` ${p.dim}│${p.reset} `)} ${p.dim}│${p.reset}`);
+
+      // Separator after header
+      if (isHeader) {
+        const sep = colWidths.map((w) => "─".repeat(w)).join(`─┼─`);
+        this.writeLine(`${p.dim}├─${sep}─┤${p.reset}`);
+      }
     }
   }
 
@@ -198,10 +277,10 @@ export class MarkdownRenderer {
     text = text.replace(/\*\*\*(.+?)\*\*\*/g, `${p.bold}${p.italic}$1${p.reset}`);
     // Bold
     text = text.replace(/\*\*(.+?)\*\*/g, `${p.bold}$1${p.reset}`);
-    text = text.replace(/__(.+?)__/g, `${p.bold}$1${p.reset}`);
+    text = text.replace(/(?<!\w)__(.+?)__(?!\w)/g, `${p.bold}$1${p.reset}`);
     // Italic
     text = text.replace(/\*(.+?)\*/g, `${p.italic}$1${p.reset}`);
-    text = text.replace(/_(.+?)_/g, `${p.italic}$1${p.reset}`);
+    text = text.replace(/(?<!\w)_(.+?)_(?!\w)/g, `${p.italic}$1${p.reset}`);
     // Strikethrough
     text = text.replace(/~~(.+?)~~/g, `${p.dim}$1${p.reset}`);
     // Links
@@ -221,4 +300,14 @@ export class MarkdownRenderer {
     this.firstLine = false;
     this.pendingLines.push(`  ${text}`);
   }
+}
+
+/** Parse a markdown table row into trimmed cell strings, or null if not a table row. */
+function parseTableRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null;
+  // Split on |, drop first and last empty entries
+  const parts = trimmed.split("|");
+  if (parts.length < 3) return null; // need at least |cell|
+  return parts.slice(1, -1).map((c) => c.trim());
 }

--- a/src/utils/stream-transform.ts
+++ b/src/utils/stream-transform.ts
@@ -116,16 +116,23 @@ export interface FencedBlockTransformOptions {
  *     },
  *   });
  */
+export interface FencedBlockTransformHandle {
+  /** Flush any buffered text (e.g. before tool calls, to preserve interleaving). */
+  flush(): void;
+}
+
 export function createFencedBlockTransform(
   bus: EventBus,
   opts: FencedBlockTransformOptions,
-): void {
+): FencedBlockTransformHandle {
   let buffer = "";
   let inFence = false;
   let fenceMatch: RegExpMatchArray | null = null;
   let fenceLines: string[] = [];
+  let flushing = false;
 
   bus.onPipe("agent:response-chunk", (e) => {
+    if (flushing) return e; // pass through during flush to avoid re-buffering
     // Collect text from blocks or raw text
     let incoming = "";
     if (e.blocks) {
@@ -157,27 +164,32 @@ export function createFencedBlockTransform(
     return { ...e, text: "", blocks: [...existing, ...blocks] };
   });
 
-  bus.onPipe("agent:response-done", (e) => {
-    if (buffer || inFence) {
-      // Flush: unclosed fence → emit content as text
-      let remaining = buffer;
-      if (inFence) {
-        // Reconstruct the opening fence + accumulated lines
-        remaining = (fenceMatch?.[0] ?? "") + "\n" + fenceLines.join("\n") + (remaining ? "\n" + remaining : "");
-        inFence = false;
-        fenceMatch = null;
-        fenceLines = [];
-      }
-      if (remaining) {
-        bus.emitTransform("agent:response-chunk", {
-          text: remaining,
-          blocks: [{ type: "text", text: remaining }],
-        });
-      }
-      buffer = "";
+  function flushBuffer(): void {
+    if (!buffer && !inFence) return;
+    let remaining = buffer;
+    if (inFence) {
+      remaining = (fenceMatch?.[0] ?? "") + "\n" + fenceLines.join("\n") + (remaining ? "\n" + remaining : "");
+      inFence = false;
+      fenceMatch = null;
+      fenceLines = [];
     }
+    buffer = "";
+    if (remaining) {
+      flushing = true;
+      bus.emitTransform("agent:response-chunk", {
+        text: "",
+        blocks: [{ type: "text", text: remaining }],
+      });
+      flushing = false;
+    }
+  }
+
+  bus.onPipe("agent:response-done", (e) => {
+    flushBuffer();
     return e;
   });
+
+  return { flush: flushBuffer };
 }
 
 interface FencedPendingState {

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -4,6 +4,7 @@
  * Follows the render(width) -> string[] protocol for completed tools.
  * Also provides a spinner/timer component for in-progress tools.
  */
+import * as path from "node:path";
 import { visibleLen } from "./ansi.js";
 import { palette as p } from "./palette.js";
 
@@ -102,13 +103,14 @@ export function renderToolCall(
 
   // Build a compact detail string to append after the title
   let detail = "";
+  const cwd = process.cwd();
   if (mode === "full") {
     if (tool.command) {
       detail = `$ ${tool.command}`;
     } else if (tool.locations && tool.locations.length > 0) {
       const loc = tool.locations[0]!;
       const lineInfo = loc.line ? `:${loc.line}` : "";
-      detail = `${loc.path}${lineInfo}`;
+      detail = `${shortenPath(loc.path, cwd)}${lineInfo}`;
     } else if (tool.rawInput) {
       const raw = tool.rawInput as Record<string, unknown>;
       if (raw && typeof raw === "object") {
@@ -142,7 +144,7 @@ export function renderToolCall(
   if (mode === "full" && tool.locations && tool.locations.length > 1) {
     for (const loc of tool.locations.slice(1)) {
       const lineInfo = loc.line ? `:${loc.line}` : "";
-      lines.push(`  ${p.dim}${loc.path}${lineInfo}${p.reset}`);
+      lines.push(`  ${p.dim}${shortenPath(loc.path, cwd)}${lineInfo}${p.reset}`);
     }
   }
 
@@ -263,6 +265,17 @@ export function renderSpinnerLine(
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Shorten an absolute path to a relative or tilde-prefixed form.
+ */
+function shortenPath(p: string, cwd: string): string {
+  if (p.startsWith(cwd + "/")) return p.slice(cwd.length + 1);
+  if (p.startsWith(cwd)) return p.slice(cwd.length) || ".";
+  const home = process.env.HOME;
+  if (home && p.startsWith(home + "/")) return "~/" + p.slice(home.length + 1);
+  return p;
+}
 
 function truncateVisible(text: string, maxWidth: number): string {
   if (visibleLen(text) <= maxWidth) return text;


### PR DESCRIPTION
## Summary

- **Inter-tool text interleaving**: Flush fenced block transform buffer before tool calls so text between tools renders inline rather than batching at the end. Prevents re-buffering during flush and avoids duplication from downstream pipe transforms (e.g., latex-images extension).
- **Collapsed thinking indicator**: Show `… thinking` between tool calls when thinking text is not expanded (ctrl+t).
- **Parallel tool grouping**: Defer rendering of parallel tool calls until completion so each tool's header + output + status appear together as a block.
- **Crash fix (Invalid array length)**: Guard `wrapLine` against NaN/negative `maxWidth` — caused an infinite loop when the latex-images extension passed undefined width, eventually overflowing the result array.
- **Stream stall fix**: Catch errors in `sessionUpdate` handler to prevent them from propagating as ACP error responses that stall the agent.
- **Spinner/border fix**: Stop spinner in `endAgentResponse` so it doesn't overwrite the bottom border.
- **Remove prompt timeout**: User can Ctrl-C to cancel; the 5-minute timeout was too short when including tool execution time.
- **Compact output**: Shorten absolute paths in tool headers (relative to cwd or `~/`), reduce default `maxCommandOutputLines` from 5 to 3.
- **Width guards**: Clamp minimum widths in MarkdownRenderer (10), box-frame (6), and diff-renderer (1) to prevent `.repeat()` crashes with negative values.

## Test plan

- [ ] Run with a query that triggers multiple tool calls and verify text appears between tools, not batched at end
- [ ] Verify parallel tool calls render as grouped blocks (header + output + ✓)
- [ ] Verify `… thinking` indicator appears before first tool call
- [ ] Run with latex-images extension and verify no "Invalid array length" crash
- [ ] Verify Ctrl-C cancels a long-running prompt
- [ ] Check tool headers show shortened paths