### PR TITLE
add startup banner and prompt indicator for session identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ Configure via `~/.agent-sh/settings.json`. Define named providers with multiple 
 
 Cycle models with **Shift+Tab**, switch providers with `/provider <name>`, switch backends with `/backend <name>`. API keys support `$ENV_VAR` syntax.
 
+Additional options:
+
+| Key | Default | Description |
+|---|---|---|
+| `startupBanner` | `true` | Show startup banner with model info and usage hints |
+| `promptIndicator` | `true` | Show `⚡ agent-sh` badge in shell prompt |
+
+Set either to `false` to disable.
+
 See the [Usage Guide](docs/usage.md#configuration) for the full settings reference.
 
 ## Documentation

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import fileAutocomplete from "./extensions/file-autocomplete.js";
 import shellRecall from "./extensions/shell-recall.js";
 import commandSuggest from "./extensions/command-suggest.js";
 import { loadExtensions } from "./extension-loader.js";
+import { getSettings } from "./settings.js";
 import type { AgentShellConfig } from "./types.js";
 
 /**
@@ -295,6 +296,28 @@ async function main(): Promise<void> {
   // Extensions had their chance to register via agent:register-backend.
   // If none did, the built-in AgentLoop gets wired to bus events.
   core.activateBackend();
+
+  // ── Startup banner ───────────────────────────────────────────
+  const settings = getSettings();
+  if (settings.startupBanner !== false) {
+    const termW = process.stdout.columns || 80;
+    const lines: string[] = [];
+
+    const info = agentInfo as { name: string; version: string; model?: string } | null;
+    if (info) {
+      const modelPart = info.model ? ` · ${info.model}` : "";
+      lines.push(`${p.accent}${p.bold}agent-sh${p.reset}${p.dim} v${info.version}${modelPart}${p.reset}`);
+    } else if (core.llmClient) {
+      lines.push(`${p.accent}${p.bold}agent-sh${p.reset}${p.dim} · ${core.llmClient.model}${p.reset}`);
+    } else {
+      lines.push(`${p.accent}${p.bold}agent-sh${p.reset}`);
+    }
+
+    const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}?${p.muted} to run in shell · ${p.warning}/help${p.muted} for commands${p.reset}`;
+    lines.push(hint);
+
+    process.stdout.write("\n" + lines.join("\n") + "\n");
+  }
 
   // ── Terminal lifecycle ────────────────────────────────────────
   process.on("SIGTERM", cleanup);

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,14 +300,9 @@ async function main(): Promise<void> {
   // ── Startup banner ───────────────────────────────────────────
   const settings = getSettings();
   if (settings.startupBanner !== false) {
-    const termW = process.stdout.columns || 80;
     const lines: string[] = [];
 
-    const info = agentInfo as { name: string; version: string; model?: string } | null;
-    if (info) {
-      const modelPart = info.model ? ` · ${info.model}` : "";
-      lines.push(`${p.accent}${p.bold}agent-sh${p.reset}${p.dim} v${info.version}${modelPart}${p.reset}`);
-    } else if (core.llmClient) {
+    if (core.llmClient) {
       lines.push(`${p.accent}${p.bold}agent-sh${p.reset}${p.dim} · ${core.llmClient.model}${p.reset}`);
     } else {
       lines.push(`${p.accent}${p.bold}agent-sh${p.reset}`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,6 +64,12 @@ export interface Settings {
   // ── Agent integration ─────────────────────────────────────
   /** Additional directories to scan for skills (supports ~ expansion). */
   skillPaths?: string[];
+
+  // ── Identity & startup ───────────────────────────────────
+  /** Show a startup banner when agent-sh launches. */
+  startupBanner?: boolean;
+  /** Show a subtle agent-sh indicator in the shell prompt. */
+  promptIndicator?: boolean;
 }
 
 const DEFAULTS: Required<Settings> = {
@@ -82,6 +88,8 @@ const DEFAULTS: Required<Settings> = {
   readOutputMaxLines: 0,
   diffMaxLines: 20,
   skillPaths: [],
+  startupBanner: true,
+  promptIndicator: true,
 };
 
 let cached: Settings | null = null;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -5,6 +5,7 @@ import * as pty from "node-pty";
 import type { EventBus } from "./event-bus.js";
 import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
+import { getSettings } from "./settings.js";
 
 export class Shell implements InputContext {
   private ptyProcess: pty.IPty;
@@ -56,12 +57,15 @@ export class Shell implements InputContext {
     const promptMarker = 'printf "\\e]9999;PROMPT\\a"';
 
     this.isZsh = isZsh;
+    const settings = getSettings();
+    const showIndicator = settings.promptIndicator !== false;
+
     if (isZsh) {
       // For zsh: use ZDOTDIR to source user's real config, then append
       // our hooks via precmd_functions (additive — doesn't clobber p10k/omz).
       this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-"));
       const userZdotdir = env.ZDOTDIR || env.HOME || os.homedir();
-      fs.writeFileSync(path.join(this.tmpDir, ".zshrc"), [
+      const zshrcLines = [
         `ZDOTDIR="${userZdotdir}"`,
         `[ -f "${userZdotdir}/.zshrc" ] && source "${userZdotdir}/.zshrc"`,
         "",
@@ -71,6 +75,20 @@ export class Shell implements InputContext {
         `  ${promptMarker}`,
         "}",
         "precmd_functions+=(__agent_sh_precmd)",
+      ];
+
+      if (showIndicator) {
+        zshrcLines.push(
+          "",
+          "# agent-sh prompt indicator (subtle right-prompt badge)",
+          '__agent_sh_indicator() {',
+          '  RPROMPT="%F{8}%F{6}⚡ agent-sh%f"',
+          "}",
+          "precmd_functions+=(__agent_sh_indicator)",
+        );
+      }
+
+      zshrcLines.push(
         "",
         "# End-of-prompt marker via zle-line-init (fires after prompt is rendered)",
         "# Chain onto existing widget (p10k uses zle-line-init) rather than clobbering",
@@ -94,7 +112,9 @@ export class Shell implements InputContext {
         "}",
         "zle -N __agent_sh_redraw",
         "bindkey '\\e[9999~' __agent_sh_redraw",
-      ].join("\n") + "\n");
+      );
+
+      fs.writeFileSync(path.join(this.tmpDir, ".zshrc"), zshrcLines.join("\n") + "\n");
       env.ZDOTDIR = this.tmpDir;
       shellArgs = ["--no-globalrcs"];
     } else {
@@ -102,7 +122,7 @@ export class Shell implements InputContext {
       // real bashrc then appends our hooks. No HOME override needed.
       this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-"));
       const userHome = env.HOME || os.homedir();
-      fs.writeFileSync(path.join(this.tmpDir, ".bashrc"), [
+      const bashrcLines = [
         `[ -f "${userHome}/.bashrc" ] && source "${userHome}/.bashrc"`,
         "",
         "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
@@ -110,7 +130,18 @@ export class Shell implements InputContext {
         "",
         "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",
         'case "$PS1" in *9998*) ;; *) PS1="${PS1}\\[\\e]9998;READY\\a\\]";; esac',
-      ].join("\n") + "\n");
+      ];
+
+      if (showIndicator) {
+        bashrcLines.push(
+          "",
+          "# agent-sh prompt indicator (subtle badge appended to PS1)",
+          '__agent_sh_ps1_suffix="\\[\\033[90m\\033[36m\\]⚡ agent-sh\\[\\033[0m\\] "',
+          'case "$PS1" in *"__agent_sh_ps1_suffix"*) ;; *) PS1="$PS1\$__agent_sh_ps1_suffix";; esac',
+        );
+      }
+
+      fs.writeFileSync(path.join(this.tmpDir, ".bashrc"), bashrcLines.join("\n") + "\n");
       shellArgs = ["--rcfile", path.join(this.tmpDir, ".bashrc")];
     }
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -80,9 +80,9 @@ export class Shell implements InputContext {
       if (showIndicator) {
         zshrcLines.push(
           "",
-          "# agent-sh prompt indicator (subtle right-prompt badge)",
+          "# agent-sh prompt indicator (append to existing RPROMPT)",
           '__agent_sh_indicator() {',
-          '  RPROMPT="%F{8}%F{6}⚡ agent-sh%f"',
+          '  RPROMPT="${RPROMPT:+$RPROMPT }%F{6}⚡ agent-sh%f"',
           "}",
           "precmd_functions+=(__agent_sh_indicator)",
         );
@@ -137,7 +137,7 @@ export class Shell implements InputContext {
           "",
           "# agent-sh prompt indicator (subtle badge appended to PS1)",
           '__agent_sh_ps1_suffix="\\[\\033[90m\\033[36m\\]⚡ agent-sh\\[\\033[0m\\] "',
-          'case "$PS1" in *"__agent_sh_ps1_suffix"*) ;; *) PS1="$PS1\$__agent_sh_ps1_suffix";; esac',
+          'case "$PS1" in *agent-sh*) ;; *) PS1="$PS1\$__agent_sh_ps1_suffix";; esac',
         );
       }
 


### PR DESCRIPTION
## Summary
- Add a startup banner displaying version, connected model, and usage hints (`> ? /help`) when agent-sh launches
- Add a persistent `⚡ agent-sh` badge in the shell prompt (zsh RPROMPT / bash PS1 suffix)
- Both features are configurable via `startupBanner` and `promptIndicator` in `~/.agent-sh/settings.json` (default: `true`)

## Motivation
Users had no visual cue distinguishing agent-sh from a regular shell session. This adds two lightweight identity signals without disrupting existing shell configs or themes.