### PR TITLE
terminal buffer, overlay agent, and interactive program support

### DIFF
--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -111,16 +111,17 @@ export default function activate({ bus, advise }: ExtensionContext): void {
     }
     const visibleContent = responseLines.slice(scrollOffset, scrollOffset + contentH);
 
-    // Build the composited frame
-    const out: string[] = [SYNC_START, `\x1b[H`]; // home cursor
+    // Build the composited frame — use absolute cursor positioning per row
+    const out: string[] = [SYNC_START];
 
     for (let row = 0; row < rows; row++) {
+      out.push(`\x1b[${row + 1};1H`); // move to row (1-indexed)
       const bgLine = (bgLines[row] || "").padEnd(cols).slice(0, cols);
       const relRow = row - boxTop;
 
       if (relRow < 0 || relRow >= boxH) {
         // Background row — render dimmed
-        out.push(`${DIM}${bgLine}${RESET}`);
+        out.push(`${DIM}${bgLine}${RESET}\x1b[K`);
       } else if (relRow === 0) {
         // Top border
         const title = phase === "input" ? " agent " : phase === "done" ? " done " : " ... ";
@@ -175,8 +176,6 @@ export default function activate({ bus, advise }: ExtensionContext): void {
       }
     }
 
-    out.push(SYNC_END);
-
     // Position cursor for input
     if (phase === "input") {
       const cursorRow = boxTop + 1;
@@ -184,19 +183,15 @@ export default function activate({ bus, advise }: ExtensionContext): void {
       out.push(`\x1b[${cursorRow + 1};${cursorCol + 1}H`);
     }
 
-    process.stdout.write(out.join("\x1b[K\n").replace(/\n$/, ""));
+    out.push(SYNC_END);
+
+    // Write using absolute cursor positioning per row — no \n to avoid scrollback pollution
+    process.stdout.write(out.join(""));
   }
 
   function restoreScreen(): void {
-    // Re-render the original screen from the buffer
-    const bgLines = getScreenLines();
-    const rows = process.stdout.rows || 24;
-    const out = [SYNC_START, `\x1b[H`];
-    for (let row = 0; row < rows; row++) {
-      out.push(bgLines[row] || "");
-    }
-    out.push(SYNC_END);
-    process.stdout.write(out.join("\x1b[K\n").replace(/\n$/, ""));
+    // Just clear and let the foreground program redraw itself
+    process.stdout.write(`${SYNC_START}\x1b[2J\x1b[H${SYNC_END}`);
   }
 
   // ── Phase transitions ─────────────────────────────────────

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -190,8 +190,9 @@ export default function activate({ bus, advise }: ExtensionContext): void {
   }
 
   function restoreScreen(): void {
-    // Just clear and let the foreground program redraw itself
-    process.stdout.write(`${SYNC_START}\x1b[2J\x1b[H${SYNC_END}`);
+    // Leave alternate screen buffer — terminal automatically restores
+    // the original screen content (vim, shell, whatever was running)
+    process.stdout.write("\x1b[?1049l");
   }
 
   // ── Phase transitions ─────────────────────────────────────
@@ -206,6 +207,12 @@ export default function activate({ bus, advise }: ExtensionContext): void {
 
     // Hold stdout — suppresses PTY and TUI
     bus.emit("shell:stdout-hold", {});
+
+    // Switch to alternate screen buffer — nothing we draw here
+    // affects the main terminal or scrollback. On dismiss, the
+    // terminal automatically restores the original screen.
+    process.stdout.write("\x1b[?1049h");
+
     compositeAndRender();
   }
 

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -2,15 +2,16 @@
  * Overlay agent extension.
  *
  * Provides a hotkey (Ctrl+]) to summon the agent from anywhere — even
- * inside vim, htop, or ssh. Renders a full-screen response view,
- * then returns to the previous program on dismiss.
+ * inside vim, htop, or ssh. Renders a full-screen response view by
+ * holding stdout (suppresses both PTY and TUI output), then returns
+ * to the previous program on dismiss.
  *
  * Flow:
  *   1. Ctrl+] → input bar at bottom of screen
- *   2. Type query, Enter → clear screen, hold PTY stdout, submit
- *   3. Agent response renders on the clear screen (TUI renderer)
+ *   2. Type query, Enter → hold stdout, clear screen, submit
+ *   3. Response streams directly to stdout (TUI renderer is suppressed)
  *   4. On completion → "Ctrl+] to dismiss" prompt
- *   5. Ctrl+] → release stdout, force program redraw (Ctrl+L to PTY)
+ *   5. Ctrl+] → release stdout, Ctrl+L to PTY to force program redraw
  *
  * Usage:
  *   agent-sh -e ./examples/extensions/overlay-agent.ts
@@ -21,6 +22,10 @@
 import type { ExtensionContext } from "agent-sh/types";
 
 const TRIGGER = "\x1d"; // Ctrl+]
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const CYAN = "\x1b[36m";
 
 type Phase = "idle" | "input" | "responding" | "done";
 
@@ -57,15 +62,9 @@ export default function activate({ bus }: ExtensionContext): void {
     process.stdout.write("\x1b8"); // restore cursor
   }
 
-  function showDismissPrompt(): void {
-    process.stdout.write(
-      `\n\x1b[2m  Press Ctrl+] to return\x1b[0m\n`
-    );
-  }
-
   // ── Phase transitions ─────────────────────────────────────
 
-  function activate(): void {
+  function activate_overlay(): void {
     phase = "input";
     buffer = "";
     cursor = 0;
@@ -79,11 +78,14 @@ export default function activate({ bus }: ExtensionContext): void {
     phase = "responding";
     clearInputBar();
 
-    // Hold PTY stdout so vim doesn't redraw over the response
+    // Hold stdout — suppresses both PTY output AND TUI renderer
     bus.emit("shell:stdout-hold", {});
 
-    // Clear screen for response
+    // Clear screen and show query header
+    const cols = process.stdout.columns || 80;
     process.stdout.write("\x1b[2J\x1b[H");
+    process.stdout.write(`${CYAN}${BOLD}❯${RESET} ${query}\n`);
+    process.stdout.write(`${DIM}${"─".repeat(cols)}${RESET}\n`);
 
     bus.emit("agent:submit", { query });
   }
@@ -91,13 +93,13 @@ export default function activate({ bus }: ExtensionContext): void {
   function dismiss(): void {
     if (renderTimer) { clearTimeout(renderTimer); renderTimer = null; }
 
-    const wasResponding = phase === "responding" || phase === "done";
+    const wasActive = phase === "responding" || phase === "done";
     phase = "idle";
     buffer = "";
     cursor = 0;
 
-    if (wasResponding) {
-      // Release PTY stdout
+    if (wasActive) {
+      // Release stdout — TUI renderer and PTY output resume
       bus.emit("shell:stdout-release", {});
 
       // Force the foreground program to redraw (Ctrl+L)
@@ -170,7 +172,7 @@ export default function activate({ bus }: ExtensionContext): void {
 
   // ── Bus wiring ────────────────────────────────────────────
 
-  // Re-render input bar after PTY output (vim redraws over it)
+  // Re-render input bar after PTY output (foreground program redraws over it)
   bus.on("shell:pty-data", () => {
     if (phase !== "input") return;
     if (renderTimer) clearTimeout(renderTimer);
@@ -180,17 +182,42 @@ export default function activate({ bus }: ExtensionContext): void {
     }, 16);
   });
 
+  // Stream response text directly to stdout (TUI renderer is suppressed)
+  bus.on("agent:response-chunk", (e) => {
+    if (phase !== "responding") return;
+    for (const block of e.blocks) {
+      if (block.type === "text" && block.text) {
+        process.stdout.write(block.text);
+      }
+    }
+  });
+
+  // Tool call status — show compact one-liners
+  bus.on("agent:tool-started", (e) => {
+    if (phase !== "responding") return;
+    process.stdout.write(`\n${DIM}▶ ${e.title}${RESET}`);
+    if (e.displayDetail) process.stdout.write(`${DIM} ${e.displayDetail}${RESET}`);
+  });
+
+  bus.on("agent:tool-completed", (e) => {
+    if (phase !== "responding") return;
+    const mark = e.exitCode === 0 ? " ✓" : ` ✗ exit ${e.exitCode}`;
+    process.stdout.write(`${DIM}${mark}${RESET}\n`);
+  });
+
   // When agent finishes, show dismiss prompt
   bus.on("agent:processing-done", () => {
     if (phase === "responding") {
       phase = "done";
-      showDismissPrompt();
+      const cols = process.stdout.columns || 80;
+      process.stdout.write(`\n${DIM}${"─".repeat(cols)}${RESET}\n`);
+      process.stdout.write(`${DIM}  Press Ctrl+] to return${RESET}\n`);
     }
   });
 
   // Intercept input: activate on trigger, capture while active
   bus.onPipe("input:intercept", (payload) => {
-    // During "done" phase, any Ctrl+] or Escape dismisses
+    // Done phase: any dismiss key returns to program
     if (phase === "done") {
       if (payload.data === TRIGGER || payload.data === "\x1b" || payload.data === "\x03") {
         dismiss();
@@ -198,13 +225,13 @@ export default function activate({ bus }: ExtensionContext): void {
       return { ...payload, consumed: true };
     }
 
-    // During input phase, handle editing
+    // Input phase: editing
     if (phase === "input") {
       handleKey(payload.data);
       return { ...payload, consumed: true };
     }
 
-    // During responding phase, only allow Ctrl+C to cancel
+    // Responding phase: only Ctrl+C to cancel agent
     if (phase === "responding") {
       if (payload.data === "\x03") {
         bus.emit("agent:cancel-request", {});
@@ -212,9 +239,9 @@ export default function activate({ bus }: ExtensionContext): void {
       return { ...payload, consumed: true };
     }
 
-    // Idle: check for trigger
+    // Idle: trigger activates overlay
     if (payload.data === TRIGGER) {
-      activate();
+      activate_overlay();
       return { ...payload, consumed: true };
     }
 

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -2,16 +2,10 @@
  * Overlay agent extension.
  *
  * Provides a hotkey (Ctrl+]) to summon the agent from anywhere — even
- * inside vim, htop, or ssh. Renders a full-screen response view by
- * holding stdout (suppresses both PTY and TUI output), then returns
- * to the previous program on dismiss.
+ * inside vim, htop, or ssh. Composites a floating response box on top
+ * of the current terminal content using a headless xterm.js buffer.
  *
- * Flow:
- *   1. Ctrl+] → input bar at bottom of screen
- *   2. Type query, Enter → hold stdout, clear screen, submit
- *   3. Response streams directly to stdout (TUI renderer is suppressed)
- *   4. On completion → "Ctrl+] to dismiss" prompt
- *   5. Ctrl+] → release stdout, Ctrl+L to PTY to force program redraw
+ * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  *
  * Usage:
  *   agent-sh -e ./examples/extensions/overlay-agent.ts
@@ -19,94 +13,232 @@
  *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
  *   cp examples/extensions/overlay-agent.ts ~/.agent-sh/extensions/
  */
+import { createRequire } from "module";
 import type { ExtensionContext } from "agent-sh/types";
+
+const require = createRequire(import.meta.url);
+const { Terminal } = require("@xterm/headless") as typeof import("@xterm/headless");
+const { SerializeAddon } = require("@xterm/addon-serialize") as typeof import("@xterm/addon-serialize");
 
 const TRIGGER = "\x1d"; // Ctrl+]
 const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
 const CYAN = "\x1b[36m";
+const INVERSE = "\x1b[7m";
+
+// Synchronized output (prevents flicker)
+const SYNC_START = "\x1b[?2026h";
+const SYNC_END = "\x1b[?2026l";
 
 type Phase = "idle" | "input" | "responding" | "done";
 
-export default function activate({ bus }: ExtensionContext): void {
+/** Strip all ANSI escape sequences. */
+function stripAnsi(str: string): string {
+  return str
+    .replace(/\x1b\][^\x07]*\x07/g, "")
+    .replace(/\x1b\[[^m]*m/g, "")
+    .replace(/\x1b\[\?[^a-zA-Z]*[a-zA-Z]/g, "")
+    .replace(/\x1b\[[^a-zA-Z]*[a-zA-Z]/g, "")
+    .replace(/\r/g, "");
+}
+
+export default function activate({ bus, advise }: ExtensionContext): void {
+  // ── Headless terminal (shared with terminal-buffer context) ──
+  const term = new Terminal({
+    cols: process.stdout.columns || 80,
+    rows: process.stdout.rows || 24,
+    allowProposedApi: true,
+    scrollback: 200,
+  });
+  const serialize = new SerializeAddon();
+  term.loadAddon(serialize);
+
+  bus.on("shell:pty-data", ({ raw }) => { term.write(raw); });
+
+  // Also inject clean buffer into agent context (like terminal-buffer.ts)
+  advise("context:build-extra", (next: () => string) => {
+    const base = next();
+    const raw = serialize.serialize().trim();
+    if (!raw) return base;
+    const clean = stripAnsi(raw).trim();
+    if (!clean) return base;
+    const lines = clean.split("\n");
+    const capped = lines.length > 80 ? lines.slice(-80).join("\n") : clean;
+    const isAlt = term.buffer.active.type === "alternate";
+    const header = isAlt ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
+    const section = `${header}\n${capped}\n</terminal_buffer>`;
+    return base ? base + "\n" + section : section;
+  });
+
+  // ── Overlay state ─────────────────────────────────────────
   let phase: Phase = "idle";
-  let buffer = "";
-  let cursor = 0;
+  let inputBuffer = "";
+  let inputCursor = 0;
   let renderTimer: ReturnType<typeof setTimeout> | null = null;
+  let responseLines: string[] = [];
+  let currentResponseLine = "";
+  let scrollOffset = 0;
 
-  // ── Input bar rendering ───────────────────────────────────
+  // ── Screen snapshot & compositing ─────────────────────────
 
-  function renderInputBar(): void {
-    const cols = process.stdout.columns || 80;
+  function getScreenLines(): string[] {
+    const raw = serialize.serialize();
+    const lines = stripAnsi(raw).split("\n");
     const rows = process.stdout.rows || 24;
-
-    process.stdout.write("\x1b7"); // save cursor
-    process.stdout.write(`\x1b[${rows};1H`); // move to bottom
-
-    const label = "\x1b[7m agent \x1b[0m ";
-    const maxInput = cols - 9;
-    const displayBuf = buffer.length > maxInput
-      ? buffer.slice(buffer.length - maxInput)
-      : buffer;
-
-    process.stdout.write("\x1b[2K" + label + displayBuf);
-
-    const displayCursor = cursor - (buffer.length - displayBuf.length);
-    process.stdout.write(`\x1b[${rows};${9 + displayCursor}H`);
+    // Pad or trim to exactly terminal height
+    while (lines.length < rows) lines.push("");
+    return lines.slice(0, rows);
   }
 
-  function clearInputBar(): void {
+  function compositeAndRender(): void {
+    const cols = process.stdout.columns || 80;
     const rows = process.stdout.rows || 24;
-    process.stdout.write(`\x1b[${rows};1H\x1b[2K`);
-    process.stdout.write("\x1b8"); // restore cursor
+    const bgLines = getScreenLines();
+
+    // Box dimensions
+    const boxW = Math.min(cols - 4, 100);
+    const boxH = Math.min(rows - 4, Math.max(8, Math.floor(rows * 0.6)));
+    const boxTop = Math.floor((rows - boxH) / 2);
+    const boxLeft = Math.floor((cols - boxW) / 2);
+
+    // Box content: response lines with scroll
+    const contentH = boxH - 2; // minus top/bottom border
+    const totalContent = responseLines.length;
+    // Auto-scroll to bottom
+    if (totalContent > contentH) {
+      scrollOffset = totalContent - contentH;
+    }
+    const visibleContent = responseLines.slice(scrollOffset, scrollOffset + contentH);
+
+    // Build the composited frame
+    const out: string[] = [SYNC_START, `\x1b[H`]; // home cursor
+
+    for (let row = 0; row < rows; row++) {
+      const bgLine = (bgLines[row] || "").padEnd(cols).slice(0, cols);
+      const relRow = row - boxTop;
+
+      if (relRow < 0 || relRow >= boxH) {
+        // Background row — render dimmed
+        out.push(`${DIM}${bgLine}${RESET}`);
+      } else if (relRow === 0) {
+        // Top border
+        const title = phase === "input" ? " agent " : phase === "done" ? " done " : " ... ";
+        const titleStr = `${INVERSE}${title}${RESET}`;
+        const borderAfter = boxW - title.length - 1;
+        const border = "─" + "─".repeat(title.length > 0 ? 0 : boxW - 2) + "─";
+        // Compose: dim bg left, box border, dim bg right
+        const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
+        const boxBorder = `╭${"─".repeat(boxW - 2)}╮`;
+        // Overlay title in the border
+        const titleInBorder = `╭─${titleStr}${"─".repeat(Math.max(0, boxW - title.length - 3))}╮`;
+        const right = `${DIM}${bgLine.slice(boxLeft + boxW)}${RESET}`;
+        out.push(left + titleInBorder + right);
+      } else if (relRow === boxH - 1) {
+        // Bottom border
+        const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
+        let footer = "";
+        if (phase === "done") {
+          footer = ` Ctrl+] to return `;
+        } else if (phase === "responding") {
+          footer = ` streaming... `;
+        } else if (phase === "input") {
+          footer = ` Enter to send, Esc to cancel `;
+        }
+        const footerPad = Math.max(0, boxW - footer.length - 3);
+        const boxBorder = `╰${"─".repeat(footerPad)}${DIM}${footer}${RESET}${"─"}╯`;
+        const right = `${DIM}${bgLine.slice(boxLeft + boxW)}${RESET}`;
+        out.push(left + boxBorder + right);
+      } else {
+        // Content row
+        const contentIdx = relRow - 1;
+        let content = "";
+        if (phase === "input") {
+          if (contentIdx === 0) {
+            content = `${CYAN}❯${RESET} ${inputBuffer}`;
+          }
+        } else {
+          content = visibleContent[contentIdx] || "";
+        }
+        // Truncate content to box width
+        const plainContent = stripAnsi(content);
+        const contentW = boxW - 4; // 2 border + 2 padding
+        const displayContent = plainContent.length > contentW
+          ? content.slice(0, contentW - 1) + "…"
+          : content;
+        const pad = Math.max(0, contentW - stripAnsi(displayContent).length);
+
+        const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
+        const boxLine = `│ ${displayContent}${" ".repeat(pad)} │`;
+        const right = `${DIM}${bgLine.slice(boxLeft + boxW)}${RESET}`;
+        out.push(left + boxLine + right);
+      }
+    }
+
+    out.push(SYNC_END);
+
+    // Position cursor for input
+    if (phase === "input") {
+      const cursorRow = boxTop + 1;
+      const cursorCol = boxLeft + 4 + inputCursor; // "│ ❯ " = 4 chars
+      out.push(`\x1b[${cursorRow + 1};${cursorCol + 1}H`);
+    }
+
+    process.stdout.write(out.join("\x1b[K\n").replace(/\n$/, ""));
+  }
+
+  function restoreScreen(): void {
+    // Re-render the original screen from the buffer
+    const bgLines = getScreenLines();
+    const rows = process.stdout.rows || 24;
+    const out = [SYNC_START, `\x1b[H`];
+    for (let row = 0; row < rows; row++) {
+      out.push(bgLines[row] || "");
+    }
+    out.push(SYNC_END);
+    process.stdout.write(out.join("\x1b[K\n").replace(/\n$/, ""));
   }
 
   // ── Phase transitions ─────────────────────────────────────
 
-  function activate_overlay(): void {
+  function activateOverlay(): void {
     phase = "input";
-    buffer = "";
-    cursor = 0;
-    renderInputBar();
+    inputBuffer = "";
+    inputCursor = 0;
+    responseLines = [];
+    currentResponseLine = "";
+    scrollOffset = 0;
+
+    // Hold stdout — suppresses PTY and TUI
+    bus.emit("shell:stdout-hold", {});
+    compositeAndRender();
   }
 
   function submit(): void {
-    const query = buffer.trim();
+    const query = inputBuffer.trim();
     if (!query) { dismiss(); return; }
 
     phase = "responding";
-    clearInputBar();
+    responseLines = [`${CYAN}${BOLD}❯${RESET} ${query}`, ""];
+    currentResponseLine = "";
+    scrollOffset = 0;
 
-    // Hold stdout — suppresses both PTY output AND TUI renderer
-    bus.emit("shell:stdout-hold", {});
-
-    // Clear screen and show query header
-    const cols = process.stdout.columns || 80;
-    process.stdout.write("\x1b[2J\x1b[H");
-    process.stdout.write(`${CYAN}${BOLD}❯${RESET} ${query}\n`);
-    process.stdout.write(`${DIM}${"─".repeat(cols)}${RESET}\n`);
-
+    compositeAndRender();
     bus.emit("agent:submit", { query });
   }
 
   function dismiss(): void {
     if (renderTimer) { clearTimeout(renderTimer); renderTimer = null; }
-
-    const wasActive = phase === "responding" || phase === "done";
     phase = "idle";
-    buffer = "";
-    cursor = 0;
+    inputBuffer = "";
+    inputCursor = 0;
 
-    if (wasActive) {
-      // Release stdout — TUI renderer and PTY output resume
-      bus.emit("shell:stdout-release", {});
+    // Restore screen from buffer then release
+    restoreScreen();
+    bus.emit("shell:stdout-release", {});
 
-      // Force the foreground program to redraw (Ctrl+L)
-      bus.emit("shell:pty-write", { data: "\x0c" });
-    } else {
-      clearInputBar();
-    }
+    // Force foreground program to redraw
+    bus.emit("shell:pty-write", { data: "\x0c" });
   }
 
   // ── Input handling ────────────────────────────────────────
@@ -117,14 +249,10 @@ export default function activate({ bus }: ExtensionContext): void {
       const ch = data[i]!;
       const code = ch.charCodeAt(0);
 
-      // Escape (bare) → cancel
       if (ch === "\x1b" && data[i + 1] == null) { dismiss(); return; }
-      // Ctrl+] → cancel
       if (ch === TRIGGER) { dismiss(); return; }
-      // Ctrl+C → cancel
       if (code === 0x03) { dismiss(); return; }
 
-      // Escape sequence → arrows
       if (ch === "\x1b") {
         i++;
         const next = data[i];
@@ -132,119 +260,107 @@ export default function activate({ bus }: ExtensionContext): void {
           i++;
           while (i < data.length && data.charCodeAt(i) >= 0x20 && data.charCodeAt(i) < 0x40) i++;
           const final = data[i]; i++;
-          if (final === "C" && cursor < buffer.length) { cursor++; renderInputBar(); }
-          if (final === "D" && cursor > 0) { cursor--; renderInputBar(); }
-          if (final === "H") { cursor = 0; renderInputBar(); }
-          if (final === "F") { cursor = buffer.length; renderInputBar(); }
+          if (final === "C" && inputCursor < inputBuffer.length) { inputCursor++; compositeAndRender(); }
+          if (final === "D" && inputCursor > 0) { inputCursor--; compositeAndRender(); }
         } else { i++; }
         continue;
       }
 
-      // Enter → submit
       if (ch === "\r") { submit(); return; }
 
-      // Backspace
       if (ch === "\x7f" || ch === "\b") {
-        if (cursor > 0) {
-          buffer = buffer.slice(0, cursor - 1) + buffer.slice(cursor);
-          cursor--;
-          renderInputBar();
+        if (inputCursor > 0) {
+          inputBuffer = inputBuffer.slice(0, inputCursor - 1) + inputBuffer.slice(inputCursor);
+          inputCursor--;
+          compositeAndRender();
         }
         i++; continue;
       }
 
-      // Readline shortcuts
-      if (code === 0x01) { cursor = 0; renderInputBar(); i++; continue; }
-      if (code === 0x05) { cursor = buffer.length; renderInputBar(); i++; continue; }
-      if (code === 0x15) { buffer = ""; cursor = 0; renderInputBar(); i++; continue; }
-      if (code === 0x0b) { buffer = buffer.slice(0, cursor); renderInputBar(); i++; continue; }
-
-      // Other control → ignore
+      if (code === 0x01) { inputCursor = 0; compositeAndRender(); i++; continue; }
+      if (code === 0x05) { inputCursor = inputBuffer.length; compositeAndRender(); i++; continue; }
+      if (code === 0x15) { inputBuffer = ""; inputCursor = 0; compositeAndRender(); i++; continue; }
       if (code < 0x20) { i++; continue; }
 
-      // Printable
-      buffer = buffer.slice(0, cursor) + ch + buffer.slice(cursor);
-      cursor++;
-      renderInputBar();
+      inputBuffer = inputBuffer.slice(0, inputCursor) + ch + inputBuffer.slice(inputCursor);
+      inputCursor++;
+      compositeAndRender();
       i++;
     }
   }
 
   // ── Bus wiring ────────────────────────────────────────────
 
-  // Re-render input bar after PTY output (foreground program redraws over it)
-  bus.on("shell:pty-data", () => {
-    if (phase !== "input") return;
-    if (renderTimer) clearTimeout(renderTimer);
-    renderTimer = setTimeout(() => {
-      renderTimer = null;
-      if (phase === "input") renderInputBar();
-    }, 16);
-  });
-
-  // Stream response text directly to stdout (TUI renderer is suppressed)
   bus.on("agent:response-chunk", (e) => {
     if (phase !== "responding") return;
     for (const block of e.blocks) {
       if (block.type === "text" && block.text) {
-        process.stdout.write(block.text);
+        for (const ch of block.text) {
+          if (ch === "\n") {
+            responseLines.push(currentResponseLine);
+            currentResponseLine = "";
+          } else {
+            currentResponseLine += ch;
+          }
+        }
       }
     }
+    // Debounce re-render for streaming
+    if (renderTimer) clearTimeout(renderTimer);
+    renderTimer = setTimeout(() => {
+      renderTimer = null;
+      // Include current partial line for display
+      const displayLines = [...responseLines, currentResponseLine];
+      const savedLines = responseLines;
+      responseLines = displayLines;
+      compositeAndRender();
+      responseLines = savedLines;
+    }, 32);
   });
 
-  // Tool call status — show compact one-liners
   bus.on("agent:tool-started", (e) => {
     if (phase !== "responding") return;
-    process.stdout.write(`\n${DIM}▶ ${e.title}${RESET}`);
-    if (e.displayDetail) process.stdout.write(`${DIM} ${e.displayDetail}${RESET}`);
+    if (currentResponseLine) { responseLines.push(currentResponseLine); currentResponseLine = ""; }
+    responseLines.push(`▶ ${e.title}${e.displayDetail ? " " + e.displayDetail : ""}`);
+    compositeAndRender();
   });
 
   bus.on("agent:tool-completed", (e) => {
     if (phase !== "responding") return;
     const mark = e.exitCode === 0 ? " ✓" : ` ✗ exit ${e.exitCode}`;
-    process.stdout.write(`${DIM}${mark}${RESET}\n`);
+    if (responseLines.length > 0) {
+      responseLines[responseLines.length - 1] += mark;
+    }
+    compositeAndRender();
   });
 
-  // When agent finishes, show dismiss prompt
   bus.on("agent:processing-done", () => {
     if (phase === "responding") {
+      if (currentResponseLine) { responseLines.push(currentResponseLine); currentResponseLine = ""; }
       phase = "done";
-      const cols = process.stdout.columns || 80;
-      process.stdout.write(`\n${DIM}${"─".repeat(cols)}${RESET}\n`);
-      process.stdout.write(`${DIM}  Press Ctrl+] to return${RESET}\n`);
+      compositeAndRender();
     }
   });
 
-  // Intercept input: activate on trigger, capture while active
   bus.onPipe("input:intercept", (payload) => {
-    // Done phase: any dismiss key returns to program
     if (phase === "done") {
       if (payload.data === TRIGGER || payload.data === "\x1b" || payload.data === "\x03") {
         dismiss();
       }
       return { ...payload, consumed: true };
     }
-
-    // Input phase: editing
     if (phase === "input") {
       handleKey(payload.data);
       return { ...payload, consumed: true };
     }
-
-    // Responding phase: only Ctrl+C to cancel agent
     if (phase === "responding") {
-      if (payload.data === "\x03") {
-        bus.emit("agent:cancel-request", {});
-      }
+      if (payload.data === "\x03") bus.emit("agent:cancel-request", {});
       return { ...payload, consumed: true };
     }
-
-    // Idle: trigger activates overlay
     if (payload.data === TRIGGER) {
-      activate_overlay();
+      activateOverlay();
       return { ...payload, consumed: true };
     }
-
     return payload;
   });
 }

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -3,7 +3,7 @@
  *
  * Provides a hotkey (Ctrl+\) to summon the agent from anywhere — even
  * inside vim, htop, or ssh. Composites a floating response box on top
- * of the current terminal content using a headless xterm.js buffer.
+ * of the current terminal content.
  *
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  *
@@ -13,378 +13,65 @@
  *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
  *   cp examples/extensions/overlay-agent.ts ~/.agent-sh/extensions/
  */
-import { createRequire } from "module";
 import type { ExtensionContext } from "agent-sh/types";
 
-const require = createRequire(import.meta.url);
-const { Terminal } = require("@xterm/headless") as typeof import("@xterm/headless");
-const { SerializeAddon } = require("@xterm/addon-serialize") as typeof import("@xterm/addon-serialize");
-
-const TRIGGER = "\x1c"; // Ctrl+\
-const DIM = "\x1b[2m";
-const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
 const CYAN = "\x1b[36m";
-const INVERSE = "\x1b[7m";
+const RESET = "\x1b[0m";
 
-// Synchronized output (prevents flicker)
-const SYNC_START = "\x1b[?2026h";
-const SYNC_END = "\x1b[?2026l";
-
-type Phase = "idle" | "input" | "responding" | "done";
-
-/** Strip all ANSI escape sequences. */
-function stripAnsi(str: string): string {
-  return str
-    .replace(/\x1b\][^\x07]*\x07/g, "")
-    .replace(/\x1b\[[^m]*m/g, "")
-    .replace(/\x1b\[\?[^a-zA-Z]*[a-zA-Z]/g, "")
-    .replace(/\x1b\[[^a-zA-Z]*[a-zA-Z]/g, "")
-    .replace(/\r/g, "");
-}
-
-export default function activate({ bus, advise }: ExtensionContext): void {
-  // ── Headless terminal (shared with terminal-buffer context) ──
-  const term = new Terminal({
-    cols: process.stdout.columns || 80,
-    rows: process.stdout.rows || 24,
-    allowProposedApi: true,
-    scrollback: 200,
-  });
-  const serialize = new SerializeAddon();
-  term.loadAddon(serialize);
-
-  bus.on("shell:pty-data", ({ raw }) => { term.write(raw); });
-
-  // Also inject clean buffer into agent context (like terminal-buffer.ts)
-  advise("context:build-extra", (next: () => string) => {
-    const base = next();
-    const raw = serialize.serialize().trim();
-    if (!raw) return base;
-    const clean = stripAnsi(raw).trim();
-    if (!clean) return base;
-    const lines = clean.split("\n");
-    const capped = lines.length > 80 ? lines.slice(-80).join("\n") : clean;
-    const isAlt = term.buffer.active.type === "alternate";
-    const header = isAlt ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
-    const section = `${header}\n${capped}\n</terminal_buffer>`;
-    return base ? base + "\n" + section : section;
+export default function activate({ bus, advise, createFloatingPanel, terminalBuffer }: ExtensionContext): void {
+  const panel = createFloatingPanel({
+    trigger: "\x1c", // Ctrl+\
+    dimBackground: true,
+    autoDismissMs: 2000,
   });
 
-  // ── Overlay state ─────────────────────────────────────────
-  let phase: Phase = "idle";
-  let inputBuffer = "";
-  let inputCursor = 0;
-  let renderTimer: ReturnType<typeof setTimeout> | null = null;
-  let responseLines: string[] = [];
-  let currentResponseLine = "";
-  let scrollOffset = 0;
-
-  // ── Screen snapshot & compositing ─────────────────────────
-
-  function getScreenLines(): string[] {
-    const raw = serialize.serialize();
-    const lines = stripAnsi(raw).split("\n");
-    const rows = process.stdout.rows || 24;
-    // Pad or trim to exactly terminal height
-    while (lines.length < rows) lines.push("");
-    return lines.slice(0, rows);
+  // ── Inject terminal buffer into agent context ──────────────
+  if (terminalBuffer) {
+    advise("context:build-extra", (next: () => string) => {
+      const base = next();
+      const screen = terminalBuffer.readScreen();
+      const clean = screen.text.trim();
+      if (!clean) return base;
+      const lines = clean.split("\n");
+      const capped = lines.length > 80 ? lines.slice(-80).join("\n") : clean;
+      const header = screen.altScreen ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
+      const section = `${header}\n${capped}\n</terminal_buffer>`;
+      return base ? base + "\n" + section : section;
+    });
   }
 
-  function compositeAndRender(): void {
-    const cols = process.stdout.columns || 80;
-    const rows = process.stdout.rows || 24;
-    const bgLines = getScreenLines();
-
-    // Box dimensions
-    const boxW = Math.min(cols - 4, 100);
-    const boxH = Math.min(rows - 4, Math.max(8, Math.floor(rows * 0.6)));
-    const boxTop = Math.floor((rows - boxH) / 2);
-    const boxLeft = Math.floor((cols - boxW) / 2);
-
-    // Box content: response lines with scroll
-    const contentH = boxH - 2; // minus top/bottom border
-    const totalContent = responseLines.length;
-    // Auto-scroll to bottom
-    if (totalContent > contentH) {
-      scrollOffset = totalContent - contentH;
-    }
-    const visibleContent = responseLines.slice(scrollOffset, scrollOffset + contentH);
-
-    // Build the composited frame — use absolute cursor positioning per row
-    const out: string[] = [SYNC_START];
-
-    for (let row = 0; row < rows; row++) {
-      out.push(`\x1b[${row + 1};1H`); // move to row (1-indexed)
-      const bgLine = (bgLines[row] || "").padEnd(cols).slice(0, cols);
-      const relRow = row - boxTop;
-
-      if (relRow < 0 || relRow >= boxH) {
-        // Background row — render dimmed
-        out.push(`${DIM}${bgLine}${RESET}\x1b[K`);
-      } else if (relRow === 0) {
-        // Top border
-        const title = phase === "input" ? " agent " : phase === "done" ? " done " : " ... ";
-        const titleStr = `${INVERSE}${title}${RESET}`;
-        const borderAfter = boxW - title.length - 1;
-        const border = "─" + "─".repeat(title.length > 0 ? 0 : boxW - 2) + "─";
-        // Compose: dim bg left, box border, dim bg right
-        const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
-        const boxBorder = `╭${"─".repeat(boxW - 2)}╮`;
-        // Overlay title in the border
-        const titleInBorder = `╭─${titleStr}${"─".repeat(Math.max(0, boxW - title.length - 3))}╮`;
-        const right = `${DIM}${bgLine.slice(boxLeft + boxW)}${RESET}`;
-        out.push(left + titleInBorder + right);
-      } else if (relRow === boxH - 1) {
-        // Bottom border
-        const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
-        let footer = "";
-        if (phase === "done") {
-          footer = ` Ctrl+\ to return `;
-        } else if (phase === "responding") {
-          footer = ` streaming... `;
-        } else if (phase === "input") {
-          footer = ` Enter to send, Esc to cancel `;
-        }
-        const footerPad = Math.max(0, boxW - footer.length - 3);
-        const boxBorder = `╰${"─".repeat(footerPad)}${DIM}${footer}${RESET}${"─"}╯`;
-        const right = `${DIM}${bgLine.slice(boxLeft + boxW)}${RESET}`;
-        out.push(left + boxBorder + right);
-      } else {
-        // Content row
-        const contentIdx = relRow - 1;
-        let content = "";
-        if (phase === "input") {
-          if (contentIdx === 0) {
-            content = `${CYAN}❯${RESET} ${inputBuffer}`;
-          }
-        } else {
-          content = visibleContent[contentIdx] || "";
-        }
-        // Truncate content to box width
-        const plainContent = stripAnsi(content);
-        const contentW = boxW - 4; // 2 border + 2 padding
-        const displayContent = plainContent.length > contentW
-          ? content.slice(0, contentW - 1) + "…"
-          : content;
-        const pad = Math.max(0, contentW - stripAnsi(displayContent).length);
-
-        const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
-        const boxLine = `│ ${displayContent}${" ".repeat(pad)} │`;
-        const right = `${DIM}${bgLine.slice(boxLeft + boxW)}${RESET}`;
-        out.push(left + boxLine + right);
-      }
-    }
-
-    // Position cursor for input
-    if (phase === "input") {
-      const cursorRow = boxTop + 1;
-      const cursorCol = boxLeft + 4 + inputCursor; // "│ ❯ " = 4 chars
-      out.push(`\x1b[${cursorRow + 1};${cursorCol + 1}H`);
-    }
-
-    out.push(SYNC_END);
-
-    // Write using absolute cursor positioning per row — no \n to avoid scrollback pollution
-    process.stdout.write(out.join(""));
-  }
-
-  function restoreScreen(): void {
-    // Leave alternate screen buffer — restores the OLD main buffer.
-    process.stdout.write("\x1b[?1049l");
-
-    // The main buffer is stale (frozen when we entered alt screen).
-    // Any PTY output that happened while the overlay was active only
-    // went to the alt screen. Redraw with the current terminal state
-    // from our headless xterm.js buffer so the user sees up-to-date content.
-    const content = serialize.serialize();
-    const cursorY = term.buffer.active.cursorY;
-    const cursorX = term.buffer.active.cursorX;
-    process.stdout.write(
-      "\x1b[H\x1b[2J" + content +
-      `\x1b[${cursorY + 1};${cursorX + 1}H`
-    );
-  }
-
-  // ── Phase transitions ─────────────────────────────────────
-
-  function activateOverlay(): void {
-    phase = "input";
-    inputBuffer = "";
-    inputCursor = 0;
-    responseLines = [];
-    currentResponseLine = "";
-    scrollOffset = 0;
-
-    // Hold stdout — suppresses PTY and TUI
-    bus.emit("shell:stdout-hold", {});
-
-    // Switch to alternate screen buffer — nothing we draw here
-    // affects the main terminal or scrollback. On dismiss, the
-    // terminal automatically restores the original screen.
-    process.stdout.write("\x1b[?1049h");
-
-    compositeAndRender();
-  }
-
-  function submit(): void {
-    const query = inputBuffer.trim();
-    if (!query) { dismiss(); return; }
-
-    phase = "responding";
-    responseLines = [`${CYAN}${BOLD}❯${RESET} ${query}`, ""];
-    currentResponseLine = "";
-    scrollOffset = 0;
-
-    compositeAndRender();
+  // ── Panel lifecycle ────────────────────────────────────────
+  panel.handlers.advise("panel:submit", (_next, query: string) => {
+    panel.setActive();
+    panel.appendLine(`${CYAN}${BOLD}❯${RESET} ${query}`);
+    panel.appendLine("");
     bus.emit("agent:submit", { query });
-  }
+  });
 
-  function dismiss(): void {
-    if (renderTimer) { clearTimeout(renderTimer); renderTimer = null; }
-    phase = "idle";
-    inputBuffer = "";
-    inputCursor = 0;
-
-    // Leave alternate screen and redraw with current terminal state
-    restoreScreen();
-
-    // Reset any accumulated stdout-show refs from terminal_keys
-    bus.emit("shell:stdout-hide", {});
-    bus.emit("shell:stdout-release", {});
-  }
-
-  // ── Input handling ────────────────────────────────────────
-
-  function handleKey(data: string): void {
-    let i = 0;
-    while (i < data.length) {
-      const ch = data[i]!;
-      const code = ch.charCodeAt(0);
-
-      if (ch === "\x1b" && data[i + 1] == null) { dismiss(); return; }
-      if (ch === TRIGGER) { dismiss(); return; }
-      if (code === 0x03) { dismiss(); return; }
-
-      if (ch === "\x1b") {
-        i++;
-        const next = data[i];
-        if (next === "[" || next === "O") {
-          i++;
-          while (i < data.length && data.charCodeAt(i) >= 0x20 && data.charCodeAt(i) < 0x40) i++;
-          const final = data[i]; i++;
-          if (final === "C" && inputCursor < inputBuffer.length) { inputCursor++; compositeAndRender(); }
-          if (final === "D" && inputCursor > 0) { inputCursor--; compositeAndRender(); }
-        } else { i++; }
-        continue;
-      }
-
-      if (ch === "\r") { submit(); return; }
-
-      if (ch === "\x7f" || ch === "\b") {
-        if (inputCursor > 0) {
-          inputBuffer = inputBuffer.slice(0, inputCursor - 1) + inputBuffer.slice(inputCursor);
-          inputCursor--;
-          compositeAndRender();
-        }
-        i++; continue;
-      }
-
-      if (code === 0x01) { inputCursor = 0; compositeAndRender(); i++; continue; }
-      if (code === 0x05) { inputCursor = inputBuffer.length; compositeAndRender(); i++; continue; }
-      if (code === 0x15) { inputBuffer = ""; inputCursor = 0; compositeAndRender(); i++; continue; }
-      if (code < 0x20) { i++; continue; }
-
-      inputBuffer = inputBuffer.slice(0, inputCursor) + ch + inputBuffer.slice(inputCursor);
-      inputCursor++;
-      compositeAndRender();
-      i++;
-    }
-  }
-
-  // ── Bus wiring ────────────────────────────────────────────
-
+  // ── Stream agent response into panel ───────────────────────
   bus.on("agent:response-chunk", (e) => {
-    if (phase !== "responding") return;
+    if (!panel.active) return;
     for (const block of e.blocks) {
       if (block.type === "text" && block.text) {
-        for (const ch of block.text) {
-          if (ch === "\n") {
-            responseLines.push(currentResponseLine);
-            currentResponseLine = "";
-          } else {
-            currentResponseLine += ch;
-          }
-        }
+        panel.appendText(block.text);
       }
     }
-    // Debounce re-render for streaming
-    if (renderTimer) clearTimeout(renderTimer);
-    renderTimer = setTimeout(() => {
-      renderTimer = null;
-      // Include current partial line for display
-      const displayLines = [...responseLines, currentResponseLine];
-      const savedLines = responseLines;
-      responseLines = displayLines;
-      compositeAndRender();
-      responseLines = savedLines;
-    }, 32);
   });
 
   bus.on("agent:tool-started", (e) => {
-    if (phase !== "responding") return;
-    if (currentResponseLine) { responseLines.push(currentResponseLine); currentResponseLine = ""; }
-    responseLines.push(`▶ ${e.title}${e.displayDetail ? " " + e.displayDetail : ""}`);
-    compositeAndRender();
+    if (!panel.active) return;
+    panel.appendLine(`▶ ${e.title}${e.displayDetail ? " " + e.displayDetail : ""}`);
   });
 
   bus.on("agent:tool-completed", (e) => {
-    if (phase !== "responding") return;
+    if (!panel.active) return;
     const mark = e.exitCode === 0 ? " ✓" : ` ✗ exit ${e.exitCode}`;
-    if (responseLines.length > 0) {
-      responseLines[responseLines.length - 1] += mark;
-    }
-    compositeAndRender();
+    panel.updateLastLine((line) => line + mark);
   });
 
   bus.on("agent:processing-done", () => {
-    if (phase === "responding") {
-      // Flush any partial response line
-      if (currentResponseLine) { responseLines.push(currentResponseLine); currentResponseLine = ""; }
-      // Show final response, then auto-dismiss after brief pause
-      phase = "done";
-      compositeAndRender();
-      // Any keypress also dismisses (see input:intercept "done" handler)
-      setTimeout(() => {
-        if (phase === "done") dismiss();
-      }, 2000);
-    }
-  });
-
-  // Suppress Shell's freshPrompt \n when overlay is active — it would
-  // feed into whatever foreground program is running (e.g. Python input()).
-  bus.onPipe("shell:redraw-prompt", (payload) => {
-    if (phase !== "idle") return { ...payload, handled: true };
-    return payload;
-  });
-
-  bus.onPipe("input:intercept", (payload) => {
-    if (phase === "done") {
-      dismiss();
-      return { ...payload, consumed: true };
-    }
-    if (phase === "input") {
-      handleKey(payload.data);
-      return { ...payload, consumed: true };
-    }
-    if (phase === "responding") {
-      if (payload.data === "\x03") bus.emit("agent:cancel-request", {});
-      return { ...payload, consumed: true };
-    }
-    if (payload.data === TRIGGER) {
-      activateOverlay();
-      return { ...payload, consumed: true };
-    }
-    return payload;
+    if (!panel.active) return;
+    panel.setDone();
   });
 }

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -190,9 +190,20 @@ export default function activate({ bus, advise }: ExtensionContext): void {
   }
 
   function restoreScreen(): void {
-    // Leave alternate screen buffer — terminal automatically restores
-    // the original screen content (vim, shell, whatever was running)
+    // Leave alternate screen buffer — restores the OLD main buffer.
     process.stdout.write("\x1b[?1049l");
+
+    // The main buffer is stale (frozen when we entered alt screen).
+    // Any PTY output that happened while the overlay was active only
+    // went to the alt screen. Redraw with the current terminal state
+    // from our headless xterm.js buffer so the user sees up-to-date content.
+    const content = serialize.serialize();
+    const cursorY = term.buffer.active.cursorY;
+    const cursorX = term.buffer.active.cursorX;
+    process.stdout.write(
+      "\x1b[H\x1b[2J" + content +
+      `\x1b[${cursorY + 1};${cursorX + 1}H`
+    );
   }
 
   // ── Phase transitions ─────────────────────────────────────
@@ -235,8 +246,11 @@ export default function activate({ bus, advise }: ExtensionContext): void {
     inputBuffer = "";
     inputCursor = 0;
 
-    // Leave alternate screen — terminal restores the original screen
+    // Leave alternate screen and redraw with current terminal state
     restoreScreen();
+
+    // Reset any accumulated stdout-show refs from terminal_keys
+    bus.emit("shell:stdout-hide", {});
     bus.emit("shell:stdout-release", {});
   }
 
@@ -335,17 +349,28 @@ export default function activate({ bus, advise }: ExtensionContext): void {
 
   bus.on("agent:processing-done", () => {
     if (phase === "responding") {
+      // Flush any partial response line
       if (currentResponseLine) { responseLines.push(currentResponseLine); currentResponseLine = ""; }
+      // Show final response, then auto-dismiss after brief pause
       phase = "done";
       compositeAndRender();
+      // Any keypress also dismisses (see input:intercept "done" handler)
+      setTimeout(() => {
+        if (phase === "done") dismiss();
+      }, 2000);
     }
+  });
+
+  // Suppress Shell's freshPrompt \n when overlay is active — it would
+  // feed into whatever foreground program is running (e.g. Python input()).
+  bus.onPipe("shell:redraw-prompt", (payload) => {
+    if (phase !== "idle") return { ...payload, handled: true };
+    return payload;
   });
 
   bus.onPipe("input:intercept", (payload) => {
     if (phase === "done") {
-      if (payload.data === TRIGGER || payload.data === "\x1b" || payload.data === "\x03") {
-        dismiss();
-      }
+      dismiss();
       return { ...payload, consumed: true };
     }
     if (phase === "input") {

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -2,9 +2,15 @@
  * Overlay agent extension.
  *
  * Provides a hotkey (Ctrl+]) to summon the agent from anywhere — even
- * inside vim, htop, or ssh. Renders a minimal input bar at the bottom
- * of the terminal, captures keystrokes via `input:intercept`, and
- * dispatches the query via the bus.
+ * inside vim, htop, or ssh. Renders a full-screen response view,
+ * then returns to the previous program on dismiss.
+ *
+ * Flow:
+ *   1. Ctrl+] → input bar at bottom of screen
+ *   2. Type query, Enter → clear screen, hold PTY stdout, submit
+ *   3. Agent response renders on the clear screen (TUI renderer)
+ *   4. On completion → "Ctrl+] to dismiss" prompt
+ *   5. Ctrl+] → release stdout, force program redraw (Ctrl+L to PTY)
  *
  * Usage:
  *   agent-sh -e ./examples/extensions/overlay-agent.ts
@@ -16,47 +22,89 @@ import type { ExtensionContext } from "agent-sh/types";
 
 const TRIGGER = "\x1d"; // Ctrl+]
 
+type Phase = "idle" | "input" | "responding" | "done";
+
 export default function activate({ bus }: ExtensionContext): void {
-  let active = false;
+  let phase: Phase = "idle";
   let buffer = "";
   let cursor = 0;
+  let renderTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // ── Rendering ─────────────────────────────────────────────
+  // ── Input bar rendering ───────────────────────────────────
 
-  function render(): void {
+  function renderInputBar(): void {
     const cols = process.stdout.columns || 80;
     const rows = process.stdout.rows || 24;
 
-    // Save cursor, move to bottom row
-    process.stdout.write("\x1b7");
-    process.stdout.write(`\x1b[${rows};1H`);
+    process.stdout.write("\x1b7"); // save cursor
+    process.stdout.write(`\x1b[${rows};1H`); // move to bottom
 
-    // Clear the line and draw the input bar
     const label = "\x1b[7m agent \x1b[0m ";
-    const maxInput = cols - 9; // " agent " + space + padding
+    const maxInput = cols - 9;
     const displayBuf = buffer.length > maxInput
       ? buffer.slice(buffer.length - maxInput)
       : buffer;
 
-    process.stdout.write("\x1b[2K"); // clear line
-    process.stdout.write(label + displayBuf);
+    process.stdout.write("\x1b[2K" + label + displayBuf);
 
-    // Position cursor within the input
     const displayCursor = cursor - (buffer.length - displayBuf.length);
-    const col = 9 + displayCursor; // after " agent  "
-    process.stdout.write(`\x1b[${rows};${col}H`);
+    process.stdout.write(`\x1b[${rows};${9 + displayCursor}H`);
+  }
+
+  function clearInputBar(): void {
+    const rows = process.stdout.rows || 24;
+    process.stdout.write(`\x1b[${rows};1H\x1b[2K`);
+    process.stdout.write("\x1b8"); // restore cursor
+  }
+
+  function showDismissPrompt(): void {
+    process.stdout.write(
+      `\n\x1b[2m  Press Ctrl+] to return\x1b[0m\n`
+    );
+  }
+
+  // ── Phase transitions ─────────────────────────────────────
+
+  function activate(): void {
+    phase = "input";
+    buffer = "";
+    cursor = 0;
+    renderInputBar();
+  }
+
+  function submit(): void {
+    const query = buffer.trim();
+    if (!query) { dismiss(); return; }
+
+    phase = "responding";
+    clearInputBar();
+
+    // Hold PTY stdout so vim doesn't redraw over the response
+    bus.emit("shell:stdout-hold", {});
+
+    // Clear screen for response
+    process.stdout.write("\x1b[2J\x1b[H");
+
+    bus.emit("agent:submit", { query });
   }
 
   function dismiss(): void {
-    const rows = process.stdout.rows || 24;
+    if (renderTimer) { clearTimeout(renderTimer); renderTimer = null; }
 
-    // Clear the bottom line, restore cursor
-    process.stdout.write(`\x1b[${rows};1H\x1b[2K`);
-    process.stdout.write("\x1b8");
-
-    active = false;
+    const wasResponding = phase === "responding" || phase === "done";
+    phase = "idle";
     buffer = "";
     cursor = 0;
+
+    if (wasResponding) {
+      // Release PTY stdout
+      bus.emit("shell:stdout-release", {});
+
+      // Force the foreground program to redraw (Ctrl+L)
+      bus.emit("shell:pty-write", { data: "\x0c" });
+    } else {
+      clearInputBar();
+    }
   }
 
   // ── Input handling ────────────────────────────────────────
@@ -67,110 +115,106 @@ export default function activate({ bus }: ExtensionContext): void {
       const ch = data[i]!;
       const code = ch.charCodeAt(0);
 
-      // Escape → cancel (bare escape, not part of a sequence)
-      if (ch === "\x1b" && data[i + 1] == null) {
-        dismiss();
-        return;
-      }
+      // Escape (bare) → cancel
+      if (ch === "\x1b" && data[i + 1] == null) { dismiss(); return; }
+      // Ctrl+] → cancel
+      if (ch === TRIGGER) { dismiss(); return; }
+      // Ctrl+C → cancel
+      if (code === 0x03) { dismiss(); return; }
 
-      // Ctrl+G again → cancel
-      if (ch === TRIGGER) {
-        dismiss();
-        return;
-      }
-
-      // Escape sequence → handle arrows, skip the rest
+      // Escape sequence → arrows
       if (ch === "\x1b") {
-        i++; // skip \x1b
+        i++;
         const next = data[i];
-        if (next === "[") {
-          i++; // skip [
-          // Read params
-          while (i < data.length && data.charCodeAt(i) >= 0x20 && data.charCodeAt(i) < 0x40) i++;
-          const final = data[i];
-          i++; // skip final byte
-          if (final === "C" && cursor < buffer.length) { cursor++; render(); }
-          if (final === "D" && cursor > 0) { cursor--; render(); }
-          if (final === "H") { cursor = 0; render(); }
-          if (final === "F") { cursor = buffer.length; render(); }
-        } else if (next === "O") {
-          i++; // skip O
-          const final = data[i];
+        if (next === "[" || next === "O") {
           i++;
-          if (final === "C" && cursor < buffer.length) { cursor++; render(); }
-          if (final === "D" && cursor > 0) { cursor--; render(); }
-          if (final === "H") { cursor = 0; render(); }
-          if (final === "F") { cursor = buffer.length; render(); }
-        } else {
-          i++; // skip alt+key
-        }
+          while (i < data.length && data.charCodeAt(i) >= 0x20 && data.charCodeAt(i) < 0x40) i++;
+          const final = data[i]; i++;
+          if (final === "C" && cursor < buffer.length) { cursor++; renderInputBar(); }
+          if (final === "D" && cursor > 0) { cursor--; renderInputBar(); }
+          if (final === "H") { cursor = 0; renderInputBar(); }
+          if (final === "F") { cursor = buffer.length; renderInputBar(); }
+        } else { i++; }
         continue;
       }
 
       // Enter → submit
-      if (ch === "\r") {
-        const query = buffer.trim();
-        dismiss();
-        if (query) {
-          bus.emit("agent:submit", { query });
-        }
-        return;
-      }
-
-      // Ctrl+C → cancel
-      if (code === 0x03) {
-        dismiss();
-        return;
-      }
+      if (ch === "\r") { submit(); return; }
 
       // Backspace
       if (ch === "\x7f" || ch === "\b") {
         if (cursor > 0) {
           buffer = buffer.slice(0, cursor - 1) + buffer.slice(cursor);
           cursor--;
-          render();
+          renderInputBar();
         }
-        i++;
-        continue;
+        i++; continue;
       }
 
-      // Ctrl+A → beginning
-      if (code === 0x01) { cursor = 0; render(); i++; continue; }
-      // Ctrl+E → end
-      if (code === 0x05) { cursor = buffer.length; render(); i++; continue; }
-      // Ctrl+U → clear line
-      if (code === 0x15) { buffer = ""; cursor = 0; render(); i++; continue; }
-      // Ctrl+K → kill to end
-      if (code === 0x0b) { buffer = buffer.slice(0, cursor); render(); i++; continue; }
+      // Readline shortcuts
+      if (code === 0x01) { cursor = 0; renderInputBar(); i++; continue; }
+      if (code === 0x05) { cursor = buffer.length; renderInputBar(); i++; continue; }
+      if (code === 0x15) { buffer = ""; cursor = 0; renderInputBar(); i++; continue; }
+      if (code === 0x0b) { buffer = buffer.slice(0, cursor); renderInputBar(); i++; continue; }
 
-      // Other control chars → ignore
+      // Other control → ignore
       if (code < 0x20) { i++; continue; }
 
-      // Printable character
+      // Printable
       buffer = buffer.slice(0, cursor) + ch + buffer.slice(cursor);
       cursor++;
-      render();
+      renderInputBar();
       i++;
     }
   }
 
   // ── Bus wiring ────────────────────────────────────────────
 
-  // Single intercept point: activates on Ctrl+G, captures while active.
-  // This runs before input-handler's own logic, so Ctrl+G never reaches
-  // the PTY (no bell in vim) and typed characters don't leak through.
+  // Re-render input bar after PTY output (vim redraws over it)
+  bus.on("shell:pty-data", () => {
+    if (phase !== "input") return;
+    if (renderTimer) clearTimeout(renderTimer);
+    renderTimer = setTimeout(() => {
+      renderTimer = null;
+      if (phase === "input") renderInputBar();
+    }, 16);
+  });
+
+  // When agent finishes, show dismiss prompt
+  bus.on("agent:processing-done", () => {
+    if (phase === "responding") {
+      phase = "done";
+      showDismissPrompt();
+    }
+  });
+
+  // Intercept input: activate on trigger, capture while active
   bus.onPipe("input:intercept", (payload) => {
-    if (active) {
+    // During "done" phase, any Ctrl+] or Escape dismisses
+    if (phase === "done") {
+      if (payload.data === TRIGGER || payload.data === "\x1b" || payload.data === "\x03") {
+        dismiss();
+      }
+      return { ...payload, consumed: true };
+    }
+
+    // During input phase, handle editing
+    if (phase === "input") {
       handleKey(payload.data);
       return { ...payload, consumed: true };
     }
 
-    // Check if the input contains the trigger to activate
+    // During responding phase, only allow Ctrl+C to cancel
+    if (phase === "responding") {
+      if (payload.data === "\x03") {
+        bus.emit("agent:cancel-request", {});
+      }
+      return { ...payload, consumed: true };
+    }
+
+    // Idle: check for trigger
     if (payload.data === TRIGGER) {
-      active = true;
-      buffer = "";
-      cursor = 0;
-      render();
+      activate();
       return { ...payload, consumed: true };
     }
 

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -1,0 +1,179 @@
+/**
+ * Overlay agent extension.
+ *
+ * Provides a hotkey (Ctrl+G) to summon the agent from anywhere — even
+ * inside vim, htop, or ssh. Renders a minimal input bar at the bottom
+ * of the terminal, captures keystrokes via `input:intercept`, and
+ * dispatches the query via the bus.
+ *
+ * Usage:
+ *   agent-sh -e ./examples/extensions/overlay-agent.ts
+ *
+ *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
+ *   cp examples/extensions/overlay-agent.ts ~/.agent-sh/extensions/
+ */
+import type { ExtensionContext } from "agent-sh/types";
+
+const TRIGGER = "\x07"; // Ctrl+G
+
+export default function activate({ bus }: ExtensionContext): void {
+  let active = false;
+  let buffer = "";
+  let cursor = 0;
+
+  // ── Rendering ─────────────────────────────────────────────
+
+  function render(): void {
+    const cols = process.stdout.columns || 80;
+    const rows = process.stdout.rows || 24;
+
+    // Save cursor, move to bottom row
+    process.stdout.write("\x1b7");
+    process.stdout.write(`\x1b[${rows};1H`);
+
+    // Clear the line and draw the input bar
+    const label = "\x1b[7m agent \x1b[0m ";
+    const maxInput = cols - 9; // " agent " + space + padding
+    const displayBuf = buffer.length > maxInput
+      ? buffer.slice(buffer.length - maxInput)
+      : buffer;
+
+    process.stdout.write("\x1b[2K"); // clear line
+    process.stdout.write(label + displayBuf);
+
+    // Position cursor within the input
+    const displayCursor = cursor - (buffer.length - displayBuf.length);
+    const col = 9 + displayCursor; // after " agent  "
+    process.stdout.write(`\x1b[${rows};${col}H`);
+  }
+
+  function dismiss(): void {
+    const rows = process.stdout.rows || 24;
+
+    // Clear the bottom line, restore cursor
+    process.stdout.write(`\x1b[${rows};1H\x1b[2K`);
+    process.stdout.write("\x1b8");
+
+    active = false;
+    buffer = "";
+    cursor = 0;
+  }
+
+  // ── Input handling ────────────────────────────────────────
+
+  function handleKey(data: string): void {
+    let i = 0;
+    while (i < data.length) {
+      const ch = data[i]!;
+      const code = ch.charCodeAt(0);
+
+      // Escape → cancel (bare escape, not part of a sequence)
+      if (ch === "\x1b" && data[i + 1] == null) {
+        dismiss();
+        return;
+      }
+
+      // Ctrl+G again → cancel
+      if (ch === TRIGGER) {
+        dismiss();
+        return;
+      }
+
+      // Escape sequence → handle arrows, skip the rest
+      if (ch === "\x1b") {
+        i++; // skip \x1b
+        const next = data[i];
+        if (next === "[") {
+          i++; // skip [
+          // Read params
+          while (i < data.length && data.charCodeAt(i) >= 0x20 && data.charCodeAt(i) < 0x40) i++;
+          const final = data[i];
+          i++; // skip final byte
+          if (final === "C" && cursor < buffer.length) { cursor++; render(); }
+          if (final === "D" && cursor > 0) { cursor--; render(); }
+          if (final === "H") { cursor = 0; render(); }
+          if (final === "F") { cursor = buffer.length; render(); }
+        } else if (next === "O") {
+          i++; // skip O
+          const final = data[i];
+          i++;
+          if (final === "C" && cursor < buffer.length) { cursor++; render(); }
+          if (final === "D" && cursor > 0) { cursor--; render(); }
+          if (final === "H") { cursor = 0; render(); }
+          if (final === "F") { cursor = buffer.length; render(); }
+        } else {
+          i++; // skip alt+key
+        }
+        continue;
+      }
+
+      // Enter → submit
+      if (ch === "\r") {
+        const query = buffer.trim();
+        dismiss();
+        if (query) {
+          bus.emit("agent:submit", { query });
+        }
+        return;
+      }
+
+      // Ctrl+C → cancel
+      if (code === 0x03) {
+        dismiss();
+        return;
+      }
+
+      // Backspace
+      if (ch === "\x7f" || ch === "\b") {
+        if (cursor > 0) {
+          buffer = buffer.slice(0, cursor - 1) + buffer.slice(cursor);
+          cursor--;
+          render();
+        }
+        i++;
+        continue;
+      }
+
+      // Ctrl+A → beginning
+      if (code === 0x01) { cursor = 0; render(); i++; continue; }
+      // Ctrl+E → end
+      if (code === 0x05) { cursor = buffer.length; render(); i++; continue; }
+      // Ctrl+U → clear line
+      if (code === 0x15) { buffer = ""; cursor = 0; render(); i++; continue; }
+      // Ctrl+K → kill to end
+      if (code === 0x0b) { buffer = buffer.slice(0, cursor); render(); i++; continue; }
+
+      // Other control chars → ignore
+      if (code < 0x20) { i++; continue; }
+
+      // Printable character
+      buffer = buffer.slice(0, cursor) + ch + buffer.slice(cursor);
+      cursor++;
+      render();
+      i++;
+    }
+  }
+
+  // ── Bus wiring ────────────────────────────────────────────
+
+  // Single intercept point: activates on Ctrl+G, captures while active.
+  // This runs before input-handler's own logic, so Ctrl+G never reaches
+  // the PTY (no bell in vim) and typed characters don't leak through.
+  bus.onPipe("input:intercept", (payload) => {
+    if (active) {
+      handleKey(payload.data);
+      return { ...payload, consumed: true };
+    }
+
+    // Check if the input contains the trigger to activate
+    if (payload.data === TRIGGER) {
+      active = true;
+      buffer = "";
+      cursor = 0;
+      render();
+      return { ...payload, consumed: true };
+    }
+
+    return payload;
+  });
+}

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -1,7 +1,7 @@
 /**
  * Overlay agent extension.
  *
- * Provides a hotkey (Ctrl+G) to summon the agent from anywhere — even
+ * Provides a hotkey (Ctrl+]) to summon the agent from anywhere — even
  * inside vim, htop, or ssh. Renders a minimal input bar at the bottom
  * of the terminal, captures keystrokes via `input:intercept`, and
  * dispatches the query via the bus.
@@ -14,7 +14,7 @@
  */
 import type { ExtensionContext } from "agent-sh/types";
 
-const TRIGGER = "\x07"; // Ctrl+G
+const TRIGGER = "\x1d"; // Ctrl+]
 
 export default function activate({ bus }: ExtensionContext): void {
   let active = false;

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -14,6 +14,7 @@
  *   cp examples/extensions/overlay-agent.ts ~/.agent-sh/extensions/
  */
 import type { ExtensionContext } from "agent-sh/types";
+import { formatScreenContext } from "agent-sh/utils/terminal-buffer.js";
 
 const BOLD = "\x1b[1m";
 const CYAN = "\x1b[36m";
@@ -28,17 +29,9 @@ export default function activate({ bus, advise, createFloatingPanel, terminalBuf
 
   // ── Inject terminal buffer into agent context ──────────────
   if (terminalBuffer) {
-    advise("context:build-extra", (next: () => string) => {
-      const base = next();
-      const screen = terminalBuffer.readScreen();
-      const clean = screen.text.trim();
-      if (!clean) return base;
-      const lines = clean.split("\n");
-      const capped = lines.length > 80 ? lines.slice(-80).join("\n") : clean;
-      const header = screen.altScreen ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
-      const section = `${header}\n${capped}\n</terminal_buffer>`;
-      return base ? base + "\n" + section : section;
-    });
+    advise("context:build-extra", (next: () => string) =>
+      formatScreenContext(terminalBuffer.readScreen(), 80, next()),
+    );
   }
 
   // ── Panel lifecycle ────────────────────────────────────────

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -1,7 +1,7 @@
 /**
  * Overlay agent extension.
  *
- * Provides a hotkey (Ctrl+]) to summon the agent from anywhere — even
+ * Provides a hotkey (Ctrl+\) to summon the agent from anywhere — even
  * inside vim, htop, or ssh. Composites a floating response box on top
  * of the current terminal content using a headless xterm.js buffer.
  *
@@ -20,7 +20,7 @@ const require = createRequire(import.meta.url);
 const { Terminal } = require("@xterm/headless") as typeof import("@xterm/headless");
 const { SerializeAddon } = require("@xterm/addon-serialize") as typeof import("@xterm/addon-serialize");
 
-const TRIGGER = "\x1d"; // Ctrl+]
+const TRIGGER = "\x1c"; // Ctrl+\
 const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -140,7 +140,7 @@ export default function activate({ bus, advise }: ExtensionContext): void {
         const left = `${DIM}${bgLine.slice(0, boxLeft)}${RESET}`;
         let footer = "";
         if (phase === "done") {
-          footer = ` Ctrl+] to return `;
+          footer = ` Ctrl+\ to return `;
         } else if (phase === "responding") {
           footer = ` streaming... `;
         } else if (phase === "input") {

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -235,12 +235,9 @@ export default function activate({ bus, advise }: ExtensionContext): void {
     inputBuffer = "";
     inputCursor = 0;
 
-    // Restore screen from buffer then release
+    // Leave alternate screen — terminal restores the original screen
     restoreScreen();
     bus.emit("shell:stdout-release", {});
-
-    // Force foreground program to redraw
-    bus.emit("shell:pty-write", { data: "\x0c" });
   }
 
   // ── Input handling ────────────────────────────────────────

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -198,10 +198,14 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
       const keys = interpretEscapes(raw);
       const settleMs = (args.settle_ms as number) ?? 150;
 
+      // Temporarily show PTY output so the user sees the program's response
+      bus.emit("shell:stdout-show", {});
+      process.stdout.write("\n");
       bus.emit("shell:pty-write", { data: keys });
 
       // Wait for the terminal to process the keystrokes and render
       await settle(settleMs);
+      bus.emit("shell:stdout-hide", {});
 
       // Return the screen state after the keystrokes
       const { text, altScreen, cursorX, cursorY } = readScreen();

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -198,14 +198,15 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
       const keys = interpretEscapes(raw);
       const settleMs = (args.settle_ms as number) ?? 150;
 
-      // Temporarily show PTY output so the user sees the program's response
+      // Force PTY output visible so the user sees the program's response.
+      // Stays visible for the rest of agent processing — Shell resets
+      // paused=false on processing-done anyway.
       bus.emit("shell:stdout-show", {});
       process.stdout.write("\n");
       bus.emit("shell:pty-write", { data: keys });
 
       // Wait for the terminal to process the keystrokes and render
       await settle(settleMs);
-      bus.emit("shell:stdout-hide", {});
 
       // Return the screen state after the keystrokes
       const { text, altScreen, cursorX, cursorY } = readScreen();

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -1,0 +1,88 @@
+/**
+ * Terminal buffer extension.
+ *
+ * Maintains a headless xterm.js terminal fed from raw PTY data.
+ * Provides an accurate, clean-text snapshot of the terminal screen
+ * that the agent can use for context — handling ANSI codes, cursor
+ * movement, alternate screen (vim/htop), and line wrapping correctly.
+ *
+ * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ *
+ * Usage:
+ *   agent-sh -e ./examples/extensions/terminal-buffer.ts
+ *
+ *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
+ *   cp examples/extensions/terminal-buffer.ts ~/.agent-sh/extensions/
+ */
+import { createRequire } from "module";
+import type { ExtensionContext } from "agent-sh/types";
+
+// xterm packages are CJS-only; use createRequire in ESM context
+const require = createRequire(import.meta.url);
+const { Terminal } = require("@xterm/headless") as typeof import("@xterm/headless");
+const { SerializeAddon } = require("@xterm/addon-serialize") as typeof import("@xterm/addon-serialize");
+
+const DEFAULT_COLS = 220;
+const DEFAULT_ROWS = 50;
+const MAX_CONTEXT_LINES = 80;
+
+/** Strip all ANSI escape sequences and carriage returns. */
+function stripAnsi(str: string): string {
+  return str
+    .replace(/\x1b\][^\x07]*\x07/g, "")        // OSC sequences
+    .replace(/\x1b\[[^m]*m/g, "")                // SGR (color) sequences
+    .replace(/\x1b\[\?[^a-zA-Z]*[a-zA-Z]/g, "") // private mode sequences
+    .replace(/\x1b\[[^a-zA-Z]*[a-zA-Z]/g, "")   // CSI sequences
+    .replace(/\r/g, "");                          // carriage returns
+}
+
+export default function activate({ bus, advise }: ExtensionContext): void {
+  const term = new Terminal({
+    cols: DEFAULT_COLS,
+    rows: DEFAULT_ROWS,
+    allowProposedApi: true,
+    scrollback: 200,
+  });
+  const serialize = new SerializeAddon();
+  term.loadAddon(serialize);
+
+  // Feed raw PTY output into the virtual terminal
+  bus.on("shell:pty-data", ({ raw }) => {
+    term.write(raw);
+  });
+
+  // Inject terminal buffer into agent context
+  advise("context:build-extra", (next: () => string) => {
+    const base = next();
+    const raw = serialize.serialize().trim();
+    if (!raw) return base;
+
+    // Strip ANSI codes for clean agent-readable text
+    const buffer = stripAnsi(raw);
+    if (!buffer.trim()) return base;
+
+    // Limit to last N lines to keep context budget reasonable
+    const lines = buffer.split("\n");
+    const trimmed = lines.length > MAX_CONTEXT_LINES
+      ? lines.slice(-MAX_CONTEXT_LINES).join("\n")
+      : buffer;
+
+    const isAlt = term.buffer.active.type === "alternate";
+    const header = isAlt ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
+
+    const section = `${header}\n${trimmed}\n</terminal_buffer>`;
+    return base ? base + "\n" + section : section;
+  });
+
+  // On-demand snapshot for extensions (e.g. keystroke injection feedback loop)
+  bus.on("shell:buffer-request", () => {
+    bus.emit("shell:buffer-snapshot", {
+      text: serialize.serialize(),
+      altScreen: term.buffer.active.type === "alternate",
+      cursor: {
+        x: term.buffer.active.cursorX,
+        y: term.buffer.active.cursorY,
+      },
+    });
+  });
+}

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -71,10 +71,14 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
   const serialize = new SerializeAddon();
   term.loadAddon(serialize);
 
-  // Feed raw PTY output into the virtual terminal
-  bus.on("shell:pty-data", ({ raw }) => {
-    term.write(raw);
-  });
+  // Buffer PTY data and drip-feed to xterm in the background.
+  // Synchronous term.write() in the pty-data handler introduces enough
+  // latency to change PTY read coalescing, causing visual artifacts.
+  let pending = "";
+  bus.on("shell:pty-data", ({ raw }) => { pending += raw; });
+  setInterval(() => {
+    if (pending) { const d = pending; pending = ""; term.write(d); }
+  }, 50);
 
   // ── Helper: read clean screen text ──────────────────────────
 

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -21,27 +21,8 @@
  *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
  *   cp examples/extensions/terminal-buffer.ts ~/.agent-sh/extensions/
  */
-import { createRequire } from "module";
 import type { ExtensionContext } from "agent-sh/types";
-
-// xterm packages are CJS-only; use createRequire in ESM context
-const require = createRequire(import.meta.url);
-const { Terminal } = require("@xterm/headless") as typeof import("@xterm/headless");
-const { SerializeAddon } = require("@xterm/addon-serialize") as typeof import("@xterm/addon-serialize");
-
-const DEFAULT_COLS = 220;
-const DEFAULT_ROWS = 50;
-const MAX_CONTEXT_LINES = 80;
-
-/** Strip all ANSI escape sequences and carriage returns. */
-function stripAnsi(str: string): string {
-  return str
-    .replace(/\x1b\][^\x07]*\x07/g, "")        // OSC sequences
-    .replace(/\x1b\[[^m]*m/g, "")                // SGR (color) sequences
-    .replace(/\x1b\[\?[^a-zA-Z]*[a-zA-Z]/g, "") // private mode sequences
-    .replace(/\x1b\[[^a-zA-Z]*[a-zA-Z]/g, "")   // CSI sequences
-    .replace(/\r/g, "");                          // carriage returns
-}
+import { TerminalBuffer, formatScreenContext } from "agent-sh/utils/terminal-buffer.js";
 
 /** Wait for PTY output to settle after sending keystrokes. */
 function settle(ms = 100): Promise<void> {
@@ -62,53 +43,17 @@ function interpretEscapes(str: string): string {
 }
 
 export default function activate({ bus, advise, registerTool }: ExtensionContext): void {
-  const term = new Terminal({
-    cols: DEFAULT_COLS,
-    rows: DEFAULT_ROWS,
-    allowProposedApi: true,
-    scrollback: 200,
-  });
-  const serialize = new SerializeAddon();
-  term.loadAddon(serialize);
-
-  // Buffer PTY data and drip-feed to xterm in the background.
-  // Synchronous term.write() in the pty-data handler introduces enough
-  // latency to change PTY read coalescing, causing visual artifacts.
-  let pending = "";
-  bus.on("shell:pty-data", ({ raw }) => { pending += raw; });
-  setInterval(() => {
-    if (pending) { const d = pending; pending = ""; term.write(d); }
-  }, 50);
-
-  // ── Helper: read clean screen text ──────────────────────────
-
-  function readScreen(): { text: string; altScreen: boolean; cursorX: number; cursorY: number } {
-    const raw = serialize.serialize();
-    return {
-      text: stripAnsi(raw),
-      altScreen: term.buffer.active.type === "alternate",
-      cursorX: term.buffer.active.cursorX,
-      cursorY: term.buffer.active.cursorY,
-    };
+  const tb = TerminalBuffer.createWired(bus);
+  if (!tb) {
+    console.warn("terminal-buffer: @xterm/headless not installed — extension disabled");
+    return;
   }
 
   // ── Context injection ───────────────────────────────────────
 
-  advise("context:build-extra", (next: () => string) => {
-    const base = next();
-    const { text, altScreen } = readScreen();
-    const trimmed = text.trim();
-    if (!trimmed) return base;
-
-    const lines = trimmed.split("\n");
-    const capped = lines.length > MAX_CONTEXT_LINES
-      ? lines.slice(-MAX_CONTEXT_LINES).join("\n")
-      : trimmed;
-
-    const header = altScreen ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
-    const section = `${header}\n${capped}\n</terminal_buffer>`;
-    return base ? base + "\n" + section : section;
-  });
+  advise("context:build-extra", (next: () => string) =>
+    formatScreenContext(tb.readScreen(), 80, next()),
+  );
 
   // ── Agent tools ─────────────────────────────────────────────
 
@@ -131,7 +76,7 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
     }),
 
     async execute() {
-      const { text, altScreen, cursorX, cursorY } = readScreen();
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
       const info = [
         altScreen ? "mode: alternate screen" : "mode: normal",
         `cursor: row=${cursorY} col=${cursorX}`,
@@ -213,7 +158,7 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
       await settle(settleMs);
 
       // Return the screen state after the keystrokes
-      const { text, altScreen, cursorX, cursorY } = readScreen();
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
       const info = [
         altScreen ? "mode: alternate screen" : "mode: normal",
         `cursor: row=${cursorY} col=${cursorX}`,
@@ -230,7 +175,7 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
   // ── Bus snapshot for other extensions ───────────────────────
 
   bus.on("shell:buffer-request", () => {
-    const { text, altScreen, cursorX, cursorY } = readScreen();
+    const { text, altScreen, cursorX, cursorY } = tb.readScreen();
     bus.emit("shell:buffer-snapshot", {
       text,
       altScreen,

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -6,6 +6,13 @@
  * that the agent can use for context — handling ANSI codes, cursor
  * movement, alternate screen (vim/htop), and line wrapping correctly.
  *
+ * Registers two agent tools:
+ *   - terminal_read: get the current screen contents + cursor position
+ *   - terminal_keys: send raw keystrokes into the user's live PTY
+ *
+ * Together these let the agent operate inside interactive programs
+ * (vim, htop, less, etc.) by reading the screen and typing keys.
+ *
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  *
  * Usage:
@@ -36,7 +43,12 @@ function stripAnsi(str: string): string {
     .replace(/\r/g, "");                          // carriage returns
 }
 
-export default function activate({ bus, advise }: ExtensionContext): void {
+/** Wait for PTY output to settle after sending keystrokes. */
+function settle(ms = 100): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default function activate({ bus, advise, registerTool }: ExtensionContext): void {
   const term = new Terminal({
     cols: DEFAULT_COLS,
     rows: DEFAULT_ROWS,
@@ -51,38 +63,155 @@ export default function activate({ bus, advise }: ExtensionContext): void {
     term.write(raw);
   });
 
-  // Inject terminal buffer into agent context
+  // ── Helper: read clean screen text ──────────────────────────
+
+  function readScreen(): { text: string; altScreen: boolean; cursorX: number; cursorY: number } {
+    const raw = serialize.serialize();
+    return {
+      text: stripAnsi(raw),
+      altScreen: term.buffer.active.type === "alternate",
+      cursorX: term.buffer.active.cursorX,
+      cursorY: term.buffer.active.cursorY,
+    };
+  }
+
+  // ── Context injection ───────────────────────────────────────
+
   advise("context:build-extra", (next: () => string) => {
     const base = next();
-    const raw = serialize.serialize().trim();
-    if (!raw) return base;
+    const { text, altScreen } = readScreen();
+    const trimmed = text.trim();
+    if (!trimmed) return base;
 
-    // Strip ANSI codes for clean agent-readable text
-    const buffer = stripAnsi(raw);
-    if (!buffer.trim()) return base;
-
-    // Limit to last N lines to keep context budget reasonable
-    const lines = buffer.split("\n");
-    const trimmed = lines.length > MAX_CONTEXT_LINES
+    const lines = trimmed.split("\n");
+    const capped = lines.length > MAX_CONTEXT_LINES
       ? lines.slice(-MAX_CONTEXT_LINES).join("\n")
-      : buffer;
+      : trimmed;
 
-    const isAlt = term.buffer.active.type === "alternate";
-    const header = isAlt ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
-
-    const section = `${header}\n${trimmed}\n</terminal_buffer>`;
+    const header = altScreen ? "<terminal_buffer mode=\"alternate\">" : "<terminal_buffer>";
+    const section = `${header}\n${capped}\n</terminal_buffer>`;
     return base ? base + "\n" + section : section;
   });
 
-  // On-demand snapshot for extensions (e.g. keystroke injection feedback loop)
-  bus.on("shell:buffer-request", () => {
-    bus.emit("shell:buffer-snapshot", {
-      text: serialize.serialize(),
-      altScreen: term.buffer.active.type === "alternate",
-      cursor: {
-        x: term.buffer.active.cursorX,
-        y: term.buffer.active.cursorY,
+  // ── Agent tools ─────────────────────────────────────────────
+
+  registerTool({
+    name: "terminal_read",
+    description:
+      "Read the current terminal screen contents. Returns clean text (ANSI stripped) " +
+      "with cursor position and whether an alternate-screen program (vim, htop, less) is active. " +
+      "Use this to see what the user sees before sending keystrokes with terminal_keys.",
+    input_schema: {
+      type: "object",
+      properties: {},
+    },
+    showOutput: true,
+
+    getDisplayInfo: () => ({
+      kind: "read" as const,
+      icon: "⊞",
+      locations: [],
+    }),
+
+    async execute() {
+      const { text, altScreen, cursorX, cursorY } = readScreen();
+      const info = [
+        altScreen ? "mode: alternate screen" : "mode: normal",
+        `cursor: row=${cursorY} col=${cursorX}`,
+      ].join(", ");
+
+      return {
+        content: `[${info}]\n\n${text}`,
+        exitCode: 0,
+        isError: false,
+      };
+    },
+  });
+
+  registerTool({
+    name: "terminal_keys",
+    description:
+      "Send keystrokes to the user's live terminal. The keys are written directly to the PTY " +
+      "as if the user typed them. Use escape sequences for special keys:\n" +
+      "  - Escape: \\x1b\n" +
+      "  - Enter/Return: \\r\n" +
+      "  - Tab: \\t\n" +
+      "  - Ctrl+C: \\x03\n" +
+      "  - Ctrl+D: \\x04\n" +
+      "  - Ctrl+Z: \\x1a\n" +
+      "  - Arrow keys: \\x1b[A (up), \\x1b[B (down), \\x1b[C (right), \\x1b[D (left)\n" +
+      "  - Backspace: \\x7f\n\n" +
+      "Example: to quit vim without saving, send keys=\"\\x1b:q!\\r\" (Escape, :q!, Enter).\n" +
+      "Always call terminal_read after sending keys to verify the result.",
+    input_schema: {
+      type: "object",
+      properties: {
+        keys: {
+          type: "string",
+          description:
+            "The keystrokes to send. Use \\x1b for Escape, \\r for Enter, \\t for Tab, " +
+            "\\x03 for Ctrl+C, etc. Regular characters are sent as-is.",
+        },
+        settle_ms: {
+          type: "number",
+          description:
+            "Milliseconds to wait after sending keys for the terminal to settle before " +
+            "returning (default: 150). Increase for slow programs.",
+        },
       },
+      required: ["keys"],
+    },
+    showOutput: false,
+
+    getDisplayInfo: (args) => ({
+      kind: "execute" as const,
+      icon: "⌨",
+      locations: [],
+    }),
+
+    formatCall: (args) => {
+      const keys = args.keys as string;
+      // Show a readable version of the keys
+      return keys
+        .replace(/\x1b/g, "ESC")
+        .replace(/\r/g, "⏎")
+        .replace(/\t/g, "TAB")
+        .replace(/\x03/g, "^C")
+        .replace(/\x7f/g, "BS");
+    },
+
+    async execute(args) {
+      const keys = args.keys as string;
+      const settleMs = (args.settle_ms as number) ?? 150;
+
+      bus.emit("shell:pty-write", { data: keys });
+
+      // Wait for the terminal to process the keystrokes and render
+      await settle(settleMs);
+
+      // Return the screen state after the keystrokes
+      const { text, altScreen, cursorX, cursorY } = readScreen();
+      const info = [
+        altScreen ? "mode: alternate screen" : "mode: normal",
+        `cursor: row=${cursorY} col=${cursorX}`,
+      ].join(", ");
+
+      return {
+        content: `Keys sent. Screen after:\n[${info}]\n\n${text}`,
+        exitCode: 0,
+        isError: false,
+      };
+    },
+  });
+
+  // ── Bus snapshot for other extensions ───────────────────────
+
+  bus.on("shell:buffer-request", () => {
+    const { text, altScreen, cursorX, cursorY } = readScreen();
+    bus.emit("shell:buffer-snapshot", {
+      text,
+      altScreen,
+      cursor: { x: cursorX, y: cursorY },
     });
   });
 }

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -48,6 +48,19 @@ function settle(ms = 100): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Interpret C-style escape sequences in a string (e.g. \r → CR, \x1b → ESC). */
+function interpretEscapes(str: string): string {
+  return str.replace(/\\(x[0-9a-fA-F]{2}|r|n|t|\\|0)/g, (_, seq: string) => {
+    if (seq === "r") return "\r";
+    if (seq === "n") return "\n";
+    if (seq === "t") return "\t";
+    if (seq === "\\") return "\\";
+    if (seq === "0") return "\0";
+    if (seq.startsWith("x")) return String.fromCharCode(parseInt(seq.slice(1), 16));
+    return seq;
+  });
+}
+
 export default function activate({ bus, advise, registerTool }: ExtensionContext): void {
   const term = new Terminal({
     cols: DEFAULT_COLS,
@@ -181,7 +194,8 @@ export default function activate({ bus, advise, registerTool }: ExtensionContext
     },
 
     async execute(args) {
-      const keys = args.keys as string;
+      const raw = args.keys as string;
+      const keys = interpretEscapes(raw);
       const settleMs = (args.settle_ms as number) ?? 150;
 
       bus.emit("shell:pty-write", { data: keys });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "./utils/stream-transform": {
       "types": "./dist/utils/stream-transform.d.ts",
       "default": "./dist/utils/stream-transform.js"
+    },
+    "./utils/terminal-buffer": {
+      "types": "./dist/utils/terminal-buffer.d.ts",
+      "default": "./dist/utils/terminal-buffer.js"
     }
   },
   "files": [

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -1,5 +1,6 @@
 import type { EventBus } from "./event-bus.js";
 import type { Exchange, ToolCallRecord } from "./types.js";
+import type { HandlerRegistry } from "./utils/handler-registry.js";
 import { getSettings } from "./settings.js";
 
 // Non-configurable thresholds (agent response and tool output follow shell settings)
@@ -17,8 +18,14 @@ export class ContextManager {
   private pendingToolCalls: ToolCallRecord[] = [];
   private firstPrompt = true;
   private agentShellActive = false; // true while user_shell command is executing
+  private handlers: HandlerRegistry | null = null;
 
-  constructor(bus: EventBus) {
+  constructor(bus: EventBus, handlers?: HandlerRegistry) {
+    if (handlers) {
+      this.handlers = handlers;
+      // Extensions can advise this to inject extra context (e.g. terminal buffer)
+      handlers.define("context:build-extra", () => "");
+    }
     this.currentCwd = process.cwd();
     this.sessionStart = Date.now();
 
@@ -355,6 +362,10 @@ export class ContextManager {
     for (const ex of exchanges) {
       out += "\n" + this.formatExchangeTruncated(ex);
     }
+
+    // Allow extensions to inject extra context (e.g. terminal buffer snapshot)
+    const extra = this.handlers?.call("context:build-extra") as string | undefined;
+    if (extra) out += "\n" + extra + "\n";
 
     out += "\n</shell_context>\n";
     return out;

--- a/src/core.ts
+++ b/src/core.ts
@@ -57,7 +57,7 @@ export interface AgentShellCore {
 export function createCore(config: AgentShellConfig): AgentShellCore {
   const bus = new EventBus();
   const handlers = new HandlerRegistry();
-  const contextManager = new ContextManager(bus);
+  const contextManager = new ContextManager(bus, handlers);
 
   // ── Resolve provider ─────────────────────────────────────────
   const settings = settingsMod.getSettings();

--- a/src/core.ts
+++ b/src/core.ts
@@ -26,6 +26,8 @@ import * as streamTransform from "./utils/stream-transform.js";
 import * as settingsMod from "./settings.js";
 import { resolveProvider, getProviderNames, type ResolvedProvider } from "./settings.js";
 import { HandlerRegistry } from "./utils/handler-registry.js";
+import { TerminalBuffer } from "./utils/terminal-buffer.js";
+import { FloatingPanel, type FloatingPanelConfig } from "./utils/floating-panel.js";
 
 // Re-export types that library consumers need
 export { EventBus } from "./event-bus.js";
@@ -261,6 +263,14 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     bus.emit("config:changed", {});
   });
 
+  // ── Lazy singleton terminal buffer ──────────────────────────
+  let terminalBufferSingleton: TerminalBuffer | null | undefined; // undefined = not yet created
+  const getTerminalBuffer = (): TerminalBuffer | null => {
+    if (terminalBufferSingleton !== undefined) return terminalBufferSingleton;
+    terminalBufferSingleton = TerminalBuffer.createWired(bus);
+    return terminalBufferSingleton;
+  };
+
   return {
     bus,
     contextManager,
@@ -339,6 +349,11 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         define: (name, fn) => handlers.define(name, fn),
         advise: (name, wrapper) => handlers.advise(name, wrapper),
         call: (name, ...args) => handlers.call(name, ...args),
+        get terminalBuffer() { return getTerminalBuffer(); },
+        createFloatingPanel: (config: FloatingPanelConfig) => {
+          const tb = config.dimBackground !== false ? getTerminalBuffer() : null;
+          return new FloatingPanel(bus, { ...config, terminalBuffer: tb ?? undefined });
+        },
       };
     },
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -137,6 +137,12 @@ export interface ShellEvents {
   "shell:stdout-hold": Record<string, never>;
   "shell:stdout-release": Record<string, never>;
 
+  // Temporarily force PTY output visible even while agent is processing
+  // (ref-counted). Used by tools like terminal_keys that need the user
+  // to see the foreground program's response to injected keystrokes.
+  "shell:stdout-show": Record<string, never>;
+  "shell:stdout-hide": Record<string, never>;
+
   // Terminal interception (sync pipe: extensions can intercept before execution)
   "agent:terminal-intercept": {
     command: string;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -19,6 +19,18 @@ export interface ShellEvents {
   "shell:agent-exec-start": Record<string, never>;
   "shell:agent-exec-done": Record<string, never>;
 
+  // Raw PTY output stream (every byte from the shell process).
+  // Extensions can use this to feed a virtual terminal, log, or replay.
+  "shell:pty-data": { raw: string };
+
+  // Terminal buffer snapshot (request/response pattern via bus)
+  "shell:buffer-request": Record<string, never>;
+  "shell:buffer-snapshot": {
+    text: string;
+    altScreen: boolean;
+    cursor: { x: number; y: number };
+  };
+
   // Agent input (frontend → core: user submitted a query or wants to cancel)
   "agent:submit": { query: string };
   "agent:cancel-request": { silent?: boolean };

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -23,6 +23,10 @@ export interface ShellEvents {
   // Extensions can use this to feed a virtual terminal, log, or replay.
   "shell:pty-data": { raw: string };
 
+  // Write raw bytes to the PTY (keystroke injection).
+  // Extensions use this to send keystrokes into the user's live shell.
+  "shell:pty-write": { data: string };
+
   // Terminal buffer snapshot (request/response pattern via bus)
   "shell:buffer-request": Record<string, never>;
   "shell:buffer-snapshot": {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -132,6 +132,11 @@ export interface ShellEvents {
   // PTY or mode handler — enables overlay UIs during foreground programs.
   "input:intercept": { data: string; consumed: boolean };
 
+  // Stdout hold/release (ref-counted). While held, PTY output is not written
+  // to stdout — enables overlay extensions to render without interference.
+  "shell:stdout-hold": Record<string, never>;
+  "shell:stdout-release": Record<string, never>;
+
   // Terminal interception (sync pipe: extensions can intercept before execution)
   "agent:terminal-intercept": {
     command: string;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -127,6 +127,11 @@ export interface ShellEvents {
   // Generic keypress forwarding (control chars not handled by input-handler)
   "input:keypress": { key: string };
 
+  // Raw input intercept (sync pipe: fired before any input processing).
+  // Extensions set `consumed: true` to swallow input before it reaches the
+  // PTY or mode handler — enables overlay UIs during foreground programs.
+  "input:intercept": { data: string; consumed: boolean };
+
   // Terminal interception (sync pipe: extensions can intercept before execution)
   "agent:terminal-intercept": {
     command: string;

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -1,0 +1,56 @@
+/**
+ * Built-in overlay agent.
+ *
+ * Provides a hotkey (Ctrl+\) to summon the agent from anywhere — even
+ * inside vim, htop, or ssh. Composites a floating response box on top
+ * of the current terminal content.
+ *
+ * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ */
+import type { ExtensionContext } from "../types.js";
+
+const BOLD = "\x1b[1m";
+const CYAN = "\x1b[36m";
+const RESET = "\x1b[0m";
+
+export default function activate({ bus, createFloatingPanel }: ExtensionContext): void {
+  const panel = createFloatingPanel({
+    trigger: "\x1c", // Ctrl+\
+    dimBackground: true,
+    autoDismissMs: 2000,
+  });
+
+  // ── Panel lifecycle ────────────────────────────────────────
+  panel.handlers.advise("panel:submit", (_next, query: string) => {
+    panel.setActive();
+    panel.appendLine(`${CYAN}${BOLD}❯${RESET} ${query}`);
+    panel.appendLine("");
+    bus.emit("agent:submit", { query });
+  });
+
+  // ── Stream agent response into panel ───────────────────────
+  bus.on("agent:response-chunk", (e) => {
+    if (!panel.active) return;
+    for (const block of e.blocks) {
+      if (block.type === "text" && block.text) {
+        panel.appendText(block.text);
+      }
+    }
+  });
+
+  bus.on("agent:tool-started", (e) => {
+    if (!panel.active) return;
+    panel.appendLine(`▶ ${e.title}${e.displayDetail ? " " + e.displayDetail : ""}`);
+  });
+
+  bus.on("agent:tool-completed", (e) => {
+    if (!panel.active) return;
+    const mark = e.exitCode === 0 ? " ✓" : ` ✗ exit ${e.exitCode}`;
+    panel.updateLastLine((line) => line + mark);
+  });
+
+  bus.on("agent:processing-done", () => {
+    if (!panel.active) return;
+    panel.setDone();
+  });
+}

--- a/src/extensions/terminal-buffer.ts
+++ b/src/extensions/terminal-buffer.ts
@@ -1,10 +1,5 @@
 /**
- * Terminal buffer extension.
- *
- * Maintains a headless xterm.js terminal fed from raw PTY data.
- * Provides an accurate, clean-text snapshot of the terminal screen
- * that the agent can use for context — handling ANSI codes, cursor
- * movement, alternate screen (vim/htop), and line wrapping correctly.
+ * Built-in terminal buffer extension.
  *
  * Registers two agent tools:
  *   - terminal_read: get the current screen contents + cursor position
@@ -14,21 +9,10 @@
  * (vim, htop, less, etc.) by reading the screen and typing keys.
  *
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
- *
- * Usage:
- *   agent-sh -e ./examples/extensions/terminal-buffer.ts
- *
- *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
- *   cp examples/extensions/terminal-buffer.ts ~/.agent-sh/extensions/
  */
-import type { ExtensionContext } from "agent-sh/types";
+import type { ExtensionContext } from "../types.js";
 
-/** Wait for PTY output to settle after sending keystrokes. */
-function settle(ms = 100): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/** Interpret C-style escape sequences in a string (e.g. \r → CR, \x1b → ESC). */
+/** Interpret C-style escape sequences (e.g. \r → CR, \x1b → ESC). */
 function interpretEscapes(str: string): string {
   return str.replace(/\\(x[0-9a-fA-F]{2}|r|n|t|\\|0)/g, (_, seq: string) => {
     if (seq === "r") return "\r";
@@ -41,17 +25,12 @@ function interpretEscapes(str: string): string {
   });
 }
 
-export default function activate({ bus, terminalBuffer: tb, registerTool }: ExtensionContext): void {
-  if (!tb) {
-    console.warn("terminal-buffer: @xterm/headless not installed — extension disabled");
-    return;
-  }
+function settle(ms = 100): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-  // ── Agent tools ─────────────────────────────────────────────
-  // Context injection is intentionally NOT done here — the terminal
-  // buffer content would bloat every agent message.  The agent can
-  // call terminal_read on demand, and the overlay extension injects
-  // context only when the overlay is active.
+export default function activate({ bus, terminalBuffer: tb, registerTool }: ExtensionContext): void {
+  if (!tb) return; // @xterm/headless not installed
 
   registerTool({
     name: "terminal_read",
@@ -121,7 +100,7 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
     },
     showOutput: false,
 
-    getDisplayInfo: (args) => ({
+    getDisplayInfo: () => ({
       kind: "execute" as const,
       icon: "⌨",
       locations: [],
@@ -129,8 +108,6 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
 
     formatCall: (args) => {
       const keys = args.keys as string;
-      // Show a readable version of the keys — handle both literal
-      // escape strings (\\x1b) and actual bytes (\x1b)
       return keys
         .replace(/\\x1b|\x1b/g, "ESC")
         .replace(/\\r|\r/g, "⏎")
@@ -146,17 +123,12 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
       const keys = interpretEscapes(raw);
       const settleMs = (args.settle_ms as number) ?? 150;
 
-      // Force PTY output visible so the user sees the program's response.
-      // Stays visible for the rest of agent processing — Shell resets
-      // paused=false on processing-done anyway.
       bus.emit("shell:stdout-show", {});
       process.stdout.write("\n");
       bus.emit("shell:pty-write", { data: keys });
 
-      // Wait for the terminal to process the keystrokes and render
       await settle(settleMs);
 
-      // Return the screen state after the keystrokes
       const { text, altScreen, cursorX, cursorY } = tb.readScreen();
       const info = [
         altScreen ? "mode: alternate screen" : "mode: normal",
@@ -169,16 +141,5 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
         isError: false,
       };
     },
-  });
-
-  // ── Bus snapshot for other extensions ───────────────────────
-
-  bus.on("shell:buffer-request", () => {
-    const { text, altScreen, cursorX, cursorY } = tb.readScreen();
-    bus.emit("shell:buffer-snapshot", {
-      text,
-      altScreen,
-      cursor: { x: cursorX, y: cursorY },
-    });
   });
 }

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -138,6 +138,10 @@ export default function activate(ctx: ExtensionContext): void {
   const writer = new StdoutWriter();
   const s = createRenderState();
 
+  // Suppress all TUI output while stdout is held (overlay extensions)
+  bus.on("shell:stdout-hold", () => { writer.hold(); });
+  bus.on("shell:stdout-release", () => { writer.release(); });
+
   // Track backend/model info for display on response border
   let backendInfo: { name: string; model?: string; provider?: string; contextWindow?: number } | null = null;
   bus.on("agent:info", (info) => { backendInfo = info; });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import slashCommands from "./extensions/slash-commands.js";
 import fileAutocomplete from "./extensions/file-autocomplete.js";
 import shellRecall from "./extensions/shell-recall.js";
 import commandSuggest from "./extensions/command-suggest.js";
+import terminalBuffer from "./extensions/terminal-buffer.js";
+import overlayAgent from "./extensions/overlay-agent.js";
 import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
 import { discoverSkills } from "./agent/skills.js";
@@ -250,6 +252,8 @@ async function main(): Promise<void> {
   fileAutocomplete(extCtx);
   shellRecall(extCtx);
   commandSuggest(extCtx);
+  terminalBuffer(extCtx);
+  overlayAgent(extCtx);
 
   // Load user extensions (may register alternative agent backends)
   if (process.env.DEBUG) {

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -259,7 +259,7 @@ export class InputHandler {
           this.enterMode(mode);
           return; // don't process remaining chars
         }
-        this.lineBuffer += ch;
+        if (!this.ctx.isForegroundBusy()) this.lineBuffer += ch;
         this.ctx.writeToPty(ch);
       }
     }

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -172,6 +172,10 @@ export class InputHandler {
   }
 
   handleInput(data: string): void {
+    // Allow extensions to capture raw input (e.g. overlay prompt during vim)
+    const intercepted = this.bus.emitPipe("input:intercept", { data, consumed: false });
+    if (intercepted.consumed) return;
+
     // If agent is running (processing a query), only Ctrl-C and control keys
     if (this.ctx.isAgentActive()) {
       if (data === "\x03") {

--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -123,7 +123,15 @@ export class OutputParser {
       this.lastCommand = "";
       this.currentOutputCapture = "";
     } else {
+      // Cap capture buffer to avoid unbounded growth when a foreground
+      // program (tmux, vim, etc.) produces output without prompt markers.
+      // Keep only the tail — the final output is what matters for
+      // command-done context.
+      const MAX_CAPTURE = 128 * 1024; // 128 KB
       this.currentOutputCapture += data;
+      if (this.currentOutputCapture.length > MAX_CAPTURE) {
+        this.currentOutputCapture = this.currentOutputCapture.slice(-MAX_CAPTURE);
+      }
     }
   }
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -14,6 +14,7 @@ export class Shell implements InputContext {
   private outputParser: OutputParser;
   private paused = false;
   private stdoutHoldCount = 0;
+  private stdoutShowCount = 0;
   private echoSkip = false;
   private agentActive = false;
   private isZsh = false;
@@ -212,6 +213,12 @@ export class Shell implements InputContext {
     this.bus.on("shell:stdout-release", () => {
       this.stdoutHoldCount = Math.max(0, this.stdoutHoldCount - 1);
     });
+
+    // Ref-counted stdout show — tools temporarily force output visible during agent processing
+    this.bus.on("shell:stdout-show", () => { this.stdoutShowCount++; });
+    this.bus.on("shell:stdout-hide", () => {
+      this.stdoutShowCount = Math.max(0, this.stdoutShowCount - 1);
+    });
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──
@@ -275,7 +282,8 @@ export class Shell implements InputContext {
       this.bus.emit("shell:pty-data", { raw: data });
       this.outputParser.processData(data);
 
-      if (this.paused || this.stdoutHoldCount > 0) return;
+      if (this.stdoutHoldCount > 0) return;
+      if (this.paused && this.stdoutShowCount === 0) return;
 
       // During user_shell exec, skip the command echo (first line)
       if (this.echoSkip) {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -6,6 +6,7 @@ import type { EventBus } from "./event-bus.js";
 import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
 import { getSettings } from "./settings.js";
+import { RefCounter } from "./utils/output-writer.js";
 
 export class Shell implements InputContext {
   private ptyProcess: pty.IPty;
@@ -13,8 +14,8 @@ export class Shell implements InputContext {
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
   private paused = false;
-  private stdoutHoldCount = 0;
-  private stdoutShowCount = 0;
+  private stdoutHold = new RefCounter();
+  private stdoutShow = new RefCounter();
   private echoSkip = false;
   private agentActive = false;
   private isZsh = false;
@@ -209,16 +210,12 @@ export class Shell implements InputContext {
     });
 
     // Ref-counted stdout hold — overlay extensions suppress PTY output
-    this.bus.on("shell:stdout-hold", () => { this.stdoutHoldCount++; });
-    this.bus.on("shell:stdout-release", () => {
-      this.stdoutHoldCount = Math.max(0, this.stdoutHoldCount - 1);
-    });
+    this.bus.on("shell:stdout-hold", () => { this.stdoutHold.increment(); });
+    this.bus.on("shell:stdout-release", () => { this.stdoutHold.decrement(); });
 
     // Ref-counted stdout show — tools temporarily force output visible during agent processing
-    this.bus.on("shell:stdout-show", () => { this.stdoutShowCount++; });
-    this.bus.on("shell:stdout-hide", () => {
-      this.stdoutShowCount = Math.max(0, this.stdoutShowCount - 1);
-    });
+    this.bus.on("shell:stdout-show", () => { this.stdoutShow.increment(); });
+    this.bus.on("shell:stdout-hide", () => { this.stdoutShow.decrement(); });
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──
@@ -291,8 +288,8 @@ export class Shell implements InputContext {
       this.bus.emit("shell:pty-data", { raw: data });
       this.outputParser.processData(data);
 
-      if (this.stdoutHoldCount > 0) return;
-      if (this.paused && this.stdoutShowCount === 0) return;
+      if (this.stdoutHold.active) return;
+      if (this.paused && !this.stdoutShow.active) return;
 
       // During user_shell exec, skip the command echo (first line)
       if (this.echoSkip) {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -200,6 +200,11 @@ export class Shell implements InputContext {
     this.setupOutput();
     this.setupInput();
     this.setupAgentLifecycle();
+
+    // Allow extensions to inject raw keystrokes into the PTY
+    this.bus.on("shell:pty-write", ({ data }) => {
+      this.ptyProcess.write(data);
+    });
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -266,9 +266,18 @@ export class Shell implements InputContext {
    * Heavy redraw: send \n to PTY to trigger a full precmd → prompt cycle.
    * Use this after agent responses where stdout has moved far from where
    * zle expects the cursor. The blank line is acceptable as a separator.
+   *
+   * Routed through shell:redraw-prompt pipe so extensions (e.g. overlay)
+   * can suppress it by setting `handled: true`.
    */
   freshPrompt(): void {
-    this.ptyProcess.write("\n");
+    const result = this.bus.emitPipe("shell:redraw-prompt", {
+      cwd: this.outputParser.getCwd(),
+      handled: false,
+    });
+    if (!result.handled) {
+      this.ptyProcess.write("\n");
+    }
   }
 
   onCommandEntered(command: string, cwd: string): void {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -260,6 +260,7 @@ export class Shell implements InputContext {
 
   private setupOutput(): void {
     this.ptyProcess.onData((data: string) => {
+      this.bus.emit("shell:pty-data", { raw: data });
       this.outputParser.processData(data);
 
       if (this.paused) return;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -13,6 +13,7 @@ export class Shell implements InputContext {
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
   private paused = false;
+  private stdoutHoldCount = 0;
   private echoSkip = false;
   private agentActive = false;
   private isZsh = false;
@@ -205,6 +206,12 @@ export class Shell implements InputContext {
     this.bus.on("shell:pty-write", ({ data }) => {
       this.ptyProcess.write(data);
     });
+
+    // Ref-counted stdout hold — overlay extensions suppress PTY output
+    this.bus.on("shell:stdout-hold", () => { this.stdoutHoldCount++; });
+    this.bus.on("shell:stdout-release", () => {
+      this.stdoutHoldCount = Math.max(0, this.stdoutHoldCount - 1);
+    });
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──
@@ -268,7 +275,7 @@ export class Shell implements InputContext {
       this.bus.emit("shell:pty-data", { raw: data });
       this.outputParser.processData(data);
 
-      if (this.paused) return;
+      if (this.paused || this.stdoutHoldCount > 0) return;
 
       // During user_shell exec, skip the command echo (first line)
       if (this.echoSkip) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import type { LlmClient } from "./utils/llm-client.js";
 import type { ColorPalette } from "./utils/palette.js";
 import type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
 import type { ToolDefinition } from "./agent/types.js";
+import type { TerminalBuffer } from "./utils/terminal-buffer.js";
+import type { FloatingPanel, FloatingPanelConfig } from "./utils/floating-panel.js";
 
 export type { ContentBlock } from "./event-bus.js";
 export type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
@@ -77,6 +79,19 @@ export interface ExtensionContext {
   advise: (name: string, wrapper: (next: (...args: any[]) => any, ...args: any[]) => any) => void;
   /** Call a named handler. */
   call: (name: string, ...args: any[]) => any;
+
+  // ── Terminal utilities ────────────────────────────────────────
+  /**
+   * Shared headless terminal buffer mirroring PTY output.
+   * Lazily created on first access. Returns null if @xterm/headless is not installed.
+   */
+  terminalBuffer: TerminalBuffer | null;
+  /**
+   * Create a floating panel overlay. The panel composites a bordered box
+   * over the terminal with input routing, dimmed background, and
+   * handler-based customization.
+   */
+  createFloatingPanel: (config: FloatingPanelConfig) => FloatingPanel;
 }
 
 /**

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -6,18 +6,22 @@
  * stdout hold/release, input routing, compositing, scroll, and
  * screen restore.
  *
- * Rendering is customizable via the handler/advise pattern:
+ * Rendering is fully customizable via the handler/advise pattern:
  *
- *   // Define a custom content renderer
- *   ctx.define("panel:render-content", (renderCtx) => {
- *     return [`Hello from custom renderer (${renderCtx.width} cols)`];
+ *   // Replace the entire frame renderer
+ *   panel.handlers.define("panel:render-frame", (ctx) => {
+ *     // ctx has geo, content, bgLines, phase, title, footer, border
+ *     return { rows: myCustomRows, cursorSeq: "" };
  *   });
  *
- *   // Or wrap the default renderer
- *   ctx.advise("panel:render-content", (next, renderCtx) => {
- *     const lines = next(renderCtx);
- *     lines.push("── custom footer ──");
- *     return lines;
+ *   // Or advise individual pieces
+ *   panel.handlers.advise("panel:render-border-top", (next, ctx) => {
+ *     return `┏━ ${ctx.title} ${"━".repeat(ctx.geo.boxW - ctx.title.length - 5)}┓`;
+ *   });
+ *
+ *   panel.handlers.advise("panel:composite-row", (next, boxLine, bgLine, ...) => {
+ *     // custom compositing (e.g. no dimming, blur effect, etc.)
+ *     return next(boxLine, bgLine, ...);
  *   });
  *
  * When @xterm/headless is needed (for dimmed background compositing):
@@ -119,6 +123,58 @@ export interface RenderResult {
   cursor?: { row: number; col: number };
 }
 
+/**
+ * Box geometry computed from config + terminal size.
+ */
+export interface BoxGeometry {
+  /** Terminal columns. */
+  cols: number;
+  /** Terminal rows. */
+  rows: number;
+  /** Box width in columns (including borders). */
+  boxW: number;
+  /** Box height in rows (including borders). */
+  boxH: number;
+  /** Box top offset (0-indexed row). */
+  boxTop: number;
+  /** Box left offset (0-indexed column). */
+  boxLeft: number;
+  /** Usable content width inside box. */
+  contentW: number;
+  /** Usable content height inside box. */
+  contentH: number;
+}
+
+/**
+ * Context passed to the render-frame handler.
+ */
+export interface FrameContext {
+  /** Box geometry. */
+  geo: BoxGeometry;
+  /** Content render result (from render-content handler). */
+  content: RenderResult;
+  /** Background lines from the terminal buffer (null if no dimming). */
+  bgLines: string[] | null;
+  /** Current panel phase. */
+  phase: Phase;
+  /** Current title text. */
+  title: string;
+  /** Current footer text. */
+  footer: string;
+  /** Border characters for the configured border style. */
+  border: { tl: string; tr: string; bl: string; br: string; h: string; v: string };
+}
+
+/**
+ * Result from render-frame handler.
+ */
+export interface FrameResult {
+  /** One string per terminal row. */
+  rows: string[];
+  /** ANSI sequence to position the cursor (empty string if no cursor). */
+  cursorSeq: string;
+}
+
 export type Phase = "idle" | "input" | "active" | "done";
 
 // ── FloatingPanel ───────────────────────────────────────────────
@@ -137,6 +193,10 @@ export class FloatingPanel {
    *
    * Registered handlers:
    *   - `{prefix}:render-content(ctx: RenderContext) -> RenderResult`
+   *   - `{prefix}:render-frame(ctx: FrameContext) -> FrameResult`
+   *   - `{prefix}:render-border-top(ctx: FrameContext) -> string`
+   *   - `{prefix}:render-border-bottom(ctx: FrameContext) -> string`
+   *   - `{prefix}:composite-row(content: string, bgLine: string|null, boxLeft: number, boxW: number, cols: number) -> string`
    *   - `{prefix}:submit(query: string) -> void`
    *   - `{prefix}:dismiss() -> void`
    *   - `{prefix}:input(data: string) -> boolean`
@@ -160,7 +220,7 @@ export class FloatingPanel {
   private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
   private resizeHandler: (() => void) | null = null;
   private prevFrame: string[] = [];
-  private dismissing = false;
+  private suppressNextRedraw = false;
 
   constructor(bus: EventBus, config: FloatingPanelConfig, handlers?: HandlerRegistry) {
     this.bus = bus;
@@ -223,10 +283,94 @@ export class FloatingPanel {
       return display + " ".repeat(pad);
     });
 
+    // Default border-top renderer
+    this.handlers.define(`${p}:render-border-top`, (ctx: FrameContext): string => {
+      const { geo, border: b, title: _unused } = ctx;
+      const titleText = ctx.title || (ctx.phase === "input" ? "input" : ctx.phase === "done" ? "done" : "...");
+      const titleStr = ` ${INVERSE} ${titleText} ${RESET} `;
+      const titleVisLen = titleText.length + 4;
+      const dashCount = Math.max(0, geo.boxW - titleVisLen - 3);
+      return `${b.tl}${b.h}${titleStr}${b.h.repeat(dashCount)}${b.tr}`;
+    });
+
+    // Default border-bottom renderer
+    this.handlers.define(`${p}:render-border-bottom`, (ctx: FrameContext): string => {
+      const { geo, border: b } = ctx;
+      if (ctx.footer) {
+        const footerPad = Math.max(0, geo.boxW - ctx.footer.length - 3);
+        return `${b.bl}${b.h.repeat(footerPad)}${DIM}${ctx.footer}${RESET}${b.h}${b.br}`;
+      }
+      return `${b.bl}${b.h.repeat(geo.boxW - 2)}${b.br}`;
+    });
+
+    // Default composite-row: merge content on top of dimmed background
+    this.handlers.define(`${p}:composite-row`, (
+      boxLine: string, bgLine: string | null, boxLeft: number, boxW: number, cols: number,
+    ): string => {
+      if (bgLine !== null) {
+        const bg = bgLine.padEnd(cols);
+        return `${DIM}${bg.slice(0, boxLeft)}${RESET}${boxLine}${DIM}${bg.slice(boxLeft + boxW)}${RESET}`;
+      }
+      return boxLine;
+    });
+
+    // Default frame renderer: assembles borders, content rows, and background
+    this.handlers.define(`${p}:render-frame`, (ctx: FrameContext): FrameResult => {
+      const { geo, content, bgLines, border: b } = ctx;
+      const visibleContent = [...(content.lines ?? [])];
+      while (visibleContent.length < geo.contentH) visibleContent.push("");
+
+      const composite = (boxLine: string, bgLine: string | null): string =>
+        this.handlers.call(`${p}:composite-row`, boxLine, bgLine, geo.boxLeft, geo.boxW, geo.cols);
+
+      const buildRow = (c: string, w: number): string =>
+        this.handlers.call(`${p}:build-row`, c, w);
+
+      const frame: string[] = [];
+      for (let row = 0; row < geo.rows; row++) {
+        const relRow = row - geo.boxTop;
+        if (relRow < 0 || relRow >= geo.boxH) {
+          // Outside box
+          if (bgLines) {
+            frame.push(`${DIM}${(bgLines[row] || "").padEnd(geo.cols).slice(0, geo.cols)}${RESET}\x1b[K`);
+          } else {
+            frame.push("\x1b[2K");
+          }
+        } else if (relRow === 0) {
+          const borderTop = this.handlers.call(`${p}:render-border-top`, ctx) as string;
+          frame.push(composite(borderTop, bgLines?.[row] ?? null));
+        } else if (relRow === geo.boxH - 1) {
+          const borderBottom = this.handlers.call(`${p}:render-border-bottom`, ctx) as string;
+          frame.push(composite(borderBottom, bgLines?.[row] ?? null));
+        } else {
+          const contentIdx = relRow - 1;
+          const raw = visibleContent[contentIdx] || "";
+          const rendered = buildRow(raw, geo.contentW);
+          const boxLine = `${b.v} ${rendered} ${b.v}`;
+          frame.push(composite(boxLine, bgLines?.[row] ?? null));
+        }
+      }
+
+      let cursorSeq = "";
+      if (content.cursor) {
+        const cursorRow = geo.boxTop + 1 + content.cursor.row;
+        const cursorCol = geo.boxLeft + 2 + content.cursor.col;
+        cursorSeq = `\x1b[${cursorRow + 1};${cursorCol + 1}H`;
+      }
+
+      return { rows: frame, cursorSeq };
+    });
+
     // ── Wire bus events ───────────────────────────────────────
     bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
     bus.onPipe("shell:redraw-prompt", (payload) => {
-      if (this.phase !== "idle" || this.dismissing) {
+      if (this.phase !== "idle") {
+        return { ...payload, handled: true };
+      }
+      // After dismiss, suppress one redraw — restoreScreen already
+      // restored the terminal content, so freshPrompt's \n is unwanted.
+      if (this.suppressNextRedraw) {
+        this.suppressNextRedraw = false;
         return { ...payload, handled: true };
       }
       return payload;
@@ -288,24 +432,18 @@ export class FloatingPanel {
     if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
     if (this.resizeHandler) { process.stdout.off("resize", this.resizeHandler); this.resizeHandler = null; }
 
-    // Set dismissing flag BEFORE going idle — suppresses shell:redraw-prompt
-    // events that fire synchronously during stdout-release (freshPrompt \n).
-    this.dismissing = true;
+    this.suppressNextRedraw = true;
     this.phase = "idle";
     this.editor.clear();
     this.prevFrame = [];
 
     this.restoreScreen();
 
+    // Reset any accumulated stdout-show refs, then release hold.
     this.bus.emit("shell:stdout-hide", {});
     this.bus.emit("shell:stdout-release", {});
 
     this.handlers.call(`${this.prefix}:dismiss`);
-
-    // Clear flag after all synchronous handlers have run.
-    // Use queueMicrotask so it clears before the next event loop tick
-    // but after the current synchronous cascade.
-    queueMicrotask(() => { this.dismissing = false; });
   }
 
   // ── Public content API ──────────────────────────────────────
@@ -448,13 +586,12 @@ export class FloatingPanel {
     }
   }
 
-  // ── Frame building ────────────────────────────────────────
+  // ── Geometry ───────────────────────────────────────────────
 
-  private buildFrame(): { rows: string[]; cursorSeq: string } {
+  /** Compute box geometry from config + current terminal size. */
+  computeGeometry(): BoxGeometry {
     const cols = process.stdout.columns || 80;
     const rows = process.stdout.rows || 24;
-
-    // Compute box geometry
     const boxW = Math.min(this.resolveSize(this.config.width, cols - 4), this.config.maxWidth);
     const boxH = Math.min(
       this.resolveSize(this.config.height, rows - 4),
@@ -462,13 +599,18 @@ export class FloatingPanel {
     );
     const boxTop = Math.floor((rows - boxH) / 2);
     const boxLeft = Math.floor((cols - boxW) / 2);
-    const contentH = boxH - 2;
-    const contentW = boxW - 4;
+    return { cols, rows, boxW, boxH, boxTop, boxLeft, contentW: boxW - 4, contentH: boxH - 2 };
+  }
 
-    // ── Call render-content handler ────────────────────────
-    const ctx: RenderContext = {
-      width: contentW,
-      height: contentH,
+  // ── Frame building ────────────────────────────────────────
+
+  private buildFrame(): FrameResult {
+    const geo = this.computeGeometry();
+
+    // Call render-content handler
+    const renderCtx: RenderContext = {
+      width: geo.contentW,
+      height: geo.contentH,
       phase: this.phase,
       inputBuffer: this.editor.buffer,
       inputCursor: this.editor.cursor,
@@ -476,100 +618,23 @@ export class FloatingPanel {
       contentLines: this.contentLines,
       partialLine: this.currentPartialLine,
     };
-    const result: RenderResult = this.handlers.call(`${this.prefix}:render-content`, ctx);
-    const visibleContent = result?.lines ?? [];
-    const cursor = result?.cursor;
+    const content: RenderResult = this.handlers.call(`${this.prefix}:render-content`, renderCtx);
 
-    // Pad content to fill height
-    while (visibleContent.length < contentH) visibleContent.push("");
+    // Get background
+    const bgLines = this.buffer?.getScreenLines(geo.rows) ?? null;
 
-    // ── Get background ────────────────────────────────────
-    const bgLines = this.buffer?.getScreenLines(rows) ?? null;
+    // Build frame context and delegate to render-frame handler
+    const frameCtx: FrameContext = {
+      geo,
+      content,
+      bgLines,
+      phase: this.phase,
+      title: this.title,
+      footer: this.footer,
+      border: this.border,
+    };
 
-    // ── Compose each row ──────────────────────────────────
-    const frame: string[] = [];
-    const b = this.border;
-    const dim = bgLines ? DIM : "";
-    const buildRow = (content: string, w: number): string =>
-      this.handlers.call(`${this.prefix}:build-row`, content, w);
-
-    for (let row = 0; row < rows; row++) {
-      const relRow = row - boxTop;
-      let line: string;
-
-      if (relRow < 0 || relRow >= boxH) {
-        if (bgLines) {
-          const bgLine = (bgLines[row] || "").padEnd(cols).slice(0, cols);
-          line = `${dim}${bgLine}${RESET}\x1b[K`;
-        } else {
-          line = "\x1b[2K";
-        }
-      } else if (relRow === 0) {
-        line = this.buildBorderTop(boxW, boxLeft, bgLines?.[row] ?? null, cols, b, dim);
-      } else if (relRow === boxH - 1) {
-        line = this.buildBorderBottom(boxW, boxLeft, bgLines?.[row] ?? null, cols, b, dim);
-      } else {
-        const contentIdx = relRow - 1;
-        const raw = visibleContent[contentIdx] || "";
-        const rendered = buildRow(raw, contentW);
-        const boxLine = `${b.v} ${rendered} ${b.v}`;
-
-        if (bgLines) {
-          const bg = (bgLines[row] || "").padEnd(cols);
-          line = `${dim}${bg.slice(0, boxLeft)}${RESET}${boxLine}${dim}${bg.slice(boxLeft + boxW)}${RESET}`;
-        } else {
-          line = boxLine;
-        }
-      }
-
-      frame.push(line);
-    }
-
-    let cursorSeq = "";
-    if (cursor) {
-      const cursorRow = boxTop + 1 + cursor.row;
-      const cursorCol = boxLeft + 2 + cursor.col;
-      cursorSeq = `\x1b[${cursorRow + 1};${cursorCol + 1}H`;
-    }
-
-    return { rows: frame, cursorSeq };
-  }
-
-  private buildBorderTop(
-    boxW: number, boxLeft: number, bgRow: string | null,
-    cols: number, b: typeof this.border, dim: string,
-  ): string {
-    const titleText = this.title || (this.phase === "input" ? "input" : this.phase === "done" ? "done" : "...");
-    const titleStr = ` ${INVERSE} ${titleText} ${RESET} `;
-    const titleVisLen = titleText.length + 4; // text + 4 spaces (2 inside inverse, 2 outside)
-    const dashCount = Math.max(0, boxW - titleVisLen - 3); // 3 = tl + h-before-title + tr
-    const borderLine = `${b.tl}${b.h}${titleStr}${b.h.repeat(dashCount)}${b.tr}`;
-
-    if (bgRow !== null) {
-      const bg = bgRow.padEnd(cols);
-      return `${dim}${bg.slice(0, boxLeft)}${RESET}${borderLine}${dim}${bg.slice(boxLeft + boxW)}${RESET}`;
-    }
-    return borderLine;
-  }
-
-  private buildBorderBottom(
-    boxW: number, boxLeft: number, bgRow: string | null,
-    cols: number, b: typeof this.border, dim: string,
-  ): string {
-    const footerText = this.footer || "";
-    let borderLine: string;
-    if (footerText) {
-      const footerPad = Math.max(0, boxW - footerText.length - 3);
-      borderLine = `${b.bl}${b.h.repeat(footerPad)}${DIM}${footerText}${RESET}${b.h}${b.br}`;
-    } else {
-      borderLine = `${b.bl}${b.h.repeat(boxW - 2)}${b.br}`;
-    }
-
-    if (bgRow !== null) {
-      const bg = bgRow.padEnd(cols);
-      return `${dim}${bg.slice(0, boxLeft)}${RESET}${borderLine}${dim}${bg.slice(boxLeft + boxW)}${RESET}`;
-    }
-    return borderLine;
+    return this.handlers.call(`${this.prefix}:render-frame`, frameCtx);
   }
 
   // ── Rendering ─────────────────────────────────────────────
@@ -616,15 +681,11 @@ export class FloatingPanel {
   // ── Screen helpers ────────────────────────────────────────
 
   private restoreScreen(): void {
+    // Leave alt screen — the terminal restores the saved main buffer.
+    // We intentionally do NOT rewrite from the xterm buffer here:
+    // the xterm only sees PTY data, not direct stdout writes (banner,
+    // TUI output, etc.), so its content doesn't match the real screen.
     process.stdout.write("\x1b[?1049l");
-    if (this.buffer) {
-      const content = this.buffer.serialize();
-      const cursor = this.buffer.getCursor();
-      process.stdout.write(
-        "\x1b[H\x1b[2J" + content +
-        `\x1b[${cursor.y + 1};${cursor.x + 1}H`,
-      );
-    }
   }
 
   private resolveSize(spec: number | string, available: number): number {

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -271,7 +271,13 @@ export class FloatingPanel {
     this.border = BORDERS[this.config.borderStyle];
     this.triggerSeqs = buildTriggerSequences(config.trigger);
 
-    // ── Register default handlers ─────────────────────────────
+    this.registerDefaultHandlers();
+    this.wireEvents();
+  }
+
+  // ── Default handler registration ───────────────────────────
+
+  private registerDefaultHandlers(): void {
     const p = this.prefix;
 
     // Default content renderer: uses built-in appendText/appendLine buffer
@@ -315,7 +321,7 @@ export class FloatingPanel {
 
     // Default border-top renderer
     this.handlers.define(`${p}:render-border-top`, (ctx: FrameContext): string => {
-      const { geo, border: b, title: _unused } = ctx;
+      const { geo, border: b } = ctx;
       const titleText = ctx.title || (ctx.phase === "input" ? "input" : ctx.phase === "done" ? "done" : "...");
       const titleStr = ` ${INVERSE} ${titleText} ${RESET} `;
       const titleVisLen = titleText.length + 4;
@@ -350,8 +356,8 @@ export class FloatingPanel {
       const visibleContent = [...(content.lines ?? [])];
       while (visibleContent.length < geo.contentH) visibleContent.push("");
 
-      const composite = (boxLine: string, bgLine: string | null): string =>
-        this.handlers.call(`${p}:composite-row`, boxLine, bgLine, geo.boxLeft, geo.boxW, geo.cols);
+      const composite = (boxLine: string, bg: string | null): string =>
+        this.handlers.call(`${p}:composite-row`, boxLine, bg, geo.boxLeft, geo.boxW, geo.cols);
 
       const buildRow = (c: string, w: number): string =>
         this.handlers.call(`${p}:build-row`, c, w);
@@ -359,6 +365,8 @@ export class FloatingPanel {
       const frame: string[] = [];
       for (let row = 0; row < geo.rows; row++) {
         const relRow = row - geo.boxTop;
+        const bg = bgLines?.[row] ?? null;
+
         if (relRow < 0 || relRow >= geo.boxH) {
           // Outside box
           if (bgLines) {
@@ -367,17 +375,13 @@ export class FloatingPanel {
             frame.push("\x1b[2K");
           }
         } else if (relRow === 0) {
-          const borderTop = this.handlers.call(`${p}:render-border-top`, ctx) as string;
-          frame.push(composite(borderTop, bgLines?.[row] ?? null));
+          frame.push(composite(this.handlers.call(`${p}:render-border-top`, ctx), bg));
         } else if (relRow === geo.boxH - 1) {
-          const borderBottom = this.handlers.call(`${p}:render-border-bottom`, ctx) as string;
-          frame.push(composite(borderBottom, bgLines?.[row] ?? null));
+          frame.push(composite(this.handlers.call(`${p}:render-border-bottom`, ctx), bg));
         } else {
-          const contentIdx = relRow - 1;
-          const raw = visibleContent[contentIdx] || "";
-          const rendered = buildRow(raw, geo.contentW);
-          const boxLine = `${b.v} ${rendered} ${b.v}`;
-          frame.push(composite(boxLine, bgLines?.[row] ?? null));
+          const raw = visibleContent[relRow - 1] || "";
+          const boxLine = `${b.v} ${buildRow(raw, geo.contentW)} ${b.v}`;
+          frame.push(composite(boxLine, bg));
         }
       }
 
@@ -390,16 +394,19 @@ export class FloatingPanel {
 
       return { rows: frame, cursorSeq };
     });
+  }
 
-    // ── Wire bus events ───────────────────────────────────────
+  // ── Bus event wiring ───────────────────────────────────────
+
+  private wireEvents(): void {
     // Buffer PTY output while overlay is open so we can replay it on dismiss.
     // Alt screen restore discards anything written while it was active.
-    bus.on("shell:pty-data", ({ raw }) => {
+    this.bus.on("shell:pty-data", ({ raw }) => {
       if (this.phase !== "idle") this.ptyBuffer += raw;
     });
 
-    bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
-    bus.onPipe("shell:redraw-prompt", (payload) => {
+    this.bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
+    this.bus.onPipe("shell:redraw-prompt", (payload) => {
       if (this.phase !== "idle") {
         return { ...payload, handled: true };
       }
@@ -576,38 +583,31 @@ export class FloatingPanel {
   // ── Input handling ──────────────────────────────────────────
 
   private handleIntercept(payload: { data: string; consumed: boolean }): { data: string; consumed: boolean } {
-    if (this.phase === "done") {
-      this.dismiss();
-      return { ...payload, consumed: true };
-    }
+    const consumed = { ...payload, consumed: true };
+    const { data } = payload;
 
-    if (this.phase === "input") {
-      this.handleInputKey(payload.data);
-      return { ...payload, consumed: true };
-    }
-
-    if (this.phase === "active") {
-      const data = payload.data;
-      if (data === "\x03") {
-        this.bus.emit("agent:cancel-request", {});
-        return { ...payload, consumed: true };
-      }
-      if (data === "\x1b" || this.isTrigger(data)) {
+    switch (this.phase) {
+      case "done":
         this.dismiss();
-        return { ...payload, consumed: true };
-      }
-      if (this.handlers.call(`${this.prefix}:input`, data)) {
-        return { ...payload, consumed: true };
-      }
-      return { ...payload, consumed: true };
-    }
+        return consumed;
 
-    if (this.isTrigger(payload.data)) {
-      this.open();
-      return { ...payload, consumed: true };
-    }
+      case "input":
+        this.handleInputKey(data);
+        return consumed;
 
-    return payload;
+      case "active":
+        if (data === "\x03") this.bus.emit("agent:cancel-request", {});
+        else if (data === "\x1b" || this.isTrigger(data)) this.dismiss();
+        else this.handlers.call(`${this.prefix}:input`, data);
+        return consumed;
+
+      default: // idle
+        if (this.isTrigger(data)) {
+          this.open();
+          return consumed;
+        }
+        return payload;
+    }
   }
 
   private handleInputKey(data: string): void {

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -54,6 +54,29 @@ const BORDERS: Record<BorderStyle, { tl: string; tr: string; bl: string; br: str
   heavy:   { tl: "\u250f", tr: "\u2513", bl: "\u2517", br: "\u251b", h: "\u2501", v: "\u2503" },
 };
 
+// ── Trigger sequence helpers ────────────────────────────────────
+// Programs like vim enable xterm's modifyOtherKeys or the kitty
+// keyboard protocol, which encode Ctrl+key as CSI sequences instead
+// of raw control bytes.  We pre-compute every encoding of the
+// trigger so it works regardless of what the foreground process has
+// negotiated with the terminal.
+
+function buildTriggerSequences(trigger: string): string[] {
+  const seqs = [trigger];
+  if (trigger.length === 1) {
+    const code = trigger.charCodeAt(0);
+    if (code < 32) {
+      // Ctrl+key: base codepoint is code | 0x40 (e.g. 0x1c → 0x5c = '\')
+      const base = code | 0x40;
+      // xterm modifyOtherKeys mode 2: ESC[27;5;<base>~
+      seqs.push(`\x1b[27;5;${base}~`);
+      // kitty keyboard protocol: ESC[<base>;5u
+      seqs.push(`\x1b[${base};5u`);
+    }
+  }
+  return seqs;
+}
+
 // ── Types ───────────────────────────────────────────────────────
 
 export interface FloatingPanelConfig {
@@ -208,6 +231,10 @@ export class FloatingPanel {
   private buffer: TerminalBuffer | null = null;
   private bufferInitialized = false;
 
+  // ── Trigger sequences ───────────────────────────────────────
+  /** All byte sequences that should be recognized as the trigger key. */
+  private readonly triggerSeqs: string[];
+
   // ── State ───────────────────────────────────────────────────
   private phase: Phase = "idle";
   private editor = new LineEditor();
@@ -240,6 +267,7 @@ export class FloatingPanel {
       handlerPrefix: this.prefix,
     };
     this.border = BORDERS[this.config.borderStyle];
+    this.triggerSeqs = buildTriggerSequences(config.trigger);
 
     // ── Register default handlers ─────────────────────────────
     const p = this.prefix;
@@ -375,6 +403,11 @@ export class FloatingPanel {
       }
       return payload;
     });
+  }
+
+  /** Check whether data matches any encoding of the trigger key. */
+  private isTrigger(data: string): boolean {
+    return this.triggerSeqs.includes(data);
   }
 
   // ── Lazy terminal buffer setup ──────────────────────────────
@@ -534,7 +567,7 @@ export class FloatingPanel {
         this.bus.emit("agent:cancel-request", {});
         return { ...payload, consumed: true };
       }
-      if (data === "\x1b" || data === this.config.trigger) {
+      if (data === "\x1b" || this.isTrigger(data)) {
         this.dismiss();
         return { ...payload, consumed: true };
       }
@@ -544,7 +577,7 @@ export class FloatingPanel {
       return { ...payload, consumed: true };
     }
 
-    if (payload.data === this.config.trigger) {
+    if (this.isTrigger(payload.data)) {
       this.open();
       return { ...payload, consumed: true };
     }
@@ -553,10 +586,12 @@ export class FloatingPanel {
   }
 
   private handleInputKey(data: string): void {
+    // Check full data string against trigger sequences (may be multi-byte)
+    if (this.isTrigger(data)) { this.dismiss(); return; }
+
     for (let i = 0; i < data.length; i++) {
       const ch = data[i]!;
       if (ch === "\x1b" && data[i + 1] == null) { this.dismiss(); return; }
-      if (ch === this.config.trigger) { this.dismiss(); return; }
       if (ch.charCodeAt(0) === 0x03) { this.dismiss(); return; }
     }
 

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -248,6 +248,8 @@ export class FloatingPanel {
   private resizeHandler: (() => void) | null = null;
   private prevFrame: string[] = [];
   private suppressNextRedraw = false;
+  private ptyBuffer = "";  // PTY output accumulated while overlay is open
+  private usedAltScreen = false;  // whether we entered our own alt screen
 
   constructor(bus: EventBus, config: FloatingPanelConfig, handlers?: HandlerRegistry) {
     this.bus = bus;
@@ -390,6 +392,12 @@ export class FloatingPanel {
     });
 
     // ── Wire bus events ───────────────────────────────────────
+    // Buffer PTY output while overlay is open so we can replay it on dismiss.
+    // Alt screen restore discards anything written while it was active.
+    bus.on("shell:pty-data", ({ raw }) => {
+      if (this.phase !== "idle") this.ptyBuffer += raw;
+    });
+
     bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
     bus.onPipe("shell:redraw-prompt", (payload) => {
       if (this.phase !== "idle") {
@@ -450,8 +458,17 @@ export class FloatingPanel {
     this.footer = "";
     this.prevFrame = [];
 
+    this.ptyBuffer = "";
     this.bus.emit("shell:stdout-hold", {});
-    process.stdout.write("\x1b[?1049h");
+
+    // If a foreground program (vim, htop) is already on alt screen,
+    // don't enter a second alt screen — it doesn't nest.  Instead,
+    // render directly on the current screen and restore from the
+    // xterm buffer on dismiss.
+    this.usedAltScreen = !(this.buffer?.altScreen);
+    if (this.usedAltScreen) {
+      process.stdout.write("\x1b[?1049h");
+    }
 
     this.resizeHandler = () => { this.prevFrame = []; this.render(); };
     process.stdout.on("resize", this.resizeHandler);
@@ -471,6 +488,14 @@ export class FloatingPanel {
     this.prevFrame = [];
 
     this.restoreScreen();
+
+    // Replay any PTY output that arrived while the overlay was open.
+    // Alt screen restore discarded it, but it represents real work
+    // the agent did (commands run, output produced).
+    if (this.ptyBuffer) {
+      process.stdout.write(this.ptyBuffer);
+      this.ptyBuffer = "";
+    }
 
     // Reset any accumulated stdout-show refs, then release hold.
     this.bus.emit("shell:stdout-hide", {});
@@ -716,11 +741,25 @@ export class FloatingPanel {
   // ── Screen helpers ────────────────────────────────────────
 
   private restoreScreen(): void {
-    // Leave alt screen — the terminal restores the saved main buffer.
-    // We intentionally do NOT rewrite from the xterm buffer here:
-    // the xterm only sees PTY data, not direct stdout writes (banner,
-    // TUI output, etc.), so its content doesn't match the real screen.
-    process.stdout.write("\x1b[?1049l");
+    if (this.usedAltScreen) {
+      // Leave alt screen — the terminal restores the saved main buffer.
+      process.stdout.write("\x1b[?1049l");
+    } else {
+      // We were already on alt screen (vim, htop, etc.) so we didn't
+      // enter our own.  Restore by rewriting the screen content from
+      // the xterm buffer, which mirrors what the foreground program
+      // had rendered.
+      const raw = this.buffer?.serialize() ?? "";
+      const rows = process.stdout.rows || 24;
+      const lines = raw.split("\n");
+      const out: string[] = [SYNC_START];
+      for (let i = 0; i < rows; i++) {
+        out.push(`\x1b[${i + 1};1H\x1b[2K`);
+        if (i < lines.length) out.push(lines[i]!);
+      }
+      out.push(SYNC_END);
+      process.stdout.write(out.join(""));
+    }
   }
 
   private resolveSize(spec: number | string, available: number): number {

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -1,0 +1,638 @@
+/**
+ * Floating panel utility for overlay extensions.
+ *
+ * Provides a composited floating box rendered over the terminal using
+ * an alternate screen buffer. Handles the full overlay lifecycle:
+ * stdout hold/release, input routing, compositing, scroll, and
+ * screen restore.
+ *
+ * Rendering is customizable via the handler/advise pattern:
+ *
+ *   // Define a custom content renderer
+ *   ctx.define("panel:render-content", (renderCtx) => {
+ *     return [`Hello from custom renderer (${renderCtx.width} cols)`];
+ *   });
+ *
+ *   // Or wrap the default renderer
+ *   ctx.advise("panel:render-content", (next, renderCtx) => {
+ *     const lines = next(renderCtx);
+ *     lines.push("── custom footer ──");
+ *     return lines;
+ *   });
+ *
+ * When @xterm/headless is needed (for dimmed background compositing):
+ *   npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ *
+ * Usage from extensions:
+ *   import { FloatingPanel } from "agent-sh/utils/floating-panel.js";
+ */
+import { stripAnsi } from "./ansi.js";
+import { LineEditor } from "./line-editor.js";
+import { TerminalBuffer } from "./terminal-buffer.js";
+import { HandlerRegistry } from "./handler-registry.js";
+import type { EventBus } from "../event-bus.js";
+import type { BorderStyle } from "./box-frame.js";
+
+// ── ANSI constants ──────────────────────────────────────────────
+
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+const INVERSE = "\x1b[7m";
+const SYNC_START = "\x1b[?2026h";
+const SYNC_END = "\x1b[?2026l";
+
+// ── Border characters ───────────────────────────────────────────
+
+const BORDERS: Record<BorderStyle, { tl: string; tr: string; bl: string; br: string; h: string; v: string }> = {
+  rounded: { tl: "\u256d", tr: "\u256e", bl: "\u2570", br: "\u256f", h: "\u2500", v: "\u2502" },
+  square:  { tl: "\u250c", tr: "\u2510", bl: "\u2514", br: "\u2518", h: "\u2500", v: "\u2502" },
+  double:  { tl: "\u2554", tr: "\u2557", bl: "\u255a", br: "\u255d", h: "\u2550", v: "\u2551" },
+  heavy:   { tl: "\u250f", tr: "\u2513", bl: "\u2517", br: "\u251b", h: "\u2501", v: "\u2503" },
+};
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface FloatingPanelConfig {
+  /** Key sequence that toggles the panel (e.g. "\x1c" for Ctrl+\). */
+  trigger: string;
+  /** Panel width. Number = columns, string with % = percentage. Default: "80%". */
+  width?: number | string;
+  /** Max width in columns. Default: 100. */
+  maxWidth?: number;
+  /** Panel height. Number = rows, string with % = percentage. Default: "60%". */
+  height?: number | string;
+  /** Min content rows inside the panel. Default: 6. */
+  minHeight?: number;
+  /** Border style. Default: "rounded". */
+  borderStyle?: BorderStyle;
+  /**
+   * Show dimmed terminal content behind the panel. Default: true.
+   * Requires @xterm/headless — falls back to blank background if unavailable.
+   */
+  dimBackground?: boolean;
+  /** Auto-dismiss delay in ms when done (0 = disabled). Default: 0. */
+  autoDismissMs?: number;
+  /** Icon shown before the input cursor. Default: "\u276f". */
+  promptIcon?: string;
+  /**
+   * Pre-existing TerminalBuffer to reuse. If provided, the panel will
+   * not create its own headless terminal. Useful when sharing a buffer
+   * with other features (e.g. context injection, terminal_read tool).
+   */
+  terminalBuffer?: TerminalBuffer;
+  /**
+   * Handler namespace prefix. Default: "panel".
+   * All handlers are registered as `{prefix}:render-content`,
+   * `{prefix}:submit`, etc. Use different prefixes for multiple panels.
+   */
+  handlerPrefix?: string;
+}
+
+/**
+ * Context passed to the render-content handler.
+ */
+export interface RenderContext {
+  /** Available width for content (inside box, excluding borders and padding). */
+  width: number;
+  /** Available height for content (rows inside box). */
+  height: number;
+  /** Current panel phase. */
+  phase: Phase;
+  /** Current input buffer text (during input phase). */
+  inputBuffer: string;
+  /** Current input cursor position (during input phase). */
+  inputCursor: number;
+  /** Current scroll offset. */
+  scrollOffset: number;
+  /** Built-in content lines (from appendText/appendLine). */
+  contentLines: readonly string[];
+  /** Current partial line being streamed. */
+  partialLine: string;
+}
+
+/**
+ * Result from render-content handler.
+ */
+export interface RenderResult {
+  lines: string[];
+  /** Optional cursor position within the content area. */
+  cursor?: { row: number; col: number };
+}
+
+export type Phase = "idle" | "input" | "active" | "done";
+
+// ── FloatingPanel ───────────────────────────────────────────────
+
+export class FloatingPanel {
+  // ── Configuration ───────────────────────────────────────────
+  private readonly config: Required<Omit<FloatingPanelConfig, "terminalBuffer">>;
+  private readonly bus: EventBus;
+  private readonly border: { tl: string; tr: string; bl: string; br: string; h: string; v: string };
+  private readonly externalBuffer: TerminalBuffer | undefined;
+  private readonly prefix: string;
+
+  /**
+   * Handler registry for this panel. Extensions use `handlers.advise()`
+   * to customize rendering and behavior.
+   *
+   * Registered handlers:
+   *   - `{prefix}:render-content(ctx: RenderContext) -> RenderResult`
+   *   - `{prefix}:submit(query: string) -> void`
+   *   - `{prefix}:dismiss() -> void`
+   *   - `{prefix}:input(data: string) -> boolean`
+   *   - `{prefix}:build-row(content: string, width: number) -> string`
+   */
+  readonly handlers: HandlerRegistry;
+
+  // ── Headless terminal (lazy, optional) ──────────────────────
+  private buffer: TerminalBuffer | null = null;
+  private bufferInitialized = false;
+
+  // ── State ───────────────────────────────────────────────────
+  private phase: Phase = "idle";
+  private editor = new LineEditor();
+  private contentLines: string[] = [];
+  private currentPartialLine = "";
+  private scrollOffset = 0;
+  private title = "";
+  private footer = "";
+  private renderTimer: ReturnType<typeof setTimeout> | null = null;
+  private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
+  private resizeHandler: (() => void) | null = null;
+  private prevFrame: string[] = [];
+  private dismissing = false;
+
+  constructor(bus: EventBus, config: FloatingPanelConfig, handlers?: HandlerRegistry) {
+    this.bus = bus;
+    this.externalBuffer = config.terminalBuffer;
+    this.prefix = config.handlerPrefix ?? "panel";
+    this.handlers = handlers ?? new HandlerRegistry();
+    this.config = {
+      trigger: config.trigger,
+      width: config.width ?? "80%",
+      maxWidth: config.maxWidth ?? 100,
+      height: config.height ?? "60%",
+      minHeight: config.minHeight ?? 6,
+      borderStyle: config.borderStyle ?? "rounded",
+      dimBackground: config.dimBackground ?? true,
+      autoDismissMs: config.autoDismissMs ?? 0,
+      promptIcon: config.promptIcon ?? "\u276f",
+      handlerPrefix: this.prefix,
+    };
+    this.border = BORDERS[this.config.borderStyle];
+
+    // ── Register default handlers ─────────────────────────────
+    const p = this.prefix;
+
+    // Default content renderer: uses built-in appendText/appendLine buffer
+    this.handlers.define(`${p}:render-content`, (ctx: RenderContext): RenderResult => {
+      if (ctx.phase === "input") {
+        return {
+          lines: [`\x1b[36m${this.config.promptIcon}${RESET} ${ctx.inputBuffer}`],
+          cursor: { row: 0, col: this.config.promptIcon.length + 1 + ctx.inputCursor },
+        };
+      }
+      const all = [...ctx.contentLines, ...(ctx.partialLine ? [ctx.partialLine] : [])];
+      // Auto-scroll
+      let offset = ctx.scrollOffset;
+      if (all.length > ctx.height) {
+        offset = all.length - ctx.height;
+      } else {
+        offset = 0;
+      }
+      this.scrollOffset = offset;
+      return { lines: all.slice(offset, offset + ctx.height) };
+    });
+
+    // Default submit: no-op (extension overrides)
+    this.handlers.define(`${p}:submit`, (_query: string) => {});
+
+    // Default dismiss: no-op
+    this.handlers.define(`${p}:dismiss`, () => {});
+
+    // Default custom input handler: don't consume
+    this.handlers.define(`${p}:input`, (_data: string): boolean => false);
+
+    // Default row builder: truncate and pad
+    this.handlers.define(`${p}:build-row`, (content: string, width: number): string => {
+      const plain = stripAnsi(content);
+      const display = plain.length > width
+        ? content.slice(0, width - 1) + "\u2026"
+        : content;
+      const pad = Math.max(0, width - stripAnsi(display).length);
+      return display + " ".repeat(pad);
+    });
+
+    // ── Wire bus events ───────────────────────────────────────
+    bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
+    bus.onPipe("shell:redraw-prompt", (payload) => {
+      if (this.phase !== "idle" || this.dismissing) {
+        return { ...payload, handled: true };
+      }
+      return payload;
+    });
+  }
+
+  // ── Lazy terminal buffer setup ──────────────────────────────
+
+  private ensureBuffer(): TerminalBuffer | null {
+    if (this.bufferInitialized) return this.buffer;
+    this.bufferInitialized = true;
+
+    if (!this.config.dimBackground) return null;
+
+    if (this.externalBuffer) {
+      this.buffer = this.externalBuffer;
+    } else {
+      this.buffer = TerminalBuffer.createWired(this.bus);
+    }
+
+    return this.buffer;
+  }
+
+  // ── Public lifecycle ────────────────────────────────────────
+
+  get active(): boolean {
+    return this.phase !== "idle";
+  }
+
+  get terminalBuffer(): TerminalBuffer | null {
+    return this.buffer;
+  }
+
+  open(): void {
+    if (this.phase !== "idle") return;
+    this.ensureBuffer();
+
+    this.phase = "input";
+    this.editor.clear();
+    this.contentLines = [];
+    this.currentPartialLine = "";
+    this.scrollOffset = 0;
+    this.title = "";
+    this.footer = "";
+    this.prevFrame = [];
+
+    this.bus.emit("shell:stdout-hold", {});
+    process.stdout.write("\x1b[?1049h");
+
+    this.resizeHandler = () => { this.prevFrame = []; this.render(); };
+    process.stdout.on("resize", this.resizeHandler);
+
+    this.render();
+  }
+
+  dismiss(): void {
+    if (this.phase === "idle") return;
+    if (this.renderTimer) { clearTimeout(this.renderTimer); this.renderTimer = null; }
+    if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
+    if (this.resizeHandler) { process.stdout.off("resize", this.resizeHandler); this.resizeHandler = null; }
+
+    // Set dismissing flag BEFORE going idle — suppresses shell:redraw-prompt
+    // events that fire synchronously during stdout-release (freshPrompt \n).
+    this.dismissing = true;
+    this.phase = "idle";
+    this.editor.clear();
+    this.prevFrame = [];
+
+    this.restoreScreen();
+
+    this.bus.emit("shell:stdout-hide", {});
+    this.bus.emit("shell:stdout-release", {});
+
+    this.handlers.call(`${this.prefix}:dismiss`);
+
+    // Clear flag after all synchronous handlers have run.
+    // Use queueMicrotask so it clears before the next event loop tick
+    // but after the current synchronous cascade.
+    queueMicrotask(() => { this.dismissing = false; });
+  }
+
+  // ── Public content API ──────────────────────────────────────
+
+  appendText(text: string): void {
+    for (const ch of text) {
+      if (ch === "\n") {
+        this.contentLines.push(this.currentPartialLine);
+        this.currentPartialLine = "";
+      } else {
+        this.currentPartialLine += ch;
+      }
+    }
+    this.scheduleRender();
+  }
+
+  appendLine(line: string): void {
+    if (this.currentPartialLine) {
+      this.contentLines.push(this.currentPartialLine);
+      this.currentPartialLine = "";
+    }
+    this.contentLines.push(line);
+    this.scheduleRender();
+  }
+
+  updateLastLine(fn: (line: string) => string): void {
+    if (this.contentLines.length > 0) {
+      this.contentLines[this.contentLines.length - 1] = fn(this.contentLines[this.contentLines.length - 1]!);
+    }
+    this.scheduleRender();
+  }
+
+  clearContent(): void {
+    this.contentLines = [];
+    this.currentPartialLine = "";
+    this.scrollOffset = 0;
+    this.scheduleRender();
+  }
+
+  setTitle(title: string): void {
+    this.title = title;
+    this.scheduleRender();
+  }
+
+  setFooter(footer: string): void {
+    this.footer = footer;
+    this.scheduleRender();
+  }
+
+  setActive(): void {
+    this.phase = "active";
+  }
+
+  setDone(): void {
+    this.phase = "done";
+    this.render();
+    if (this.config.autoDismissMs > 0) {
+      this.autoDismissTimer = setTimeout(() => {
+        if (this.phase === "done") this.dismiss();
+      }, this.config.autoDismissMs);
+    }
+  }
+
+  getInput(): string {
+    return this.editor.buffer;
+  }
+
+  requestRender(): void {
+    this.scheduleRender();
+  }
+
+  // ── Input handling ──────────────────────────────────────────
+
+  private handleIntercept(payload: { data: string; consumed: boolean }): { data: string; consumed: boolean } {
+    if (this.phase === "done") {
+      this.dismiss();
+      return { ...payload, consumed: true };
+    }
+
+    if (this.phase === "input") {
+      this.handleInputKey(payload.data);
+      return { ...payload, consumed: true };
+    }
+
+    if (this.phase === "active") {
+      const data = payload.data;
+      if (data === "\x03") {
+        this.bus.emit("agent:cancel-request", {});
+        return { ...payload, consumed: true };
+      }
+      if (data === "\x1b" || data === this.config.trigger) {
+        this.dismiss();
+        return { ...payload, consumed: true };
+      }
+      if (this.handlers.call(`${this.prefix}:input`, data)) {
+        return { ...payload, consumed: true };
+      }
+      return { ...payload, consumed: true };
+    }
+
+    if (payload.data === this.config.trigger) {
+      this.open();
+      return { ...payload, consumed: true };
+    }
+
+    return payload;
+  }
+
+  private handleInputKey(data: string): void {
+    for (let i = 0; i < data.length; i++) {
+      const ch = data[i]!;
+      if (ch === "\x1b" && data[i + 1] == null) { this.dismiss(); return; }
+      if (ch === this.config.trigger) { this.dismiss(); return; }
+      if (ch.charCodeAt(0) === 0x03) { this.dismiss(); return; }
+    }
+
+    const actions = this.editor.feed(data);
+    for (const action of actions) {
+      switch (action.action) {
+        case "submit": {
+          const query = this.editor.buffer.trim();
+          if (!query) { this.dismiss(); return; }
+          this.phase = "active";
+          this.editor.clear();
+          this.handlers.call(`${this.prefix}:submit`, query);
+          return;
+        }
+        case "cancel":
+          this.dismiss();
+          return;
+        case "changed":
+        case "tab":
+        case "shift+tab":
+        case "arrow-up":
+        case "arrow-down":
+        case "delete-empty":
+          this.render();
+          break;
+      }
+    }
+  }
+
+  // ── Frame building ────────────────────────────────────────
+
+  private buildFrame(): { rows: string[]; cursorSeq: string } {
+    const cols = process.stdout.columns || 80;
+    const rows = process.stdout.rows || 24;
+
+    // Compute box geometry
+    const boxW = Math.min(this.resolveSize(this.config.width, cols - 4), this.config.maxWidth);
+    const boxH = Math.min(
+      this.resolveSize(this.config.height, rows - 4),
+      Math.max(this.config.minHeight + 2, rows - 4),
+    );
+    const boxTop = Math.floor((rows - boxH) / 2);
+    const boxLeft = Math.floor((cols - boxW) / 2);
+    const contentH = boxH - 2;
+    const contentW = boxW - 4;
+
+    // ── Call render-content handler ────────────────────────
+    const ctx: RenderContext = {
+      width: contentW,
+      height: contentH,
+      phase: this.phase,
+      inputBuffer: this.editor.buffer,
+      inputCursor: this.editor.cursor,
+      scrollOffset: this.scrollOffset,
+      contentLines: this.contentLines,
+      partialLine: this.currentPartialLine,
+    };
+    const result: RenderResult = this.handlers.call(`${this.prefix}:render-content`, ctx);
+    const visibleContent = result?.lines ?? [];
+    const cursor = result?.cursor;
+
+    // Pad content to fill height
+    while (visibleContent.length < contentH) visibleContent.push("");
+
+    // ── Get background ────────────────────────────────────
+    const bgLines = this.buffer?.getScreenLines(rows) ?? null;
+
+    // ── Compose each row ──────────────────────────────────
+    const frame: string[] = [];
+    const b = this.border;
+    const dim = bgLines ? DIM : "";
+    const buildRow = (content: string, w: number): string =>
+      this.handlers.call(`${this.prefix}:build-row`, content, w);
+
+    for (let row = 0; row < rows; row++) {
+      const relRow = row - boxTop;
+      let line: string;
+
+      if (relRow < 0 || relRow >= boxH) {
+        if (bgLines) {
+          const bgLine = (bgLines[row] || "").padEnd(cols).slice(0, cols);
+          line = `${dim}${bgLine}${RESET}\x1b[K`;
+        } else {
+          line = "\x1b[2K";
+        }
+      } else if (relRow === 0) {
+        line = this.buildBorderTop(boxW, boxLeft, bgLines?.[row] ?? null, cols, b, dim);
+      } else if (relRow === boxH - 1) {
+        line = this.buildBorderBottom(boxW, boxLeft, bgLines?.[row] ?? null, cols, b, dim);
+      } else {
+        const contentIdx = relRow - 1;
+        const raw = visibleContent[contentIdx] || "";
+        const rendered = buildRow(raw, contentW);
+        const boxLine = `${b.v} ${rendered} ${b.v}`;
+
+        if (bgLines) {
+          const bg = (bgLines[row] || "").padEnd(cols);
+          line = `${dim}${bg.slice(0, boxLeft)}${RESET}${boxLine}${dim}${bg.slice(boxLeft + boxW)}${RESET}`;
+        } else {
+          line = boxLine;
+        }
+      }
+
+      frame.push(line);
+    }
+
+    let cursorSeq = "";
+    if (cursor) {
+      const cursorRow = boxTop + 1 + cursor.row;
+      const cursorCol = boxLeft + 2 + cursor.col;
+      cursorSeq = `\x1b[${cursorRow + 1};${cursorCol + 1}H`;
+    }
+
+    return { rows: frame, cursorSeq };
+  }
+
+  private buildBorderTop(
+    boxW: number, boxLeft: number, bgRow: string | null,
+    cols: number, b: typeof this.border, dim: string,
+  ): string {
+    const titleText = this.title || (this.phase === "input" ? "input" : this.phase === "done" ? "done" : "...");
+    const titleStr = ` ${INVERSE} ${titleText} ${RESET} `;
+    const titleVisLen = titleText.length + 4; // text + 4 spaces (2 inside inverse, 2 outside)
+    const dashCount = Math.max(0, boxW - titleVisLen - 3); // 3 = tl + h-before-title + tr
+    const borderLine = `${b.tl}${b.h}${titleStr}${b.h.repeat(dashCount)}${b.tr}`;
+
+    if (bgRow !== null) {
+      const bg = bgRow.padEnd(cols);
+      return `${dim}${bg.slice(0, boxLeft)}${RESET}${borderLine}${dim}${bg.slice(boxLeft + boxW)}${RESET}`;
+    }
+    return borderLine;
+  }
+
+  private buildBorderBottom(
+    boxW: number, boxLeft: number, bgRow: string | null,
+    cols: number, b: typeof this.border, dim: string,
+  ): string {
+    const footerText = this.footer || "";
+    let borderLine: string;
+    if (footerText) {
+      const footerPad = Math.max(0, boxW - footerText.length - 3);
+      borderLine = `${b.bl}${b.h.repeat(footerPad)}${DIM}${footerText}${RESET}${b.h}${b.br}`;
+    } else {
+      borderLine = `${b.bl}${b.h.repeat(boxW - 2)}${b.br}`;
+    }
+
+    if (bgRow !== null) {
+      const bg = bgRow.padEnd(cols);
+      return `${dim}${bg.slice(0, boxLeft)}${RESET}${borderLine}${dim}${bg.slice(boxLeft + boxW)}${RESET}`;
+    }
+    return borderLine;
+  }
+
+  // ── Rendering ─────────────────────────────────────────────
+
+  private scheduleRender(): void {
+    if (this.renderTimer) return;
+    this.renderTimer = setTimeout(() => {
+      this.renderTimer = null;
+      this.render();
+    }, 32);
+  }
+
+  private render(): void {
+    if (this.phase === "idle") return;
+
+    const { rows: frame, cursorSeq } = this.buildFrame();
+
+    // Differential write — only send rows that changed
+    const out: string[] = [SYNC_START];
+    let dirty = false;
+
+    for (let i = 0; i < frame.length; i++) {
+      if (frame[i] !== this.prevFrame[i]) {
+        out.push(`\x1b[${i + 1};1H`);
+        out.push(frame[i]!);
+        dirty = true;
+      }
+    }
+    for (let i = frame.length; i < this.prevFrame.length; i++) {
+      out.push(`\x1b[${i + 1};1H\x1b[2K`);
+      dirty = true;
+    }
+
+    if (cursorSeq) out.push(cursorSeq);
+    out.push(SYNC_END);
+
+    if (this.prevFrame.length === 0 || dirty) {
+      process.stdout.write(out.join(""));
+    }
+
+    this.prevFrame = frame;
+  }
+
+  // ── Screen helpers ────────────────────────────────────────
+
+  private restoreScreen(): void {
+    process.stdout.write("\x1b[?1049l");
+    if (this.buffer) {
+      const content = this.buffer.serialize();
+      const cursor = this.buffer.getCursor();
+      process.stdout.write(
+        "\x1b[H\x1b[2J" + content +
+        `\x1b[${cursor.y + 1};${cursor.x + 1}H`,
+      );
+    }
+  }
+
+  private resolveSize(spec: number | string, available: number): number {
+    if (typeof spec === "number") return Math.min(spec, available);
+    if (typeof spec === "string" && spec.endsWith("%")) {
+      const pct = parseInt(spec, 10) / 100;
+      return Math.floor(available * pct);
+    }
+    return available;
+  }
+}

--- a/src/utils/output-writer.ts
+++ b/src/utils/output-writer.ts
@@ -13,7 +13,15 @@ export interface OutputWriter {
 
 /** Default writer that forwards to process.stdout. */
 export class StdoutWriter implements OutputWriter {
+  /** When > 0, all writes are silently dropped. Ref-counted. */
+  private _holdCount = 0;
+
+  hold(): void { this._holdCount++; }
+  release(): void { this._holdCount = Math.max(0, this._holdCount - 1); }
+  get held(): boolean { return this._holdCount > 0; }
+
   write(text: string): void {
+    if (this._holdCount > 0) return;
     if (process.stdout.writable) {
       try { process.stdout.write(text); } catch {}
     }

--- a/src/utils/output-writer.ts
+++ b/src/utils/output-writer.ts
@@ -6,6 +6,16 @@
  * alternative frontends, and a single point of control for output.
  */
 
+/** Simple ref-counted counter. Increment/decrement never goes below zero. */
+export class RefCounter {
+  private count = 0;
+  increment(): void { this.count++; }
+  decrement(): void { this.count = Math.max(0, this.count - 1); }
+  reset(): void { this.count = 0; }
+  get active(): boolean { return this.count > 0; }
+  get value(): number { return this.count; }
+}
+
 export interface OutputWriter {
   write(text: string): void;
   get columns(): number;
@@ -14,14 +24,14 @@ export interface OutputWriter {
 /** Default writer that forwards to process.stdout. */
 export class StdoutWriter implements OutputWriter {
   /** When > 0, all writes are silently dropped. Ref-counted. */
-  private _holdCount = 0;
+  private readonly _hold = new RefCounter();
 
-  hold(): void { this._holdCount++; }
-  release(): void { this._holdCount = Math.max(0, this._holdCount - 1); }
-  get held(): boolean { return this._holdCount > 0; }
+  hold(): void { this._hold.increment(); }
+  release(): void { this._hold.decrement(); }
+  get held(): boolean { return this._hold.active; }
 
   write(text: string): void {
-    if (this._holdCount > 0) return;
+    if (this._hold.active) return;
     if (process.stdout.writable) {
       try { process.stdout.write(text); } catch {}
     }

--- a/src/utils/terminal-buffer.ts
+++ b/src/utils/terminal-buffer.ts
@@ -68,6 +68,32 @@ export interface ScreenSnapshot {
   cursorY: number;
 }
 
+/**
+ * Format a screen snapshot as an XML context block for agent injection.
+ * Trims, caps to `maxLines` (from the bottom), and wraps in `<terminal_buffer>`.
+ * Returns the combined context string (baseContext + section), or just
+ * baseContext if the screen is empty.
+ */
+export function formatScreenContext(
+  screen: ScreenSnapshot,
+  maxLines = 80,
+  baseContext?: string,
+): string {
+  const trimmed = screen.text.trim();
+  if (!trimmed) return baseContext ?? "";
+
+  const lines = trimmed.split("\n");
+  const capped = lines.length > maxLines
+    ? lines.slice(-maxLines).join("\n")
+    : trimmed;
+
+  const header = screen.altScreen
+    ? "<terminal_buffer mode=\"alternate\">"
+    : "<terminal_buffer>";
+  const section = `${header}\n${capped}\n</terminal_buffer>`;
+  return baseContext ? baseContext + "\n" + section : section;
+}
+
 // ── TerminalBuffer ──────────────────────────────────────────────
 
 export class TerminalBuffer {
@@ -127,25 +153,37 @@ export class TerminalBuffer {
 
   /** Read clean screen text with metadata. */
   readScreen(): ScreenSnapshot {
-    const raw = this.serializeAddon.serialize();
+    const buf = this.term.buffer.active;
+    const lines = this.readViewportLines(buf);
     return {
-      text: stripAnsi(raw),
-      altScreen: this.term.buffer.active.type === "alternate",
-      cursorX: this.term.buffer.active.cursorX,
-      cursorY: this.term.buffer.active.cursorY,
+      text: lines.join("\n"),
+      altScreen: buf.type === "alternate",
+      cursorX: buf.cursorX,
+      cursorY: buf.cursorY,
     };
   }
 
   /**
    * Get terminal screen as lines, padded/trimmed to exactly `rows` lines.
-   * Clean text only (ANSI stripped).
+   * Clean text only (ANSI stripped).  Reads from the active buffer's
+   * viewport (not scrollback), so it works correctly on both the normal
+   * and alternate screen buffers.
    */
   getScreenLines(rows?: number): string[] {
     const targetRows = rows ?? (process.stdout.rows || 24);
-    const raw = this.serializeAddon.serialize();
-    const lines = stripAnsi(raw).split("\n");
-    while (lines.length < targetRows) lines.push("");
-    return lines.slice(0, targetRows);
+    return this.readViewportLines(this.term.buffer.active, targetRows);
+  }
+
+  /** Read visible viewport lines from a buffer. */
+  private readViewportLines(buf: any, rows?: number): string[] {
+    const targetRows = rows ?? buf.length;
+    const base = buf.baseY ?? 0;
+    const lines: string[] = [];
+    for (let y = 0; y < targetRows; y++) {
+      const line = buf.getLine(base + y);
+      lines.push(line ? line.translateToString(true) : "");
+    }
+    return lines;
   }
 
   /** Get cursor position. */

--- a/src/utils/terminal-buffer.ts
+++ b/src/utils/terminal-buffer.ts
@@ -1,0 +1,153 @@
+/**
+ * Headless terminal buffer backed by xterm.js.
+ *
+ * Provides accurate terminal screen capture — correctly handles ANSI
+ * codes, cursor movement, alternate screen (vim/htop), line wrapping,
+ * and scrollback.
+ *
+ * Used by:
+ *   - floating-panel.ts: composited overlay rendering + screen restore
+ *   - terminal-buffer extension: agent tools (terminal_read, terminal_keys)
+ *   - Any extension needing a virtual terminal snapshot
+ *
+ * The xterm dependency is loaded lazily on first use. If @xterm/headless
+ * is not installed, create() returns null.
+ *
+ * Install (optional):
+ *   npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ */
+import { createRequire } from "module";
+import { stripAnsi } from "./ansi.js";
+import type { EventBus } from "../event-bus.js";
+
+// ── Lazy xterm loader ───────────────────────────────────────────
+
+const require = createRequire(import.meta.url);
+
+let loadAttempted = false;
+let available = false;
+let TerminalCtor: any;
+let SerializeAddonCtor: any;
+
+function ensureXterm(): boolean {
+  if (loadAttempted) return available;
+  loadAttempted = true;
+  try {
+    TerminalCtor = require("@xterm/headless").Terminal;
+    SerializeAddonCtor = require("@xterm/addon-serialize").SerializeAddon;
+    available = true;
+  } catch {
+    available = false;
+  }
+  return available;
+}
+
+/** Check if @xterm/headless is installed without loading it. */
+export function isXtermAvailable(): boolean {
+  return ensureXterm();
+}
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface TerminalBufferConfig {
+  /** Terminal width in columns. Default: process.stdout.columns || 80. */
+  cols?: number;
+  /** Terminal height in rows. Default: process.stdout.rows || 24. */
+  rows?: number;
+  /** Scrollback buffer size. Default: 200. */
+  scrollback?: number;
+}
+
+export interface ScreenSnapshot {
+  /** Clean text with ANSI sequences stripped. */
+  text: string;
+  /** Whether the alternate screen buffer is active (vim, htop, etc.). */
+  altScreen: boolean;
+  /** Cursor position. */
+  cursorX: number;
+  cursorY: number;
+}
+
+// ── TerminalBuffer ──────────────────────────────────────────────
+
+export class TerminalBuffer {
+  private readonly term: any;
+  private readonly serializeAddon: any;
+
+  private constructor(term: any, serialize: any) {
+    this.term = term;
+    this.serializeAddon = serialize;
+  }
+
+  /**
+   * Create a new TerminalBuffer. Returns null if xterm is not installed.
+   */
+  static create(config?: TerminalBufferConfig): TerminalBuffer | null {
+    if (!ensureXterm()) return null;
+    const cols = config?.cols ?? (process.stdout.columns || 80);
+    const rows = config?.rows ?? (process.stdout.rows || 24);
+    const scrollback = config?.scrollback ?? 200;
+
+    const term = new TerminalCtor({ cols, rows, allowProposedApi: true, scrollback });
+    const serialize = new SerializeAddonCtor();
+    term.loadAddon(serialize);
+    return new TerminalBuffer(term, serialize);
+  }
+
+  /**
+   * Create a TerminalBuffer and wire it to a bus's shell:pty-data event.
+   * Returns null if xterm is not installed.
+   */
+  static createWired(bus: EventBus, config?: TerminalBufferConfig): TerminalBuffer | null {
+    const tb = TerminalBuffer.create(config);
+    if (!tb) return null;
+    bus.on("shell:pty-data", ({ raw }) => { tb.write(raw); });
+    return tb;
+  }
+
+  /** Write raw data into the virtual terminal. */
+  write(data: string): void {
+    this.term.write(data);
+  }
+
+  /** Get the raw serialized terminal output (includes ANSI sequences). */
+  serialize(): string {
+    return this.serializeAddon.serialize();
+  }
+
+  /** Read clean screen text with metadata. */
+  readScreen(): ScreenSnapshot {
+    const raw = this.serializeAddon.serialize();
+    return {
+      text: stripAnsi(raw),
+      altScreen: this.term.buffer.active.type === "alternate",
+      cursorX: this.term.buffer.active.cursorX,
+      cursorY: this.term.buffer.active.cursorY,
+    };
+  }
+
+  /**
+   * Get terminal screen as lines, padded/trimmed to exactly `rows` lines.
+   * Clean text only (ANSI stripped).
+   */
+  getScreenLines(rows?: number): string[] {
+    const targetRows = rows ?? (process.stdout.rows || 24);
+    const raw = this.serializeAddon.serialize();
+    const lines = stripAnsi(raw).split("\n");
+    while (lines.length < targetRows) lines.push("");
+    return lines.slice(0, targetRows);
+  }
+
+  /** Get cursor position. */
+  getCursor(): { x: number; y: number } {
+    return {
+      x: this.term.buffer.active.cursorX,
+      y: this.term.buffer.active.cursorY,
+    };
+  }
+
+  /** Whether the alternate screen buffer is active. */
+  get altScreen(): boolean {
+    return this.term.buffer.active.type === "alternate";
+  }
+}

--- a/src/utils/terminal-buffer.ts
+++ b/src/utils/terminal-buffer.ts
@@ -101,7 +101,17 @@ export class TerminalBuffer {
   static createWired(bus: EventBus, config?: TerminalBufferConfig): TerminalBuffer | null {
     const tb = TerminalBuffer.create(config);
     if (!tb) return null;
-    bus.on("shell:pty-data", ({ raw }) => { tb.write(raw); });
+    // Buffer PTY data and drip-feed to xterm in the background.
+    // Synchronous term.write() in the pty-data handler introduces enough
+    // latency to change PTY read coalescing, causing visual artifacts.
+    let pending = "";
+    bus.on("shell:pty-data", ({ raw }) => { pending += raw; });
+    setInterval(() => {
+      if (pending) { const d = pending; pending = ""; tb.write(d); }
+    }, 50);
+    process.stdout.on("resize", () => {
+      tb.resize(process.stdout.columns || 80, process.stdout.rows || 24);
+    });
     return tb;
   }
 
@@ -144,6 +154,11 @@ export class TerminalBuffer {
       x: this.term.buffer.active.cursorX,
       y: this.term.buffer.active.cursorY,
     };
+  }
+
+  /** Resize the virtual terminal. */
+  resize(cols: number, rows: number): void {
+    this.term.resize(cols, rows);
   }
 
   /** Whether the alternate screen buffer is active. */


### PR DESCRIPTION
## Summary

Adds the ability for agents to see and interact with the user's terminal — including full-screen programs like vim, htop, and ssh.

### Core primitives
- **`shell:pty-data` event** — broadcasts raw PTY output on the bus
- **`TerminalBuffer`** — headless xterm.js mirror of the terminal, exposed as `ctx.terminalBuffer` (lazy singleton)
- **`FloatingPanel`** — composited overlay rendered on alt screen, exposed as `ctx.createFloatingPanel(config)`
- **`shell:stdout-hold/release`** and **`shell:stdout-show/hide`** — stdout flow control for overlays and tools

### Built-in tools
- **`terminal_read`** — read the current screen contents (ANSI stripped, cursor position, alt screen detection)
- **`terminal_keys`** — send keystrokes to the PTY (with escape sequence support)

### Built-in overlay agent
- **Ctrl+\** summons the agent from anywhere — even inside vim, htop, or ssh
- Floating panel with dimmed background compositing
- Streams agent responses, tool calls, and status into the panel
- Auto-dismisses after completion

### Key fixes
- **Alt screen nesting** — detects when a foreground program is already on alt screen and skips nested alt screen (restores by rewriting from xterm buffer)
- **Keyboard protocol support** — recognizes modifyOtherKeys (`\e[27;5;92~`) and kitty protocol (`\e[92;5u`) encodings so the trigger works inside vim
- **PTY replay on dismiss** — buffers PTY output during overlay and replays on dismiss so agent command output isn't lost
- **Viewport-based buffer reading** — reads from xterm's active buffer viewport instead of serialize(), fixing stale content on alt screen
- **Drip-feed PTY data** — buffers pty-data and flushes via setInterval(50ms) to avoid read coalescing artifacts

### Handler-based rendering
FloatingPanel rendering is fully customizable via the handler/advise pattern:
- `render-frame` — replace the entire visual
- `render-border-top` / `render-border-bottom` — custom title/footer bars
- `composite-row` — custom background compositing
- `render-content` / `build-row` — content and row formatting

## Test plan
- [ ] Launch `ash`, verify `terminal_read` and `terminal_keys` tools appear
- [ ] Open vim, press Ctrl+\, verify overlay appears with vim's screen dimmed in background
- [ ] Submit a query through overlay, verify response streams into panel
- [ ] Dismiss overlay, verify vim screen is properly restored
- [ ] Run a command via overlay agent, verify output appears after dismiss
- [ ] Test overlay at normal shell prompt (alt screen save/restore path)