### PR TITLE
fix: agent sees shell history-recalled and tab-completed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,13 @@ agent-sh flips this. It's your shell first — full PTY, your rc config, your al
 ## Quick Start
 
 ```bash
-# Install
 npm install -g agent-sh
-
-# Run with any OpenAI-compatible API
-OPENAI_API_KEY="your-key" agent-sh --model gpt-4o
-
-# Or with a local model
-agent-sh --api-key dummy --base-url http://localhost:11434/v1 --model llama3
-
-# Or with a backend extension (Claude Code, pi, etc.)
-agent-sh -e examples/extensions/claude-code-bridge
+agent-sh
 ```
 
-Requires Node.js 18+. See the [Usage Guide](docs/usage.md) for provider examples (OpenAI, Ollama, OpenRouter, Together, Groq, LM Studio, vLLM).
+Set `OPENAI_API_KEY` in your environment (or configure providers in `~/.agent-sh/settings.json`). Works with any OpenAI-compatible API — see the [Usage Guide](docs/usage.md) for provider examples (OpenAI, Ollama, OpenRouter, Together, Groq, LM Studio, vLLM).
+
+Requires Node.js 18+.
 
 ## Input Modes
 
@@ -114,10 +107,11 @@ See the [Usage Guide](docs/usage.md#configuration) for the full settings referen
 ## Development
 
 ```bash
-npm run dev                        # development mode (no build step)
-npm run build                      # build
-npm start                          # run built version
-DEBUG=1 npm start                  # debug mode (logs protocol details)
+git clone https://github.com/guanyilun/agent-sh.git
+cd agent-sh
+npm install
+npm run build
+npm start
 ```
 
 ## License

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,6 +20,21 @@
 
 **Solution**: Some models have limited or no tool/function calling support. Try a more capable model (e.g., gpt-4o, claude-sonnet-4-6 via OpenRouter).
 
+**Problem**: Garbled output, startup banner overwritten, or messy prompt rendering
+
+**Cause**: Powerlevel10k's **instant prompt** feature races with agent-sh's TUI. Instant prompt caches the previous prompt, displays it immediately, redirects stdout/stderr during shell init, then redraws the prompt using cursor-movement sequences — all of which can overwrite agent-sh's output.
+
+**Solution**: Guard the instant prompt block in your `~/.zshrc` so it's skipped inside agent-sh:
+
+```zsh
+# Disable p10k instant prompt inside agent-sh (it races with TUI rendering)
+if [[ -z "$AGENT_SH" && -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+```
+
+Your normal p10k prompt still works — only the "flash cached prompt then redraw" behavior is disabled.
+
 ## Common Errors
 
 **Error**: "API key not found" or "401 Unauthorized"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "dev": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "pi": "node dist/index.js --agent pi-acp",
-    "claude": "node dist/index.js --agent claude-agent-acp",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -239,7 +239,15 @@ export class EventBus {
     event: K,
     payload: ShellEvents[K],
   ): void {
-    const transformed = this.emitPipe(event, payload);
+    let transformed: ShellEvents[K];
+    try {
+      transformed = this.emitPipe(event, payload);
+    } catch (err) {
+      if (process.env.DEBUG) {
+        process.stderr.write(`[event-bus] pipe error on ${String(event)}: ${err}\n`);
+      }
+      transformed = payload; // fall back to untransformed
+    }
     this.emitter.emit(event, transformed);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ async function main(): Promise<void> {
     id: "help",
     trigger: "?",
     label: "help",
-    promptIcon: "⟩",
+    promptIcon: "❯",
     indicator: "❓",
     onSubmit(query, b) {
       const onToolDone = (e: { kind?: string }) => {
@@ -300,18 +300,20 @@ async function main(): Promise<void> {
   // ── Startup banner ───────────────────────────────────────────
   const settings = getSettings();
   if (settings.startupBanner !== false) {
-    const lines: string[] = [];
-
-    if (core.llmClient) {
-      lines.push(`${p.accent}${p.bold}agent-sh${p.reset}${p.dim} · ${core.llmClient.model}${p.reset}`);
-    } else {
-      lines.push(`${p.accent}${p.bold}agent-sh${p.reset}`);
-    }
-
+    const title = core.llmClient
+      ? `${p.accent}${p.bold}agent-sh${p.reset}${p.dim} · ${core.llmClient.model}${p.reset}`
+      : `${p.accent}${p.bold}agent-sh${p.reset}`;
     const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}?${p.muted} to run in shell · ${p.warning}/help${p.muted} for commands${p.reset}`;
-    lines.push(hint);
 
-    process.stdout.write("\n" + lines.join("\n") + "\n");
+    const termW = process.stdout.columns || 80;
+    const borderLine = `${p.muted}${"─".repeat(Math.min(termW, 60))}${p.reset}`;
+
+    process.stdout.write(
+      "\n" + borderLine + "\n" +
+      "  " + title + "\n" +
+      "  " + hint + "\n" +
+      borderLine + "\n\n",
+    );
   }
 
   // ── Terminal lifecycle ────────────────────────────────────────

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -221,8 +221,31 @@ export class InputHandler {
       } else if (ch === "\x04") {
         this.lineBuffer = "";
         this.ctx.writeToPty(ch);
+      } else if (ch === "\x1b") {
+        // Escape sequence — forward the entire sequence to the PTY but
+        // don't let it corrupt lineBuffer.  Skip CSI (ESC [ ... final)
+        // and SS3 (ESC O <char>) sequences; anything else: just ESC.
+        let seq = ch;
+        if (i + 1 < data.length) {
+          const next = data[i + 1]!;
+          if (next === "[") {
+            // CSI: ESC [ (params) (intermediates) final_byte
+            seq += next; i++;
+            while (i + 1 < data.length && data[i + 1]!.charCodeAt(0) < 0x40) {
+              i++; seq += data[i]!;
+            }
+            if (i + 1 < data.length) { i++; seq += data[i]!; } // final byte
+          } else if (next === "O") {
+            // SS3: ESC O <char>
+            seq += next; i++;
+            if (i + 1 < data.length) { i++; seq += data[i]!; }
+          } else {
+            // ESC + single char (alt-key, etc.)
+            seq += next; i++;
+          }
+        }
+        this.ctx.writeToPty(seq);
       } else if (ch.charCodeAt(0) < 32 && ch !== "\t") {
-        this.lineBuffer = "";
         this.ctx.writeToPty(ch);
       } else {
         // Check if trigger char at start of empty line → enter that mode
@@ -450,7 +473,10 @@ export class InputHandler {
           if (this.autocompleteActive) {
             this.applyAutocomplete();
           }
-          const query = act.buffer.trim();
+          // Use editor.buffer (not act.buffer) so autocomplete selections
+          // take effect — act.buffer is a stale snapshot from before
+          // applyAutocomplete() updated the buffer.
+          const query = this.editor.buffer.trim();
           if (query) {
             // Add to history (avoid consecutive duplicates)
             if (this.history.length === 0 || this.history[this.history.length - 1] !== query) {

--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -21,6 +21,7 @@ export class OutputParser {
   /** Process a chunk of PTY output data. */
   processData(data: string): void {
     this.parseOSC7(data);
+    data = this.handlePreexec(data);
     this.parsePromptMarker(data);
     this.parsePromptEnd(data);
   }
@@ -50,6 +51,36 @@ export class OutputParser {
   }
 
   // ── Parsing ─────────────────────────────────────────────────
+
+  /**
+   * Detect preexec marker (OSC 9997) emitted by the shell's preexec hook.
+   * This carries the actual command text from the shell — more reliable than
+   * the InputHandler's lineBuffer which can't track history recall or tab
+   * completion. Returns data with the OSC stripped out.
+   */
+  private handlePreexec(data: string): string {
+    const marker = "\x1b]9997;";
+    const idx = data.indexOf(marker);
+    if (idx === -1) return data;
+
+    const endIdx = data.indexOf("\x07", idx + marker.length);
+    if (endIdx === -1) return data; // incomplete OSC, wait for next chunk
+
+    const command = data.slice(idx + marker.length, endIdx);
+
+    // Authoritative command from the shell — override any lineBuffer guess
+    this.lastCommand = command;
+    this.currentOutputCapture = ""; // discard echoed text accumulated before preexec
+
+    if (!this.foregroundBusy) {
+      this.foregroundBusy = true;
+      this.bus.emit("shell:foreground-busy", { busy: true });
+    }
+    this.bus.emit("shell:command-start", { command, cwd: this.cwd });
+
+    // Return only data after the OSC — everything before was the echo
+    return data.slice(endIdx + 1);
+  }
 
   private parseOSC7(data: string): void {
     const match = data.match(/\x1b\]7;file:\/\/[^/]*(\/[^\x07\x1b]*)/);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -77,6 +77,13 @@ export class Shell implements InputContext {
         ...(showIndicator ? [`  ${titleCmd}`] : []),
         "}",
         "precmd_functions+=(__agent_sh_precmd)",
+        "",
+        "# Preexec hook: emit actual command text so agent-sh can track",
+        "# history-recalled and tab-completed commands accurately",
+        "__agent_sh_preexec() {",
+        '  printf "\\e]9997;%s\\a" "$1"',
+        "}",
+        "preexec_functions+=(__agent_sh_preexec)",
       ];
 
       zshrcLines.push(
@@ -117,7 +124,20 @@ export class Shell implements InputContext {
         `[ -f "${userHome}/.bashrc" ] && source "${userHome}/.bashrc"`,
         "",
         "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
-        `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}${osc7Cmd}; ${promptMarker}${showIndicator ? `; ${titleCmd}` : ""}"`,
+        `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}__agent_sh_preexec_ran=0; ${osc7Cmd}; ${promptMarker}${showIndicator ? `; ${titleCmd}` : ""}"`,
+        "",
+        "# Preexec hook via DEBUG trap: emit actual command text so agent-sh",
+        "# can track history-recalled and tab-completed commands accurately",
+        "__agent_sh_preexec_ran=0",
+        "__agent_sh_emit_preexec() {",
+        '  [[ $__agent_sh_preexec_ran == 1 ]] && return',
+        '  [[ -n $COMP_LINE ]] && return',
+        "  __agent_sh_preexec_ran=1",
+        "  local this_cmd",
+        `  this_cmd=$(HISTTIMEFORMAT='' builtin history 1 | command sed 's/^ *[0-9]* *//')`,
+        `  printf '\\e]9997;%s\\a' "$this_cmd"`,
+        "}",
+        "trap '__agent_sh_emit_preexec' DEBUG",
         "",
         "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",
         'case "$PS1" in *9998*) ;; *) PS1="${PS1}\\[\\e]9998;READY\\a\\]";; esac',
@@ -302,6 +322,7 @@ export class Shell implements InputContext {
       this.echoSkip = true;
       this.paused = false;
       process.stdout.write("\n");
+      this.bus.emit("shell:agent-exec-start", {});
 
       const output = await new Promise<{ output: string; cwd: string }>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -323,6 +344,7 @@ export class Shell implements InputContext {
 
       this.paused = true;
       this.echoSkip = false;
+      this.bus.emit("shell:agent-exec-done", {});
 
       return { ...payload, output: output.output, cwd: output.cwd, done: true };
     });


### PR DESCRIPTION
## Summary

- Commands recalled via shell history (arrow-up) or tab-completed were invisible to the agent because `InputHandler.lineBuffer` only tracked direct keystrokes
- Added `preexec` hooks (zsh: `preexec_functions`, bash: `DEBUG` trap) that emit the actual command text via OSC 9997
- `OutputParser.handlePreexec()` parses the OSC and authoritatively overrides the unreliable lineBuffer-based command tracking
- Also fixes escape sequences corrupting lineBuffer, adds error resilience to `emitTransform`, and emits `shell:agent-exec-start/done` events for proper agent command tagging

## How it works

The shell's preexec hook fires right before command execution and emits `\e]9997;<command>\a`. The OutputParser detects this, sets `lastCommand` to the real command text, and discards the echoed text. When the prompt marker (OSC 9999) arrives, `shell:command-done` fires with the correct command — regardless of how the user entered it.

## Robustness

- **zsh**: Uses `preexec_functions` array — additive, won't clobber p10k, oh-my-zsh, or existing hooks
- **bash**: Uses `DEBUG` trap with a guard flag reset in `PROMPT_COMMAND`. Uses `history 1` for the full command line. Skips during tab completion (`$COMP_LINE` check)
- **Fallback**: The existing lineBuffer-based `onCommandEntered` still works as a fallback for unsupported shells

## Test plan

- [ ] Verify arrow-up history recall is visible to agent in zsh
- [ ] Verify tab-completed commands are visible to agent in zsh
- [ ] Verify normal typed commands still work
- [ ] Verify agent-initiated `user_shell` commands still work
- [ ] Test in bash if available