### PR TITLE
Improve agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ Not a shell that lives in an agent — an agent that lives in a shell.
 
 I live in a terminal. I don't want an agent that can run shell commands when it needs to — I want my shell, with an agent I can reach for when *I* need to. Most AI tools get this backwards: the LLM drives the experience and the shell is bolted on as an afterthought. No real PTY, no job control, no vim, fragile `cd` tracking. The agent is the main character and your terminal is a prop.
 
-agent-sh flips this. It's your shell first — full PTY, your rc config, your aliases, everything just works. But type `?` or `>` at the start of a line, and you're talking to an agent that has full context of what you've been doing.
+agent-sh flips this. It's your shell first — full PTY, your rc config, your aliases, everything just works. But type `>` at the start of a line, and you're talking to an agent that has full context of what you've been doing.
 
 ```
 ⚡ src $ ls -la                          # real shell command
 ⚡ src $ cd ../tests && npm test          # real cd, env, aliases — all just work
 ⚡ src $ vim file.ts                      # opens vim in the same PTY
-⚡ src $ > explain the last error          # execute mode → agent investigates using its own tools
-⚡ src $ ? deploy to staging              # help mode → agent runs it in your live shell
+⚡ src $ > explain the last error          # agent investigates using its own tools
+⚡ src $ > deploy to staging              # agent runs it in your live shell
 ```
 
 ## Key Features
 
 **Real terminal, zero compromise.** Full PTY with your shell config, aliases, and environment. Shell starts instantly — the agent connects asynchronously in the background.
 
-**Context-aware agent.** Every query includes your cwd, recent commands, and their output. Run a failing test, type `? fix this`, and the agent knows exactly what happened. It has built-in tools for file read/write/edit, bash, grep, glob — no external setup needed.
+**Context-aware agent.** Every query includes your cwd, recent commands, and their output. Run a failing test, type `> fix this`, and the agent knows exactly what happened. It has built-in tools for file read/write/edit, bash, grep, glob — no external setup needed.
 
-**Two input modes.** `>` for questions and tasks — the agent investigates using its own isolated tools. `?` for commands that run directly in your live shell, affecting your real environment. The agent knows which mode it's in and behaves accordingly.
+**Agent decides how to help.** One entry point (`>`), three tool categories. The agent uses scratchpad tools to investigate, `display` to show you output, and `user_shell` for commands with lasting effects. No need to pick a mode — the agent reasons about which tools to use based on your intent.
 
 **Any LLM, any backend.** Works with any OpenAI-compatible API out of the box. Define multiple providers in settings and cycle between models at runtime with Shift+Tab. Or swap in a completely different agent — [Claude Code](examples/extensions/claude-code-bridge/) and [pi](examples/extensions/pi-bridge/) run as drop-in backend extensions.
 
@@ -42,14 +42,15 @@ Set `OPENAI_API_KEY` in your environment (or configure providers in `~/.agent-sh
 
 Requires Node.js 18+.
 
-## Input Modes
+## Agent Mode
 
-- **`>` Execute mode** — Agent uses its own tools (bash, file read/write, search) to investigate and answer. Stays in execute mode for follow-ups.
-- **`?` Help mode** — Agent runs a command in your live shell. Your aliases, env vars, and cwd apply. Returns to shell after.
+Type `>` at the start of a line to talk to the agent. The agent decides how to help:
 
-Everything else works as a normal shell — commands go straight to the PTY. Modes are extensible — see [Extensions: Custom Input Modes](docs/extensions.md#custom-input-modes).
+- **Scratchpad tools** (`bash`, `read_file`, `grep`, `glob`, etc.) — for investigation. Output goes to the agent, not your terminal.
+- **`display`** — shows output in your terminal (e.g. `cat`, `git log`). You see it; the agent doesn't process it.
+- **`user_shell`** — runs commands with lasting effects (`cd`, `npm install`, etc.) in your live shell.
 
-> **Why `>` for the main mode?** `>` is easy to type and the most common interaction — asking the agent to do things. `?` is reserved for when you need the agent to run something directly in your live shell.
+Everything else works as a normal shell — commands go straight to the PTY. Input modes are extensible — see [Extensions: Custom Input Modes](docs/extensions.md#custom-input-modes).
 
 ### Slash Commands
 

--- a/README.md
+++ b/README.md
@@ -62,39 +62,7 @@ Everything else works as a normal shell — commands go straight to the PTY. Inp
 
 ## Configuration
 
-Configure via `~/.agent-sh/settings.json`. Define named providers with multiple models:
-
-```json
-{
-  "defaultProvider": "openai",
-  "providers": {
-    "openai": {
-      "apiKey": "$OPENAI_API_KEY",
-      "defaultModel": "gpt-4o",
-      "models": ["gpt-4o", "gpt-4o-mini"]
-    },
-    "ollama": {
-      "apiKey": "not-needed",
-      "baseURL": "http://localhost:11434/v1",
-      "defaultModel": "llama3",
-      "models": ["llama3", "mistral"]
-    }
-  }
-}
-```
-
-Cycle models with **Shift+Tab**, switch providers with `/provider <name>`, switch backends with `/backend <name>`. API keys support `$ENV_VAR` syntax.
-
-Additional options:
-
-| Key | Default | Description |
-|---|---|---|
-| `startupBanner` | `true` | Show startup banner with model info and usage hints |
-| `promptIndicator` | `true` | Show `⚡ agent-sh` in terminal tab/window title |
-
-Set either to `false` to disable.
-
-See the [Usage Guide](docs/usage.md#configuration) for the full settings reference.
+Configure via `~/.agent-sh/settings.json`. See the [Usage Guide](docs/usage.md#configuration) for the full settings reference (providers, models, extensions, skills, and more).
 
 ## Documentation
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -7,7 +7,7 @@ The internal agent (AgentLoop) is the default backend when you provide `--api-ke
 Here's what happens when you submit a query:
 
 ```
-User types "? fix the failing test"
+User types "> fix the failing test"
   │
   ├─ 1. Context assembly — gather recent shell commands, output, cwd
   ├─ 2. System prompt — tools + context + guidelines, rebuilt every call
@@ -54,13 +54,11 @@ Shell output can be large. The context manager applies a budget to keep things r
 The system prompt is rebuilt on **every LLM call** (not cached), so context is always fresh. It includes:
 
 1. **Identity** — "You are an AI coding assistant in agent-sh..."
-2. **Input modes** — instructions for execute mode vs help mode
+2. **Tool decision guide** — when to use scratchpad tools vs display vs user_shell
 3. **Available tools** — name + description of every registered tool
 4. **Tool usage guidelines** — read before editing, prefer edit over write, use grep/glob to find files, etc.
 5. **Shell context** — the assembled context from above
 6. **Metadata** — current date, working directory
-
-The per-query **mode instruction** (e.g. `[mode: execute]` or `[mode: help]`) is prepended to the user message, not the system prompt. This tells the agent how to behave for this specific query.
 
 ## Project Conventions
 
@@ -131,8 +129,8 @@ This keeps the system prompt small regardless of how many skills you have.
 Users can force-load a skill directly:
 
 ```
-? /skill:docker-deploy
-? /skill:docker-deploy deploy the staging branch
+> /skill:docker-deploy
+> /skill:docker-deploy deploy the staging branch
 ```
 
 This injects the full skill content into the conversation. Tab completion works for skill names.
@@ -178,26 +176,27 @@ Tools that require permission: **bash**, **write_file**, **edit_file** (anything
 
 ## Built-in Tools
 
-The agent has 8 built-in tools. The most important distinction is between `bash` and `user_shell` — they look similar but work completely differently.
+The agent has 9 built-in tools. The most important distinction is between `bash`, `display`, and `user_shell` — they all run shell commands but in different ways:
 
-### bash vs user_shell
-
-These two tools both run shell commands, but in **different worlds**:
+### bash vs display vs user_shell
 
 - **`bash`** — runs in an **isolated subprocess** (`/bin/bash -c`). The agent uses this for investigation: reading files, running tests, checking state. A `cd` here doesn't affect your shell. Output is captured and returned to the LLM.
-- **`user_shell`** — runs in **your live PTY**. The agent uses this for commands that should affect your shell: `cd`, `export`, `source`, `npm install`, anything the user needs to see. Output appears in your terminal directly.
+- **`display`** — runs in **your live PTY** but for **read-only display**. The agent uses this when the user asks to see something (`cat`, `git log`, `diff`). Output appears in your terminal but is NOT returned to the LLM.
+- **`user_shell`** — runs in **your live PTY** for commands with **lasting effects**: `cd`, `export`, `source`, `npm install`. Output appears in your terminal directly.
 
-Why the split? Two reasons:
+The agent decides which tool to use based on intent — no user mode selection needed. The three-way split provides:
 
-1. **Safety** — bash runs in isolation, so the agent can't accidentally break your shell state. user_shell is the explicit "touch the user's environment" action.
-2. **Token efficiency** — user_shell returns `"Command executed"` by default instead of the full output. The user already sees it in the terminal; sending it back to the LLM wastes tokens. The agent can pass `return_output: true` when it actually needs to read the result.
+1. **Safety** — bash runs in isolation, so the agent can't accidentally break your shell state.
+2. **Clarity** — display vs user_shell makes the agent's intent explicit (showing vs acting).
+3. **Token efficiency** — display and user_shell return minimal text by default instead of the full output. The user already sees it in the terminal; sending it back to the LLM wastes tokens.
 
 ### All tools
 
 | Tool | Purpose | Permission | Modifies files |
 |---|---|---|---|
 | `bash` | Run commands in isolated subprocess | Yes | Yes |
-| `user_shell` | Run commands in user's live PTY | No | Yes |
+| `display` | Show command output to user in live PTY | No | No |
+| `user_shell` | Run commands with lasting effects in user's live PTY | No | Yes |
 | `read_file` | Read file contents (line-numbered, with offset/limit) | No | No |
 | `write_file` | Create or overwrite a file | Yes | Yes |
 | `edit_file` | Find-and-replace in a file (old_text → new_text) | Yes | Yes |

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -202,9 +202,66 @@ The agent decides which tool to use based on intent — no user mode selection n
 | `edit_file` | Find-and-replace in a file (old_text → new_text) | Yes | Yes |
 | `grep` | Search file contents with regex (via ripgrep) | No | No |
 | `glob` | Find files by name pattern | No | No |
-| `ls` | List directory contents | No | No |
+| `ls` | List directory contents (with timestamps and sizes) | No | No |
 
 **Common pattern**: all file-based tools resolve relative paths from the current working directory (`contextManager.getCwd()`).
+
+### Tool-specific enhancements
+
+**`grep`** supports three output modes and pagination:
+
+- `output_mode`: `files_with_matches` (default, file paths only), `content` (matching lines with optional `context_before`/`context_after`), or `count` (match counts per file)
+- `case_insensitive`: case-insensitive search
+- `head_limit` / `offset`: pagination — default limits are 200 entries for `files_with_matches`, 150 for `content`/`count`. Pass `head_limit=0` for unlimited. Long lines in `content` mode are capped at 500 characters.
+
+**`read_file`** deduplicates reads:
+
+- Tracks file modification time. If a file hasn't changed since the last read (same offset/limit), returns a stub instead of re-reading — saves context tokens.
+- Files over 2MB require `offset` and `limit` to prevent OOM.
+- Cache is automatically invalidated when a file-modifying tool (`write_file`, `edit_file`) succeeds on the same path.
+
+**`edit_file`** provides diagnostic hints:
+
+- When `old_text` isn't found, the tool searches for the closest match and suggests fixes (e.g. whitespace differences, wrong line location).
+
+**`glob`** returns results sorted by modification time (newest first), capped at 200 files.
+
+**`ls`** returns formatted output with timestamps (YYYY-MM-DD HH:MM) and human-readable file sizes.
+
+### Tool batching and parallel execution
+
+When the LLM requests multiple tool calls in a single response, the agent groups and executes them efficiently:
+
+1. **Batch event** — before execution, the agent emits `agent:tool-batch` with tools grouped by kind (`read`, `search`, `execute`, etc.). The TUI uses this to render group headers with tree-style connectors.
+
+2. **Parallel execution** — read-only tools (no `requiresPermission`, no `modifiesFiles`) run in parallel via `Promise.all`. Permission-requiring tools run sequentially to avoid overlapping permission prompts.
+
+3. **Output truncation** — tool results over 16KB (~4K tokens) are head+tail truncated before being added to the conversation, preventing a single tool call from blowing through the context window.
+
+### Structured result display
+
+Tools can provide structured result information for the TUI via two optional methods on `ToolDefinition`:
+
+- **`formatCall(args)`** — returns a short display string when the tool is called (e.g. the file path or search pattern). Shown in the TUI next to the tool icon.
+- **`formatResult(args, result)`** — returns a `ToolResultDisplay` with an optional `summary` string (e.g. "42 files", "cached") and an optional structured `body` for richer rendering (diffs, line lists). The TUI's `render:result-body` handler renders the body — extensions can advise it.
+
+### Retry and error handling
+
+The agent retries transient failures with exponential backoff:
+
+- **Context overflow** — compacts the conversation and retries immediately
+- **Rate limits (429)** — respects `Retry-After` header, otherwise backs off exponentially
+- **Transient errors (500/502/503, network)** — exponential backoff (1s, 2s, 4s..., capped at 30s), up to 3 retries
+- **Non-retryable errors** — reported with provider-aware context (model name, endpoint, actionable hints)
+
+### Thinking levels
+
+The agent supports configurable thinking/reasoning levels for models that support `reasoning_effort`:
+
+- Levels: `off` (default), `low`, `medium`, `high`
+- Set via the `config:set-thinking` event (wired to `/thinking` slash command)
+- Query current state via `config:get-thinking` pipe
+- The agent validates that the current model/provider supports reasoning before enabling
 
 ### Tool interface
 
@@ -213,6 +270,7 @@ Every tool implements this interface:
 ```typescript
 interface ToolDefinition {
   name: string;
+  displayName?: string;           // short label for TUI (defaults to name)
   description: string;
   input_schema: Record<string, unknown>;  // JSON Schema for parameters
 
@@ -224,6 +282,11 @@ interface ToolDefinition {
   requiresPermission?: boolean;   // gate via permission:request
   modifiesFiles?: boolean;        // triggers file watcher
   showOutput?: boolean;           // stream output to TUI (default: true)
+
+  // Display hooks (all optional)
+  getDisplayInfo?: (args) => ToolDisplayInfo;  // icon, kind, file locations
+  formatCall?: (args) => string;               // short call summary for TUI
+  formatResult?: (args, result) => ToolResultDisplay;  // structured result
 }
 
 interface ToolResult {
@@ -231,9 +294,24 @@ interface ToolResult {
   exitCode: number | null;
   isError: boolean;
 }
+
+interface ToolResultDisplay {
+  summary?: string;      // one-line (e.g. "42 files", "+3/-1")
+  body?: ToolResultBody; // structured content for richer rendering
+}
+
+type ToolResultBody =
+  | { kind: "diff"; diff: unknown; filePath: string }
+  | { kind: "lines"; lines: string[]; maxLines?: number }
+
+interface ToolDisplayInfo {
+  kind: "read" | "write" | "execute" | "search" | "display";
+  locations?: { path: string; line?: number | null }[];
+  icon?: string;         // custom icon (e.g. "◆", "⌕")
+}
 ```
 
-The `onChunk` callback enables streaming tool output to the TUI in real-time (used by `bash`). Tools that don't stream (like `read_file`) just return the final result.
+The `onChunk` callback enables streaming tool output to the TUI in real-time (used by `bash`). Tools that don't stream (like `read_file`) just return the final result. Extensions can wrap `onChunk` via the `tool:execute` handler to intercept or transform streamed output (e.g. secret redaction).
 
 ## Streaming
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,8 +44,8 @@ All components communicate exclusively through typed bus events. The backend has
 1. agent-sh spawns a real PTY running your shell (zsh or bash, with your full rc config) and sets up raw stdin passthrough
 2. It creates the agent backend (AgentLoop or extension-provided) which self-wires to bus events
 3. All keyboard input goes directly to the PTY — zero latency, full terminal compatibility
-4. When you type `>` or `?` at the start of a line, agent-sh intercepts and enters an agent input mode
-5. On Enter, the query is emitted as `agent:submit` with a mode instruction (`[mode: execute]` or `[mode: help]`)
+4. When you type `>` at the start of a line, agent-sh intercepts and enters agent input mode
+5. On Enter, the query is emitted as `agent:submit` and the agent decides which tools to use
 6. The backend handles the query — streaming LLM responses, executing tools, emitting events
 7. The TUI renderer extension renders streamed content inline (markdown, diffs, tool calls)
 8. When the backend finishes (`agent:processing-done`), normal shell operation resumes
@@ -58,7 +58,7 @@ The connection between them is **context**: each query includes shell context (r
 
 ### user_shell — The Bridge
 
-For commands that *should* affect the live shell (`cd`, `export`, `source`, user-facing commands), the agent uses `user_shell`. This tool writes the command to the actual PTY via bus events:
+For commands that *should* affect the live shell (`cd`, `export`, `source`, installing packages) or that the user wants to see (`cat`, `git log`), the agent uses `user_shell` or `display`. These tools write commands to the actual PTY via bus events:
 
 ```
 agent calls user_shell({ command: "cd src" })
@@ -122,7 +122,7 @@ agent-sh/
 │   │   ├── system-prompt.ts       # System prompt builder
 │   │   └── tools/          # Built-in tool implementations
 │   │       ├── bash.ts, read-file.ts, write-file.ts, edit-file.ts
-│   │       ├── grep.ts, glob.ts, ls.ts, user-shell.ts
+│   │       ├── grep.ts, glob.ts, ls.ts, user-shell.ts, display.ts
 │   │
 │   ├── utils/              # Shared primitives
 │   │   ├── llm-client.ts   # OpenAI SDK wrapper (shared by agent loop + extensions)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,8 +46,8 @@ All components communicate exclusively through typed bus events. The backend has
 3. All keyboard input goes directly to the PTY — zero latency, full terminal compatibility
 4. When you type `>` at the start of a line, agent-sh intercepts and enters agent input mode
 5. On Enter, the query is emitted as `agent:submit` and the agent decides which tools to use
-6. The backend handles the query — streaming LLM responses, executing tools, emitting events
-7. The TUI renderer extension renders streamed content inline (markdown, diffs, tool calls)
+6. The backend handles the query — streaming LLM responses, executing tools, emitting events. Read-only tools run in parallel; permission-requiring tools run sequentially.
+7. The TUI renderer extension renders streamed content inline (markdown, diffs, tool calls with tree-style grouping)
 8. When the backend finishes (`agent:processing-done`), normal shell operation resumes
 
 ## Shell ↔ Agent Boundary
@@ -56,9 +56,14 @@ The shell and the agent are **separate worlds** by default. The PTY runs your re
 
 The connection between them is **context**: each query includes shell context (recent commands, output, cwd). The agent sees what you've been doing but can't touch your shell state — unless it uses `user_shell`.
 
-### user_shell — The Bridge
+### user_shell & display — The Bridge
 
-For commands that *should* affect the live shell (`cd`, `export`, `source`, installing packages) or that the user wants to see (`cat`, `git log`), the agent uses `user_shell` or `display`. These tools write commands to the actual PTY via bus events:
+Two tools cross the shell↔agent boundary via `shell:exec-request`:
+
+- **`user_shell`** — for commands with lasting effects (`cd`, `export`, `source`, `npm install`). Output goes to the user's terminal; the agent gets `"Command executed"` by default (set `return_output=true` to inspect).
+- **`display`** — for read-only display (`cat`, `git log`, `diff`). Output goes to the user's terminal; the agent gets `"Output displayed to user."` — it never sees the content.
+
+Both write commands to the actual PTY via the same bus event:
 
 ```
 agent calls user_shell({ command: "cd src" })
@@ -69,7 +74,7 @@ agent calls user_shell({ command: "cd src" })
           → result returned to agent
 ```
 
-With the internal agent, `user_shell` is a built-in tool. Extension backends can implement it however they choose — see [Extensions: Custom Agent Backends](extensions.md#custom-agent-backends).
+With the internal agent, both are built-in tools. Extension backends can implement them however they choose — see [Extensions: Custom Agent Backends](extensions.md#custom-agent-backends).
 
 ## Agent Backend
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -528,9 +528,9 @@ agent-sh -e ./examples/extensions/latex-images.ts
 
 ## Custom Input Modes
 
-Input modes change what happens when the user types and presses Enter. Each mode binds a trigger character (typed at the start of an empty line) to a custom `onSubmit` handler. The built-in modes (`>` for execute, `?` for help) are registered this way — they're not special.
+Input modes change what happens when the user types and presses Enter. Each mode binds a trigger character (typed at the start of an empty line) to a custom `onSubmit` handler. The built-in mode (`>` for agent) is registered this way — it's not special.
 
-The flow: user types trigger → prompt changes to show the mode → user types their input → presses Enter → `onSubmit` fires → your handler emits `agent:submit` with a `modeInstruction` that gets prepended to the agent's system prompt, telling it how to behave in this mode.
+The flow: user types trigger → prompt changes to show the mode → user types their input → presses Enter → `onSubmit` fires → your handler emits `agent:submit`. You can optionally include a `modeInstruction` that gets prepended to the user message.
 
 ```typescript
 bus.emit("input-mode:register", {
@@ -540,11 +540,8 @@ bus.emit("input-mode:register", {
   promptIcon: "⟩",           // chevron/icon character
   indicator: "🌐",           // status indicator before the icon
   onSubmit(query, bus) {
-    // This is where you control what the agent sees.
-    // modeInstruction is prepended to the prompt — it's how you steer the agent.
     bus.emit("agent:submit", {
       query,                 // what the user typed
-      modeLabel: "Translate",
       modeInstruction: "[mode: translate] Translate the following to Spanish.",
     });
   },
@@ -559,7 +556,7 @@ bus.emit("input-mode:register", {
 | `label` | `string` | Shown in the prompt area |
 | `promptIcon` | `string` | Chevron/icon character in the prompt |
 | `indicator` | `string` | Status indicator before the icon |
-| `onSubmit` | `(query, bus) => void` | Called on Enter. Emits `agent:submit` with `query` + `modeInstruction` |
+| `onSubmit` | `(query, bus) => void` | Called on Enter. Emits `agent:submit` with `query` + optional `modeInstruction` |
 | `returnToSelf` | `boolean` | Re-enter this mode after the agent finishes |
 
 Each trigger character can only be claimed by one mode. Slash commands and readline keybindings work in every mode.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -383,7 +383,7 @@ ctx.advise("conversation:prepare", (next, messages) => {
 });
 ```
 
-**`tool:execute`** — Wraps every tool call. The `ctx` argument contains `{ name, id, args, tool }`. Extensions can block tools, add logging, implement custom permission policies, retry on failure, or run tools in a sandbox:
+**`tool:execute`** — Wraps every tool call. The `ctx` argument contains `{ name, id, args, tool, onChunk }`. Extensions can block tools, add logging, implement custom permission policies, retry on failure, run tools in a sandbox, or intercept/transform streamed output:
 
 ```typescript
 // Safe mode — block all file-modifying tools
@@ -411,7 +411,19 @@ ctx.advise("tool:execute", async (next, ctx) => {
   }
   return next(ctx);
 });
+
+// Secret redaction — wrap onChunk to scrub streaming output + final result
+ctx.advise("tool:execute", async (next, ctx) => {
+  const origOnChunk = ctx.onChunk;
+  if (origOnChunk) {
+    ctx.onChunk = (chunk) => origOnChunk(redact(chunk));
+  }
+  const result = await next(ctx);
+  return { ...result, content: redact(result.content) };
+});
 ```
+
+The `onChunk` callback controls what the user sees during tool execution (streamed to terminal). Wrapping it lets extensions transform output in real time — for example, redacting secrets before they hit the screen. See `examples/extensions/secret-guard.ts` for a complete implementation.
 
 #### Rendering handlers
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -209,7 +209,7 @@ A backend listens for input events and emits output events. The TUI and all exte
 
 | Event | Payload | Description |
 |---|---|---|
-| `agent:submit` | `{ query, modeInstruction?, modeLabel? }` | User submitted a query |
+| `agent:submit` | `{ query }` | User submitted a query |
 | `agent:cancel-request` | `{ silent? }` | User requested cancellation |
 | `agent:reset-session` | `{}` | User issued reset — clear conversation state |
 
@@ -218,7 +218,7 @@ A backend listens for input events and emits output events. The TUI and all exte
 | Step | Event | Payload | Notes |
 |---|---|---|---|
 | 1 | `agent:processing-start` | `{}` | Starts spinner in TUI |
-| 2 | `agent:query` | `{ query, modeLabel? }` | Echoes the query for display |
+| 2 | `agent:query` | `{ query }` | Echoes the query for display |
 | 3 | `agent:response-chunk` | `{ blocks: ContentBlock[] }` | Use `emitTransform` so content pipeline runs. Emit 0+ times |
 | 4 | `agent:response-done` | `{ response }` | Full response text |
 | 5 | `agent:processing-done` | `{}` | Stops spinner, returns control to prompt |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -55,7 +55,7 @@ TypeScript and JavaScript are both supported (`.ts`, `.tsx`, `.mts`, `.js`, `.mj
 | `createBlockTransform` | `(opts) => void` | Register an inline delimiter transform (e.g. `$$...$$`) |
 | `createFencedBlockTransform` | `(opts) => void` | Register a fenced block transform (e.g. ` ```lang...``` `) |
 | `getExtensionSettings` | `(namespace, defaults) => T` | Read extension settings from `~/.agent-sh/settings.json` |
-| `registerTool` | `(tool: ToolDefinition) => void` | Register a tool for the built-in agent (no-op for bridge backends) |
+| `registerTool` | `(tool: ToolDefinition) => void` | Register a tool for the built-in agent (no-op for bridge backends). Tools can include optional `getDisplayInfo`, `formatCall`, and `formatResult` for TUI integration — see [Internal Agent: Tool interface](agent.md#tool-interface) |
 | `getTools` | `() => ToolDefinition[]` | Get all registered tools (for subagent tool subsets) |
 | `define` | `(name, fn) => void` | Register a named handler |
 | `advise` | `(name, wrapper) => void` | Wrap a named handler (receives `next` + args) |
@@ -228,11 +228,14 @@ A backend listens for input events and emits output events. The TUI and all exte
 | Event | Payload | When |
 |---|---|---|
 | `agent:thinking-chunk` | `{ text }` | Reasoning tokens (e.g. DeepSeek-r1) |
-| `agent:tool-started` | `{ title, toolCallId?, kind? }` | Tool execution beginning |
+| `agent:tool-batch` | `{ groups: [{ kind, tools: [{ name, displayDetail? }] }] }` | Before tool execution — all tools grouped by kind |
+| `agent:tool-started` | `{ title, toolCallId?, kind?, icon?, displayDetail?, locations?, batchIndex?, batchTotal? }` | Tool execution beginning |
 | `agent:tool-output-chunk` | `{ chunk }` | Streamed tool output |
-| `agent:tool-completed` | `{ toolCallId?, exitCode }` | Tool execution finished |
+| `agent:tool-completed` | `{ toolCallId?, exitCode, kind?, resultDisplay? }` | Tool execution finished |
 | `agent:error` | `{ message }` | Error during processing |
 | `agent:usage` | `{ prompt_tokens, completion_tokens, total_tokens }` | Token usage stats |
+
+The `agent:tool-batch` event lets the TUI prepare group headers before tools execute. `agent:tool-started` now carries display metadata (`icon`, `displayDetail` from `formatCall()`, batch position). `agent:tool-completed` includes a `resultDisplay` (from `formatResult()`) with an optional `summary` string and structured `body`.
 
 ### Switching backends at runtime
 
@@ -433,6 +436,16 @@ These are registered by the tui-renderer and let extensions customize how conten
 |---|---|---|
 | `render:code-block` | `(language: string, code: string, width: number) → void` | Render a fenced code block (default: syntax highlighting) |
 | `render:image` | `(data: Buffer) → void` | Display an image in the terminal (default: iTerm2/Kitty protocol) |
+| `render:result-body` | `(body: ToolResultBody, width: number) → string[]` | Render structured tool result body (default: diffs or line lists) |
+
+The `render:result-body` handler is called when a tool's `formatResult()` returns a structured `body`. Extensions can advise it to customize how specific result types are displayed:
+
+```typescript
+ctx.advise("render:result-body", (next, body, width) => {
+  if (body.kind === "diff") return myCustomDiffRenderer(body.diff, body.filePath, width);
+  return next(body, width);
+});
+```
 
 #### Custom handlers
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,4 +194,4 @@ The agent automatically receives structured context about your shell session wit
 - **Recent commands and output** — truncated summaries of recent shell activity
 - **Full history access** — the agent can recall full output of truncated exchanges
 
-This means you can run a failing command, then type `? fix this` and the agent knows exactly what happened. Context size is tunable via settings.
+This means you can run a failing command, then type `> fix this` and the agent knows exactly what happened. Context size is tunable via settings.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -182,9 +182,19 @@ When cycling across providers (e.g. from OpenAI to Ollama), the API key and base
 | `shellHeadLines` / `shellTailLines` | `5` / `5` | Lines kept from start/end of truncated output |
 | `recallExpandMaxLines` | `100` | Max lines for recall expand |
 | `maxCommandOutputLines` | `3` | Max tool output lines shown inline in TUI |
-| `readOutputMaxLines` | `0` | Max read tool output lines shown inline (0 = hidden) |
+| `readOutputMaxLines` | `10` | Max read tool output lines shown inline (0 = hidden) |
 | `diffMaxLines` | `20` | Max diff lines before "ctrl+o to expand" |
-| `enableMcp` | `true` | Register MCP server for bridge tools |
+
+## Startup Banner
+
+On launch, agent-sh displays a structured startup banner showing:
+
+- **Backend** — which agent backend is active (`agent-sh`, `claude-code`, `pi`, etc.)
+- **Model** — current model with provider in brackets (e.g. `gpt-4o [openai]`)
+- **Extensions** — loaded extensions (from CLI `-e`, settings, or `~/.agent-sh/extensions/`)
+- **Skills** — discovered skills (global + project)
+
+Set `startupBanner: false` in settings to disable.
 
 ## Shell Context
 

--- a/examples/extensions/claude-code-bridge/index.ts
+++ b/examples/extensions/claude-code-bridge/index.ts
@@ -30,8 +30,8 @@ function createUserShellTool(bus: EventBus) {
 
   return tool(
     "user_shell",
-    "Run a command in the user's live shell (visible in terminal). " +
-    "Use for cd, export, source, or commands the user wants to see. " +
+    "Run a command with lasting effects in the user's live shell (cd, export, " +
+    "install packages, start servers) or show output the user wants to see. " +
     "Set return_output=true only if you need to inspect the result.",
     {
       command: z.string().describe("Command to execute in user's shell"),
@@ -71,12 +71,8 @@ export default function activate(ctx: ExtensionContext): void {
   const listeners: Array<{ event: string; fn: Function }> = [];
 
   const wireListeners = () => {
-    const onSubmit = async ({ query: userQuery, modeInstruction, modeLabel }: any) => {
-      const prompt = modeInstruction
-        ? `${modeInstruction}\n${userQuery}`
-        : userQuery;
-
-      bus.emit("agent:query", { query: userQuery, modeLabel });
+    const onSubmit = async ({ query: userQuery }: any) => {
+      bus.emit("agent:query", { query: userQuery });
       bus.emit("agent:processing-start", {});
 
       let fullResponseText = "";
@@ -84,7 +80,7 @@ export default function activate(ctx: ExtensionContext): void {
 
       try {
         activeQuery = query({
-          prompt,
+          prompt: userQuery,
           options: {
             cwd: process.cwd(),
             systemPrompt: {
@@ -92,9 +88,9 @@ export default function activate(ctx: ExtensionContext): void {
               preset: "claude_code",
               append:
                 "You are running inside agent-sh, a terminal wrapper.\n" +
-                "EXECUTE mode ('>'): Use your standard tools. Do NOT use user_shell.\n" +
-                "HELP mode ('?'): Run the command via mcp__agent-sh__user_shell. Just run it, no explanation.\n" +
-                "Each prompt includes a per-query mode instruction — follow it.",
+                "Use your standard tools (Read, Edit, Write, Bash, Glob, Grep) for investigation.\n" +
+                "Use mcp__agent-sh__user_shell to run commands in the user's live shell when they ask to see output or need lasting effects (cd, install, start servers).\n" +
+                "Default to standard tools. Use user_shell when the user is the intended audience for the output or the command has real effects.",
             },
             mcpServers: { "agent-sh": shellServer },
             allowedTools: [

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -48,17 +48,16 @@ function createUserShellToolDef(bus: EventBus) {
     name: "user_shell",
     label: "user_shell",
     description:
-      "Run a command in the user's live shell (visible in terminal). " +
-      "Use for cd, export, source, or commands the user wants to see. " +
+      "Run a command with lasting effects in the user's live shell (cd, export, " +
+      "install packages, start servers) or show output the user wants to see. " +
       "Output is shown directly to the user. Set return_output=true only " +
       "if you need to inspect the result.",
-    promptSnippet: "Execute commands in the user's live terminal (PTY). Use in HELP mode.",
+    promptSnippet: "Execute commands in the user's live terminal (PTY).",
     promptGuidelines: [
-      "You are running inside agent-sh, a terminal wrapper with two interaction modes.",
-      "EXECUTE mode (triggered by '>'): Use your standard tools (bash, file ops). Do NOT use user_shell.",
-      "HELP mode (triggered by '?'): Run the command via user_shell. Do not explain or confirm — just run it.",
-      "Each prompt includes a per-query mode instruction — follow it.",
-      "user_shell executes in the user's actual shell (their aliases, env vars, cwd). Use bash for background work.",
+      "You are running inside agent-sh, a terminal wrapper.",
+      "Use your standard tools (bash, file ops) for investigation — output goes to you, not the user.",
+      "Use user_shell to run commands in the user's live shell when they ask to see output or need lasting effects (cd, install, start servers).",
+      "Default to standard tools. Use user_shell when the user is the intended audience for the output or the command has real effects.",
     ],
     parameters: schema,
 
@@ -203,7 +202,7 @@ export default function activate(ctx: ExtensionContext): void {
   const listeners: Array<{ event: string; fn: Function }> = [];
 
   const wireListeners = () => {
-    const onSubmit = async ({ query, modeInstruction, modeLabel }: any) => {
+    const onSubmit = async ({ query }: any) => {
       if (!session) {
         bus.emit("agent:error", {
           message: booting ? "pi is still starting up..." : "pi session not initialized",
@@ -212,12 +211,11 @@ export default function activate(ctx: ExtensionContext): void {
         return;
       }
 
-      const prompt = modeInstruction ? `${modeInstruction}\n${query}` : query;
-      bus.emit("agent:query", { query, modeLabel });
+      bus.emit("agent:query", { query });
       bus.emit("agent:processing-start", {});
 
       try {
-        await session.prompt(prompt);
+        await session.prompt(query);
       } catch (err) {
         bus.emit("agent:error", {
           message: err instanceof Error ? err.message : String(err),

--- a/examples/extensions/secret-guard.ts
+++ b/examples/extensions/secret-guard.ts
@@ -1,0 +1,100 @@
+/**
+ * Secret guard extension.
+ *
+ * Redacts sensitive patterns (API keys, tokens, passwords) from tool output
+ * — both the streamed terminal display and the content sent back to the LLM.
+ *
+ * Usage:
+ *   agent-sh -e ./examples/extensions/secret-guard.ts
+ *
+ *   # Or install permanently:
+ *   cp examples/extensions/secret-guard.ts ~/.agent-sh/extensions/
+ *
+ * Configuration (~/.agent-sh/settings.json):
+ *   {
+ *     "secret-guard": {
+ *       "extraPatterns": ["CUSTOM_\\w+=\\S+"],
+ *       "redactText": "***REDACTED***"
+ *     }
+ *   }
+ */
+import type { ExtensionContext } from "agent-sh/types";
+
+// Common secret patterns — each matches key=value or key: value formats
+const DEFAULT_PATTERNS = [
+  // API keys and tokens (generic)
+  /(?:api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token|secret[_-]?key|private[_-]?key)\s*[=:]\s*\S+/gi,
+  // AWS
+  /(?:AKIA|ASIA)[A-Z0-9]{16}/g,
+  /(?:aws_secret_access_key|aws_session_token)\s*[=:]\s*\S+/gi,
+  // Bearer tokens
+  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
+  // GitHub tokens
+  /gh[pousr]_[A-Za-z0-9_]{36,}/g,
+  // Anthropic / OpenAI keys
+  /sk-(?:ant-)?[A-Za-z0-9\-_]{10,}/g,
+  // Generic long hex/base64 secrets (env var assignment)
+  /(?:SECRET|TOKEN|PASSWORD|PASSWD|API_KEY|PRIVATE_KEY)\s*[=:]\s*\S+/gi,
+  // Connection strings with passwords
+  /[a-z+]+:\/\/[^:]+:[^@\s]+@/gi,
+];
+
+export default function activate(ctx: ExtensionContext) {
+  const { bus } = ctx;
+  const config = ctx.getExtensionSettings("secret-guard", {
+    extraPatterns: [] as string[],
+    redactText: "***REDACTED***",
+  });
+
+  const patterns = [
+    ...DEFAULT_PATTERNS,
+    ...config.extraPatterns.map((p: string) => new RegExp(p, "gi")),
+  ];
+
+  function redact(text: string): string {
+    let result = text;
+    for (const pattern of patterns) {
+      // Reset lastIndex for stateful regex (global flag)
+      pattern.lastIndex = 0;
+      result = result.replace(pattern, config.redactText);
+    }
+    return result;
+  }
+
+  // Redact the dynamic context (shell history, cwd, etc.) before it's sent
+  // to the LLM. This is the chokepoint — everything the model sees passes
+  // through dynamic-context:build.
+  ctx.advise("dynamic-context:build", (next) => {
+    return redact(next());
+  });
+
+  // Advise tool:execute to wrap both streaming output and final result.
+  // Chunks from child processes arrive at arbitrary byte boundaries, so a
+  // secret like "sk-ant-abc123" could be split across two chunks.  We
+  // line-buffer: accumulate until we see '\n', redact complete lines, flush.
+  ctx.advise("tool:execute", async (next, toolCtx) => {
+    const origOnChunk = toolCtx.onChunk;
+    if (origOnChunk) {
+      let buf = "";
+      toolCtx.onChunk = (chunk: string) => {
+        buf += chunk;
+        const lastNl = buf.lastIndexOf("\n");
+        if (lastNl !== -1) {
+          // Flush all complete lines, redacted
+          origOnChunk(redact(buf.slice(0, lastNl + 1)));
+          buf = buf.slice(lastNl + 1);
+        }
+      };
+
+      const result = await next(toolCtx);
+
+      // Flush any remaining partial line
+      if (buf) origOnChunk(redact(buf));
+
+      return { ...result, content: redact(result.content) };
+    }
+
+    const result = await next(toolCtx);
+    return { ...result, content: redact(result.content) };
+  });
+}

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -28,7 +28,7 @@ import { STATIC_SYSTEM_PROMPT, buildDynamicContext } from "./system-prompt.js";
 
 // Core tool factories
 import { createBashTool } from "./tools/bash.js";
-import { createReadFileTool } from "./tools/read-file.js";
+import { createReadFileTool, type FileReadCache } from "./tools/read-file.js";
 import { createWriteFileTool } from "./tools/write-file.js";
 import { createEditFileTool } from "./tools/edit-file.js";
 import { createGrepTool } from "./tools/grep.js";
@@ -48,6 +48,7 @@ export class AgentLoop implements AgentBackend {
   private abortController: AbortController | null = null;
   private toolRegistry = new ToolRegistry();
   private conversation = new ConversationState();
+  private fileReadCache: FileReadCache = new Map();
   private modes: AgentMode[];
   private currentModeIndex = 0;
   private boundListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
@@ -337,7 +338,7 @@ export class AgentLoop implements AgentBackend {
     this.toolRegistry.register(
       createBashTool({ getCwd, getEnv, bus: this.bus }),
     );
-    this.toolRegistry.register(createReadFileTool(getCwd));
+    this.toolRegistry.register(createReadFileTool(getCwd, this.fileReadCache));
     this.toolRegistry.register(createWriteFileTool(getCwd));
     this.toolRegistry.register(createEditFileTool(getCwd));
     this.toolRegistry.register(createGrepTool(getCwd));
@@ -375,6 +376,8 @@ export class AgentLoop implements AgentBackend {
       args: Record<string, unknown>;
       tool: ToolDefinition;
       onChunk?: (chunk: string) => void;
+      batchIndex?: number;
+      batchTotal?: number;
     }) => {
       const { name, id, args, tool } = ctx;
       const display = tool.getDisplayInfo?.(args) ?? { kind: "execute" as const };
@@ -383,7 +386,9 @@ export class AgentLoop implements AgentBackend {
       // Permission gating
       if (tool.requiresPermission) {
         let permKind = "tool-call";
-        let permTitle = name;
+        let permTitle = typeof args.description === "string"
+          ? `${name}: ${args.description}`
+          : name;
         let metadata: Record<string, unknown> = { args };
 
         // For file-modifying tools, pre-compute diff for display
@@ -436,8 +441,10 @@ export class AgentLoop implements AgentBackend {
 
       // Emit tool-started for TUI
       this.bus.emit("agent:tool-started", {
-        title: name, toolCallId: id,
+        title: typeof args.description === "string" ? `${name}: ${args.description}` : name,
+        toolCallId: id,
         kind: display.kind, locations: display.locations, rawInput: args,
+        batchIndex: ctx.batchIndex, batchTotal: ctx.batchTotal,
       });
       this.bus.emit("agent:tool-call", { tool: name, args });
 
@@ -447,6 +454,12 @@ export class AgentLoop implements AgentBackend {
         ? ctx.onChunk
         : undefined;
       const result = await tool.execute(args, onChunk);
+
+      // Invalidate read cache when a file is modified
+      if (tool.modifiesFiles && typeof args.path === "string" && !result.isError) {
+        const absPath = path.resolve(process.cwd(), args.path);
+        this.fileReadCache.delete(absPath);
+      }
 
       // Emit completion events
       this.bus.emit("agent:tool-completed", {
@@ -552,7 +565,8 @@ export class AgentLoop implements AgentBackend {
 
       // Execute tool calls — run read-only tools in parallel, permission-
       // requiring tools sequentially (to avoid overlapping permission prompts).
-      const executeSingle = async (tc: PendingToolCall) => {
+      const batchTotal = toolCalls.length;
+      const executeSingle = async (tc: PendingToolCall, batchIndex?: number) => {
         const tool = this.toolRegistry.get(tc.name);
         if (!tool) {
           this.conversation.addToolResult(
@@ -580,7 +594,8 @@ export class AgentLoop implements AgentBackend {
         };
         const result = await this.handlers.call(
           "tool:execute",
-          { name: tc.name, id: tc.id, args, tool, onChunk: defaultOnChunk },
+          { name: tc.name, id: tc.id, args, tool, onChunk: defaultOnChunk,
+            batchIndex, batchTotal: batchTotal > 1 ? batchTotal : undefined },
         );
 
         // Add tool result to conversation (truncate large outputs to avoid
@@ -626,14 +641,18 @@ export class AgentLoop implements AgentBackend {
       }
 
       // Run read-only tools in parallel
+      let batchIdx = 0;
       if (parallel.length > 0 && !signal.aborted) {
-        await Promise.all(parallel.map(tc => signal.aborted ? Promise.resolve() : executeSingle(tc)));
+        await Promise.all(parallel.map(tc => {
+          const idx = ++batchIdx;
+          return signal.aborted ? Promise.resolve() : executeSingle(tc, idx);
+        }));
       }
 
       // Run permission-requiring tools sequentially
       for (const tc of sequential) {
         if (signal.aborted) break;
-        await executeSingle(tc);
+        await executeSingle(tc, ++batchIdx);
       }
 
       // Loop back — LLM sees tool results

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -35,6 +35,7 @@ import { createGrepTool } from "./tools/grep.js";
 import { createGlobTool } from "./tools/glob.js";
 import { createLsTool } from "./tools/ls.js";
 import { createUserShellTool } from "./tools/user-shell.js";
+import { createDisplayTool } from "./tools/display.js";
 import { createListSkillsTool } from "./tools/list-skills.js";
 import { discoverProjectSkills } from "./skills.js";
 
@@ -346,6 +347,9 @@ export class AgentLoop implements AgentBackend {
     this.toolRegistry.register(createLsTool(getCwd));
     this.toolRegistry.register(
       createUserShellTool({ getCwd, bus: this.bus }),
+    );
+    this.toolRegistry.register(
+      createDisplayTool({ getCwd, bus: this.bus }),
     );
     this.toolRegistry.register(createListSkillsTool(getCwd));
   }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -443,7 +443,7 @@ export class AgentLoop implements AgentBackend {
       this.bus.emit("agent:tool-started", {
         title: typeof args.description === "string" ? `${name}: ${args.description}` : name,
         toolCallId: id,
-        kind: display.kind, locations: display.locations, rawInput: args,
+        kind: display.kind, icon: display.icon, locations: display.locations, rawInput: args,
         batchIndex: ctx.batchIndex, batchTotal: ctx.batchTotal,
       });
       this.bus.emit("agent:tool-call", { tool: name, args });

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -444,10 +444,12 @@ export class AgentLoop implements AgentBackend {
       }
 
       // Emit tool-started for TUI
+      const label = tool.displayName ?? name;
       this.bus.emit("agent:tool-started", {
-        title: typeof args.description === "string" ? `${name}: ${args.description}` : name,
+        title: typeof args.description === "string" ? `${label}: ${args.description}` : label,
         toolCallId: id,
         kind: display.kind, icon: display.icon, locations: display.locations, rawInput: args,
+        displayDetail: tool.formatCall?.(args),
         batchIndex: ctx.batchIndex, batchTotal: ctx.batchTotal,
       });
       this.bus.emit("agent:tool-call", { tool: name, args });
@@ -465,10 +467,14 @@ export class AgentLoop implements AgentBackend {
         this.fileReadCache.delete(absPath);
       }
 
-      // Emit completion events
-      this.bus.emit("agent:tool-completed", {
+      // Compute result display: tool-provided → default (none)
+      const resultDisplay = tool.formatResult?.(args, result);
+
+      // Emit completion events (via transform pipe so extensions can override)
+      this.bus.emitTransform("agent:tool-completed", {
         toolCallId: id, exitCode: result.exitCode,
         rawOutput: result.content, kind: display.kind,
+        resultDisplay,
       });
       this.bus.emit("agent:tool-output", {
         tool: name, output: result.content, exitCode: result.exitCode,
@@ -558,6 +564,22 @@ export class AgentLoop implements AgentBackend {
 
       // No tool calls → agent is done
       if (toolCalls.length === 0) break;
+
+      // Emit batch info so the TUI can render group headers upfront
+      {
+        const groupMap = new Map<string, Array<{ name: string; displayDetail?: string }>>();
+        for (const tc of toolCalls) {
+          const tool = this.toolRegistry.get(tc.name);
+          const kind = tool?.getDisplayInfo?.((() => { try { return JSON.parse(tc.argumentsJson); } catch { return {}; } })())?.kind ?? "execute";
+          let args: Record<string, unknown> = {};
+          try { args = JSON.parse(tc.argumentsJson); } catch {}
+          const detail = tool?.formatCall?.(args);
+          if (!groupMap.has(kind)) groupMap.set(kind, []);
+          groupMap.get(kind)!.push({ name: tc.name, displayDetail: detail });
+        }
+        const groups = Array.from(groupMap.entries()).map(([kind, tools]) => ({ kind, tools }));
+        this.bus.emit("agent:tool-batch", { groups });
+      }
 
       // Execute tool calls — run read-only tools in parallel, permission-
       // requiring tools sequentially (to avoid overlapping permission prompts).

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -89,8 +89,8 @@ export class AgentLoop implements AgentBackend {
       this.boundListeners.push({ event, fn });
     };
 
-    on("agent:submit", ({ query, modeInstruction, modeLabel }) => {
-      this.handleQuery(query, modeInstruction, modeLabel).catch(() => {});
+    on("agent:submit", ({ query, modeInstruction }) => {
+      this.handleQuery(query, modeInstruction).catch(() => {});
     });
     on("agent:cancel-request", (e) => {
       this.abortController?.abort(e.silent ? "silent" : undefined);
@@ -481,7 +481,6 @@ export class AgentLoop implements AgentBackend {
   private async handleQuery(
     query: string,
     modeInstruction?: string,
-    modeLabel?: string,
   ): Promise<void> {
     // Cancel any in-flight loop (concurrent prompt handling)
     if (this.abortController) {
@@ -493,7 +492,7 @@ export class AgentLoop implements AgentBackend {
     // raise the limit to avoid spurious warnings on multi-tool queries.
     setMaxListeners(50, signal);
 
-    this.bus.emit("agent:query", { query, modeLabel });
+    this.bus.emit("agent:query", { query });
     this.bus.emit("agent:processing-start", {});
     let responseText = "";
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -368,10 +368,13 @@ export class AgentLoop implements AgentBackend {
 
     // Wraps each tool call: permission → execute → emit events.
     // Extensions advise to add safe-mode, logging, metrics, custom policies.
+    // The ctx.onChunk callback is exposed so advisors can wrap it to
+    // intercept/transform streamed tool output (e.g. secret redaction).
     h.define("tool:execute", async (ctx: {
       name: string; id: string;
       args: Record<string, unknown>;
       tool: ToolDefinition;
+      onChunk?: (chunk: string) => void;
     }) => {
       const { name, id, args, tool } = ctx;
       const display = tool.getDisplayInfo?.(args) ?? { kind: "execute" as const };
@@ -438,9 +441,10 @@ export class AgentLoop implements AgentBackend {
       });
       this.bus.emit("agent:tool-call", { tool: name, args });
 
-      // Execute — suppress streaming output if diff was already shown
+      // Execute — use ctx.onChunk so advisors can wrap the streaming callback.
+      // Suppress streaming output if diff was already shown.
       const onChunk = (tool.showOutput !== false && !diffShown)
-        ? (chunk: string) => { this.bus.emit("agent:tool-output-chunk", { chunk }); }
+        ? ctx.onChunk
         : undefined;
       const result = await tool.execute(args, onChunk);
 
@@ -546,17 +550,16 @@ export class AgentLoop implements AgentBackend {
       // No tool calls → agent is done
       if (toolCalls.length === 0) break;
 
-      // Execute each tool call
-      for (const tc of toolCalls) {
-        if (signal.aborted) break;
-
+      // Execute tool calls — run read-only tools in parallel, permission-
+      // requiring tools sequentially (to avoid overlapping permission prompts).
+      const executeSingle = async (tc: PendingToolCall) => {
         const tool = this.toolRegistry.get(tc.name);
         if (!tool) {
           this.conversation.addToolResult(
             tc.id,
             `Error: Unknown tool "${tc.name}"`,
           );
-          continue;
+          return;
         }
 
         let args: Record<string, unknown>;
@@ -567,21 +570,70 @@ export class AgentLoop implements AgentBackend {
             tc.id,
             `Error: Invalid JSON arguments for ${tc.name}`,
           );
-          continue;
+          return;
         }
 
         // Execute via handler — extensions can advise to add safe-mode,
         // logging, metrics, custom permission policies, etc.
+        const defaultOnChunk = (chunk: string) => {
+          this.bus.emit("agent:tool-output-chunk", { chunk });
+        };
         const result = await this.handlers.call(
           "tool:execute",
-          { name: tc.name, id: tc.id, args, tool },
+          { name: tc.name, id: tc.id, args, tool, onChunk: defaultOnChunk },
         );
 
-        // Add tool result to conversation
-        const content = result.isError
+        // Add tool result to conversation (truncate large outputs to avoid
+        // blowing through the context window on a single tool call)
+        let content = result.isError
           ? `Error: ${result.content}`
           : result.content;
+        const maxBytes = 16_384; // ~4k tokens
+        if (content.length > maxBytes) {
+          const headBytes = Math.floor(maxBytes * 0.6);
+          const tailBytes = maxBytes - headBytes;
+          const lines = content.split("\n");
+          let headEnd = 0, headLen = 0;
+          for (let i = 0; i < lines.length && headLen + lines[i].length + 1 <= headBytes; i++) {
+            headLen += lines[i].length + 1;
+            headEnd = i + 1;
+          }
+          let tailStart = lines.length, tailLen = 0;
+          for (let i = lines.length - 1; i >= headEnd && tailLen + lines[i].length + 1 <= tailBytes; i--) {
+            tailLen += lines[i].length + 1;
+            tailStart = i;
+          }
+          const omitted = tailStart - headEnd;
+          content = [
+            ...lines.slice(0, headEnd),
+            `\n[… ${omitted} lines omitted (output truncated to ${Math.round(maxBytes / 1024)}KB) …]\n`,
+            ...lines.slice(tailStart),
+          ].join("\n");
+        }
         this.conversation.addToolResult(tc.id, content);
+      };
+
+      // Partition into parallel-safe (read-only) and sequential (needs permission)
+      const parallel: PendingToolCall[] = [];
+      const sequential: PendingToolCall[] = [];
+      for (const tc of toolCalls) {
+        const tool = this.toolRegistry.get(tc.name);
+        if (tool && !tool.requiresPermission && !tool.modifiesFiles) {
+          parallel.push(tc);
+        } else {
+          sequential.push(tc);
+        }
+      }
+
+      // Run read-only tools in parallel
+      if (parallel.length > 0 && !signal.aborted) {
+        await Promise.all(parallel.map(tc => signal.aborted ? Promise.resolve() : executeSingle(tc)));
+      }
+
+      // Run permission-requiring tools sequentially
+      for (const tc of sequential) {
+        if (signal.aborted) break;
+        await executeSingle(tc);
       }
 
       // Loop back — LLM sees tool results

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -89,8 +89,8 @@ export class AgentLoop implements AgentBackend {
       this.boundListeners.push({ event, fn });
     };
 
-    on("agent:submit", ({ query, modeInstruction }) => {
-      this.handleQuery(query, modeInstruction).catch(() => {});
+    on("agent:submit", ({ query }) => {
+      this.handleQuery(query).catch(() => {});
     });
     on("agent:cancel-request", (e) => {
       this.abortController?.abort(e.silent ? "silent" : undefined);
@@ -478,10 +478,7 @@ export class AgentLoop implements AgentBackend {
     });
   }
 
-  private async handleQuery(
-    query: string,
-    modeInstruction?: string,
-  ): Promise<void> {
+  private async handleQuery(query: string): Promise<void> {
     // Cancel any in-flight loop (concurrent prompt handling)
     if (this.abortController) {
       this.abortController.abort();
@@ -497,11 +494,7 @@ export class AgentLoop implements AgentBackend {
     let responseText = "";
 
     try {
-      // Prepend mode instruction to the user message
-      const userMessage = modeInstruction
-        ? `${modeInstruction}\n${query}`
-        : query;
-      this.conversation.addUserMessage(userMessage);
+      this.conversation.addUserMessage(query);
 
       responseText = await this.executeLoop(signal);
     } catch (e) {

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -123,11 +123,13 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
 
       if (bus) {
         const display = tool.getDisplayInfo?.(args) ?? { kind: "execute" };
-        bus.emit("agent:tool-completed", {
+        const resultDisplay = tool.formatResult?.(args, result);
+        bus.emitTransform("agent:tool-completed", {
           toolCallId: tc.id,
           exitCode: result.exitCode,
           rawOutput: result.content,
           kind: display.kind,
+          resultDisplay,
         });
       }
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -46,32 +46,37 @@ export const STATIC_SYSTEM_PROMPT = `You are an AI coding assistant embedded in 
 You have access to the user's shell environment and can read, write, and execute code.
 You share the user's working directory, environment variables, and shell history.
 
-# Input Modes
+# Tool Decision Guide
 
-The user interacts with you through two modes:
+You have three categories of tools — choose based on who needs the output and
+whether the command has lasting effects:
 
-EXECUTE mode (triggered by '>'): The user is asking questions or requesting tasks.
-Use your internal tools (bash, file operations, etc.) to accomplish tasks.
-Do NOT use user_shell in this mode unless the user explicitly asks to run
-something in their live shell.
+**Scratchpad tools** (bash, read_file, grep, glob, ls, edit_file, write_file):
+Use these to investigate, search, read, and modify files. Output is returned
+to you for reasoning — the user doesn't see it directly.
 
-HELP mode (triggered by '?'): The user wants a command run in their live shell.
-You may use your tools to investigate first (read files, grep, etc.), but the
-final action must be running the command via user_shell with return_output=false.
-The user sees the output directly — you don't need to see or summarize it.
-Do not explain, confirm, or comment on the result — just run it and stop.
+**Display** (display):
+Use this to show output to the user in their terminal. The user sees the
+output directly, but it is NOT returned to you. Use when:
+- The user asks to see something (cat a file, git log, git diff, man page)
+- The output is for the user to read, not for you to process
 
-Each prompt includes a per-query mode instruction — follow it.
+**Live shell** (user_shell):
+Use this to run commands with lasting effects in the user's real shell. Use for:
+- Commands that affect shell state (cd, export, source)
+- Installing packages, starting servers, running builds
+- Any command where the user wants real side effects
+- Set return_output=true only if you need to inspect the result
+
+Default to scratchpad tools for your own investigation. Use display when the
+user is the intended audience. Use user_shell when the command has real effects.
 
 # Tool Usage Guidelines
 - Use read_file before editing a file you haven't seen
 - Prefer edit_file over write_file for modifying existing files
 - Use grep/glob to find files before reading them
 - Keep bash commands focused; avoid long-running blocking commands
-- Always check command exit codes for errors
-- user_shell runs commands in the user's live terminal — use for cd, export, source, etc.
-- user_shell output is shown directly to the user but NOT returned to you by default.
-  Set return_output=true if you need to inspect the result to answer a question.`;
+- Always check command exit codes for errors`;
 
 /**
  * Build the dynamic context — injected as a user message before each query.

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -10,7 +10,11 @@ export function createBashTool(opts: {
   return {
     name: "bash",
     description:
-      "Execute a bash command in an isolated subprocess. Output is captured and returned to you. Does not affect the user's shell state.",
+      "Execute a bash command in an isolated subprocess. Output is captured and returned. " +
+      "Does not affect the user's shell state (use user_shell for cd, export, source). " +
+      "Do NOT use bash for file searching — use grep/glob instead. " +
+      "Do NOT use bash for reading files — use read_file instead. " +
+      "Provide a description parameter to explain what the command does.",
     input_schema: {
       type: "object",
       properties: {
@@ -21,6 +25,11 @@ export function createBashTool(opts: {
         timeout: {
           type: "number",
           description: "Timeout in seconds (default: 60)",
+        },
+        description: {
+          type: "string",
+          description:
+            "Short description of what this command does (e.g., 'Install dependencies', 'Run test suite')",
         },
       },
       required: ["command"],

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -41,6 +41,7 @@ export function createBashTool(opts: {
 
     getDisplayInfo: (args) => ({
       kind: "execute",
+      icon: "▶",
       locations: [],
     }),
 

--- a/src/agent/tools/display.ts
+++ b/src/agent/tools/display.ts
@@ -2,56 +2,48 @@ import type { EventBus } from "../../event-bus.js";
 import type { ToolDefinition } from "../types.js";
 
 /**
- * user_shell — runs commands in the user's live PTY shell.
+ * display — shows command output to the user in their live terminal.
  *
- * Unlike bash, this affects the user's shell state (cd, export, source).
- * Output is shown directly in the terminal. By default, the agent doesn't
- * see the output (return_output=false) to save tokens.
+ * Unlike bash (scratchpad), the user sees the output directly in their shell.
+ * Unlike user_shell, this is for read-only display — no lasting side effects.
+ * The agent does NOT receive the output back.
  */
-export function createUserShellTool(opts: {
+export function createDisplayTool(opts: {
   getCwd: () => string;
   bus: EventBus;
 }): ToolDefinition {
   return {
-    name: "user_shell",
+    name: "display",
     description:
-      "Run a command with lasting effects in the user's live shell (cd, export, install packages, start servers, apply changes). Output is shown directly to the user but NOT returned to you by default — set return_output=true if you need to inspect the result.",
+      "Show command output to the user in their terminal. Use when the user asks to see something (cat, git log, diff, man, etc.) and you don't need to process the output yourself. Output is NOT returned to you.",
     input_schema: {
       type: "object",
       properties: {
         command: {
           type: "string",
-          description: "Command to execute in user's shell",
+          description: "Command to run and display output to the user",
         },
         timeout: {
           type: "number",
           description: "Timeout in seconds (default: 30)",
-        },
-        return_output: {
-          type: "boolean",
-          default: false,
-          description:
-            "Whether to return the command output to you. Default false — output is shown directly to the user. Set true only if you need to inspect the result to answer a question.",
         },
       },
       required: ["command"],
     },
 
     showOutput: false,
-    modifiesFiles: true,
+    modifiesFiles: false,
 
     getDisplayInfo: () => ({
-      kind: "execute",
-      icon: "▷",
+      kind: "display" as const,
+      icon: "◇",
       locations: [],
     }),
 
     async execute(args) {
       const command = args.command as string;
       const timeoutSec = (args.timeout as number) ?? 30;
-      const returnOutput = (args.return_output as boolean) ?? false;
 
-      // Execute via the shell-exec extension's async pipe with timeout
       let result: { output: string; exitCode: number | null; [k: string]: unknown };
       try {
         const execPromise = opts.bus.emitPipeAsync(
@@ -83,18 +75,10 @@ export function createUserShellTool(opts: {
       const exitCode = result.exitCode ?? 0;
       const isError = exitCode !== 0 && exitCode !== null;
 
-      if (returnOutput) {
-        return {
-          content: result.output || "(no output)",
-          exitCode,
-          isError,
-        };
-      }
-
       return {
         content: isError
           ? `Command failed with exit code ${exitCode}.`
-          : "Command executed.",
+          : "Output displayed to user.",
         exitCode,
         isError,
       };

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -42,7 +42,10 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
   return {
     name: "edit_file",
     description:
-      "Edit a file by replacing an exact text match with new text. The old_text must appear exactly once in the file. Include enough context to make the match unique.",
+      "Edit a file by replacing an exact text match with new text. " +
+      "The old_text must appear exactly once unless replace_all=true. " +
+      "Include enough context to make the match unique. " +
+      "Use replace_all for variable renames or bulk string replacements.",
     input_schema: {
       type: "object",
       properties: {
@@ -57,6 +60,11 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
         new_text: {
           type: "string",
           description: "Replacement text",
+        },
+        replace_all: {
+          type: "boolean",
+          description:
+            "Replace ALL occurrences instead of requiring a unique match. Useful for variable renames.",
         },
       },
       required: ["path", "old_text", "new_text"],
@@ -75,6 +83,7 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
       const filePath = args.path as string;
       const oldText = args.old_text as string;
       const newText = args.new_text as string;
+      const replaceAll = (args.replace_all as boolean) ?? false;
       const absPath = path.resolve(getCwd(), filePath);
 
       try {
@@ -95,19 +104,18 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
             isError: true,
           };
         }
-        if (occurrences > 1) {
+        if (occurrences > 1 && !replaceAll) {
           return {
-            content: `Error: old_text found ${occurrences} times, must be unique. Add more surrounding context.`,
+            content: `Error: old_text found ${occurrences} times, must be unique. Add more surrounding context or use replace_all=true.`,
             exitCode: 1,
             isError: true,
           };
         }
 
         const normalizedNew = newText.replace(/\r\n/g, "\n");
-        const newContent = normalized.replace(
-          normalizedOld,
-          normalizedNew,
-        );
+        const newContent = replaceAll
+          ? normalized.split(normalizedOld).join(normalizedNew)
+          : normalized.replace(normalizedOld, normalizedNew);
 
         // Restore original line endings — only convert if the file was
         // predominantly CRLF (>50% of line endings), to avoid corrupting

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -76,6 +76,7 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
 
     getDisplayInfo: (args) => ({
       kind: "write",
+      icon: "✎",
       locations: [{ path: args.path as string }],
     }),
 

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -80,6 +80,12 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
       locations: [{ path: args.path as string }],
     }),
 
+    formatResult: (_args, result) => {
+      if (result.isError) return {};
+      const m = result.content.match(/\((\+\d+(?:\s-\d+)?)\)/);
+      return m ? { summary: m[1] } : {};
+    },
+
     async execute(args, onChunk) {
       const filePath = args.path as string;
       const oldText = args.old_text as string;

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -3,6 +3,41 @@ import * as path from "node:path";
 import type { ToolDefinition } from "../types.js";
 import { computeDiff } from "../../utils/diff.js";
 
+/**
+ * Find the closest matching region in the file content to help diagnose
+ * why an exact match failed. Returns a hint string.
+ */
+function findClosestMatch(content: string, needle: string): string {
+  const hints: string[] = [];
+
+  // Check if trimming whitespace would match
+  const trimmedNeedle = needle.replace(/[ \t]+$/gm, "").replace(/^[ \t]+/gm, "");
+  const trimmedContent = content.replace(/[ \t]+$/gm, "").replace(/^[ \t]+/gm, "");
+  if (trimmedContent.includes(trimmedNeedle)) {
+    hints.push(" Whitespace (indentation or trailing spaces) differs — check leading/trailing spaces on each line.");
+    return hints.join("");
+  }
+
+  // Check if the first line exists to narrow down the region
+  const needleLines = needle.split("\n");
+  const firstLine = needleLines[0].trim();
+  if (firstLine.length > 10) {
+    const contentLines = content.split("\n");
+    const matches = contentLines
+      .map((l, i) => ({ line: i + 1, text: l }))
+      .filter((l) => l.text.includes(firstLine));
+
+    if (matches.length > 0 && needleLines.length > 1) {
+      const loc = matches.map((m) => `line ${m.line}`).join(", ");
+      hints.push(` First line found at ${loc}, but subsequent lines differ. The file may have changed — use read_file to see current content around that region.`);
+      return hints.join("");
+    }
+  }
+
+  hints.push(" Use read_file to verify the current file contents before retrying.");
+  return hints.join("");
+}
+
 export function createEditFileTool(getCwd: () => string): ToolDefinition {
   return {
     name: "edit_file",
@@ -52,8 +87,10 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
         const occurrences =
           normalized.split(normalizedOld).length - 1;
         if (occurrences === 0) {
+          // Try to find the closest match to help the agent self-correct
+          const hint = findClosestMatch(normalized, normalizedOld);
           return {
-            content: `Error: old_text not found in ${filePath}`,
+            content: `Error: old_text not found in ${filePath}.${hint}`,
             exitCode: 1,
             isError: true,
           };
@@ -72,8 +109,12 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
           normalizedNew,
         );
 
-        // Restore original line endings
-        const useCRLF = content.includes("\r\n");
+        // Restore original line endings — only convert if the file was
+        // predominantly CRLF (>50% of line endings), to avoid corrupting
+        // mixed-ending files.
+        const crlfCount = (content.match(/\r\n/g) || []).length;
+        const lfCount = (content.match(/(?<!\r)\n/g) || []).length;
+        const useCRLF = crlfCount > 0 && crlfCount >= lfCount;
         const finalContent = useCRLF
           ? newContent.replace(/\n/g, "\r\n")
           : newContent;

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -27,6 +27,12 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
 
     showOutput: false,
 
+    formatResult: (_args, result) => {
+      if (result.isError || result.content === "No files matched.") return { summary: "0 files" };
+      const lines = result.content.split("\n").filter(l => l && !l.startsWith("["));
+      return { summary: `${lines.length} files` };
+    },
+
     getDisplayInfo: (args) => ({
       kind: "search",
       icon: "⌕",

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -29,6 +29,7 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
 
     getDisplayInfo: (args) => ({
       kind: "search",
+      icon: "⌕",
       locations: args.path
         ? [{ path: args.path as string }]
         : [],

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { executeCommand } from "../../executor.js";
 import type { ToolDefinition } from "../types.js";
 
@@ -5,7 +7,9 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
   return {
     name: "glob",
     description:
-      "Find files matching a glob pattern. Returns file paths sorted by modification time.",
+      "Find files by name pattern. Returns paths sorted by modification time (newest first). " +
+      "ALWAYS use this instead of find/ls via bash. " +
+      "Use glob to locate files, then read_file or grep to inspect contents.",
     input_schema: {
       type: "object",
       properties: {
@@ -42,7 +46,7 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
         shellEsc(searchPath),
       ];
       const { session, done } = executeCommand({
-        command: parts.join(" ") + " | head -200",
+        command: parts.join(" "),
         cwd: getCwd(),
         timeout: 10_000,
       });
@@ -56,14 +60,31 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
         };
       }
 
-      const lines = session.output.trim().split("\n");
-      const suffix =
-        lines.length >= 200
-          ? `\n[Results capped at 200 files]`
-          : "";
+      const cwd = getCwd();
+      const files = session.output.trim().split("\n");
+
+      // Sort by modification time (newest first)
+      const withMtime = await Promise.all(
+        files.map(async (f) => {
+          try {
+            const abs = path.resolve(cwd, f);
+            const stat = await fs.stat(abs);
+            return { file: f, mtime: stat.mtimeMs };
+          } catch {
+            return { file: f, mtime: 0 };
+          }
+        }),
+      );
+      withMtime.sort((a, b) => b.mtime - a.mtime);
+
+      const sorted = withMtime.slice(0, 200).map((e) => e.file);
+      const truncated = files.length > 200;
+      const suffix = truncated
+        ? `\n[Results capped at 200 files, ${files.length - 200} more matched]`
+        : "";
 
       return {
-        content: session.output.trim() + suffix,
+        content: sorted.join("\n") + suffix,
         exitCode: 0,
         isError: false,
       };

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -34,9 +34,15 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
       const pattern = args.pattern as string;
       const searchPath = (args.path as string) ?? ".";
 
-      // Use find + shell glob via bash, or rg --files --glob
+      // Use ripgrep for correct glob matching + .gitignore awareness
+      const shellEsc = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
+      const parts = [
+        "rg", "--files",
+        "--glob", shellEsc(pattern),
+        shellEsc(searchPath),
+      ];
       const { session, done } = executeCommand({
-        command: `find ${JSON.stringify(searchPath)} -path ${JSON.stringify(pattern)} -type f 2>/dev/null | head -200`,
+        command: parts.join(" ") + " | head -200",
         cwd: getCwd(),
         timeout: 10_000,
       });

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -62,6 +62,22 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
 
     showOutput: false,
 
+    formatResult: (args, result) => {
+      if (result.isError || result.content === "No matches found.") return { summary: "0 matches" };
+      const lines = result.content.split("\n").filter(Boolean);
+      // Strip pagination info line from count
+      const resultLines = lines.filter(l => !l.startsWith("[Showing "));
+      const mode = (args.output_mode as string) ?? "files_with_matches";
+      if (mode === "files_with_matches") {
+        return { summary: `${resultLines.length} files` };
+      }
+      if (mode === "count") {
+        const total = resultLines.reduce((sum, l) => sum + (parseInt(l.split(":").pop() ?? "0", 10) || 0), 0);
+        return { summary: `${total} matches` };
+      }
+      return { summary: `${resultLines.length} lines` };
+    },
+
     getDisplayInfo: (args) => ({
       kind: "search",
       icon: "⌕",

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -64,6 +64,7 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
 
     getDisplayInfo: (args) => ({
       kind: "search",
+      icon: "⌕",
       locations: args.path
         ? [{ path: args.path as string }]
         : [],

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -5,7 +5,12 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
   return {
     name: "grep",
     description:
-      "Search file contents using ripgrep (rg). Returns matching lines with file paths and line numbers.",
+      "Search file contents using ripgrep. ALWAYS use this instead of running grep/rg via bash. " +
+      "Supports three output modes: " +
+      "'files_with_matches' (default, returns file paths only — use this to find which files contain a pattern), " +
+      "'content' (matching lines with optional context_before/context_after), and " +
+      "'count' (match counts per file). " +
+      "Use head_limit and offset for pagination.",
     input_schema: {
       type: "object",
       properties: {
@@ -21,6 +26,35 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
           type: "string",
           description:
             "Glob pattern for files to include (e.g., '*.ts')",
+        },
+        output_mode: {
+          type: "string",
+          enum: ["files_with_matches", "content", "count"],
+          description:
+            "Output mode: 'files_with_matches' (default, file paths only), " +
+            "'content' (matching lines), 'count' (match counts per file)",
+        },
+        case_insensitive: {
+          type: "boolean",
+          description: "Case insensitive search (default: false)",
+        },
+        context_before: {
+          type: "number",
+          description: "Lines to show before each match (content mode only)",
+        },
+        context_after: {
+          type: "number",
+          description: "Lines to show after each match (content mode only)",
+        },
+        head_limit: {
+          type: "number",
+          description:
+            "Max lines/entries to return (default: 200 for files_with_matches, 150 for content/count). Pass 0 for unlimited.",
+        },
+        offset: {
+          type: "number",
+          description:
+            "Skip first N lines/entries before applying head_limit. Use with head_limit for pagination.",
         },
       },
       required: ["pattern"],
@@ -39,15 +73,39 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
       const pattern = args.pattern as string;
       const searchPath = (args.path as string) ?? ".";
       const include = args.include as string | undefined;
+      const mode = (args.output_mode as string) ?? "files_with_matches";
+      const caseInsensitive = args.case_insensitive as boolean | undefined;
+      const contextBefore = args.context_before as number | undefined;
+      const contextAfter = args.context_after as number | undefined;
+      const headLimit = args.head_limit as number | undefined;
+      const offset = (args.offset as number) ?? 0;
 
       const shellEsc = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
-      const parts = [
-        "rg",
-        "--line-number",
-        "--no-heading",
-        "--color=never",
-        "--max-count=200",
-      ];
+      const parts = ["rg", "--color=never"];
+
+      // Mode-specific flags
+      if (mode === "files_with_matches") {
+        parts.push("--files-with-matches");
+      } else if (mode === "count") {
+        parts.push("--count");
+      } else {
+        // content mode
+        parts.push("--line-number", "--no-heading");
+        if (contextBefore != null && contextBefore > 0) {
+          parts.push(`-B${contextBefore}`);
+        }
+        if (contextAfter != null && contextAfter > 0) {
+          parts.push(`-A${contextAfter}`);
+        }
+        // If neither -A nor -B specified, use --max-count to limit per-file
+        if (contextBefore == null && contextAfter == null) {
+          parts.push("--max-count=50");
+        }
+      }
+
+      if (caseInsensitive) {
+        parts.push("-i");
+      }
       if (include) {
         parts.push("--glob", shellEsc(include));
       }
@@ -69,20 +127,45 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
         };
       }
 
-      // Truncate to ~100 lines
-      const lines = session.output.split("\n");
-      if (lines.length > 100) {
-        return {
-          content:
-            lines.slice(0, 100).join("\n") +
-            `\n[${lines.length - 100} more lines truncated]`,
-          exitCode: 0,
-          isError: false,
-        };
+      let output = session.output;
+
+      // Cap individual line lengths to 500 chars to prevent minified/base64 flood
+      if (mode === "content") {
+        const MAX_LINE_LEN = 500;
+        output = output
+          .split("\n")
+          .map((line) =>
+            line.length > MAX_LINE_LEN
+              ? line.slice(0, MAX_LINE_LEN) + "… [truncated]"
+              : line,
+          )
+          .join("\n");
+      }
+
+      // Apply pagination (offset + head_limit)
+      const defaultLimit = mode === "files_with_matches" ? 200 : 150;
+      const limit = headLimit === 0 ? Infinity : (headLimit ?? defaultLimit);
+      const lines = output.split("\n");
+      const total = lines.length;
+
+      // Apply offset then limit
+      const sliced = lines.slice(offset, offset + limit);
+      const paginated = sliced.join("\n");
+
+      const parts2: string[] = [];
+      if (paginated) parts2.push(paginated);
+
+      // Show pagination info when offset is used or results were truncated
+      if (offset > 0 || offset + limit < total) {
+        const shown = sliced.length;
+        const remaining = Math.max(0, total - offset - shown);
+        parts2.push(
+          `\n[Showing ${shown} results (offset=${offset}, limit=${limit === Infinity ? "unlimited" : limit})${remaining > 0 ? `, ${remaining} more available` : ""}]`,
+        );
       }
 
       return {
-        content: session.output || "No matches found.",
+        content: parts2.join("\n") || "No matches found.",
         exitCode: 0,
         isError: false,
       };

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -40,6 +40,7 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
       const searchPath = (args.path as string) ?? ".";
       const include = args.include as string | undefined;
 
+      const shellEsc = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
       const parts = [
         "rg",
         "--line-number",
@@ -48,9 +49,9 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
         "--max-count=200",
       ];
       if (include) {
-        parts.push("--glob", JSON.stringify(include));
+        parts.push("--glob", shellEsc(include));
       }
-      parts.push(JSON.stringify(pattern), JSON.stringify(searchPath));
+      parts.push("-e", shellEsc(pattern), shellEsc(searchPath));
 
       const { session, done } = executeCommand({
         command: parts.join(" "),

--- a/src/agent/tools/ls.ts
+++ b/src/agent/tools/ls.ts
@@ -35,6 +35,12 @@ export function createLsTool(getCwd: () => string): ToolDefinition {
         : [],
     }),
 
+    formatResult: (_args, result) => {
+      if (result.isError || result.content === "(empty directory)") return { summary: "0 entries" };
+      const lines = result.content.split("\n").filter(Boolean);
+      return { summary: `${lines.length} entries` };
+    },
+
     async execute(args) {
       const dirPath = (args.path as string) ?? ".";
       const absPath = path.resolve(getCwd(), dirPath);

--- a/src/agent/tools/ls.ts
+++ b/src/agent/tools/ls.ts
@@ -13,7 +13,8 @@ export function createLsTool(getCwd: () => string): ToolDefinition {
   return {
     name: "ls",
     description:
-      "List files and directories in a given path.",
+      "List files and directories with timestamps and sizes. " +
+      "Use for exploring a single directory. Use glob for recursive file search by pattern.",
     input_schema: {
       type: "object",
       properties: {

--- a/src/agent/tools/ls.ts
+++ b/src/agent/tools/ls.ts
@@ -29,6 +29,7 @@ export function createLsTool(getCwd: () => string): ToolDefinition {
 
     getDisplayInfo: (args) => ({
       kind: "read",
+      icon: "◆",
       locations: args.path
         ? [{ path: args.path as string }]
         : [],

--- a/src/agent/tools/ls.ts
+++ b/src/agent/tools/ls.ts
@@ -2,6 +2,13 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ToolDefinition } from "../types.js";
 
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}K`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}G`;
+}
+
 export function createLsTool(getCwd: () => string): ToolDefinition {
   return {
     name: "ls",
@@ -35,9 +42,22 @@ export function createLsTool(getCwd: () => string): ToolDefinition {
           withFileTypes: true,
         });
 
-        const lines = entries.map((e) =>
-          e.isDirectory() ? `${e.name}/` : e.name,
-        );
+        const lines: string[] = [];
+        for (const e of entries) {
+          const fullPath = path.join(absPath, e.name);
+          try {
+            const stat = await fs.stat(fullPath);
+            const size = e.isDirectory() ? "-" : formatSize(stat.size);
+            const mtime = stat.mtime.toISOString().slice(0, 16).replace("T", " ");
+            lines.push(
+              `${mtime}  ${size.padStart(8)}  ${e.isDirectory() ? e.name + "/" : e.name}`,
+            );
+          } catch {
+            lines.push(
+              `${"?".padStart(16)}  ${"?".padStart(8)}  ${e.isDirectory() ? e.name + "/" : e.name}`,
+            );
+          }
+        }
 
         return {
           content: lines.join("\n") || "(empty directory)",

--- a/src/agent/tools/read-file.ts
+++ b/src/agent/tools/read-file.ts
@@ -45,6 +45,7 @@ export function createReadFileTool(
 
     getDisplayInfo: (args) => ({
       kind: "read",
+      icon: "◆",
       locations: [{ path: args.path as string }],
     }),
 

--- a/src/agent/tools/read-file.ts
+++ b/src/agent/tools/read-file.ts
@@ -2,11 +2,26 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ToolDefinition } from "../types.js";
 
-export function createReadFileTool(getCwd: () => string): ToolDefinition {
+/** Tracks the last-read state of a file for deduplication. */
+export interface FileReadState {
+  mtimeMs: number;
+  offset: number;
+  limit: number | undefined;
+}
+
+/** Shared cache — keyed by absolute path. */
+export type FileReadCache = Map<string, FileReadState>;
+
+export function createReadFileTool(
+  getCwd: () => string,
+  cache?: FileReadCache,
+): ToolDefinition {
   return {
     name: "read_file",
     description:
-      "Read a file's contents with line numbers. Optionally specify offset and limit for large files.",
+      "Read a file's contents with line numbers. Use offset and limit for large files. " +
+      "Always read a file before editing it. " +
+      "If the file hasn't changed since last read, returns a stub to save context.",
     input_schema: {
       type: "object",
       properties: {
@@ -36,10 +51,31 @@ export function createReadFileTool(getCwd: () => string): ToolDefinition {
     async execute(args) {
       const filePath = args.path as string;
       const absPath = path.resolve(getCwd(), filePath);
+      const reqOffset = (args.offset as number) ?? 1;
+      const reqLimit = args.limit as number | undefined;
 
       try {
-        // Check file size before reading to avoid OOM on huge files
         const stat = await fs.stat(absPath);
+
+        // Deduplication: if the file hasn't changed and same range, return stub
+        if (cache) {
+          const prev = cache.get(absPath);
+          if (
+            prev &&
+            prev.mtimeMs === stat.mtimeMs &&
+            prev.offset === reqOffset &&
+            prev.limit === reqLimit
+          ) {
+            return {
+              content:
+                "File unchanged since last read. The content from the earlier read_file result in this conversation is still current — refer to that instead of re-reading.",
+              exitCode: 0,
+              isError: false,
+            };
+          }
+        }
+
+        // Check file size before reading to avoid OOM on huge files
         const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
         if (stat.size > MAX_FILE_SIZE && !args.offset && !args.limit) {
           const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
@@ -53,8 +89,8 @@ export function createReadFileTool(getCwd: () => string): ToolDefinition {
         const content = await fs.readFile(absPath, "utf-8");
         const lines = content.split("\n");
 
-        const start = ((args.offset as number) ?? 1) - 1; // 1-indexed → 0-indexed
-        const end = args.limit ? start + (args.limit as number) : lines.length;
+        const start = reqOffset - 1; // 1-indexed → 0-indexed
+        const end = reqLimit ? start + reqLimit : lines.length;
         const slice = lines.slice(start, end);
 
         // Add line numbers (1-indexed)
@@ -66,6 +102,15 @@ export function createReadFileTool(getCwd: () => string): ToolDefinition {
         const suffix = truncated
           ? `\n[${lines.length - end} more lines, use offset=${end + 1} to continue]`
           : "";
+
+        // Update cache on successful read
+        if (cache) {
+          cache.set(absPath, {
+            mtimeMs: stat.mtimeMs,
+            offset: reqOffset,
+            limit: reqLimit,
+          });
+        }
 
         return { content: numbered + suffix, exitCode: 0, isError: false };
       } catch (err) {

--- a/src/agent/tools/read-file.ts
+++ b/src/agent/tools/read-file.ts
@@ -49,6 +49,13 @@ export function createReadFileTool(
       locations: [{ path: args.path as string }],
     }),
 
+    formatResult: (_args, result) => {
+      if (result.isError) return {};
+      if (result.content.startsWith("File unchanged")) return { summary: "cached" };
+      const lines = result.content.split("\n").filter(l => !l.startsWith("["));
+      return { summary: `${lines.length} lines` };
+    },
+
     async execute(args) {
       const filePath = args.path as string;
       const absPath = path.resolve(getCwd(), filePath);

--- a/src/agent/tools/read-file.ts
+++ b/src/agent/tools/read-file.ts
@@ -38,6 +38,18 @@ export function createReadFileTool(getCwd: () => string): ToolDefinition {
       const absPath = path.resolve(getCwd(), filePath);
 
       try {
+        // Check file size before reading to avoid OOM on huge files
+        const stat = await fs.stat(absPath);
+        const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+        if (stat.size > MAX_FILE_SIZE && !args.offset && !args.limit) {
+          const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
+          return {
+            content: `File is ${sizeMB}MB (${stat.size} bytes) — too large to read in full. Use offset and limit to read specific sections, e.g. offset=1 limit=200.`,
+            exitCode: 1,
+            isError: true,
+          };
+        }
+
         const content = await fs.readFile(absPath, "utf-8");
         const lines = content.split("\n");
 

--- a/src/agent/tools/user-shell.ts
+++ b/src/agent/tools/user-shell.ts
@@ -42,6 +42,7 @@ export function createUserShellTool(opts: {
 
     getDisplayInfo: () => ({
       kind: "execute",
+      icon: "▷",
       locations: [],
     }),
 

--- a/src/agent/tools/user-shell.ts
+++ b/src/agent/tools/user-shell.ts
@@ -15,13 +15,17 @@ export function createUserShellTool(opts: {
   return {
     name: "user_shell",
     description:
-      "Run a command in the user's live shell (visible in terminal). Output is returned to you by default. Use for cd, export, source, or commands the user wants to see. Set return_output=false for long-running or interactive commands.",
+      "Run a command in the user's live shell (visible in terminal). Output is NOT returned to you by default — set return_output=true if you need to inspect the result. Use for cd, export, source, or commands the user wants to see.",
     input_schema: {
       type: "object",
       properties: {
         command: {
           type: "string",
           description: "Command to execute in user's shell",
+        },
+        timeout: {
+          type: "number",
+          description: "Timeout in seconds (default: 30)",
         },
         return_output: {
           type: "boolean",
@@ -43,31 +47,55 @@ export function createUserShellTool(opts: {
 
     async execute(args) {
       const command = args.command as string;
+      const timeoutSec = (args.timeout as number) ?? 30;
       const returnOutput = (args.return_output as boolean) ?? false;
 
-      // Execute via the shell-exec extension's async pipe
-      const result = await opts.bus.emitPipeAsync(
-        "shell:exec-request",
-        {
-          command,
-          output: "",
-          cwd: opts.getCwd(),
-          done: false,
-        },
-      );
+      // Execute via the shell-exec extension's async pipe with timeout
+      let result: { output: string; exitCode: number | null; [k: string]: unknown };
+      try {
+        const execPromise = opts.bus.emitPipeAsync(
+          "shell:exec-request",
+          {
+            command,
+            output: "",
+            cwd: opts.getCwd(),
+            exitCode: null as number | null,
+            done: false,
+          },
+        );
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("timeout")), timeoutSec * 1000),
+        );
+        result = await Promise.race([execPromise, timeoutPromise]);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg === "timeout") {
+          return {
+            content: `Command timed out after ${timeoutSec}s.`,
+            exitCode: -1,
+            isError: true,
+          };
+        }
+        return { content: `Error: ${msg}`, exitCode: -1, isError: true };
+      }
+
+      const exitCode = result.exitCode ?? 0;
+      const isError = exitCode !== 0 && exitCode !== null;
 
       if (returnOutput) {
         return {
           content: result.output || "(no output)",
-          exitCode: 0,
-          isError: false,
+          exitCode,
+          isError,
         };
       }
 
       return {
-        content: "Command executed.",
-        exitCode: 0,
-        isError: false,
+        content: isError
+          ? `Command failed with exit code ${exitCode}.`
+          : "Command executed.",
+        exitCode,
+        isError,
       };
     },
   };

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -7,7 +7,8 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
   return {
     name: "write_file",
     description:
-      "Create or overwrite a file with the given content. Creates parent directories if needed. Prefer edit_file for modifying existing files.",
+      "Create a new file or completely overwrite an existing one. Creates parent directories if needed. " +
+      "ALWAYS prefer edit_file for modifying existing files — only use write_file for new files or complete rewrites.",
     input_schema: {
       type: "object",
       properties: {

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -30,6 +30,7 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
 
     getDisplayInfo: (args) => ({
       kind: "write",
+      icon: "✎",
       locations: [{ path: args.path as string }],
     }),
 

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -34,6 +34,12 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
       locations: [{ path: args.path as string }],
     }),
 
+    formatResult: (_args, result) => {
+      if (result.isError) return {};
+      const m = result.content.match(/\((\+\d+(?:\s-\d+)?)\)/);
+      return m ? { summary: m[1] } : {};
+    },
+
     async execute(args, onChunk) {
       const filePath = args.path as string;
       const content = args.content as string;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -26,7 +26,7 @@ export interface ToolResult {
 }
 
 export interface ToolDisplayInfo {
-  kind: "read" | "write" | "execute" | "search";
+  kind: "read" | "write" | "execute" | "search" | "display";
   locations?: { path: string; line?: number | null }[];
   /** Custom icon character for TUI display (e.g., "◆", "⌕"). When set, the TUI shows
    *  icon + detail only. When absent, the tool name is shown alongside the detail. */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -28,6 +28,9 @@ export interface ToolResult {
 export interface ToolDisplayInfo {
   kind: "read" | "write" | "execute" | "search";
   locations?: { path: string; line?: number | null }[];
+  /** Custom icon character for TUI display (e.g., "◆", "⌕"). When set, the TUI shows
+   *  icon + detail only. When absent, the tool name is shown alongside the detail. */
+  icon?: string;
 }
 
 export interface ToolDefinition {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -25,6 +25,18 @@ export interface ToolResult {
   isError: boolean;
 }
 
+/** Structured result display — returned by formatResult or computed by defaults. */
+export interface ToolResultDisplay {
+  /** One-line summary shown next to ✓/✗ (e.g. "42 papers found", "+3/-1"). */
+  summary?: string;
+  /** Structured content to render below the status line. */
+  body?: ToolResultBody;
+}
+
+export type ToolResultBody =
+  | { kind: "diff"; diff: unknown; filePath: string }
+  | { kind: "lines"; lines: string[]; maxLines?: number }
+
 export interface ToolDisplayInfo {
   kind: "read" | "write" | "execute" | "search" | "display";
   locations?: { path: string; line?: number | null }[];
@@ -35,6 +47,8 @@ export interface ToolDisplayInfo {
 
 export interface ToolDefinition {
   name: string;
+  /** Short label for TUI display (e.g. "search" instead of "ads_search"). Defaults to name. */
+  displayName?: string;
   description: string;
   input_schema: Record<string, unknown>;
 
@@ -54,4 +68,19 @@ export interface ToolDefinition {
 
   /** Derive display metadata (icon kind, file paths) for the TUI. */
   getDisplayInfo?: (args: Record<string, unknown>) => ToolDisplayInfo;
+
+  /**
+   * Format a short display string for the TUI when this tool is called.
+   * Return a concise summary of the args (e.g. the query, the file path).
+   * When absent, the TUI derives the detail from common arg fields (command, path, pattern).
+   */
+  formatCall?: (args: Record<string, unknown>) => string;
+
+  /**
+   * Format result display for the TUI after execution completes.
+   * Return a summary string and/or structured body to render.
+   * When absent, defaults are computed based on tool kind.
+   * Extensions can further override via bus.onPipe("agent:tool-completed", ...).
+   */
+  formatResult?: (args: Record<string, unknown>, result: ToolResult) => ToolResultDisplay;
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -267,21 +267,19 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     llmClient,
 
     activateBackend() {
+      // Silent — backend info is shown in the startup banner.
+      // Runtime switches (config:switch-backend) still emit ui:info.
       const preferred = settings.defaultBackend;
       if (preferred && backends.has(preferred)) {
-        activateByName(preferred);
+        activateByName(preferred, true);
       } else if (backends.size > 0 && !agentLoop) {
-        activateByName(backends.keys().next().value!);
+        activateByName(backends.keys().next().value!, true);
       } else if (agentLoop) {
         agentLoop.wire();
         activeBackendName = "agent-sh";
         bus.emit("agent:info", { name: "agent-sh", version: "0.4", model: llmClient?.model, provider: activeProvider?.id, contextWindow: activeProvider?.contextWindow });
       } else if (backends.size > 0) {
-        activateByName(backends.keys().next().value!);
-      }
-
-      if (activeBackendName) {
-        bus.emit("ui:info", { message: `Backend: ${activeBackendName}` });
+        activateByName(backends.keys().next().value!, true);
       }
     },
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -45,7 +45,7 @@ export interface AgentShellCore {
   /** Activate the agent backend (call after extensions load). */
   activateBackend(): void;
   /** Convenience: emit agent:submit and await the response. */
-  query(text: string, opts?: { mode?: string }): Promise<string>;
+  query(text: string): Promise<string>;
   /** Convenience: emit agent:cancel-request. */
   cancel(): void;
   /** Build an ExtensionContext for loading extensions against this core. */
@@ -285,7 +285,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
       }
     },
 
-    async query(text, opts) {
+    async query(text) {
       return new Promise((resolve, reject) => {
         let response = "";
         let settled = false;
@@ -315,10 +315,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         bus.on("agent:processing-done", onDone);
         bus.on("agent:error", onError);
 
-        bus.emit("agent:submit", {
-          query: text,
-          modeInstruction: opts?.mode,
-        });
+        bus.emit("agent:submit", { query: text });
       });
     },
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { AgentMode } from "./types.js";
+import type { ToolResultDisplay } from "./agent/types.js";
 
 /**
  * Typed event map — every event has a known payload shape.
@@ -48,6 +49,14 @@ export interface ShellEvents {
     exitCode: number | null;
   };
 
+  // Tool batch — emitted before execution with all tool calls grouped by kind
+  "agent:tool-batch": {
+    groups: Array<{
+      kind: string;
+      tools: Array<{ name: string; displayDetail?: string }>;
+    }>;
+  };
+
   // Tool rendering (used by TUI for display — distinct data shape from above)
   "agent:tool-started": {
     title: string;
@@ -56,6 +65,8 @@ export interface ShellEvents {
     icon?: string;
     locations?: { path: string; line?: number | null }[];
     rawInput?: unknown;
+    /** Pre-formatted display detail from tool's formatCall(). */
+    displayDetail?: string;
     batchIndex?: number;
     batchTotal?: number;
   };
@@ -64,6 +75,8 @@ export interface ShellEvents {
     exitCode: number | null;
     rawOutput?: unknown;
     kind?: string;
+    /** Structured result display — set by formatResult or defaults, overridable via onPipe. */
+    resultDisplay?: ToolResultDisplay;
   };
   "agent:tool-output-chunk": { chunk: string };
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -53,6 +53,7 @@ export interface ShellEvents {
     title: string;
     toolCallId?: string;
     kind?: string;
+    icon?: string;
     locations?: { path: string; line?: number | null }[];
     rawInput?: unknown;
     batchIndex?: number;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -55,6 +55,8 @@ export interface ShellEvents {
     kind?: string;
     locations?: { path: string; line?: number | null }[];
     rawInput?: unknown;
+    batchIndex?: number;
+    batchTotal?: number;
   };
   "agent:tool-completed": {
     toolCallId?: string;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -115,6 +115,7 @@ export interface ShellEvents {
     command: string;
     output: string;
     cwd: string;
+    exitCode: number | null;
     done: boolean;
   };
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -19,14 +19,14 @@ export interface ShellEvents {
   "shell:agent-exec-done": Record<string, never>;
 
   // Agent input (frontend → core: user submitted a query or wants to cancel)
-  "agent:submit": { query: string; modeInstruction?: string; modeLabel?: string };
+  "agent:submit": { query: string };
   "agent:cancel-request": { silent?: boolean };
 
   // Input mode registration (extensions → InputHandler)
   "input-mode:register": import("./types.js").InputModeConfig;
 
   // Agent interaction
-  "agent:query": { query: string; modeLabel?: string };
+  "agent:query": { query: string };
   "agent:thinking-chunk": { text: string };
   "agent:response-chunk": { blocks: ContentBlock[] };
   "agent:response-done": { response: string };

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -39,7 +39,7 @@ async function ensureTsSupport(): Promise<void> {
 export async function loadExtensions(
   ctx: ExtensionContext,
   cliExtensions?: string[],
-): Promise<void> {
+): Promise<string[]> {
   const specifiers: string[] = [];
 
   // 1. CLI -e / --extensions
@@ -113,9 +113,7 @@ export async function loadExtensions(
     }
   }
 
-  if (loaded.length > 0) {
-    ctx.bus.emit("ui:info", { message: `Extensions: ${loaded.join(", ")}` });
-  }
+  return loaded;
 }
 
 /**

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -343,6 +343,9 @@ export default function activate(ctx: ExtensionContext): void {
     if (!s.renderer) return;
     for (const line of s.renderer.drainLines()) {
       writer.write(line + "\n");
+      // Track whether we just emitted a blank line (for contentGap dedup).
+      // Lines from the renderer are indented ("  "), so a blank line is "  " or empty.
+      lastEmittedLineBlank = line.trimEnd() === "" || line.trimEnd().replace(/\x1b\[[^m]*m/g, "").trim() === "";
     }
   }
 
@@ -357,9 +360,12 @@ export default function activate(ctx: ExtensionContext): void {
   /**
    * Insert an empty line when transitioning between different content kinds
    * (e.g., text → tool, tool → text, diff → tool) for visual breathing room.
+   * Avoids double-blanks by checking if the last emitted line was already empty.
    */
+  let lastEmittedLineBlank = false;
+
   function contentGap(kind: "text" | "tool" | "diff" | "code" | "info"): void {
-    if (s.lastContentKind && s.lastContentKind !== kind && s.renderer) {
+    if (s.lastContentKind && s.lastContentKind !== kind && s.renderer && !lastEmittedLineBlank) {
       s.renderer.writeLine("");
       drain();
     }

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -531,6 +531,7 @@ export default function activate(ctx: ExtensionContext): void {
     command?: string,
     extra?: {
       kind?: string;
+      icon?: string;
       locations?: { path: string; line?: number | null }[];
       rawInput?: unknown;
       batchIndex?: number;
@@ -548,6 +549,7 @@ export default function activate(ctx: ExtensionContext): void {
       title,
       command: command || undefined,
       kind: extra?.kind,
+      icon: extra?.icon,
       locations: extra?.locations,
       rawInput: extra?.rawInput,
     }, writer.columns);

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -88,6 +88,8 @@ interface RenderState {
   toolGroupKind: string | undefined;
   toolGroupCount: number;
   toolGroupAllOk: boolean;
+  /** Number of tools rendered individually in current group. */
+  toolGroupRendered: number;
 
   // ── Thinking ──
   isThinking: boolean;
@@ -119,6 +121,7 @@ function createRenderState(): RenderState {
     toolGroupKind: undefined,
     toolGroupCount: 0,
     toolGroupAllOk: true,
+    toolGroupRendered: 0,
     isThinking: false,
     showThinkingText: false,
     thinkingPending: false,
@@ -230,6 +233,7 @@ export default function activate(ctx: ExtensionContext): void {
 
   // Read-only tool kinds eligible for grouping
   const GROUPABLE_KINDS = new Set(["read", "search"]);
+  const GROUP_MAX_VISIBLE = 5; // show this many tools individually before collapsing
 
   bus.on("agent:tool-started", (e) => {
     fencedTransform.flush();
@@ -249,21 +253,24 @@ export default function activate(ctx: ExtensionContext): void {
     } else if (GROUPABLE_KINDS.has(e.kind ?? "") && e.kind === s.toolGroupKind) {
       // Consecutive same-kind read-only tool
       s.toolGroupCount++;
-      if (s.toolGroupCount <= 2) {
-        // Show the first 2 individually (with normal completion handling)
+      if (s.toolGroupCount <= GROUP_MAX_VISIBLE) {
+        // Show with tree connector
         showToolCall(e.title, "", {
           ...e,
           batchIndex: e.batchIndex,
           batchTotal: e.batchTotal,
+          groupContinuation: true,
         });
+        s.toolGroupRendered++;
       }
-      // 3rd+ are collapsed — rendered as summary in finalizeToolGroup
+      // Beyond max: collapsed, rendered as summary in finalizeToolGroup
     } else {
       finalizeToolGroup();
       if (GROUPABLE_KINDS.has(e.kind ?? "")) {
         s.toolGroupKind = e.kind;
         s.toolGroupCount = 1;
         s.toolGroupAllOk = true;
+        s.toolGroupRendered = 1;
       }
       showToolCall(e.title, "", {
         ...e,
@@ -276,8 +283,8 @@ export default function activate(ctx: ExtensionContext): void {
   bus.on("agent:tool-completed", (e) => {
     s.toolExitCode = e.exitCode;
     if (e.exitCode !== 0) s.toolGroupAllOk = false;
-    if (s.toolGroupCount > 2) {
-      // Collapsed tool (3rd+) — just track success/failure
+    if (s.toolGroupCount > GROUP_MAX_VISIBLE) {
+      // Collapsed tool — just track success/failure
       s.currentToolKind = undefined;
       s.spinnerStartTime = 0;
       startThinkingSpinner();
@@ -542,13 +549,15 @@ export default function activate(ctx: ExtensionContext): void {
       rawInput?: unknown;
       batchIndex?: number;
       batchTotal?: number;
+      groupContinuation?: boolean;
     },
   ): void {
     closeToolLine();
     stopCurrentSpinner();
     if (!s.renderer) startAgentResponse();
     showCollapsedThinking();
-    contentGap("tool");
+    // No gap between grouped tools — they're visually connected
+    if (!extra?.groupContinuation) contentGap("tool");
     s.renderer!.flush();
     drain();
     const lines = renderToolCall({
@@ -559,6 +568,14 @@ export default function activate(ctx: ExtensionContext): void {
       locations: extra?.locations,
       rawInput: extra?.rawInput,
     }, writer.columns);
+
+    // Replace the kind icon with a tree connector for grouped tools
+    if (extra?.groupContinuation && lines.length > 0) {
+      // Line starts with: \x1b[33m◆\x1b[0m — swap the colored icon for muted ├
+      lines[0] = lines[0]!.replace(
+        /^\x1b\[[^m]*m.\x1b\[0m/, `${p.muted}├${p.reset}`,
+      );
+    }
 
     // Prepend batch progress indicator when multiple tools in a batch
     const batchPrefix = extra?.batchTotal && extra.batchTotal > 1
@@ -643,27 +660,32 @@ export default function activate(ctx: ExtensionContext): void {
 
   /** Finalize a group of collapsed tool calls, rendering the summary. */
   function finalizeToolGroup(): void {
-    if (s.toolGroupCount <= 2) {
-      // 0–2 tools: all were rendered individually, nothing to summarize
+    if (s.toolGroupCount <= 1) {
+      // 0–1 tools: standalone, nothing to finalize
       s.toolGroupKind = undefined;
       s.toolGroupCount = 0;
+      s.toolGroupRendered = 0;
       return;
     }
     closeToolLine();
     if (!s.renderer) startAgentResponse();
-    const icon = s.toolGroupKind === "read" ? "◆" : "⌕";
-    const label = s.toolGroupKind === "read" ? "files read" : "searches";
-    const mark = s.toolGroupAllOk
-      ? `${p.success}✓${p.reset}`
-      : `${p.error}✗${p.reset}`;
-    const collapsed = s.toolGroupCount - 2; // first 2 were shown individually
-    s.renderer!.writeLine(
-      `${p.warning}${icon}${p.reset} ${p.dim}… +${collapsed} more ${label}${p.reset} ${mark}`,
-    );
+    const collapsed = s.toolGroupCount - s.toolGroupRendered;
+    if (collapsed > 0) {
+      const mark = s.toolGroupAllOk
+        ? `${p.success}✓${p.reset}`
+        : `${p.error}✗${p.reset}`;
+      s.renderer!.writeLine(
+        `  ${p.muted}⎿${p.reset} ${p.dim}+${collapsed} more${p.reset} ${mark}`,
+      );
+    } else {
+      // All were shown — close with end bracket
+      s.renderer!.writeLine(`  ${p.muted}⎿${p.reset}`);
+    }
     drain();
     s.toolGroupKind = undefined;
     s.toolGroupCount = 0;
     s.toolGroupAllOk = true;
+    s.toolGroupRendered = 0;
   }
 
   function writeCommandOutput(chunk: string): void {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -18,6 +18,7 @@ import {
   renderToolCall,
   createSpinner,
   renderSpinnerLine,
+  formatElapsed,
   type SpinnerState,
   type SpinnerOpts,
 } from "../utils/tool-display.js";
@@ -63,6 +64,8 @@ interface RenderState {
   // ── Response rendering ──
   renderer: MarkdownRenderer | null;
   hadToolCalls: boolean;
+  /** Tracks the last content kind rendered for gap injection. */
+  lastContentKind: "text" | "tool" | "diff" | "code" | "info" | null;
 
   // ── Spinner ──
   spinner: SpinnerState | null;
@@ -74,9 +77,17 @@ interface RenderState {
   // ── Tool output ──
   toolLineOpen: boolean;
   currentToolKind: string | undefined;
+  toolStartTime: number;
+  toolExitCode: number | null;
   commandOutputBuffer: string;
   commandOutputLineCount: number;
   commandOutputOverflow: number;
+  commandOverflowLines: string[];
+
+  // ── Tool grouping (collapse sequential same-type read-only tools) ──
+  toolGroupKind: string | undefined;
+  toolGroupCount: number;
+  toolGroupAllOk: boolean;
 
   // ── Thinking ──
   isThinking: boolean;
@@ -91,6 +102,7 @@ function createRenderState(): RenderState {
   return {
     renderer: null,
     hadToolCalls: false,
+    lastContentKind: null,
     spinner: null,
     spinnerLabel: "",
     spinnerOpts: {},
@@ -98,9 +110,15 @@ function createRenderState(): RenderState {
     spinnerStartTime: 0,
     toolLineOpen: false,
     currentToolKind: undefined,
+    toolStartTime: 0,
+    toolExitCode: null,
     commandOutputBuffer: "",
     commandOutputLineCount: 0,
     commandOutputOverflow: 0,
+    commandOverflowLines: [],
+    toolGroupKind: undefined,
+    toolGroupCount: 0,
+    toolGroupAllOk: true,
     isThinking: false,
     showThinkingText: false,
     thinkingPending: false,
@@ -210,28 +228,56 @@ export default function activate(ctx: ExtensionContext): void {
     endAgentResponse();
   });
 
+  // Read-only tool kinds eligible for grouping
+  const GROUPABLE_KINDS = new Set(["read", "search"]);
+
   bus.on("agent:tool-started", (e) => {
     fencedTransform.flush();
     stopCurrentSpinner();
     s.currentToolKind = e.kind;
+    s.toolStartTime = Date.now();
     if (e.title === "user_shell") {
+      finalizeToolGroup();
       closeToolLine();
       if (!s.renderer) startAgentResponse();
+      contentGap("tool");
       s.renderer!.flush();
       const cmd = (e.rawInput as any)?.command || "";
       s.renderer!.writeLine(`${p.dim}▶ user_shell: ${cmd}${p.reset}`);
       drain();
       s.hadToolCalls = true;
+    } else if (GROUPABLE_KINDS.has(e.kind ?? "") && e.kind === s.toolGroupKind) {
+      // Consecutive same-kind read-only tool — collapse into group
+      s.toolGroupCount++;
     } else {
-      showToolCall(e.title, "", e);
+      finalizeToolGroup();
+      if (GROUPABLE_KINDS.has(e.kind ?? "")) {
+        s.toolGroupKind = e.kind;
+        s.toolGroupCount = 1;
+        s.toolGroupAllOk = true;
+      }
+      showToolCall(e.title, "", {
+        ...e,
+        batchIndex: e.batchIndex,
+        batchTotal: e.batchTotal,
+      });
     }
   });
 
   bus.on("agent:tool-completed", (e) => {
-    showToolComplete(e.exitCode);
-    s.currentToolKind = undefined;
-    s.spinnerStartTime = 0;
-    startThinkingSpinner();
+    s.toolExitCode = e.exitCode;
+    if (s.toolGroupCount > 1) {
+      // Grouped tool — just track success/failure, don't render individually
+      if (e.exitCode !== 0) s.toolGroupAllOk = false;
+      s.currentToolKind = undefined;
+      s.spinnerStartTime = 0;
+      startThinkingSpinner();
+    } else {
+      showToolComplete(e.exitCode);
+      s.currentToolKind = undefined;
+      s.spinnerStartTime = 0;
+      startThinkingSpinner();
+    }
   });
   bus.on("agent:tool-output-chunk", (e) => writeCommandOutput(e.chunk));
   bus.on("agent:tool-output", () => flushCommandOutput());
@@ -253,6 +299,7 @@ export default function activate(ctx: ExtensionContext): void {
     stopCurrentSpinner();
     showCollapsedThinking();
     if (!s.renderer) startAgentResponse();
+    contentGap("info");
     s.renderer!.writeLine(`${p.error}Error: ${e.message}${p.reset}`);
     s.renderer!.writeLine("");
     drain();
@@ -302,8 +349,21 @@ export default function activate(ctx: ExtensionContext): void {
   function startAgentResponse(): void {
     s.renderer = new MarkdownRenderer(writer.columns);
     s.hadToolCalls = false;
+    s.lastContentKind = null;
     s.renderer.printTopBorder();
     drain();
+  }
+
+  /**
+   * Insert an empty line when transitioning between different content kinds
+   * (e.g., text → tool, tool → text, diff → tool) for visual breathing room.
+   */
+  function contentGap(kind: "text" | "tool" | "diff" | "code" | "info"): void {
+    if (s.lastContentKind && s.lastContentKind !== kind && s.renderer) {
+      s.renderer.writeLine("");
+      drain();
+    }
+    s.lastContentKind = kind;
   }
 
   function showCollapsedThinking(): void {
@@ -316,6 +376,7 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function endAgentResponse(): void {
+    finalizeToolGroup();
     closeToolLine();
     stopCurrentSpinner();
     if (s.renderer) {
@@ -331,7 +392,7 @@ export default function activate(ctx: ExtensionContext): void {
     const boxW = writer.columns;
     const contentW = boxW - 4;
 
-    const lines: string[] = [];
+    let lines: string[] = [];
     for (const raw of query.split("\n")) {
       if (raw.length <= contentW) {
         lines.push(`${p.accent}${raw}${p.reset}`);
@@ -345,6 +406,16 @@ export default function activate(ctx: ExtensionContext): void {
         }
         if (remaining) lines.push(`${p.accent}${remaining}${p.reset}`);
       }
+    }
+
+    // Truncate very long queries to keep the response visible
+    const MAX_QUERY_LINES = 20;
+    if (lines.length > MAX_QUERY_LINES) {
+      const overflow = lines.length - MAX_QUERY_LINES;
+      lines = [
+        ...lines.slice(0, MAX_QUERY_LINES),
+        `${p.dim}… ${overflow} more lines${p.reset}`,
+      ];
     }
 
     // Mode-specific border color and title
@@ -380,8 +451,8 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function writeAgentText(text: string): void {
+    finalizeToolGroup();
     closeToolLine();
-    const needsGap = s.hadToolCalls;
     s.hadToolCalls = false;
     if (s.isThinking) {
       s.isThinking = false;
@@ -395,26 +466,24 @@ export default function activate(ctx: ExtensionContext): void {
     showCollapsedThinking();
     stopCurrentSpinner();
     if (!s.renderer) startAgentResponse();
-    if (needsGap) writer.write("\n");
+    contentGap("text");
     s.renderer!.push(text);
     drain();
   }
 
   define("render:code-block", (language: string, code: string, width: number) => {
     flushForRaw();
+    contentGap("code");
     if (language) {
       s.renderer!.writeLine(`${p.dim}${language}${p.reset}`);
     }
     let highlighted: string;
-    if (!language) {
-      // No language specified — render as plain text to avoid false syntax detection
+    try {
+      highlighted = language
+        ? highlight(code, { language })
+        : highlight(code);  // auto-detect
+    } catch {
       highlighted = code;
-    } else {
-      try {
-        highlighted = highlight(code, { language });
-      } catch {
-        highlighted = `${p.success}${code}${p.reset}`;
-      }
     }
     const contentWidth = Math.min(90, width - 2);
     for (const line of highlighted.split("\n")) {
@@ -458,12 +527,15 @@ export default function activate(ctx: ExtensionContext): void {
       kind?: string;
       locations?: { path: string; line?: number | null }[];
       rawInput?: unknown;
+      batchIndex?: number;
+      batchTotal?: number;
     },
   ): void {
     closeToolLine();
     stopCurrentSpinner();
     if (!s.renderer) startAgentResponse();
     showCollapsedThinking();
+    contentGap("tool");
     s.renderer!.flush();
     drain();
     const lines = renderToolCall({
@@ -473,12 +545,18 @@ export default function activate(ctx: ExtensionContext): void {
       locations: extra?.locations,
       rawInput: extra?.rawInput,
     }, writer.columns);
+
+    // Prepend batch progress indicator when multiple tools in a batch
+    const batchPrefix = extra?.batchTotal && extra.batchTotal > 1
+      ? `${p.dim}[${extra.batchIndex}/${extra.batchTotal}]${p.reset} `
+      : "";
+
     for (let i = 0; i < lines.length - 1; i++) {
       s.renderer!.writeLine(lines[i]!);
     }
     drain();
     if (lines.length > 0) {
-      writer.write(`  ${lines[lines.length - 1]}`);
+      writer.write(`  ${batchPrefix}${lines[lines.length - 1]}`);
       s.toolLineOpen = true;
     }
     s.hadToolCalls = true;
@@ -488,11 +566,13 @@ export default function activate(ctx: ExtensionContext): void {
 
   function showToolComplete(exitCode: number | null): void {
     if (!s.renderer) return;
+    const elapsed = s.toolStartTime ? formatElapsed(Date.now() - s.toolStartTime) : "";
+    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
     const mark = exitCode === null
       ? `${p.muted}(timed out)${p.reset}`
       : exitCode === 0
-        ? `${p.success}✓${p.reset}`
-        : `${p.error}✗ exit ${exitCode}${p.reset}`;
+        ? `${p.success}✓${p.reset}${timer}`
+        : `${p.error}✗ exit ${exitCode}${p.reset}${timer}`;
 
     if (s.toolLineOpen && s.commandOutputLineCount === 0) {
       writer.write(` ${mark}\n`);
@@ -547,6 +627,29 @@ export default function activate(ctx: ExtensionContext): void {
     }
   }
 
+  /** Finalize a group of collapsed tool calls, rendering the summary. */
+  function finalizeToolGroup(): void {
+    if (s.toolGroupCount <= 1) {
+      s.toolGroupKind = undefined;
+      s.toolGroupCount = 0;
+      return;
+    }
+    closeToolLine();
+    if (!s.renderer) startAgentResponse();
+    const icon = s.toolGroupKind === "read" ? "◆" : "⌕";
+    const label = s.toolGroupKind === "read" ? "files read" : "searches";
+    const mark = s.toolGroupAllOk
+      ? `${p.success}✓${p.reset}`
+      : `${p.error}✗${p.reset}`;
+    s.renderer!.writeLine(
+      `${p.warning}${icon}${p.reset} ${p.dim}… +${s.toolGroupCount - 1} more ${label}${p.reset} ${mark}`,
+    );
+    drain();
+    s.toolGroupKind = undefined;
+    s.toolGroupCount = 0;
+    s.toolGroupAllOk = true;
+  }
+
   function writeCommandOutput(chunk: string): void {
     if (!s.renderer) return;
     closeToolLine();
@@ -562,10 +665,14 @@ export default function activate(ctx: ExtensionContext): void {
         s.commandOutputLineCount++;
       } else {
         s.commandOutputOverflow++;
+        s.commandOverflowLines.push(line);
       }
     }
     drain();
   }
+
+  /** Max overflow lines to show when a command fails. */
+  const FAIL_OVERFLOW_MAX = 20;
 
   function flushCommandOutput(): void {
     if (!s.renderer) return;
@@ -578,13 +685,29 @@ export default function activate(ctx: ExtensionContext): void {
         s.commandOutputLineCount++;
       } else {
         s.commandOutputOverflow++;
+        s.commandOverflowLines.push(s.commandOutputBuffer);
       }
       s.commandOutputBuffer = "";
     }
-    if (s.commandOutputOverflow > 0 && maxLines > 0) {
+
+    // On failure, show the tail of the overflow so the user can see the error
+    const failed = s.toolExitCode !== null && s.toolExitCode !== 0;
+    if (failed && s.commandOverflowLines.length > 0) {
+      const tail = s.commandOverflowLines.slice(-FAIL_OVERFLOW_MAX);
+      const skipped = s.commandOverflowLines.length - tail.length;
+      if (skipped > 0) {
+        s.renderer.writeLine(`${p.dim}  … ${skipped} lines hidden${p.reset}`);
+      }
+      for (const line of tail) {
+        s.renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
+      }
+    } else if (s.commandOutputOverflow > 0 && maxLines > 0) {
       s.renderer.writeLine(`${p.dim}  … ${s.commandOutputOverflow} more lines${p.reset}`);
     }
+
     s.commandOutputOverflow = 0;
+    s.commandOverflowLines = [];
+    s.toolExitCode = null;
     drain();
   }
 
@@ -597,6 +720,7 @@ export default function activate(ctx: ExtensionContext): void {
 
   function showFileDiff(filePath: string, diff: DiffResult): void {
     if (diff.isIdentical) return;
+    contentGap("diff");
 
     const boxW = Math.min(120, writer.columns);
     const contentW = boxW - 4;

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -27,6 +27,7 @@ import { renderBoxFrame } from "../utils/box-frame.js";
 import type { DiffResult } from "../utils/diff.js";
 import { getSettings } from "../settings.js";
 import type { ExtensionContext } from "../types.js";
+import type { ToolResultDisplay, ToolResultBody } from "../agent/types.js";
 import { StdoutWriter } from "../utils/output-writer.js";
 
 /** Encode a PNG buffer as a terminal inline image escape sequence. */
@@ -90,6 +91,8 @@ interface RenderState {
   toolGroupAllOk: boolean;
   /** Number of tools rendered individually in current group. */
   toolGroupRendered: number;
+  /** Accumulated result summaries from grouped tools. */
+  toolGroupSummaries: string[];
 
   // ── Thinking ──
   isThinking: boolean;
@@ -122,6 +125,7 @@ function createRenderState(): RenderState {
     toolGroupCount: 0,
     toolGroupAllOk: true,
     toolGroupRendered: 0,
+    toolGroupSummaries: [],
     isThinking: false,
     showThinkingText: false,
     thinkingPending: false,
@@ -231,15 +235,33 @@ export default function activate(ctx: ExtensionContext): void {
     endAgentResponse();
   });
 
-  // Read-only tool kinds eligible for grouping
+  // ── Tool batch grouping ──────────────────────────────────────────
   const GROUPABLE_KINDS = new Set(["read", "search"]);
-  const GROUP_MAX_VISIBLE = 5; // show this many tools individually before collapsing
+  const GROUP_MAX_VISIBLE = 5;
+  const KIND_ICONS: Record<string, string> = { read: "◆", search: "⌕" };
+
+  // Batch groups: kind → { total, rendered, headerShown }
+  let batchGroups = new Map<string, { total: number; rendered: number; headerShown: boolean }>();
+
+  bus.on("agent:tool-batch", (e) => {
+    fencedTransform.flush();
+    finalizeToolGroup();
+    batchGroups = new Map();
+    for (const group of e.groups) {
+      batchGroups.set(group.kind, {
+        total: group.tools.length,
+        rendered: 0,
+        headerShown: false,
+      });
+    }
+  });
 
   bus.on("agent:tool-started", (e) => {
     fencedTransform.flush();
     stopCurrentSpinner();
     s.currentToolKind = e.kind;
     s.toolStartTime = Date.now();
+
     if (e.title === "user_shell") {
       finalizeToolGroup();
       closeToolLine();
@@ -250,11 +272,39 @@ export default function activate(ctx: ExtensionContext): void {
       s.renderer!.writeLine(`${p.dim}▶ user_shell: ${cmd}${p.reset}`);
       drain();
       s.hadToolCalls = true;
-    } else if (GROUPABLE_KINDS.has(e.kind ?? "") && e.kind === s.toolGroupKind) {
-      // Consecutive same-kind read-only tool
+      return;
+    }
+
+    const kind = e.kind ?? "execute";
+    const group = batchGroups.get(kind);
+    const isGrouped = group && group.total > 1 && GROUPABLE_KINDS.has(kind);
+
+    if (isGrouped) {
+      // Render group header on first tool of this kind in the batch
+      if (!group.headerShown) {
+        finalizeToolGroup();
+        closeToolLine();
+        if (!s.renderer) startAgentResponse();
+        showCollapsedThinking();
+        contentGap("tool");
+        s.renderer!.flush();
+        drain();
+
+        const icon = KIND_ICONS[kind] ?? "▶";
+        s.renderer!.writeLine(`${p.warning}${icon}${p.reset} ${kind}`);
+        drain();
+
+        group.headerShown = true;
+        s.toolGroupKind = kind;
+        s.toolGroupCount = 0;
+        s.toolGroupRendered = 0;
+        s.toolGroupAllOk = true;
+        s.toolGroupSummaries = [];
+      }
+
       s.toolGroupCount++;
-      if (s.toolGroupCount <= GROUP_MAX_VISIBLE) {
-        // Show with tree connector
+
+      if (s.toolGroupRendered < GROUP_MAX_VISIBLE) {
         showToolCall(e.title, "", {
           ...e,
           batchIndex: e.batchIndex,
@@ -263,15 +313,9 @@ export default function activate(ctx: ExtensionContext): void {
         });
         s.toolGroupRendered++;
       }
-      // Beyond max: collapsed, rendered as summary in finalizeToolGroup
     } else {
+      // Standalone tool — single in its batch kind, or not groupable
       finalizeToolGroup();
-      if (GROUPABLE_KINDS.has(e.kind ?? "")) {
-        s.toolGroupKind = e.kind;
-        s.toolGroupCount = 1;
-        s.toolGroupAllOk = true;
-        s.toolGroupRendered = 1;
-      }
       showToolCall(e.title, "", {
         ...e,
         batchIndex: e.batchIndex,
@@ -283,13 +327,14 @@ export default function activate(ctx: ExtensionContext): void {
   bus.on("agent:tool-completed", (e) => {
     s.toolExitCode = e.exitCode;
     if (e.exitCode !== 0) s.toolGroupAllOk = false;
-    if (s.toolGroupCount > GROUP_MAX_VISIBLE) {
-      // Collapsed tool — just track success/failure
+
+    if (s.toolGroupKind) {
+      // Grouped tool — track success/failure and summaries, show aggregate on ⎿ line.
+      // Don't restart spinner between grouped tools — it's already running from group start.
+      if (e.resultDisplay?.summary) s.toolGroupSummaries.push(e.resultDisplay.summary);
       s.currentToolKind = undefined;
-      s.spinnerStartTime = 0;
-      startThinkingSpinner();
     } else {
-      showToolComplete(e.exitCode);
+      showToolComplete(e.exitCode, e.resultDisplay);
       s.currentToolKind = undefined;
       s.spinnerStartTime = 0;
       startThinkingSpinner();
@@ -368,7 +413,7 @@ export default function activate(ctx: ExtensionContext): void {
   function startAgentResponse(): void {
     s.renderer = new MarkdownRenderer(writer.columns);
     s.hadToolCalls = false;
-    s.lastContentKind = null;
+    // Preserve lastContentKind across responses so text→tool gaps work
     s.renderer.printTopBorder();
     drain();
   }
@@ -381,18 +426,20 @@ export default function activate(ctx: ExtensionContext): void {
   let lastEmittedLineBlank = false;
 
   function contentGap(kind: "text" | "tool" | "diff" | "code" | "info"): void {
-    if (s.lastContentKind && s.lastContentKind !== kind && s.renderer && !lastEmittedLineBlank) {
-      s.renderer.writeLine("");
-      drain();
+    if (s.lastContentKind && s.lastContentKind !== kind) {
+      if (s.renderer) {
+        s.renderer.flush();
+        drain();
+      }
+      writer.write("\n");
     }
     s.lastContentKind = kind;
   }
 
   function showCollapsedThinking(): void {
     if (s.thinkingPending && !s.showThinkingText) {
-      if (!s.renderer) startAgentResponse();
-      s.renderer!.writeLine(`${p.muted}… thinking${p.reset}`);
-      s.renderer!.writeLine("");
+      // Just clear the pending flag — the spinner already indicates thinking.
+      // No need for a separate "… thinking" label that clutters the output.
       s.thinkingPending = false;
     }
   }
@@ -539,6 +586,104 @@ export default function activate(ctx: ExtensionContext): void {
     ctx.call("render:image", data);
   }
 
+  /**
+   * Default renderer for tool result bodies. Extensions can advise this handler
+   * to override rendering for specific body kinds or add new ones:
+   *
+   *   ctx.advise("render:result-body", (next, body, width) => {
+   *     if (body.kind === "diff") return myCustomDiffRenderer(body, width);
+   *     return next(body, width);
+   *   });
+   */
+  define("render:result-body", (body: ToolResultBody, width: number): string[] => {
+    if (body.kind === "diff") {
+      return renderDiffBody(body.diff as DiffResult, body.filePath, width);
+    }
+    if (body.kind === "lines") {
+      return renderLinesBody(body.lines, width, body.maxLines);
+    }
+    return [];
+  });
+
+  /** Render a diff as framed box lines (pure — no TUI state side effects). */
+  function renderDiffBody(diff: DiffResult, filePath: string, width: number): string[] {
+    if (diff.isIdentical) return [];
+    const boxW = Math.min(120, width);
+    const contentW = boxW - 4;
+
+    const diffLines = renderDiff(diff, {
+      width: contentW,
+      filePath,
+      maxLines: getSettings().diffMaxLines,
+      trueColor: true,
+    });
+
+    const lastLine = diffLines[diffLines.length - 1] ?? "";
+    const isTruncated = lastLine.includes("… ");
+
+    if (isTruncated) {
+      s.lastTruncatedDiff = { filePath, diff, expanded: false };
+    } else {
+      s.lastTruncatedDiff = null;
+    }
+
+    const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
+    const footer = isTruncated
+      ? [`  ${p.dim}ctrl+o to expand${p.reset}`]
+      : undefined;
+
+    return renderBoxFrame(body, {
+      width: boxW,
+      style: "rounded",
+      borderColor: p.dim,
+      title: diffTitle(filePath, diff),
+      footer,
+    });
+  }
+
+  /** Render output lines with truncation. */
+  function renderLinesBody(lines: string[], width: number, maxLines?: number): string[] {
+    const max = maxLines ?? 10;
+    const shown = lines.slice(0, max);
+    const contentW = Math.max(1, width - 6);
+    const output: string[] = [];
+    for (const line of shown) {
+      const text = line.length > contentW ? line.slice(0, contentW - 1) + "…" : line;
+      output.push(`  ${p.dim}  ${text}${p.reset}`);
+    }
+    if (lines.length > max) {
+      output.push(`  ${p.dim}  … ${lines.length - max} more lines${p.reset}`);
+    }
+    return output;
+  }
+
+  /** Extract a detail string from tool args for group continuation display. */
+  function extractDetail(extra: { rawInput?: unknown; locations?: { path: string; line?: number | null }[] }): string {
+    if (extra.locations && extra.locations.length > 0) {
+      const loc = extra.locations[0]!;
+      const cwd = process.cwd();
+      const home = process.env.HOME;
+      let fp = loc.path;
+      if (fp.startsWith(cwd + "/")) fp = fp.slice(cwd.length + 1);
+      else if (home && fp.startsWith(home + "/")) fp = "~/" + fp.slice(home.length + 1);
+      return loc.line ? `${fp}:${loc.line}` : fp;
+    }
+    const raw = extra.rawInput as Record<string, unknown> | undefined;
+    if (!raw) return "";
+    if (typeof raw.command === "string") return `$ ${raw.command}`;
+    if (typeof raw.pattern === "string") return raw.pattern;
+    if (typeof raw.path === "string") {
+      const cwd = process.cwd();
+      const home = process.env.HOME;
+      let fp = raw.path as string;
+      if (fp.startsWith(cwd + "/")) fp = fp.slice(cwd.length + 1);
+      else if (home && fp.startsWith(home + "/")) fp = "~/" + fp.slice(home.length + 1);
+      return fp;
+    }
+    if (typeof raw.query === "string") return `"${raw.query}"`;
+    return "";
+  }
+
   function showToolCall(
     title: string,
     command?: string,
@@ -547,6 +692,7 @@ export default function activate(ctx: ExtensionContext): void {
       icon?: string;
       locations?: { path: string; line?: number | null }[];
       rawInput?: unknown;
+      displayDetail?: string;
       batchIndex?: number;
       batchTotal?: number;
       groupContinuation?: boolean;
@@ -567,43 +713,53 @@ export default function activate(ctx: ExtensionContext): void {
       icon: extra?.icon,
       locations: extra?.locations,
       rawInput: extra?.rawInput,
+      displayDetail: extra?.displayDetail,
     }, writer.columns);
 
-    // Replace the kind icon with a tree connector for grouped tools
     if (extra?.groupContinuation && lines.length > 0) {
-      // Line starts with: \x1b[33m◆\x1b[0m — swap the colored icon for muted ├
-      lines[0] = lines[0]!.replace(
-        /^\x1b\[[^m]*m.\x1b\[0m/, `${p.muted}├${p.reset}`,
-      );
+      // Swap the colored kind icon for a muted tree connector,
+      // and strip the tool name prefix — show detail only.
+      const detail = extra.displayDetail || extractDetail(extra);
+      const maxW = Math.max(1, writer.columns - 6);
+      const text = detail.length > maxW ? detail.slice(0, maxW - 1) + "…" : detail;
+      lines[0] = detail
+        ? `${p.muted}├${p.reset} ${p.dim}${text}${p.reset}`
+        : lines[0]!.replace(/^\x1b\[[^m]*m.\x1b\[0m/, `${p.muted}├${p.reset}`);
     }
 
-    // Prepend batch progress indicator when multiple tools in a batch
-    const batchPrefix = extra?.batchTotal && extra.batchTotal > 1
-      ? `${p.dim}[${extra.batchIndex}/${extra.batchTotal}]${p.reset} `
-      : "";
+    const batchPrefix = "";
 
     for (let i = 0; i < lines.length - 1; i++) {
       s.renderer!.writeLine(lines[i]!);
     }
     drain();
     if (lines.length > 0) {
-      writer.write(`  ${batchPrefix}${lines[lines.length - 1]}`);
-      s.toolLineOpen = true;
+      if (extra?.groupContinuation) {
+        // Grouped tools: close the line immediately — checkmarks go on the ⎿ summary
+        s.renderer!.writeLine(`  ${batchPrefix}${lines[lines.length - 1]}`);
+        drain();
+        s.toolLineOpen = false;
+      } else {
+        writer.write(`  ${batchPrefix}${lines[lines.length - 1]}`);
+        s.toolLineOpen = true;
+      }
     }
     s.hadToolCalls = true;
     s.commandOutputLineCount = 0;
     s.commandOutputOverflow = 0;
   }
 
-  function showToolComplete(exitCode: number | null): void {
+  function showToolComplete(exitCode: number | null, resultDisplay?: ToolResultDisplay): void {
     if (!s.renderer) return;
+    stopCurrentSpinner();
     const elapsed = s.toolStartTime ? formatElapsed(Date.now() - s.toolStartTime) : "";
     const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
+    const summary = resultDisplay?.summary ? ` ${p.dim}${resultDisplay.summary}${p.reset}` : "";
     const mark = exitCode === null
       ? `${p.muted}(timed out)${p.reset}`
       : exitCode === 0
-        ? `${p.success}✓${p.reset}${timer}`
-        : `${p.error}✗ exit ${exitCode}${p.reset}${timer}`;
+        ? `${p.success}✓${p.reset}${summary}${timer}`
+        : `${p.error}✗ exit ${exitCode}${p.reset}${summary}${timer}`;
 
     if (s.toolLineOpen && s.commandOutputLineCount === 0) {
       writer.write(` ${mark}\n`);
@@ -614,6 +770,20 @@ export default function activate(ctx: ExtensionContext): void {
       s.renderer.writeLine(`  ${mark}`);
       drain();
     }
+
+    // Render structured body if present
+    if (resultDisplay?.body) {
+      renderResultBody(resultDisplay.body);
+    }
+  }
+
+  function renderResultBody(body: ToolResultBody): void {
+    if (!s.renderer) return;
+    const lines: string[] = ctx.call("render:result-body", body, writer.columns) ?? [];
+    for (const line of lines) {
+      s.renderer!.writeLine(line);
+    }
+    if (lines.length > 0) drain();
   }
 
   // Thinking is always assumed available — the TUI renders thinking
@@ -665,27 +835,32 @@ export default function activate(ctx: ExtensionContext): void {
       s.toolGroupKind = undefined;
       s.toolGroupCount = 0;
       s.toolGroupRendered = 0;
+      s.toolGroupSummaries = [];
       return;
     }
     closeToolLine();
     if (!s.renderer) startAgentResponse();
+    const mark = s.toolGroupAllOk
+      ? `${p.success}✓${p.reset}`
+      : `${p.error}✗${p.reset}`;
+    const summary = s.toolGroupSummaries.length > 0
+      ? ` ${p.dim}${s.toolGroupSummaries.join(", ")}${p.reset}`
+      : "";
     const collapsed = s.toolGroupCount - s.toolGroupRendered;
     if (collapsed > 0) {
-      const mark = s.toolGroupAllOk
-        ? `${p.success}✓${p.reset}`
-        : `${p.error}✗${p.reset}`;
       s.renderer!.writeLine(
-        `  ${p.muted}⎿${p.reset} ${p.dim}+${collapsed} more${p.reset} ${mark}`,
+        `  ${p.muted}└${p.reset} ${p.dim}+${collapsed} more${p.reset} ${mark}${summary}`,
       );
     } else {
-      // All were shown — close with end bracket
-      s.renderer!.writeLine(`  ${p.muted}⎿${p.reset}`);
+      // All items visible — close the tree with └ mark + summary
+      s.renderer!.writeLine(`  ${p.muted}└${p.reset} ${mark}${summary}`);
     }
     drain();
     s.toolGroupKind = undefined;
     s.toolGroupCount = 0;
     s.toolGroupAllOk = true;
     s.toolGroupRendered = 0;
+    s.toolGroupSummaries = [];
   }
 
   function writeCommandOutput(chunk: string): void {
@@ -760,41 +935,14 @@ export default function activate(ctx: ExtensionContext): void {
     if (diff.isIdentical) return;
     contentGap("diff");
 
-    const boxW = Math.min(120, writer.columns);
-    const contentW = boxW - 4;
-
-    const diffLines = renderDiff(diff, {
-      width: contentW,
-      filePath,
-      maxLines: getSettings().diffMaxLines,
-      trueColor: true,
-    });
-
-    const lastLine = diffLines[diffLines.length - 1] ?? "";
-    const isTruncated = lastLine.includes("… ");
-
-    if (isTruncated) {
-      s.lastTruncatedDiff = { filePath, diff, expanded: false };
-    } else {
-      s.lastTruncatedDiff = null;
-    }
-
-    const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
-
-    const footer = isTruncated
-      ? [`  ${p.dim}ctrl+o to expand${p.reset}`]
-      : undefined;
-
-    const framed = renderBoxFrame(body, {
-      width: boxW,
-      style: "rounded",
-      borderColor: p.dim,
-      title: diffTitle(filePath, diff),
-      footer,
-    });
+    const lines: string[] = ctx.call(
+      "render:result-body",
+      { kind: "diff", diff, filePath } satisfies ToolResultBody,
+      writer.columns,
+    ) ?? [];
 
     if (!s.renderer) startAgentResponse();
-    for (const line of framed) {
+    for (const line of lines) {
       s.renderer!.writeLine(line);
     }
     drain();
@@ -841,29 +989,14 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function showFileDiffCached(entry: TruncatedDiff): void {
-    const { filePath, diff } = entry;
-    const boxW = Math.min(120, writer.columns);
-    const contentW = boxW - 4;
-
-    const diffLines = renderDiff(diff, {
-      width: contentW,
-      filePath,
-      maxLines: getSettings().diffMaxLines,
-      trueColor: true,
-    });
-
-    const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
-
-    const framed = renderBoxFrame(body, {
-      width: boxW,
-      style: "rounded",
-      borderColor: p.dim,
-      title: diffTitle(filePath, diff),
-      footer: [`  ${p.dim}ctrl+o to expand${p.reset}`],
-    });
+    const lines: string[] = ctx.call(
+      "render:result-body",
+      { kind: "diff", diff: entry.diff, filePath: entry.filePath } satisfies ToolResultBody,
+      writer.columns,
+    ) ?? [];
 
     writer.write("\n");
-    for (const line of framed) {
+    for (const line of lines) {
       writer.write(line + "\n");
     }
   }

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -425,11 +425,8 @@ export default function activate(ctx: ExtensionContext): void {
     }
 
     // Mode-specific border color and title
-    const isExecute = modeLabel === "Execute";
-    const borderColor = isExecute ? p.success : p.accent;
-    const title = modeLabel
-      ? `${borderColor}${p.bold} ${modeLabel} ${p.reset}`
-      : `${p.accent}${p.bold}❯${p.reset}`;
+    const borderColor = p.accent;
+    const title = `${p.accent}${p.bold}❯${p.reset}`;
 
     // Backend/model label on the right (backend/model, highlighted)
     const model = backendInfo?.model ?? llmClient?.model;

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -149,7 +149,7 @@ export default function activate(ctx: ExtensionContext): void {
 
   bus.on("agent:query", (e) => {
     s.spinnerStartTime = 0;
-    showUserQuery(e.query, e.modeLabel);
+    showUserQuery(e.query);
     startAgentResponse();
     startThinkingSpinner();
   });
@@ -394,7 +394,7 @@ export default function activate(ctx: ExtensionContext): void {
     }
   }
 
-  function showUserQuery(query: string, modeLabel?: string): void {
+  function showUserQuery(query: string): void {
     const boxW = writer.columns;
     const contentW = boxW - 4;
 

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -247,8 +247,17 @@ export default function activate(ctx: ExtensionContext): void {
       drain();
       s.hadToolCalls = true;
     } else if (GROUPABLE_KINDS.has(e.kind ?? "") && e.kind === s.toolGroupKind) {
-      // Consecutive same-kind read-only tool — collapse into group
+      // Consecutive same-kind read-only tool
       s.toolGroupCount++;
+      if (s.toolGroupCount <= 2) {
+        // Show the first 2 individually (with normal completion handling)
+        showToolCall(e.title, "", {
+          ...e,
+          batchIndex: e.batchIndex,
+          batchTotal: e.batchTotal,
+        });
+      }
+      // 3rd+ are collapsed — rendered as summary in finalizeToolGroup
     } else {
       finalizeToolGroup();
       if (GROUPABLE_KINDS.has(e.kind ?? "")) {
@@ -266,9 +275,9 @@ export default function activate(ctx: ExtensionContext): void {
 
   bus.on("agent:tool-completed", (e) => {
     s.toolExitCode = e.exitCode;
-    if (s.toolGroupCount > 1) {
-      // Grouped tool — just track success/failure, don't render individually
-      if (e.exitCode !== 0) s.toolGroupAllOk = false;
+    if (e.exitCode !== 0) s.toolGroupAllOk = false;
+    if (s.toolGroupCount > 2) {
+      // Collapsed tool (3rd+) — just track success/failure
       s.currentToolKind = undefined;
       s.spinnerStartTime = 0;
       startThinkingSpinner();
@@ -634,7 +643,8 @@ export default function activate(ctx: ExtensionContext): void {
 
   /** Finalize a group of collapsed tool calls, rendering the summary. */
   function finalizeToolGroup(): void {
-    if (s.toolGroupCount <= 1) {
+    if (s.toolGroupCount <= 2) {
+      // 0–2 tools: all were rendered individually, nothing to summarize
       s.toolGroupKind = undefined;
       s.toolGroupCount = 0;
       return;
@@ -646,8 +656,9 @@ export default function activate(ctx: ExtensionContext): void {
     const mark = s.toolGroupAllOk
       ? `${p.success}✓${p.reset}`
       : `${p.error}✗${p.reset}`;
+    const collapsed = s.toolGroupCount - 2; // first 2 were shown individually
     s.renderer!.writeLine(
-      `${p.warning}${icon}${p.reset} ${p.dim}… +${s.toolGroupCount - 1} more ${label}${p.reset} ${mark}`,
+      `${p.warning}${icon}${p.reset} ${p.dim}… +${collapsed} more ${label}${p.reset} ${mark}`,
     );
     drain();
     s.toolGroupKind = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
   const { bus } = core;
 
   // Track agent info from bus events (populated by extension backends)
-  let agentInfo: { name: string; version: string; model?: string } | null = null;
+  let agentInfo: { name: string; version: string; model?: string; provider?: string } | null = null;
   bus.on("agent:info", (info) => { agentInfo = info; });
 
   // ── Interactive frontend ──────────────────────────────────────
@@ -280,35 +280,44 @@ async function main(): Promise<void> {
   // ── Startup banner ───────────────────────────────────────────
   const settings = getSettings();
   if (settings.startupBanner !== false) {
-    const titleParts = [`${p.accent}${p.bold}agent-sh${p.reset}`];
-    const info = agentInfo as { name: string; version: string; model?: string } | null;
-    if (info && info.name !== "agent-sh") {
-      titleParts.push(`${p.dim}backend: ${info.name}${p.reset}`);
-    }
-    if (info?.model) {
-      titleParts.push(`${p.dim}${info.model}${p.reset}`);
-    } else if (core.llmClient) {
-      titleParts.push(`${p.dim}${core.llmClient.model}${p.reset}`);
-    }
-    const title = titleParts.join(`${p.muted} · ${p.reset}`);
+    const termW = process.stdout.columns || 80;
+    const bannerW = Math.min(termW, 60);
 
-    let details = "";
+    const productName = `${p.accent}${p.bold}agent-sh${p.reset}`;
+
+    const info = agentInfo as { name: string; version: string; model?: string; provider?: string } | null;
+    const backendName = info?.name ?? "agent-sh";
+    const model = info?.model ?? core.llmClient?.model;
+    const provider = info?.provider;
+    const modelValue = model
+      ? provider ? `${model} [${provider}]` : model
+      : null;
+
+    let sections = "";
+    sections += `\n\n  ${p.muted}Backend:${p.reset} ${p.dim}${backendName}${p.reset}`;
+    if (modelValue) {
+      sections += `\n  ${p.muted}Model:${p.reset} ${p.dim}${modelValue}${p.reset}`;
+    }
     if (loadedExtensions.length > 0) {
-      details += `\n  ${p.muted}Extensions: ${p.reset}${p.dim}${loadedExtensions.join(", ")}${p.reset}`;
+      sections += `\n\n  ${p.muted}Extensions:${p.reset}`;
+      for (const name of loadedExtensions) {
+        sections += `\n    ${p.dim}${name}${p.reset}`;
+      }
     }
     if (skills.length > 0) {
-      details += `\n  ${p.muted}Skills: ${p.reset}${p.dim}${skills.map(s => s.name).join(", ")}${p.reset}`;
+      sections += `\n\n  ${p.muted}Skills:${p.reset}`;
+      for (const s of skills) {
+        sections += `\n    ${p.dim}${s.name}${p.reset}`;
+      }
     }
 
     const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}>/help${p.muted} for commands${p.reset}`;
-
-    const termW = process.stdout.columns || 80;
-    const borderLine = `${p.muted}${"─".repeat(Math.min(termW, 60))}${p.reset}`;
+    const borderLine = `${p.muted}${"─".repeat(bannerW)}${p.reset}`;
 
     process.stdout.write(
       "\n" + borderLine + "\n" +
-      "  " + title +
-      details + "\n" +
+      "  " + productName +
+      sections + "\n" +
       "\n  " + hint + "\n" +
       borderLine + "\n\n",
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,8 +256,9 @@ async function main(): Promise<void> {
     console.error('[agent-sh] Loading extensions...');
   }
   const loadExtensionsTimeoutMs = 10000;
+  let loadedExtensions: string[] = [];
   await Promise.race([
-    loadExtensions(extCtx, config.extensions),
+    loadExtensions(extCtx, config.extensions).then((names) => { loadedExtensions = names; }),
     new Promise<void>((_, reject) =>
       setTimeout(() => reject(new Error(`Extension loading timeout after ${loadExtensionsTimeoutMs}ms`)), loadExtensionsTimeoutMs)
     ),
@@ -268,11 +269,8 @@ async function main(): Promise<void> {
     console.error('[agent-sh] Extensions loaded');
   }
 
-  // ── Show discovered skills ─────────────────────────────────────
+  // ── Discover skills ───────────────────────────────────────────
   const skills = discoverSkills(process.cwd());
-  if (skills.length > 0) {
-    bus.emit("ui:info", { message: `Skills: ${skills.map(s => s.name).join(", ")}` });
-  }
 
   // ── Activate agent backend ────────────────────────────────────
   // Extensions had their chance to register via agent:register-backend.
@@ -282,18 +280,36 @@ async function main(): Promise<void> {
   // ── Startup banner ───────────────────────────────────────────
   const settings = getSettings();
   if (settings.startupBanner !== false) {
-    const title = core.llmClient
-      ? `${p.accent}${p.bold}agent-sh${p.reset}${p.dim} · ${core.llmClient.model}${p.reset}`
-      : `${p.accent}${p.bold}agent-sh${p.reset}`;
-    const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}/help${p.muted} for commands${p.reset}`;
+    const titleParts = [`${p.accent}${p.bold}agent-sh${p.reset}`];
+    const info = agentInfo as { name: string; version: string; model?: string } | null;
+    if (info && info.name !== "agent-sh") {
+      titleParts.push(`${p.dim}backend: ${info.name}${p.reset}`);
+    }
+    if (info?.model) {
+      titleParts.push(`${p.dim}${info.model}${p.reset}`);
+    } else if (core.llmClient) {
+      titleParts.push(`${p.dim}${core.llmClient.model}${p.reset}`);
+    }
+    const title = titleParts.join(`${p.muted} · ${p.reset}`);
+
+    let details = "";
+    if (loadedExtensions.length > 0) {
+      details += `\n  ${p.muted}Extensions: ${p.reset}${p.dim}${loadedExtensions.join(", ")}${p.reset}`;
+    }
+    if (skills.length > 0) {
+      details += `\n  ${p.muted}Skills: ${p.reset}${p.dim}${skills.map(s => s.name).join(", ")}${p.reset}`;
+    }
+
+    const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}>/help${p.muted} for commands${p.reset}`;
 
     const termW = process.stdout.columns || 80;
     const borderLine = `${p.muted}${"─".repeat(Math.min(termW, 60))}${p.reset}`;
 
     process.stdout.write(
       "\n" + borderLine + "\n" +
-      "  " + title + "\n" +
-      "  " + hint + "\n" +
+      "  " + title +
+      details + "\n" +
+      "\n  " + hint + "\n" +
       borderLine + "\n\n",
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import shellRecall from "./extensions/shell-recall.js";
 import commandSuggest from "./extensions/command-suggest.js";
 import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
+import { discoverSkills } from "./agent/skills.js";
 import type { AgentShellConfig } from "./types.js";
 
 /**
@@ -132,8 +133,7 @@ Examples:
 
 Inside the shell:
   Type normally        Commands run in your real shell
-  > <query>           Ask the AI agent a question (execute mode)
-  ? <command>         Have the agent run a command in your shell (help mode)
+  > <query>           Ask the AI agent (it decides how to help)
   > /help             Show available slash commands
   Ctrl-C              Cancel agent response (or signal shell as usual)
 `);
@@ -226,41 +226,17 @@ async function main(): Promise<void> {
     console.error('[agent-sh] Shell created');
   }
 
-  // ── Input modes ──────────────────────────────────────────────
+  // ── Input mode ───────────────────────────────────────────────
   bus.emit("input-mode:register", {
-    id: "execute",
+    id: "agent",
     trigger: ">",
-    label: "execute",
+    label: "agent",
     promptIcon: "❯",
     indicator: "●",
     onSubmit(query, b) {
-      b.emit("agent:submit", { query, modeLabel: "Execute", modeInstruction: "[mode: execute]" });
+      b.emit("agent:submit", { query });
     },
     returnToSelf: true,
-  });
-
-  bus.emit("input-mode:register", {
-    id: "help",
-    trigger: "?",
-    label: "help",
-    promptIcon: "❯",
-    indicator: "❓",
-    onSubmit(query, b) {
-      const onToolDone = (e: { kind?: string }) => {
-        if (e.kind === "execute") {
-          b.emit("agent:cancel-request", { silent: true });
-        }
-      };
-      const cleanup = () => {
-        b.off("agent:tool-completed", onToolDone);
-        b.off("agent:processing-done", cleanup);
-      };
-      b.on("agent:tool-completed", onToolDone);
-      b.on("agent:processing-done", cleanup);
-
-      b.emit("agent:submit", { query, modeLabel: "Help", modeInstruction: "[mode: help]" });
-    },
-    returnToSelf: false,
   });
 
   // ── Extensions ────────────────────────────────────────────────
@@ -292,6 +268,12 @@ async function main(): Promise<void> {
     console.error('[agent-sh] Extensions loaded');
   }
 
+  // ── Show discovered skills ─────────────────────────────────────
+  const skills = discoverSkills(process.cwd());
+  if (skills.length > 0) {
+    bus.emit("ui:info", { message: `Skills: ${skills.map(s => s.name).join(", ")}` });
+  }
+
   // ── Activate agent backend ────────────────────────────────────
   // Extensions had their chance to register via agent:register-backend.
   // If none did, the built-in AgentLoop gets wired to bus events.
@@ -303,7 +285,7 @@ async function main(): Promise<void> {
     const title = core.llmClient
       ? `${p.accent}${p.bold}agent-sh${p.reset}${p.dim} · ${core.llmClient.model}${p.reset}`
       : `${p.accent}${p.bold}agent-sh${p.reset}`;
-    const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}?${p.muted} to run in shell · ${p.warning}/help${p.muted} for commands${p.reset}`;
+    const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}/help${p.muted} for commands${p.reset}`;
 
     const termW = process.stdout.columns || 80;
     const borderLine = `${p.muted}${"─".repeat(Math.min(termW, 60))}${p.reset}`;

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -550,7 +550,8 @@ export class InputHandler {
             }
             this.editor.buffer = this.history[this.historyIndex]!;
             this.editor.cursor = this.editor.buffer.length;
-            this.renderModeInput();
+            this.clearAutocompleteLines();
+            this.writeModePromptLine();
           }
           break;
 
@@ -572,7 +573,8 @@ export class InputHandler {
               this.editor.buffer = this.savedBuffer;
             }
             this.editor.cursor = this.editor.buffer.length;
-            this.renderModeInput();
+            this.clearAutocompleteLines();
+            this.writeModePromptLine();
           }
           break;
       }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -85,7 +85,7 @@ const DEFAULTS: Required<Settings> = {
   shellTailLines: 5,
   recallExpandMaxLines: 100,
   maxCommandOutputLines: 3,
-  readOutputMaxLines: 0,
+  readOutputMaxLines: 10,
   diffMaxLines: 20,
   skillPaths: [],
   startupBanner: true,

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -324,17 +324,17 @@ export class Shell implements InputContext {
       process.stdout.write("\n");
       this.bus.emit("shell:agent-exec-start", {});
 
-      const output = await new Promise<{ output: string; cwd: string }>((resolve, reject) => {
+      const output = await new Promise<{ output: string; cwd: string; exitCode: number | null }>((resolve, reject) => {
         const timeout = setTimeout(() => {
           this.bus.off("shell:command-done", handler);
           this.ptyProcess.write("\x03");
           reject(new Error("Shell exec timed out after 30s"));
         }, 30_000);
 
-        const handler = (e: { command: string; output: string; cwd: string }) => {
+        const handler = (e: { command: string; output: string; cwd: string; exitCode: number | null }) => {
           clearTimeout(timeout);
           this.bus.off("shell:command-done", handler);
-          resolve({ output: e.output, cwd: e.cwd });
+          resolve({ output: e.output, cwd: e.cwd, exitCode: e.exitCode });
         };
         this.bus.on("shell:command-done", handler);
 
@@ -346,7 +346,7 @@ export class Shell implements InputContext {
       this.echoSkip = false;
       this.bus.emit("shell:agent-exec-done", {});
 
-      return { ...payload, output: output.output, cwd: output.cwd, done: true };
+      return { ...payload, output: output.output, cwd: output.cwd, exitCode: output.exitCode, done: true };
     });
   }
 

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -64,6 +64,17 @@ export function computeDiff(
   // Build LCS table and backtrack to produce diff lines
   const a = oldText.split("\n");
   const b = newText.split("\n");
+
+  // Bail out if LCS table would be too large (avoids OOM / hang)
+  if (a.length * b.length > 10_000_000) {
+    return {
+      hunks: [],
+      added: b.length,
+      removed: a.length,
+      isIdentical: false,
+      isNewFile: false,
+    };
+  }
   const dp = buildLcs(a, b);
   const raw = backtrack(dp, a, b);
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -253,6 +253,17 @@ export class MarkdownRenderer {
     const bq = line.match(/^>\s?(.*)/);
     if (bq) return `${p.muted}│${p.reset} ${p.dim}${p.italic}${this.renderInline(bq[1] || "")}${p.reset}`;
 
+    // Task list (checkbox items) — must come before generic unordered list
+    const task = line.match(/^(\s*)[*\-+]\s+\[([ xX])\]\s+(.*)/);
+    if (task) {
+      const indent = task[1] || "";
+      const checked = task[2] !== " ";
+      const box = checked
+        ? `${p.success}☑${p.reset}`
+        : `${p.dim}☐${p.reset}`;
+      return `${indent}  ${box} ${this.renderInline(task[3] || "")}`;
+    }
+
     // Unordered list
     const ul = line.match(/^(\s*)[*\-+]\s+(.*)/);
     if (ul) {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -86,6 +86,7 @@ export class MarkdownRenderer {
   private buffer = "";
   private contentWidth: number;
   private firstLine = true;
+  private lastLineBlank = false;
   private pendingLines: string[] = [];
   private width: number;
   private tableRows: string[][] = [];
@@ -307,8 +308,12 @@ export class MarkdownRenderer {
    * The line is accumulated internally — call drainLines() to extract.
    */
   writeLine(text: string): void {
-    if (this.firstLine && visibleLen(text) === 0) return;
+    const isBlank = visibleLen(text) === 0;
+    if (this.firstLine && isBlank) return;
+    // Collapse consecutive blank lines to a single one
+    if (isBlank && this.lastLineBlank) return;
     this.firstLine = false;
+    this.lastLineBlank = isBlank;
     this.pendingLines.push(`  ${text}`);
   }
 }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -211,6 +211,11 @@ export class MarkdownRenderer {
 
     // Render rows
     const hasHeader = sepIdx.includes(1) && dataRows.length > 1;
+
+    // Top border
+    const topBorder = colWidths.map((w) => "─".repeat(w)).join(`─┬─`);
+    this.writeLine(`${p.dim}┌─${topBorder}─┐${p.reset}`);
+
     for (let i = 0; i < dataRows.length; i++) {
       const row = dataRows[i]!;
       const isHeader = hasHeader && i === 0;
@@ -227,6 +232,10 @@ export class MarkdownRenderer {
         this.writeLine(`${p.dim}├─${sep}─┤${p.reset}`);
       }
     }
+
+    // Bottom border
+    const bottomBorder = colWidths.map((w) => "─".repeat(w)).join(`─┴─`);
+    this.writeLine(`${p.dim}└─${bottomBorder}─┘${p.reset}`);
   }
 
   private renderLine(line: string): string {

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -25,6 +25,8 @@ export interface ToolCallRender {
   locations?: { path: string; line?: number | null }[];
   /** Raw input parameters sent to the tool. */
   rawInput?: unknown;
+  /** Pre-formatted display detail from tool's formatCall(). Takes precedence over rawInput extraction. */
+  displayDetail?: string;
 }
 
 export interface ToolResultRender {
@@ -110,7 +112,9 @@ export function renderToolCall(
   // Build a compact detail string to append after the title
   let detail = "";
   const cwd = process.cwd();
-  if (mode === "full") {
+  if (mode === "full" && tool.displayDetail) {
+    detail = tool.displayDetail;
+  } else if (mode === "full") {
     if (tool.command) {
       detail = `$ ${tool.command}`;
     } else if (tool.locations && tool.locations.length > 0) {
@@ -144,11 +148,13 @@ export function renderToolCall(
     }
   }
 
-  // Render as single line: icon + detail
-  // Tools with a registered icon are self-describing — show icon + detail only.
-  // Tools without a custom icon show tool name alongside detail for identification.
+  // Render as single line: icon + kind + detail
   const maxDetailW = Math.max(1, width - 4);
-  if (detail && hasCustomIcon) {
+  if (detail && hasCustomIcon && tool.kind) {
+    const combined = `${tool.kind} ${detail}`;
+    const truncated = combined.length > maxDetailW ? combined.slice(0, maxDetailW - 1) + "…" : combined;
+    lines.push(`${p.warning}${icon}${p.reset} ${p.dim}${truncated}${p.reset}`);
+  } else if (detail && hasCustomIcon) {
     if (detail.length > maxDetailW) detail = detail.slice(0, maxDetailW - 1) + "…";
     lines.push(`${p.warning}${icon}${p.reset} ${p.dim}${detail}${p.reset}`);
   } else if (detail) {

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -78,6 +78,7 @@ const KIND_ICONS: Record<string, string> = {
   move: "↗",
   search: "⌕",
   execute: "▶",
+  display: "◇",
   think: "◇",
   fetch: "↓",
   switch_mode: "⇄",

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -19,6 +19,8 @@ export interface ToolCallRender {
   command?: string;
   /** Tool kind from ACP (read, edit, execute, search, etc.). */
   kind?: string;
+  /** Custom icon character — when set, tool name is omitted (icon implies tool). */
+  icon?: string;
   /** File locations affected by the tool call. */
   locations?: { path: string; line?: number | null }[];
   /** Raw input parameters sent to the tool. */
@@ -92,7 +94,10 @@ export function renderToolCall(
   width: number,
 ): string[] {
   const mode = selectToolDisplayMode(width);
-  const icon = kindIcon(tool.kind);
+  const icon = tool.icon ?? kindIcon(tool.kind);
+  // If the tool registered a custom icon, it's self-describing — omit the name.
+  // Otherwise, include the tool name so the user knows what ran.
+  const hasCustomIcon = !!tool.icon;
 
   if (mode === "summary") {
     const text = truncateVisible(`${icon} ${tool.title}`, width);
@@ -139,15 +144,13 @@ export function renderToolCall(
   }
 
   // Render as single line: icon + detail
-  // For well-known tool kinds (read, search, execute), the icon is enough context.
-  // For extension/unknown tools, always include the tool name so the user knows what ran.
-  const isWellKnown = tool.kind && ["read", "edit", "delete", "move", "search", "execute"].includes(tool.kind);
+  // Tools with a registered icon are self-describing — show icon + detail only.
+  // Tools without a custom icon show tool name alongside detail for identification.
   const maxDetailW = Math.max(1, width - 4);
-  if (detail && isWellKnown) {
+  if (detail && hasCustomIcon) {
     if (detail.length > maxDetailW) detail = detail.slice(0, maxDetailW - 1) + "…";
     lines.push(`${p.warning}${icon}${p.reset} ${p.dim}${detail}${p.reset}`);
   } else if (detail) {
-    // Extension tool — show name: detail
     const prefix = `${tool.title}: `;
     const combined = prefix + detail;
     const truncated = combined.length > maxDetailW ? combined.slice(0, maxDetailW - 1) + "…" : combined;

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -138,12 +138,20 @@ export function renderToolCall(
     }
   }
 
-  // Render as single line: icon + detail (icon implies the tool type)
-  // Falls back to icon + title when no detail is available
+  // Render as single line: icon + detail
+  // For well-known tool kinds (read, search, execute), the icon is enough context.
+  // For extension/unknown tools, always include the tool name so the user knows what ran.
+  const isWellKnown = tool.kind && ["read", "edit", "delete", "move", "search", "execute"].includes(tool.kind);
   const maxDetailW = Math.max(1, width - 4);
-  if (detail) {
+  if (detail && isWellKnown) {
     if (detail.length > maxDetailW) detail = detail.slice(0, maxDetailW - 1) + "…";
     lines.push(`${p.warning}${icon}${p.reset} ${p.dim}${detail}${p.reset}`);
+  } else if (detail) {
+    // Extension tool — show name: detail
+    const prefix = `${tool.title}: `;
+    const combined = prefix + detail;
+    const truncated = combined.length > maxDetailW ? combined.slice(0, maxDetailW - 1) + "…" : combined;
+    lines.push(`${p.warning}${icon}${p.reset} ${p.dim}${truncated}${p.reset}`);
   } else {
     lines.push(`${p.warning}${icon} ${tool.title}${p.reset}`);
   }


### PR DESCRIPTION
## Summary

Comprehensive improvements to the agent's built-in tools, TUI rendering, and architecture.

### Agent tools
- **grep**: Three output modes (`files_with_matches`, `content`, `count`), case-insensitive search, pagination (`head_limit`/`offset`), 500-char line truncation
- **glob**: Results sorted by mtime (newest first), capped at 200 files
- **read_file**: Deduplication cache (returns stub if file unchanged since last read), 2MB file size guard, cache invalidation on writes
- **edit_file**: Fuzzy match hints when `old_text` not found (whitespace diff detection, closest match suggestions), streaming diff output
- **write_file**: Auto-creates parent directories, streaming diff output
- **bash**: `description` parameter, bus interception via `agent:terminal-intercept`
- **user_shell**: Configurable timeout, exit code propagation, `return_output` flag
- **display** (new): Show command output to user without returning to agent — for `cat`, `git log`, `diff`, etc.
- **ls**: Formatted output with timestamps and human-readable file sizes

### Agent loop
- **Parallel execution**: Read-only tools run via `Promise.all`; permission-requiring tools sequential
- **Tool batching**: `agent:tool-batch` event emitted before execution with grouped tool info
- **Structured results**: `formatResult()` / `formatCall()` / `getDisplayInfo()` on ToolDefinition for rich TUI display
- **Retry logic**: Exponential backoff for transient errors (429, 5xx, network), context overflow auto-compaction
- **Thinking levels**: Configurable `reasoning_effort` (`off`/`low`/`medium`/`high`)
- **File read cache invalidation**: Writes clear the read cache for modified paths

### TUI rendering
- **Tool grouping**: Tree-style connectors with collapse threshold for consecutive same-kind tools
- **Markdown tables**: Top and bottom borders
- **Extensible tool results**: `render:result-body` named handler for custom result rendering
- **Startup banner**: Structured sections (backend, model, extensions, skills)

### Architecture
- Merged two input modes (`>` execute, `?` help) into single agent-decided mode
- Removed `modeInstruction`/`modeLabel` from event bus and bridges
- Added Tool Decision Guide to system prompt (scratchpad vs display vs user_shell)
- Data-driven tool icons, `ToolResultDisplay`/`ToolResultBody` types

### Documentation
- Updated all docs (agent.md, architecture.md, extensions.md, usage.md) to reflect changes
- README: trimmed configuration section, updated examples for single-mode UX

## Test plan

- [ ] Verify `grep` output modes: `files_with_matches`, `content` (with context), `count`
- [ ] Verify `grep` pagination: `offset` + `head_limit`
- [ ] Test `read_file` dedup: read same file twice → second returns "File unchanged"
- [ ] Test `read_file` on >2MB file without offset/limit → error with hint
- [ ] Test `edit_file` hints when `old_text` has wrong indentation
- [ ] Test `display` tool: output appears in terminal, agent gets "Output displayed to user."
- [ ] Test parallel execution: multiple `read_file` calls resolve concurrently
- [ ] Test `user_shell` timeout and exit code propagation
- [ ] Verify tool grouping in TUI with 3+ consecutive search/read tools
- [ ] Verify startup banner shows backend, model, extensions, skills
- [ ] Build passes with `npx tsc --noEmit`