### PR TITLE
Strip slash commands to essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,8 @@ Everything else works as a normal shell — commands go straight to the PTY. Mod
 | Command | Description |
 |---|---|
 | `/help` | Show available commands |
-| `/clear` | Start a new agent session |
-| `/copy` | Copy last agent response to clipboard |
-| `/compact` | Summarize the conversation to free context |
-| `/model` | Cycle to the next model (same as Shift+Tab) |
-| `/provider <name>` | Switch to a different provider |
+| `/model [name]` | Cycle to the next model, or switch to a specific one |
 | `/backend [name]` | List backends, or switch to a named backend |
-| `/quit` | Exit agent-sh |
 
 ## Configuration
 

--- a/examples/extensions/openrouter.ts
+++ b/examples/extensions/openrouter.ts
@@ -1,0 +1,87 @@
+/**
+ * OpenRouter provider extension.
+ *
+ * Registers OpenRouter as a provider and fetches its full model catalog
+ * at startup. Models appear in /model autocomplete as "model [openrouter]"
+ * and are available for cycling with Shift+Tab.
+ *
+ * Model capabilities (reasoning, context window) are read from the
+ * OpenRouter API response — no hardcoded model lists.
+ *
+ * Setup:
+ *   export OPENROUTER_API_KEY="your-key"
+ *
+ * Usage:
+ *   agent-sh -e ./examples/extensions/openrouter.ts
+ *
+ *   # Or add to settings.json:
+ *   { "extensions": ["./examples/extensions/openrouter.ts"] }
+ */
+import type { ExtensionContext } from "agent-sh/types";
+
+const BASE_URL = "https://openrouter.ai/api/v1";
+const API_KEY = process.env.OPENROUTER_API_KEY ?? "";
+
+/** Curated default models — used immediately while the full catalog loads. */
+const DEFAULT_MODELS = [
+  "anthropic/claude-sonnet-4",
+  "google/gemini-2.5-pro-preview",
+  "openai/gpt-4.1",
+  "deepseek/deepseek-r1",
+  "meta-llama/llama-4-maverick",
+];
+
+interface OpenRouterModel {
+  id: string;
+  name: string;
+  context_length?: number;
+  supported_parameters?: string[];
+  pricing?: { prompt: string; completion: string };
+}
+
+export default function activate({ bus }: ExtensionContext): void {
+  if (!API_KEY) {
+    bus.emit("ui:error", {
+      message: "OpenRouter extension: OPENROUTER_API_KEY not set. Skipping.",
+    });
+    return;
+  }
+
+  // Register provider immediately with curated defaults
+  bus.emit("provider:register", {
+    id: "openrouter",
+    apiKey: API_KEY,
+    baseURL: BASE_URL,
+    defaultModel: DEFAULT_MODELS[0],
+    models: DEFAULT_MODELS,
+  });
+
+  // Fetch full model catalog in background, re-register with capabilities
+  fetchModels().then((models) => {
+    if (models.length > 0) {
+      bus.emit("provider:register", {
+        id: "openrouter",
+        apiKey: API_KEY,
+        baseURL: BASE_URL,
+        defaultModel: DEFAULT_MODELS[0],
+        supportsReasoningEffort: true,
+        models: models.map((m) => ({
+          id: m.id,
+          reasoning: m.supported_parameters?.includes("reasoning") ?? false,
+          contextWindow: m.context_length,
+        })),
+      });
+    }
+  }).catch(() => {
+    // Silently fall back to curated defaults
+  });
+}
+
+async function fetchModels(): Promise<OpenRouterModel[]> {
+  const res = await fetch(`${BASE_URL}/models`, {
+    headers: { Authorization: `Bearer ${API_KEY}` },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.data ?? []) as OpenRouterModel[];
+}

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -52,6 +52,9 @@ export class AgentLoop implements AgentBackend {
   private currentModeIndex = 0;
   private boundListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
   private lastProjectSkillNames = new Set<string>();
+  private static readonly THINKING_LEVELS = ["off", "low", "medium", "high"];
+
+  private thinkingLevel = "off";
 
   constructor(
     private bus: EventBus,
@@ -91,6 +94,52 @@ export class AgentLoop implements AgentBackend {
       this.abortController?.abort(e.silent ? "silent" : undefined);
     });
     on("config:cycle", () => this.cycleMode());
+    on("config:switch-model", ({ model: target }) => {
+      const idx = this.modes.findIndex((m) => m.model === target);
+      if (idx === -1) {
+        this.bus.emit("ui:error", { message: `Unknown model: ${target}` });
+        return;
+      }
+      this.currentModeIndex = idx;
+      const m = this.modes[idx];
+      if (m.providerConfig) {
+        this.llmClient.reconfigure({ ...m.providerConfig, model: m.model });
+      } else {
+        this.llmClient.model = m.model;
+      }
+      const label = m.provider ? `${m.provider}: ${m.model}` : m.model;
+      this.bus.emit("agent:info", { name: "agent-sh", version: "0.4", model: m.model, provider: m.provider, contextWindow: m.contextWindow });
+      this.bus.emit("ui:info", { message: `Model: ${label}` });
+      this.bus.emit("config:changed", {});
+    });
+    this.bus.onPipe("config:get-models", (payload) => {
+      const models = this.modes.map((m) => ({ model: m.model, provider: m.provider ?? "" }));
+      const active = this.modes[this.currentModeIndex]?.model ?? null;
+      return { models, active };
+    });
+    on("config:set-thinking", ({ level }) => {
+      if (!AgentLoop.THINKING_LEVELS.includes(level)) {
+        this.bus.emit("ui:error", { message: `Unknown thinking level: ${level}. Use: ${AgentLoop.THINKING_LEVELS.join(", ")}` });
+        return;
+      }
+      const mode = this.currentMode;
+      if (level !== "off" && mode.reasoning === false) {
+        this.bus.emit("ui:error", { message: `Model ${mode.model} does not support thinking.` });
+        return;
+      }
+      if (level !== "off" && mode.supportsReasoningEffort === false) {
+        this.bus.emit("ui:error", { message: `Provider ${mode.provider ?? "unknown"} does not support reasoning_effort.` });
+        return;
+      }
+      this.thinkingLevel = level;
+      this.bus.emit("ui:info", { message: `Thinking: ${level}` });
+      this.bus.emit("config:changed", {});
+    });
+    this.bus.onPipe("config:get-thinking", () => {
+      const mode = this.currentMode;
+      const supported = mode.reasoning !== false && mode.supportsReasoningEffort !== false;
+      return { level: this.thinkingLevel, levels: AgentLoop.THINKING_LEVELS, supported };
+    });
     on("config:set-modes", ({ modes: newModes }) => {
       this.modes = newModes;
       this.currentModeIndex = 0;
@@ -151,6 +200,15 @@ export class AgentLoop implements AgentBackend {
 
   private cancel(): void {
     this.abortController?.abort();
+  }
+
+  /** Check if reasoning_effort should be sent for the current model/provider. */
+  private shouldSendReasoningEffort(): boolean {
+    if (this.thinkingLevel === "off") return false;
+    const mode = this.currentMode;
+    if (mode.reasoning === false) return false;
+    if (mode.supportsReasoningEffort === false) return false;
+    return true;
   }
 
 
@@ -614,6 +672,7 @@ export class AgentLoop implements AgentBackend {
       messages,
       tools: this.toolRegistry.toAPITools(),
       model: this.currentModel,
+      reasoning_effort: this.shouldSendReasoningEffort() ? this.thinkingLevel : undefined,
       signal,
     });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -81,11 +81,14 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     for (const [id, p] of providerRegistry) {
       if (!p.apiKey) continue;
       for (const model of p.models) {
+        const mc = p.modelCapabilities?.get(model);
         allModes.push({
           model,
           provider: id,
           providerConfig: { apiKey: p.apiKey, baseURL: p.baseURL },
-          contextWindow: p.contextWindow,
+          contextWindow: mc?.contextWindow ?? p.contextWindow,
+          reasoning: mc?.reasoning,
+          supportsReasoningEffort: p.supportsReasoningEffort,
         });
       }
     }
@@ -180,15 +183,35 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     bus.emit("ui:info", { message: `Backends: ${list}` });
   });
 
+  bus.onPipe("config:get-backends", (payload) => {
+    const names: string[] = [];
+    if (agentLoop) names.push("agent-sh");
+    for (const name of backends.keys()) names.push(name);
+    return { names, active: activeBackendName };
+  });
+
   // ── Runtime provider management ──────────────────────────────
 
   bus.on("provider:register", (p) => {
+    const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
+    const modelIds: string[] = [];
+    const caps = new Map<string, { reasoning?: boolean; contextWindow?: number }>();
+    for (const m of rawModels) {
+      if (typeof m === "string") {
+        modelIds.push(m);
+      } else {
+        modelIds.push(m.id);
+        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow });
+      }
+    }
     providerRegistry.set(p.id, {
       id: p.id,
       apiKey: p.apiKey,
       baseURL: p.baseURL,
       defaultModel: p.defaultModel,
-      models: p.models ?? (p.defaultModel ? [p.defaultModel] : []),
+      models: modelIds,
+      supportsReasoningEffort: p.supportsReasoningEffort,
+      modelCapabilities: caps.size > 0 ? caps : undefined,
     });
   });
 
@@ -219,12 +242,17 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
       model: switchModel,
     });
 
-    const newModes: AgentMode[] = p.models.map((m) => ({
-      model: m,
-      provider: name,
-      providerConfig: { apiKey: newApiKey, baseURL: p.baseURL },
-      contextWindow: p.contextWindow,
-    }));
+    const newModes: AgentMode[] = p.models.map((m) => {
+      const mc = p.modelCapabilities?.get(m);
+      return {
+        model: m,
+        provider: name,
+        providerConfig: { apiKey: newApiKey, baseURL: p.baseURL },
+        contextWindow: mc?.contextWindow ?? p.contextWindow,
+        reasoning: mc?.reasoning,
+        supportsReasoningEffort: p.supportsReasoningEffort,
+      };
+    });
     bus.emit("config:set-modes", { modes: newModes });
 
     activeProvider = p;
@@ -309,6 +337,8 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         createFencedBlockTransform: (o) =>
           streamTransform.createFencedBlockTransform(bus, o),
         getExtensionSettings: settingsMod.getExtensionSettings,
+        registerCommand: (name, description, handler) =>
+          bus.emit("command:register", { name, description, handler }),
         registerTool: (tool) => agentLoop?.registerTool(tool),
         getTools: () => agentLoop?.getTools() ?? [],
         define: (name, fn) => handlers.define(name, fn),

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -74,6 +74,13 @@ export interface ShellEvents {
     decision: Record<string, unknown>;
   };
 
+  // Slash command registration (extensions → slash-commands)
+  "command:register": {
+    name: string;
+    description: string;
+    handler: (args: string) => Promise<void> | void;
+  };
+
   // Slash command execution
   "command:execute": {
     name: string;
@@ -117,6 +124,7 @@ export interface ShellEvents {
   // Session reset (slash command → backend: clear conversation state)
   "agent:reset-session": Record<string, never>;
 
+
   // Extension registers itself as agent backend (extension → core)
   "agent:register-backend": {
     name: string;
@@ -129,12 +137,22 @@ export interface ShellEvents {
 
   // List registered backends (slash command → core, returns via ui:info)
   "config:list-backends": Record<string, never>;
+  // Query backend names (sync pipe — for autocomplete)
+  "config:get-backends": { names: string[]; active: string | null };
 
   // Session mode/config updated (from agent backend)
   "config:changed": Record<string, never>;
 
   // Cycle session mode (input-handler → backend: cycles models within provider)
   "config:cycle": Record<string, never>;
+  // Switch to a specific model by name (slash command → backend)
+  "config:switch-model": { model: string };
+  // Query available models (sync pipe — for autocomplete)
+  "config:get-models": { models: { model: string; provider: string }[]; active: string | null };
+  // Set thinking/reasoning effort level (slash command → backend)
+  "config:set-thinking": { level: string };
+  // Query current thinking level (sync pipe — for autocomplete)
+  "config:get-thinking": { level: string; levels: string[]; supported: boolean };
 
   // Switch provider at runtime (slash command → core)
   "config:switch-provider": { provider: string };
@@ -148,12 +166,18 @@ export interface ShellEvents {
     apiKey?: string;
     baseURL?: string;
     defaultModel: string;
-    models?: string[];
+    models?: (string | { id: string; reasoning?: boolean; contextWindow?: number })[];
+    /** Provider supports the reasoning_effort parameter. Default: true. */
+    supportsReasoningEffort?: boolean;
   };
 
   // Autocomplete (sync pipe: extensions inspect buffer and append items)
   "autocomplete:request": {
     buffer: string;
+    /** Parsed slash command name (e.g. "/backend"), or null if not a command. */
+    command: string | null;
+    /** Text after the command name (e.g. "clau" for "/backend clau"), or null. */
+    commandArgs: string | null;
     items: { name: string; description: string }[];
   };
 }

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -2,11 +2,14 @@
  * Slash commands extension.
  *
  * Registers built-in slash commands on the event bus:
+ * - Listens for "command:register" to accept commands from extensions
  * - Responds to "autocomplete:request" pipe for /-prefixed completions
  * - Handles "command:execute" events and dispatches to matching handler
  * - Uses "ui:info"/"ui:error" for user feedback (no direct TUI dependency)
+ *
+ * Argument completion is composable: any extension can onPipe("autocomplete:request")
+ * and check payload.command / payload.commandArgs to add completions for any command.
  */
-import { execSync } from "node:child_process";
 import { palette as p } from "../utils/palette.js";
 import type { ExtensionContext } from "../types.js";
 import { discoverSkills, loadSkillContent, type Skill } from "../agent/skills.js";
@@ -17,94 +20,83 @@ interface SlashCommand {
   handler: (args: string) => Promise<void> | void;
 }
 
-export default function activate({ bus, contextManager, quit }: ExtensionContext): void {
-  // Track last response for /copy
-  let lastResponseText = "";
-  bus.on("agent:processing-start", () => { lastResponseText = ""; });
-  bus.on("agent:response-chunk", ({ blocks }) => {
-    for (const b of blocks) if (b.type === "text") lastResponseText += b.text;
+export default function activate({ bus, contextManager }: ExtensionContext): void {
+  const commands = new Map<string, SlashCommand>();
+
+  const register = (cmd: SlashCommand) => {
+    const name = cmd.name.startsWith("/") ? cmd.name : `/${cmd.name}`;
+    commands.set(name, { ...cmd, name });
+  };
+
+  // ── Built-in commands ─────────────────────────────────────────
+
+  register({
+    name: "/help",
+    description: "Show available commands",
+    handler: () => {
+      const maxLen = Math.max(...[...commands.values()].map(c => c.name.length));
+      const pad = maxLen + 2;
+      const lines = [...commands.values()].map(
+        (c) => `  ${p.accent}${c.name.padEnd(pad)}${p.reset} ${c.description}`
+      );
+      bus.emit("ui:info", { message: "Available commands:\n" + lines.join("\n") });
+    },
   });
 
-  const commands: SlashCommand[] = [
-    {
-      name: "/help",
-      description: "Show available commands",
-      handler: () => {
-        const lines = commands.map(
-          (c) => `  ${p.accent}${c.name.padEnd(12)}${p.reset} ${c.description}`
-        );
-        bus.emit("ui:info", { message: "Available commands:\n" + lines.join("\n") });
-      },
+  register({
+    name: "/model",
+    description: "Cycle to next model, or switch to a specific one",
+    handler: (args) => {
+      const name = args.trim();
+      if (!name) {
+        const { models, active } = bus.emitPipe("config:get-models", { models: [], active: null });
+        const current = models.find((m) => m.model === active);
+        const label = current
+          ? `${current.model}${current.provider ? ` [${current.provider}]` : ""}`
+          : active ?? "none";
+        bus.emit("ui:info", { message: `Model: ${label}` });
+      } else {
+        bus.emit("config:switch-model", { model: name });
+      }
     },
-    {
-      name: "/clear",
-      description: "Start a new agent session",
-      handler: () => {
-        bus.emit("agent:reset-session", {});
-        bus.emit("ui:info", { message: "Session cleared." });
-      },
-    },
-    {
-      name: "/copy",
-      description: "Copy last agent response to clipboard",
-      handler: () => {
-        const text = lastResponseText;
-        if (!text) {
-          bus.emit("ui:info", { message: "No agent response to copy." });
-          return;
-        }
-        try {
-          if (process.platform === "darwin") {
-            execSync("pbcopy", { input: text });
-          } else {
-            execSync("xclip -selection clipboard", { input: text });
-          }
-          bus.emit("ui:info", { message: "Copied to clipboard." });
-        } catch {
-          bus.emit("ui:error", { message: "Failed to copy to clipboard." });
-        }
-      },
-    },
-    {
-      name: "/compact",
-      description: "Ask agent to summarize the conversation",
-      handler: async () => {
-        bus.emit("agent:submit", {
-          query: "Please provide a concise summary of our conversation so far and the current state of the work.",
-        });
-      },
-    },
-    {
-      name: "/model",
-      description: "Cycle to next model",
-      handler: () => {
-        bus.emit("config:cycle", {});
-      },
-    },
-    {
-      name: "/backend",
-      description: "List or switch agent backend",
-      handler: (args) => {
-        const name = args.trim();
-        if (!name) {
-          bus.emit("config:list-backends", {});
-        } else {
-          bus.emit("config:switch-backend", { name });
-        }
-      },
-    },
-{
-      name: "/quit",
-      description: "Exit agent-sh",
-      handler: () => {
-        quit();
-      },
-    },
-  ];
+  });
 
-  // ── Skill commands (/skill:<name>) ──────────────────────────────
+  register({
+    name: "/thinking",
+    description: "Set thinking/reasoning effort level",
+    handler: (args) => {
+      const level = args.trim();
+      if (!level) {
+        const { level: current, levels, supported } = bus.emitPipe("config:get-thinking", { level: "off", levels: [], supported: true });
+        const status = supported ? current : `${current} (not supported by current model)`;
+        bus.emit("ui:info", { message: `Thinking: ${status} (options: ${levels.join(", ")})` });
+      } else {
+        bus.emit("config:set-thinking", { level });
+      }
+    },
+  });
 
-  /** Get current skills (re-discovered on each call since cwd may change). */
+  register({
+    name: "/backend",
+    description: "List or switch agent backend",
+    handler: (args) => {
+      const name = args.trim();
+      if (!name) {
+        bus.emit("config:list-backends", {});
+      } else {
+        bus.emit("config:switch-backend", { name });
+      }
+    },
+  });
+
+  // ── Extension registration ────────────────────────────────────
+
+  bus.on("command:register", (cmd) => {
+    register(cmd);
+  });
+
+  // ── Skill commands (/skill:<name>) ────────────────────────────
+
   const getSkills = (): Skill[] => {
     const cwd = contextManager?.getCwd() ?? process.cwd();
     return discoverSkills(cwd);
@@ -124,20 +116,21 @@ export default function activate({ bus, contextManager, quit }: ExtensionContext
       return;
     }
 
-    // Inject skill content as a query — agent sees the full instructions
     const query = args.trim()
       ? `${content}\n\n${args.trim()}`
       : content;
     bus.emit("agent:submit", { query });
   };
 
-  // Provide command completions for /-prefixed input
+  // ── Autocomplete: command names ───────────────────────────────
+
   bus.onPipe("autocomplete:request", (payload) => {
     if (!payload.buffer.startsWith("/")) return payload;
-    const prefix = payload.buffer.toLowerCase();
+    // Argument completion is handled by separate pipe handlers below
+    if (payload.command) return payload;
 
-    // Built-in commands
-    const matching = commands
+    const prefix = payload.buffer.toLowerCase();
+    const matching = [...commands.values()]
       .filter((c) => c.name.toLowerCase().startsWith(prefix))
       .map((c) => ({ name: c.name, description: c.description }));
 
@@ -156,16 +149,65 @@ export default function activate({ bus, contextManager, quit }: ExtensionContext
     return { ...payload, items: [...payload.items, ...matching] };
   });
 
-  // Handle command execution
+  // ── Autocomplete: /model arguments ─────────────────────────────
+
+  bus.onPipe("autocomplete:request", (payload) => {
+    if (payload.command !== "/model") return payload;
+    const partial = (payload.commandArgs ?? "").toLowerCase();
+    const { models, active } = bus.emitPipe("config:get-models", { models: [], active: null });
+    const items = models
+      .filter((m) => m.model.toLowerCase().includes(partial))
+      .slice(0, 15)
+      .map((m) => ({
+        name: `/model ${m.model}`,
+        description: `${m.provider ? `[${m.provider}]` : ""}${m.model === active ? " (active)" : ""}`,
+      }));
+    if (items.length === 0) return payload;
+    return { ...payload, items: [...payload.items, ...items] };
+  });
+
+  // ── Autocomplete: /thinking arguments ─────────────────────────
+
+  bus.onPipe("autocomplete:request", (payload) => {
+    if (payload.command !== "/thinking") return payload;
+    const partial = (payload.commandArgs ?? "").toLowerCase();
+    const { level: current, levels } = bus.emitPipe("config:get-thinking", { level: "off", levels: [], supported: true });
+    const items = levels
+      .filter((l) => l.startsWith(partial))
+      .map((l) => ({
+        name: `/thinking ${l}`,
+        description: l === current ? "(active)" : "",
+      }));
+    if (items.length === 0) return payload;
+    return { ...payload, items: [...payload.items, ...items] };
+  });
+
+  // ── Autocomplete: /backend arguments ──────────────────────────
+
+  bus.onPipe("autocomplete:request", (payload) => {
+    if (payload.command !== "/backend") return payload;
+    const partial = (payload.commandArgs ?? "").toLowerCase();
+    const { names, active } = bus.emitPipe("config:get-backends", { names: [], active: null });
+    const items = names
+      .filter((n) => n.toLowerCase().startsWith(partial))
+      .map((n) => ({
+        name: `/backend ${n}`,
+        description: n === active ? "(active)" : "",
+      }));
+    if (items.length === 0) return payload;
+    return { ...payload, items: [...payload.items, ...items] };
+  });
+
+  // ── Dispatch ──────────────────────────────────────────────────
+
   bus.on("command:execute", (e) => {
-    // Check for /skill:<name> commands
     if (e.name.startsWith("/skill:")) {
       const skillName = e.name.slice("/skill:".length);
       handleSkillCommand(skillName, e.args);
       return;
     }
 
-    const cmd = commands.find((c) => c.name === e.name);
+    const cmd = commands.get(e.name);
     if (cmd) {
       const result = cmd.handler(e.args);
       if (result instanceof Promise) {

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -293,8 +293,20 @@ export class InputHandler {
   }
 
   private updateAutocomplete(): void {
+    const buf = this.editor.buffer;
+    let command: string | null = null;
+    let commandArgs: string | null = null;
+    if (buf.startsWith("/")) {
+      const spaceIdx = buf.indexOf(" ");
+      if (spaceIdx !== -1) {
+        command = buf.slice(0, spaceIdx);
+        commandArgs = buf.slice(spaceIdx + 1);
+      }
+    }
     const { items } = this.bus.emitPipe("autocomplete:request", {
-      buffer: this.editor.buffer,
+      buffer: buf,
+      command,
+      commandArgs,
       items: [],
     });
     if (items.length > 0) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -156,6 +156,10 @@ export interface ResolvedProvider {
   defaultModel?: string;
   models: string[];
   contextWindow?: number;
+  /** Provider supports the reasoning_effort parameter. Default: true. */
+  supportsReasoningEffort?: boolean;
+  /** Per-model capabilities, keyed by model id. */
+  modelCapabilities?: Map<string, { reasoning?: boolean; contextWindow?: number }>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,10 @@ export interface AgentMode {
   providerConfig?: { apiKey: string; baseURL?: string };
   /** Context window size in tokens (for usage display). */
   contextWindow?: number;
+  /** Model supports reasoning/thinking tokens. */
+  reasoning?: boolean;
+  /** Provider supports the reasoning_effort parameter. */
+  supportsReasoningEffort?: boolean;
 }
 
 export interface AgentShellConfig {
@@ -55,6 +59,10 @@ export interface ExtensionContext {
   createFencedBlockTransform: (opts: FencedBlockTransformOptions) => void;
   /** Read extension-namespaced settings from ~/.agent-sh/settings.json. */
   getExtensionSettings: <T extends Record<string, unknown>>(namespace: string, defaults: T) => T;
+
+  // ── Slash command registration ─────────────────────────────
+  /** Register a slash command available in any input mode. */
+  registerCommand: (name: string, description: string, handler: (args: string) => Promise<void> | void) => void;
 
   // ── Tool registration (agent-sh backend only) ─────────────
   /** Register a tool for the built-in agent. No-op when using bridge backends. */

--- a/src/utils/llm-client.ts
+++ b/src/utils/llm-client.ts
@@ -47,17 +47,23 @@ export class LlmClient {
     tools?: ChatCompletionTool[];
     model?: string;
     max_tokens?: number;
+    /** Reasoning effort level (e.g. "low", "medium", "high"). Provider-dependent. */
+    reasoning_effort?: string;
     signal?: AbortSignal;
   }) {
+    const body = {
+      model: opts.model ?? this.model,
+      messages: opts.messages,
+      tools: opts.tools?.length ? opts.tools : undefined,
+      max_tokens: opts.max_tokens ?? 8192,
+      stream: true as const,
+      stream_options: { include_usage: true },
+      ...(opts.reasoning_effort
+        ? { reasoning_effort: opts.reasoning_effort as "low" | "medium" | "high" }
+        : {}),
+    };
     return this.client.chat.completions.create(
-      {
-        model: opts.model ?? this.model,
-        messages: opts.messages,
-        tools: opts.tools?.length ? opts.tools : undefined,
-        max_tokens: opts.max_tokens ?? 8192,
-        stream: true,
-        stream_options: { include_usage: true },
-      },
+      body,
       { signal: opts.signal },
     );
   }


### PR DESCRIPTION
## Summary
- Remove `/clear`, `/copy`, `/compact`, `/provider` — unused commands
- Keep `/help`, `/model`, `/backend`, `/quit`
- Remove dead code: clipboard tracking, `execSync` import, `agent:compact` event
- Update README command table

## Test plan
- [ ] `/help` lists only the 4 remaining commands
- [ ] `/model` cycles models
- [ ] `/backend` lists/switches backends
- [ ] `/quit` exits