### PR TITLE
overlay panel, context management, provider capabilities

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -23,31 +23,14 @@ The key insight: **the agent is a loop, not a single call**. The LLM calls tools
 
 ## Context Assembly
 
-Every query includes **shell context** — a structured summary of your recent terminal activity. This is how the agent knows what you've been doing.
+Every query includes two streams of context that share a unified token budget:
 
-```
-Shell Context (from ContextManager):
-  ├─ Current working directory
-  ├─ Recent shell commands + truncated output
-  ├─ Recent agent exchanges (queries + responses)
-  └─ Recent tool executions
-```
+- **Shell context** = user terminal history (commands + outputs), assembled fresh for every LLM call. It's what lets the agent understand "fix this" after you ran a failing command.
+- **Conversation state** = the OpenAI chat messages array (`user`/`assistant`/`tool` messages). This is the LLM's memory of what it already said and did.
 
-Context is **not the same as conversation state**. This is a common source of confusion:
+The two streams don't overlap — agent tool outputs live only in the conversation, while shell context tracks only user-initiated activity. Both streams support recall tools (`shell_recall` and `conversation_recall`) for recovering evicted content.
 
-- **Shell context** = your terminal history, assembled fresh for every LLM call, included in the system prompt. It's what lets the agent understand "fix this" after you ran a failing command.
-- **Conversation state** = the OpenAI chat messages array (`user`/`assistant`/`tool` messages). This is the LLM's memory of the current multi-turn conversation.
-
-They serve different purposes. Context gives the agent situational awareness. Conversation state gives it memory of what it already said and did.
-
-### Truncation and budgeting
-
-Shell output can be large. The context manager applies a budget to keep things reasonable:
-
-- **Windowing** — only the last N exchanges are included (configurable via `contextWindowSize`)
-- **Per-exchange truncation** — long outputs get head+tail with `[... omitted ...]` in the middle
-- **Budget enforcement** — if total context exceeds the byte budget, oldest exchange outputs are stripped first
-- **Recall** — the agent can use `shell_recall` to retrieve full output of truncated exchanges when needed
+See [Context Management](context-management.md) for the full design: token budgeting, truncation pipeline, priority-based compaction, and configuration.
 
 ## System Prompt
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,7 +113,8 @@ agent-sh/
 │   ├── shell.ts            # PTY lifecycle + wiring (InputHandler + OutputParser)
 │   ├── input-handler.ts    # Keyboard input, agent mode, bus-driven autocomplete
 │   ├── output-parser.ts    # OSC parsing, command boundary detection
-│   ├── context-manager.ts  # Exchange log, context assembly, recall API
+│   ├── context-manager.ts  # Shell exchange log, context assembly, recall API
+│   ├── token-budget.ts     # Unified token budget (splits context window between streams)
 │   ├── settings.ts         # User settings (~/.agent-sh/settings.json)
 │   ├── extension-loader.ts # Extension loading (-e, settings.json, extensions dir)
 │   ├── executor.ts         # Isolated child process execution (shared by shell + bash tool)
@@ -124,7 +125,7 @@ agent-sh/
 │   │   ├── index.ts        # Factory: config → AgentLoop
 │   │   ├── agent-loop.ts   # Internal agent (OpenAI-compat API, bus-driven)
 │   │   ├── tool-registry.ts       # Map-based tool registry
-│   │   ├── conversation-state.ts  # OpenAI chat messages array
+│   │   ├── conversation-state.ts  # Chat messages, priority compaction, eviction archive
 │   │   ├── system-prompt.ts       # System prompt builder
 │   │   └── tools/          # Built-in tool implementations
 │   │       ├── bash.ts, read-file.ts, write-file.ts, edit-file.ts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ index.ts — interactive terminal frontend:
   │
   ├── Built-in extensions:
   │     tuiRenderer       — markdown rendering, inline diffs, thinking display, spinner
-  │     slashCommands     — /help, /clear, /copy, /compact, /quit
+  │     slashCommands     — /help, /model, /thinking, /compact, /context
   │     fileAutocomplete  — @ file path completion
   │     shellRecall       — shell_recall terminal interception
   │     commandSuggest    — fix suggestions on failed commands (fast-path LLM)
@@ -125,7 +125,9 @@ agent-sh/
 │   │   ├── index.ts        # Factory: config → AgentLoop
 │   │   ├── agent-loop.ts   # Internal agent (OpenAI-compat API, bus-driven)
 │   │   ├── tool-registry.ts       # Map-based tool registry
-│   │   ├── conversation-state.ts  # Chat messages, priority compaction, eviction archive
+│   │   ├── conversation-state.ts  # Three-tier conversation: active + nuclear + history
+│   │   ├── nuclear-form.ts       # Nuclear one-liner generation + serialization
+│   │   ├── history-file.ts       # Persistent JSONL history file
 │   │   ├── system-prompt.ts       # System prompt builder
 │   │   └── tools/          # Built-in tool implementations
 │   │       ├── bash.ts, read-file.ts, write-file.ts, edit-file.ts

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -1,0 +1,251 @@
+# Context Management
+
+agent-sh manages two separate streams of text that compete for a finite LLM context window. Understanding how they work — and how they share space — is key to getting the most out of the agent, especially with models of different context window sizes.
+
+## The Two Streams
+
+### Stream 1: Shell Context (situational awareness)
+
+The **shell context** is what the user has been doing in the terminal. It's managed by `ContextManager` and injected as a `<shell_context>` block in the dynamic context on every LLM call.
+
+It contains:
+- **User shell commands** and their outputs (truncated)
+- **Agent query markers** — one-liners recording what the user asked
+
+Shell context answers the question: *"What has the user been doing?"*
+
+### Stream 2: Conversation (task continuity)
+
+The **conversation** is the OpenAI chat messages array — `user`, `assistant`, and `tool` messages. It's managed by `ConversationState` and appended directly to the LLM request.
+
+It contains:
+- User messages (queries)
+- Assistant messages (text responses + tool calls)
+- Tool results (outputs from bash, read_file, edit_file, etc.)
+
+Conversation answers the question: *"What has the agent been working on?"*
+
+### Why two streams?
+
+They serve different purposes and have different lifecycles:
+
+- Shell context is **rebuilt fresh** on every LLM call. It's a sliding window over the session.
+- Conversation is **accumulated** across turns within a query session. It's the LLM's working memory.
+
+A user might run 50 shell commands before ever asking the agent anything. That history lives in the shell context. Once the agent starts working, its tool calls and reasoning live in the conversation.
+
+### No duplication
+
+Agent tool outputs live **only** in the conversation stream. Shell context tracks **only** user-initiated activity (shell commands and query markers). This avoids wasting context on redundant content.
+
+## The Token Budget
+
+Both streams share a single budget derived from the model's actual context window.
+
+```
+Model context window (e.g. 200,000 tokens)
+  - System prompt overhead        (~800 tokens)
+  - Tool definitions              (~50 tokens per tool)
+  - Response reserve              (8,192 tokens)
+  - Dynamic context overhead      (~500 tokens for conventions, metadata)
+  = Content budget
+    +-- Shell context slice       (35% by default)
+    +-- Conversation slice        (65% by default)
+```
+
+The split ratio is configurable via `shellContextRatio` in `~/.agent-sh/settings.json`:
+
+```json
+{ "shellContextRatio": 0.35 }
+```
+
+When the model's `contextWindow` is not configured, the budget falls back to a conservative 60,000 tokens total.
+
+### How the budget adapts
+
+The budget recalculates automatically when you switch models. A model with 200k context gets generous budgets for both streams. A model with 8k context gets much tighter limits, but the same ratio applies.
+
+| Model context | Shell budget | Conversation budget |
+|---------------|-------------|-------------------|
+| 8,000         | ~0 tokens   | ~0 tokens (minimal overhead leaves little room) |
+| 32,000        | ~6,400      | ~12,000           |
+| 128,000       | ~37,000     | ~70,000           |
+| 200,000       | ~62,000     | ~115,000          |
+
+*(Numbers are approximate — actual values depend on tool count and prompt size.)*
+
+## Shell Context Pipeline
+
+The shell context passes through three stages before being injected into the LLM prompt:
+
+### 1. Windowing
+
+Keep only the last N exchanges. Default: 20. Configurable via `contextWindowSize`.
+
+### 2. Per-exchange truncation
+
+Long shell outputs get head+tail truncation:
+
+```
+$ find . -name "*.ts"
+  ./src/index.ts
+  ./src/core.ts
+  ./src/settings.ts
+  ./src/types.ts
+  ./src/event-bus.ts
+  [... 142 lines truncated, use shell_recall tool with expand and id 7 to see full output ...]
+  ./examples/extensions/openrouter.ts
+  ./examples/extensions/bridge.ts
+  exit 0
+```
+
+Truncation thresholds are configurable:
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `shellTruncateThreshold` | 10 lines | Lines before truncation kicks in |
+| `shellHeadLines` | 5 | Lines kept from start |
+| `shellTailLines` | 5 | Lines kept from end |
+
+### 3. Budget enforcement
+
+If the total shell context exceeds the token budget, oldest exchange outputs are stripped entirely:
+
+```
+#3 [shell cwd:/project] $ npm test
+  [output omitted, use shell_recall tool to expand id 3]
+```
+
+The agent can always recover full content via `shell_recall`.
+
+### shell_recall
+
+Truncated content is not lost — it stays in memory. The agent can search and expand it:
+
+- `shell_recall` — browse one-line summaries of recent exchanges
+- `shell_recall --search "query"` — regex search across all session history
+- `shell_recall --expand 41` — retrieve full content of exchange #41
+
+## Conversation Compaction
+
+When the conversation exceeds its token budget, it's **compacted** — low-priority turns are evicted to make room for new work.
+
+### Priority-based eviction
+
+Not all turns are equally important. Compaction evicts lowest-priority content first:
+
+| Priority | What | Why |
+|----------|------|-----|
+| Pinned | First user message + last N turns | Original task + recency |
+| High | User messages, error messages, assistant reasoning | Context and corrections matter |
+| Medium | Tool results from write/edit operations | Produced durable changes |
+| Low | Successful tool results with no errors | Can be reproduced |
+| Lowest | Read-only tool results (grep, ls, read_file) | Agent can re-read these |
+
+### Eviction archive
+
+Evicted turns are not discarded — they're moved to an archive. The `[Earlier conversation turns evicted]` marker tells the agent that content was compacted, and it can recover it.
+
+### conversation_recall
+
+Mirrors `shell_recall` for conversation content:
+
+- `conversation_recall browse` — list evicted turns with one-line summaries
+- `conversation_recall --search "query"` — search evicted conversation content
+- `conversation_recall --expand 5` — retrieve full content of evicted turn #5
+
+### Auto-compaction
+
+Compaction triggers automatically before each LLM call when the estimated token count exceeds the conversation budget. On context overflow errors from the API, a more aggressive compaction runs (60% of budget) and the request is retried.
+
+## Message Assembly
+
+Here's what the LLM actually sees on each call:
+
+```
+[0] system: Static identity + behavioral rules (cacheable)
+
+[1] user: <context>
+       # Available Tools
+       - bash: Execute shell commands...
+       - read_file: Read a file...
+       ...
+
+       # Project Conventions
+       [CLAUDE.md / AGENT.md content]
+
+       <shell_context>
+       cwd: /Users/you/project
+       session: 42 exchanges, 15m elapsed
+
+       #38 [shell cwd:/project] $ git status
+         On branch main
+         ...
+         exit 0
+
+       #39 [you] > fix the failing test
+       </shell_context>
+
+       Current date: 2025-02-17
+       Working directory: /Users/you/project
+     </context>
+
+[2] assistant: "Understood."
+
+[3..N] Conversation messages:
+       [user] fix the failing test
+       [assistant] Let me look at the test... {tool_calls: [read_file]}
+       [tool] {content: "test file contents..."}
+       [assistant] I see the issue... {tool_calls: [edit_file]}
+       [tool] {content: "File edited successfully"}
+       ...
+```
+
+## Extension Hooks
+
+Three hooks allow extensions to customize context management:
+
+| Hook | Purpose | Called when |
+|------|---------|------------|
+| `context:build-extra` | Inject additional content into `<shell_context>` | Every context build |
+| `dynamic-context:build` | Wrap or modify the entire dynamic context | Every LLM iteration |
+| `conversation:prepare` | Transform the full message array before sending | Every LLM call |
+
+Example: an extension could use `conversation:prepare` to implement LLM-based summarization of old turns, or `context:build-extra` to inject a terminal buffer snapshot.
+
+## Configuration Reference
+
+All settings in `~/.agent-sh/settings.json`:
+
+```json
+{
+  "contextWindowSize": 20,
+  "contextBudget": 16384,
+  "shellTruncateThreshold": 10,
+  "shellHeadLines": 5,
+  "shellTailLines": 5,
+  "shellContextRatio": 0.35,
+  "recallExpandMaxLines": 100
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `contextWindowSize` | 20 | Max recent shell exchanges in context |
+| `contextBudget` | 16384 | Legacy byte budget for shell context (overridden by token budget when model contextWindow is set) |
+| `shellTruncateThreshold` | 10 | Shell output lines before truncation |
+| `shellHeadLines` | 5 | Lines kept from start of truncated output |
+| `shellTailLines` | 5 | Lines kept from end of truncated output |
+| `shellContextRatio` | 0.35 | Fraction of content budget for shell context (0-1) |
+| `recallExpandMaxLines` | 100 | Max lines shell_recall returns without requiring line ranges |
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/context-manager.ts` | Shell exchange storage, windowing, truncation, recall API |
+| `src/agent/conversation-state.ts` | Conversation messages, priority compaction, eviction archive |
+| `src/token-budget.ts` | Unified budget calculator (splits context window between streams) |
+| `src/agent/agent-loop.ts` | Wires budget into compaction + context assembly |
+| `src/agent/system-prompt.ts` | Builds dynamic context, passes shell budget |
+| `src/extensions/shell-recall.ts` | Terminal interception for `__shell_recall` commands |

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -1,5 +1,25 @@
 # Context Management
 
+## Design Philosophy
+
+Most coding agents treat context as a session problem — you start a chat, work on something, and eventually the context fills up or you start a new session. This works when the agent owns the entire interaction, but agent-sh is different: **we live in a terminal.**
+
+The terminal is continuous. You run commands, switch between tasks, help a colleague, come back to what you were doing. Nobody thinks about "sessions" when using a shell. Shell history is just *there* — always available, always growing, persisting across restarts. You never manage it, but you can always search it.
+
+This is the model agent-sh follows for context management:
+
+**No sessions.** There's no "new session" or "clear." History is continuous and append-only, like `.zsh_history`. Old content naturally rolls through tiers of decreasing resolution — full content, then one-liner summaries, then a persistent file on disk.
+
+**No assumptions about workflow.** We don't try to detect topic changes, time gaps, or "the user has moved on." If someone asks about React after a database discussion, maybe they're helping a colleague for 30 seconds. Any heuristic that guesses intent will be wrong often enough to be annoying. The only reason to evict content is mechanical: the context window is full and we need space.
+
+**Two streams, no duplication.** The user's shell activity and the agent's work are fundamentally different kinds of information. Shell context provides situational awareness ("what has the user been doing?"). Conversation provides task continuity ("what has the agent been working on?"). They should share a budget but never duplicate content.
+
+**Graceful degradation.** When context is evicted, it doesn't vanish — it compresses. Full tool outputs become one-liner summaries that stay in-context. The agent always has a timeline of the entire session at decreasing resolution, and can recover full content on demand via recall tools.
+
+**Model-aware.** A 200k context model should behave differently from an 8k model. The token budget adapts to the model's actual context window, not a hardcoded threshold.
+
+## How It Works
+
 agent-sh manages context like shell history — it's always there, it persists across restarts, there are no explicit sessions. Content flows through three tiers at decreasing resolution, ensuring the agent always has a timeline of what happened while keeping within the model's context window.
 
 ## The Two Streams

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -1,136 +1,94 @@
 # Context Management
 
-agent-sh manages two separate streams of text that compete for a finite LLM context window. Understanding how they work — and how they share space — is key to getting the most out of the agent, especially with models of different context window sizes.
+agent-sh manages context like shell history — it's always there, it persists across restarts, there are no explicit sessions. Content flows through three tiers at decreasing resolution, ensuring the agent always has a timeline of what happened while keeping within the model's context window.
 
 ## The Two Streams
 
-### Stream 1: Shell Context (situational awareness)
+### Shell Context (situational awareness)
 
-The **shell context** is what the user has been doing in the terminal. It's managed by `ContextManager` and injected as a `<shell_context>` block in the dynamic context on every LLM call.
+Managed by `ContextManager`, injected as `<shell_context>` on every LLM call.
 
-It contains:
-- **User shell commands** and their outputs (truncated)
-- **Agent query markers** — one-liners recording what the user asked
+Contains only user-initiated activity:
+- User shell commands and outputs (truncated)
+- Agent query markers
 
-Shell context answers the question: *"What has the user been doing?"*
+### Conversation (task continuity)
 
-### Stream 2: Conversation (task continuity)
+Managed by `ConversationState`, appended to the LLM messages array.
 
-The **conversation** is the OpenAI chat messages array — `user`, `assistant`, and `tool` messages. It's managed by `ConversationState` and appended directly to the LLM request.
+Contains agent work:
+- User messages, assistant messages, tool calls, tool results
 
-It contains:
-- User messages (queries)
-- Assistant messages (text responses + tool calls)
-- Tool results (outputs from bash, read_file, edit_file, etc.)
+No duplication — agent tool outputs live only in the conversation stream.
 
-Conversation answers the question: *"What has the agent been working on?"*
+## Token Budget
 
-### Why two streams?
-
-They serve different purposes and have different lifecycles:
-
-- Shell context is **rebuilt fresh** on every LLM call. It's a sliding window over the session.
-- Conversation is **accumulated** across turns within a query session. It's the LLM's working memory.
-
-A user might run 50 shell commands before ever asking the agent anything. That history lives in the shell context. Once the agent starts working, its tool calls and reasoning live in the conversation.
-
-### No duplication
-
-Agent tool outputs live **only** in the conversation stream. Shell context tracks **only** user-initiated activity (shell commands and query markers). This avoids wasting context on redundant content.
-
-## The Token Budget
-
-Both streams share a single budget derived from the model's actual context window.
+Both streams share a budget derived from the model's context window:
 
 ```
 Model context window (e.g. 200,000 tokens)
-  - System prompt overhead        (~800 tokens)
-  - Tool definitions              (~50 tokens per tool)
-  - Response reserve              (8,192 tokens)
-  - Dynamic context overhead      (~500 tokens for conventions, metadata)
+  - System prompt + tool defs + response reserve
   = Content budget
-    +-- Shell context slice       (35% by default)
-    +-- Conversation slice        (65% by default)
+    +-- Shell context (35% by default)
+    +-- Conversation  (65% by default)
 ```
 
-The split ratio is configurable via `shellContextRatio` in `~/.agent-sh/settings.json`:
+Configurable via `shellContextRatio` in settings. Recalculates on model switch. Falls back to 60k tokens when `contextWindow` is not set.
 
+## Three-Tier Conversation History
+
+This is the core design. Content flows downward as the context window fills:
+
+```
+Tier 1: Active Context          full content in LLM conversation
+  | compacts when budget fills
+  | read-only items dropped, state-changing -> nuclear one-liner
+  | full content -> recall archive (in-memory)
+  v
+Tier 2: Nuclear Memory          one-liners IN the conversation + recall archive
+  | flushes when nuclear entries exceed threshold
+  | entries written to disk, removed from memory
+  v
+Tier 3: History File            ~/.agent-sh/history, JSONL, append-only
+  | truncated from front at fixed file size
+```
+
+### Tier 1: Active Context
+
+Full tool outputs, file contents, diffs — everything verbatim. This is what the LLM works with directly. Budget: `conversationBudgetTokens`.
+
+### Tier 2: Nuclear Memory
+
+When Tier 1 fills, low-priority turns are **compacted** into nuclear one-liners that stay in the conversation. The LLM always sees a timeline:
+
+```
+[Conversation history — use conversation_recall to expand any entry]
+#12 14:01 user: "Set up the project with TypeScript..."
+#13 14:02 bash: npm init -y (exit 0, 8 lines)
+#15 14:03 write_file tsconfig.json (created, 15 lines)
+#16 14:03 edit_file package.json (+2/-1)
+#18 14:05 user: "Now add the test framework"
+```
+
+Key behaviors:
+- **Read-only items are dropped** — `read_file`, `grep`, `glob`, `ls` results vanish (the agent can re-read them)
+- **State-changing actions survive** — `edit_file`, `write_file`, `bash` (with exit codes), errors, user messages
+- **Full content is archived** in memory for `conversation_recall`
+
+### Tier 3: History File
+
+When nuclear entries accumulate past `nuclearMaxEntries` (default 200), oldest entries flush to `~/.agent-sh/history` — a JSONL file that persists across restarts.
+
+On startup, the last `historyStartupEntries` (default 50) entries are loaded so the agent knows what happened in prior terminal sessions.
+
+**Multi-shell**: Multiple agent-sh instances share the same history file. Each line is well under PIPE_BUF, so `O_APPEND` writes are atomic. Only file truncation (when exceeding `historyMaxBytes`) uses a lock file.
+
+**Format**: One JSON object per line, inspectable with `jq`:
 ```json
-{ "shellContextRatio": 0.35 }
+{"seq":44,"ts":1713020580000,"iid":"a3f2","kind":"tool","tool":"edit_file","sum":"edit_file src/types.ts (+3/-1)"}
 ```
 
-When the model's `contextWindow` is not configured, the budget falls back to a conservative 60,000 tokens total.
-
-### How the budget adapts
-
-The budget recalculates automatically when you switch models. A model with 200k context gets generous budgets for both streams. A model with 8k context gets much tighter limits, but the same ratio applies.
-
-| Model context | Shell budget | Conversation budget |
-|---------------|-------------|-------------------|
-| 8,000         | ~0 tokens   | ~0 tokens (minimal overhead leaves little room) |
-| 32,000        | ~6,400      | ~12,000           |
-| 128,000       | ~37,000     | ~70,000           |
-| 200,000       | ~62,000     | ~115,000          |
-
-*(Numbers are approximate — actual values depend on tool count and prompt size.)*
-
-## Shell Context Pipeline
-
-The shell context passes through three stages before being injected into the LLM prompt:
-
-### 1. Windowing
-
-Keep only the last N exchanges. Default: 20. Configurable via `contextWindowSize`.
-
-### 2. Per-exchange truncation
-
-Long shell outputs get head+tail truncation:
-
-```
-$ find . -name "*.ts"
-  ./src/index.ts
-  ./src/core.ts
-  ./src/settings.ts
-  ./src/types.ts
-  ./src/event-bus.ts
-  [... 142 lines truncated, use shell_recall tool with expand and id 7 to see full output ...]
-  ./examples/extensions/openrouter.ts
-  ./examples/extensions/bridge.ts
-  exit 0
-```
-
-Truncation thresholds are configurable:
-
-| Setting | Default | Purpose |
-|---------|---------|---------|
-| `shellTruncateThreshold` | 10 lines | Lines before truncation kicks in |
-| `shellHeadLines` | 5 | Lines kept from start |
-| `shellTailLines` | 5 | Lines kept from end |
-
-### 3. Budget enforcement
-
-If the total shell context exceeds the token budget, oldest exchange outputs are stripped entirely:
-
-```
-#3 [shell cwd:/project] $ npm test
-  [output omitted, use shell_recall tool to expand id 3]
-```
-
-The agent can always recover full content via `shell_recall`.
-
-### shell_recall
-
-Truncated content is not lost — it stays in memory. The agent can search and expand it:
-
-- `shell_recall` — browse one-line summaries of recent exchanges
-- `shell_recall --search "query"` — regex search across all session history
-- `shell_recall --expand 41` — retrieve full content of exchange #41
-
-## Conversation Compaction
-
-When the conversation exceeds its token budget, it's **compacted** — low-priority turns are evicted to make room for new work.
-
-### Priority-based eviction
+### Priority-based compaction
 
 Not all turns are equally important. Compaction evicts lowest-priority content first:
 
@@ -142,110 +100,66 @@ Not all turns are equally important. Compaction evicts lowest-priority content f
 | Low | Successful tool results with no errors | Can be reproduced |
 | Lowest | Read-only tool results (grep, ls, read_file) | Agent can re-read these |
 
-### Eviction archive
+## Shell Context Pipeline
 
-Evicted turns are not discarded — they're moved to an archive. The `[Earlier conversation turns evicted]` marker tells the agent that content was compacted, and it can recover it.
+Shell context passes through three stages:
+
+1. **Windowing** — last N exchanges (default 20, configurable via `contextWindowSize`)
+2. **Per-exchange truncation** — long outputs get head+tail (configurable thresholds)
+3. **Budget enforcement** — oldest outputs stripped if over token budget
+
+The agent can recover full content via `shell_recall`.
+
+## Recall Tools
+
+### shell_recall
+
+Recovers truncated shell context:
+- `shell_recall` — browse recent exchanges
+- `shell_recall --search "query"` — regex search
+- `shell_recall --expand 41` — full content of exchange #41
 
 ### conversation_recall
 
-Mirrors `shell_recall` for conversation content:
+Recovers compacted conversation content across all tiers:
+- `conversation_recall browse` — list nuclear entries + recent history
+- `conversation_recall --search "query"` — search archive + history file
+- `conversation_recall --expand 5` — full content from recall archive
 
-- `conversation_recall browse` — list evicted turns with one-line summaries
-- `conversation_recall --search "query"` — search evicted conversation content
-- `conversation_recall --expand 5` — retrieve full content of evicted turn #5
+## Slash Commands
 
-### Auto-compaction
+| Command | Action |
+|---------|--------|
+| `/compact` | Manually trigger compaction (Tier 1 → Tier 2) |
+| `/context` | Show context budget usage (active tokens, nuclear entries, archive size) |
 
-Compaction triggers automatically before each LLM call when the estimated token count exceeds the conversation budget. On context overflow errors from the API, a more aggressive compaction runs (60% of budget) and the request is retried.
+History is continuous — there's no `/clear`. Old content naturally rolls through the tiers. Use `/compact` if you want to free up active context space immediately.
 
-## Message Assembly
-
-Here's what the LLM actually sees on each call:
-
-```
-[0] system: Static identity + behavioral rules (cacheable)
-
-[1] user: <context>
-       # Available Tools
-       - bash: Execute shell commands...
-       - read_file: Read a file...
-       ...
-
-       # Project Conventions
-       [CLAUDE.md / AGENT.md content]
-
-       <shell_context>
-       cwd: /Users/you/project
-       session: 42 exchanges, 15m elapsed
-
-       #38 [shell cwd:/project] $ git status
-         On branch main
-         ...
-         exit 0
-
-       #39 [you] > fix the failing test
-       </shell_context>
-
-       Current date: 2025-02-17
-       Working directory: /Users/you/project
-     </context>
-
-[2] assistant: "Understood."
-
-[3..N] Conversation messages:
-       [user] fix the failing test
-       [assistant] Let me look at the test... {tool_calls: [read_file]}
-       [tool] {content: "test file contents..."}
-       [assistant] I see the issue... {tool_calls: [edit_file]}
-       [tool] {content: "File edited successfully"}
-       ...
-```
-
-## Extension Hooks
-
-Three hooks allow extensions to customize context management:
-
-| Hook | Purpose | Called when |
-|------|---------|------------|
-| `context:build-extra` | Inject additional content into `<shell_context>` | Every context build |
-| `dynamic-context:build` | Wrap or modify the entire dynamic context | Every LLM iteration |
-| `conversation:prepare` | Transform the full message array before sending | Every LLM call |
-
-Example: an extension could use `conversation:prepare` to implement LLM-based summarization of old turns, or `context:build-extra` to inject a terminal buffer snapshot.
-
-## Configuration Reference
+## Configuration
 
 All settings in `~/.agent-sh/settings.json`:
-
-```json
-{
-  "contextWindowSize": 20,
-  "contextBudget": 16384,
-  "shellTruncateThreshold": 10,
-  "shellHeadLines": 5,
-  "shellTailLines": 5,
-  "shellContextRatio": 0.35,
-  "recallExpandMaxLines": 100
-}
-```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `contextWindowSize` | 20 | Max recent shell exchanges in context |
-| `contextBudget` | 16384 | Legacy byte budget for shell context (overridden by token budget when model contextWindow is set) |
+| `contextBudget` | 16384 | Byte budget for shell context |
 | `shellTruncateThreshold` | 10 | Shell output lines before truncation |
 | `shellHeadLines` | 5 | Lines kept from start of truncated output |
-| `shellTailLines` | 5 | Lines kept from end of truncated output |
-| `shellContextRatio` | 0.35 | Fraction of content budget for shell context (0-1) |
-| `recallExpandMaxLines` | 100 | Max lines shell_recall returns without requiring line ranges |
+| `shellTailLines` | 5 | Lines kept from end |
+| `shellContextRatio` | 0.35 | Fraction of content budget for shell context |
+| `recallExpandMaxLines` | 100 | Max lines shell_recall returns without line ranges |
+| `historyMaxBytes` | 102400 | Max history file size (100KB) |
+| `historyStartupEntries` | 50 | Prior history entries loaded on startup |
+| `nuclearMaxEntries` | 200 | Max nuclear entries in-context before flushing to disk |
 
 ## Key Files
 
 | File | Role |
 |------|------|
 | `src/context-manager.ts` | Shell exchange storage, windowing, truncation, recall API |
-| `src/agent/conversation-state.ts` | Conversation messages, priority compaction, eviction archive |
-| `src/token-budget.ts` | Unified budget calculator (splits context window between streams) |
-| `src/agent/agent-loop.ts` | Wires budget into compaction + context assembly |
-| `src/agent/system-prompt.ts` | Builds dynamic context, passes shell budget |
-| `src/extensions/shell-recall.ts` | Terminal interception for `__shell_recall` commands |
+| `src/agent/conversation-state.ts` | Three-tier conversation: active + nuclear + history |
+| `src/agent/nuclear-form.ts` | Nuclear one-liner generation, serialization, classification |
+| `src/agent/history-file.ts` | Persistent JSONL history with append, search, truncation |
+| `src/token-budget.ts` | Unified budget calculator |
+| `src/agent/agent-loop.ts` | Wires budget, history, compaction + flush |
+| `src/extensions/slash-commands.ts` | /compact, /context commands |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -629,7 +629,33 @@ panel.handlers.advise("panel:submit", (_next, query: string) => {
 
 **Config options**: `trigger`, `width`, `height`, `maxWidth`, `minHeight`, `borderStyle` (`rounded`/`square`/`double`/`heavy`), `dimBackground`, `autoDismissMs`, `promptIcon`, `handlerPrefix`.
 
-**Lifecycle**: `open()` → input phase → `setActive()` → active phase → `setDone()` → done phase → `dismiss()`.
+**Lifecycle** — the panel has four phases and three rendering states:
+
+```
+open() → [input] → submit → [active] → setDone() → [input] (follow-up)
+                                │                         │
+                              hide()                    hide()
+                                │                         │
+                          [passthrough]                dismiss()
+                       (agent still working,        (session over,
+                        TerminalBuffer renders       teardown + SIGWINCH)
+                        screen at 50ms interval)
+                                │
+                          setDone() while
+                          passthrough
+                                │
+                           auto-dismiss()
+                        (hand back control)
+```
+
+| Phase | Description |
+|-------|-------------|
+| **input** | Waiting for user query (or follow-up after agent finishes) |
+| **active** | Agent is processing — hide enters passthrough mode |
+| **done** | Legacy: used with `autoDismissMs > 0` only |
+| **idle** | Panel fully dismissed, no state retained |
+
+**Passthrough mode**: When the user hides the panel while the agent is still working (`active` phase), the panel enters passthrough mode instead of handing rendering back to the foreground program. It stays on alt screen with stdout held, and renders the TerminalBuffer content directly at 50ms intervals. This avoids ncurses curscr desync — the program's screen stays correct because we do full repaints, not differential updates. When the agent finishes (`setDone()`), passthrough auto-dismisses and hands back control via a SIGWINCH double-resize that forces ncurses to do a clean full repaint.
 
 **Content API**: `appendText(text)`, `appendLine(line)`, `updateLastLine(fn)`, `clearContent()`, `setTitle(title)`, `setFooter(footer)`.
 
@@ -647,7 +673,9 @@ panel.handlers.advise("panel:submit", (_next, query: string) => {
 | `dismiss() → void` | Handle panel dismissal |
 | `input(data) → boolean` | Custom input handling |
 
-**Alt screen nesting**: FloatingPanel detects when a foreground program (vim, htop) is already on alt screen and avoids entering a second alt screen (which doesn't nest in most terminals). Instead, it renders directly and restores from the xterm buffer on dismiss.
+**Alt screen nesting**: FloatingPanel detects when a foreground program (vim, htop) is already on alt screen and avoids entering a second alt screen (which doesn't nest in most terminals). Instead, it renders directly on top of the program's alt screen.
+
+**Screen restore**: On dismiss, the panel uses a SIGWINCH double-resize (resize to `rows-1`, then back to `rows`) to force the foreground program to fully repaint. This is necessary because ncurses ignores same-size SIGWINCH (`resizeterm` returns early when dimensions haven't changed), and ncurses's `curscr` is stale after the overlay drew on the terminal — a simple exit from alt screen would leave overlay artifacts in cells that ncurses considers unchanged.
 
 **Keyboard protocol support**: The trigger key is recognized in all encodings — raw control byte, xterm modifyOtherKeys (`\e[27;5;code~`), and kitty keyboard protocol (`\e[code;5u`). This ensures the trigger works inside vim and other programs that enable extended keyboard protocols.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@
 
 **Problem**: "context overflow" or response cut off
 
-**Solution**: The conversation is too long. Use `/clear` to start fresh, or the agent will auto-compact after the error.
+**Solution**: The conversation is too long. Use `/compact` to manually free up space, or the agent will auto-compact after the error.
 
 **Problem**: Tool calls not working (agent responds but doesn't use tools)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,14 +95,7 @@ Press **Ctrl+\\** anywhere — even inside vim, htop, or ssh — to summon the a
 
 The agent can read the terminal screen and send keystrokes via the built-in `terminal_read` and `terminal_keys` tools, enabling it to operate inside interactive programs.
 
-**Session lifecycle**:
-
-- **Ctrl+\\** opens the overlay and shows an input prompt
-- Type a query and press Enter — the agent begins processing
-- **Ctrl+\\** or **Esc** while the agent is working hides the overlay, but the agent keeps running in the background. The terminal screen stays correct via passthrough rendering from the headless terminal buffer.
-- When the agent finishes, control returns to your program automatically (with a full screen redraw via SIGWINCH)
-- If the overlay is still visible when the agent finishes, it shows a follow-up prompt for multi-turn conversation
-- **Ctrl+\\** or **Esc** at the follow-up prompt dismisses the session entirely
+While the agent is working, press **Ctrl+\\** or **Esc** to hide the overlay and continue using your program — the agent keeps running in the background and control returns automatically when it finishes. If the overlay is still visible when the agent finishes, it shows a follow-up prompt for multi-turn conversation.
 
 Requires `@xterm/headless` for the dimmed background compositing:
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,9 +91,18 @@ agent-sh --api-key dummy \
 
 ## Overlay Agent (Ctrl+\)
 
-Press **Ctrl+\\** anywhere — even inside vim, htop, or ssh — to summon the agent in a floating overlay. Type a query, and the agent's response streams into the panel. The overlay auto-dismisses after completion.
+Press **Ctrl+\\** anywhere — even inside vim, htop, or ssh — to summon the agent in a floating overlay. Type a query, and the agent's response streams into the panel.
 
 The agent can read the terminal screen and send keystrokes via the built-in `terminal_read` and `terminal_keys` tools, enabling it to operate inside interactive programs.
+
+**Session lifecycle**:
+
+- **Ctrl+\\** opens the overlay and shows an input prompt
+- Type a query and press Enter — the agent begins processing
+- **Ctrl+\\** or **Esc** while the agent is working hides the overlay, but the agent keeps running in the background. The terminal screen stays correct via passthrough rendering from the headless terminal buffer.
+- When the agent finishes, control returns to your program automatically (with a full screen redraw via SIGWINCH)
+- If the overlay is still visible when the agent finishes, it shows a follow-up prompt for multi-turn conversation
+- **Ctrl+\\** or **Esc** at the follow-up prompt dismisses the session entirely
 
 Requires `@xterm/headless` for the dimmed background compositing:
 ```bash

--- a/examples/extensions/claude-code-bridge/index.ts
+++ b/examples/extensions/claude-code-bridge/index.ts
@@ -23,6 +23,23 @@ import { z } from "zod";
 import type { ExtensionContext } from "../../src/types.js";
 import type { EventBus } from "../../src/event-bus.js";
 
+// ── Helpers ──────────────────────────────────────────────────────
+function interpretEscapes(str: string): string {
+  return str.replace(/\\(x[0-9a-fA-F]{2}|r|n|t|\\|0)/g, (_, seq: string) => {
+    if (seq === "r") return "\r";
+    if (seq === "n") return "\n";
+    if (seq === "t") return "\t";
+    if (seq === "\\") return "\\";
+    if (seq === "0") return "\0";
+    if (seq.startsWith("x")) return String.fromCharCode(parseInt(seq.slice(1), 16));
+    return seq;
+  });
+}
+
+function settle(ms = 100): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // ── user_shell MCP tool ───────────────────────────────────────────
 function createUserShellTool(bus: EventBus) {
   let liveCwd = process.cwd();
@@ -56,15 +73,72 @@ function createUserShellTool(bus: EventBus) {
   );
 }
 
+// ── terminal_read MCP tool ────────────────────────────────────────
+function createTerminalReadTool(ctx: ExtensionContext) {
+  return tool(
+    "terminal_read",
+    "Read the current terminal screen contents. Returns clean text (ANSI stripped) " +
+    "with cursor position and whether an alternate-screen program (vim, htop, less) is active. " +
+    "Use this to see what the user sees before sending keystrokes with terminal_keys.",
+    {},
+    async () => {
+      const tb = ctx.terminalBuffer;
+      if (!tb) return { content: [{ type: "text" as const, text: "terminal buffer not available" }] };
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
+      const info = [
+        altScreen ? "mode: alternate screen" : "mode: normal",
+        `cursor: row=${cursorY} col=${cursorX}`,
+      ].join(", ");
+      return { content: [{ type: "text" as const, text: `[${info}]\n\n${text}` }] };
+    },
+  );
+}
+
+// ── terminal_keys MCP tool ───────────────────────────────────────
+function createTerminalKeysTool(bus: EventBus, ctx: ExtensionContext) {
+  return tool(
+    "terminal_keys",
+    "Send keystrokes to the user's live terminal. The keys are written directly to the PTY " +
+    "as if the user typed them. Use escape sequences for special keys:\n" +
+    "  - Escape: \\x1b  - Enter: \\r  - Tab: \\t\n" +
+    "  - Ctrl+C: \\x03  - Arrow keys: \\x1b[A/B/C/D  - Backspace: \\x7f\n" +
+    "Example: to quit vim without saving, send keys=\"\\x1b:q!\\r\".\n" +
+    "Always call terminal_read after sending keys to verify the result.",
+    {
+      keys: z.string().describe("Keystrokes to send (use \\x1b for Escape, \\r for Enter, etc.)"),
+      settle_ms: z.number().optional().describe("Wait time in ms after sending keys (default: 150)"),
+    },
+    async (args) => {
+      const keys = interpretEscapes(args.keys);
+      const settleMs = args.settle_ms ?? 150;
+      bus.emit("shell:stdout-show", {});
+      process.stdout.write("\n");
+      bus.emit("shell:pty-write", { data: keys });
+      await settle(settleMs);
+
+      const tb = ctx.terminalBuffer;
+      if (!tb) return { content: [{ type: "text" as const, text: "Keys sent." }] };
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
+      const info = [
+        altScreen ? "mode: alternate screen" : "mode: normal",
+        `cursor: row=${cursorY} col=${cursorX}`,
+      ].join(", ");
+      return { content: [{ type: "text" as const, text: `Keys sent. Screen after:\n[${info}]\n\n${text}` }] };
+    },
+  );
+}
+
 // ── Extension entry point ─────────────────────────────────────────
 export default function activate(ctx: ExtensionContext): void {
   const { bus } = ctx;
 
   const shellTool = createUserShellTool(bus);
+  const termReadTool = createTerminalReadTool(ctx);
+  const termKeysTool = createTerminalKeysTool(bus, ctx);
   const shellServer = createSdkMcpServer({
     name: "agent-sh",
     version: "1.0.0",
-    tools: [shellTool],
+    tools: [shellTool, termReadTool, termKeysTool],
   });
 
   let activeQuery: Query | null = null;
@@ -95,6 +169,8 @@ export default function activate(ctx: ExtensionContext): void {
             mcpServers: { "agent-sh": shellServer },
             allowedTools: [
               "mcp__agent-sh__user_shell",
+              "mcp__agent-sh__terminal_read",
+              "mcp__agent-sh__terminal_keys",
               "Read", "Edit", "Write", "Bash", "Glob", "Grep",
             ],
             permissionMode: "acceptEdits",

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -26,7 +26,22 @@ import { Type } from "@sinclair/typebox";
 import type { ExtensionContext } from "../../src/types.js";
 import type { EventBus } from "../../src/event-bus.js";
 
-// ── agent-sh context injected via tool promptGuidelines + promptSnippet ──
+// ── Helpers ──────────────────────────────────────────────────────
+function interpretEscapes(str: string): string {
+  return str.replace(/\\(x[0-9a-fA-F]{2}|r|n|t|\\|0)/g, (_, seq: string) => {
+    if (seq === "r") return "\r";
+    if (seq === "n") return "\n";
+    if (seq === "t") return "\t";
+    if (seq === "\\") return "\\";
+    if (seq === "0") return "\0";
+    if (seq.startsWith("x")) return String.fromCharCode(parseInt(seq.slice(1), 16));
+    return seq;
+  });
+}
+
+function settle(ms = 100): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // ── user_shell as a pi ToolDefinition ─────────────────────────────
 function createUserShellToolDef(bus: EventBus) {
@@ -81,12 +96,82 @@ function createUserShellToolDef(bus: EventBus) {
   };
 }
 
+// ── terminal_read as a pi ToolDefinition ─────────────────────────
+function createTerminalReadToolDef(ctx: ExtensionContext) {
+  return {
+    name: "terminal_read",
+    label: "terminal_read",
+    description:
+      "Read the current terminal screen contents. Returns clean text (ANSI stripped) " +
+      "with cursor position and whether an alternate-screen program (vim, htop, less) is active.",
+    promptSnippet: "Read the terminal screen to see what the user sees.",
+    promptGuidelines: [
+      "Use terminal_read to see the current terminal screen before sending keystrokes.",
+      "Check altScreen to know if a full-screen program (vim, htop) is running.",
+    ],
+    parameters: Type.Object({}),
+    async execute() {
+      const tb = ctx.terminalBuffer;
+      if (!tb) return { content: [{ type: "text", text: "terminal buffer not available" }], details: undefined };
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
+      const info = [
+        altScreen ? "mode: alternate screen" : "mode: normal",
+        `cursor: row=${cursorY} col=${cursorX}`,
+      ].join(", ");
+      return { content: [{ type: "text", text: `[${info}]\n\n${text}` }], details: undefined };
+    },
+  };
+}
+
+// ── terminal_keys as a pi ToolDefinition ─────────────────────────
+function createTerminalKeysToolDef(bus: EventBus, ctx: ExtensionContext) {
+  return {
+    name: "terminal_keys",
+    label: "terminal_keys",
+    description:
+      "Send keystrokes to the user's live terminal as if the user typed them. " +
+      "Use escape sequences: \\x1b for Escape, \\r for Enter, \\t for Tab, " +
+      "\\x03 for Ctrl+C, \\x1b[A/B/C/D for arrow keys, \\x7f for Backspace. " +
+      "Example: \\x1b:q!\\r to quit vim. Always call terminal_read after.",
+    promptSnippet: "Send keystrokes to interactive programs in the terminal.",
+    promptGuidelines: [
+      "Use terminal_keys to type into interactive programs (vim, htop, less).",
+      "Always call terminal_read after sending keys to verify the result.",
+    ],
+    parameters: Type.Object({
+      keys: Type.String({ description: "Keystrokes to send (use \\x1b for Escape, \\r for Enter, etc.)" }),
+      settle_ms: Type.Optional(
+        Type.Number({ description: "Wait time in ms after sending keys (default: 150)" }),
+      ),
+    }),
+    async execute(_toolCallId: string, params: any) {
+      const keys = interpretEscapes(params.keys);
+      const settleMs = params.settle_ms ?? 150;
+      bus.emit("shell:stdout-show", {});
+      process.stdout.write("\n");
+      bus.emit("shell:pty-write", { data: keys });
+      await settle(settleMs);
+
+      const tb = ctx.terminalBuffer;
+      if (!tb) return { content: [{ type: "text", text: "Keys sent." }], details: undefined };
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
+      const info = [
+        altScreen ? "mode: alternate screen" : "mode: normal",
+        `cursor: row=${cursorY} col=${cursorX}`,
+      ].join(", ");
+      return { content: [{ type: "text", text: `Keys sent. Screen after:\n[${info}]\n\n${text}` }], details: undefined };
+    },
+  };
+}
+
 // ── Extension entry point ─────────────────────────────────────────
 export default function activate(ctx: ExtensionContext): void {
   const { bus } = ctx;
   const cwd = process.cwd();
 
   const userShellTool = createUserShellToolDef(bus);
+  const termReadTool = createTerminalReadToolDef(ctx);
+  const termKeysTool = createTerminalKeysToolDef(bus, ctx);
 
   // ── Boot pi session (async — register backend synchronously first) ──
   let session: any = null;
@@ -105,7 +190,7 @@ export default function activate(ctx: ExtensionContext): void {
         const result = await createAgentSessionFromServices({
           services,
           sessionManager: opts.sessionManager ?? sessionManager,
-          customTools: [userShellTool],
+          customTools: [userShellTool, termReadTool, termKeysTool],
         });
         return { ...result, services };
       };

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -25,6 +25,7 @@ import type { AgentBackend, ToolDefinition } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState } from "./conversation-state.js";
 import { STATIC_SYSTEM_PROMPT, buildDynamicContext } from "./system-prompt.js";
+import { TokenBudget } from "../token-budget.js";
 
 // Core tool factories
 import { createBashTool } from "./tools/bash.js";
@@ -50,6 +51,7 @@ export class AgentLoop implements AgentBackend {
   private toolRegistry = new ToolRegistry();
   private conversation = new ConversationState();
   private fileReadCache: FileReadCache = new Map();
+  private tokenBudget: TokenBudget;
   private modes: AgentMode[];
   private currentModeIndex = 0;
   private boundListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
@@ -72,8 +74,14 @@ export class AgentLoop implements AgentBackend {
     ];
     this.currentModeIndex = initialModeIndex ?? 0;
 
+    // Unified token budget — adapts to current model's context window
+    this.tokenBudget = new TokenBudget(this.currentMode.contextWindow);
+
     // Register core tools
     this.registerCoreTools();
+
+    // Update token budget with tool count
+    this.tokenBudget.update(undefined, this.toolRegistry.all().length);
 
     // Register handlers — extensions can advise these
     this.registerHandlers();
@@ -109,6 +117,7 @@ export class AgentLoop implements AgentBackend {
       } else {
         this.llmClient.model = m.model;
       }
+      this.tokenBudget.update(m.contextWindow, this.toolRegistry.all().length);
       const label = m.provider ? `${m.provider}: ${m.model}` : m.model;
       this.bus.emit("agent:info", { name: "agent-sh", version: "0.4", model: m.model, provider: m.provider, contextWindow: m.contextWindow });
       this.bus.emit("ui:info", { message: `Model: ${label}` });
@@ -151,6 +160,7 @@ export class AgentLoop implements AgentBackend {
       } else {
         this.llmClient.model = m.model;
       }
+      this.tokenBudget.update(m.contextWindow, this.toolRegistry.all().length);
       this.bus.emit("config:changed", {});
     });
     on("config:add-modes", ({ modes: extra }) => {
@@ -240,6 +250,7 @@ export class AgentLoop implements AgentBackend {
       this.llmClient.model = newMode.model;
     }
 
+    this.tokenBudget.update(newMode.contextWindow, this.toolRegistry.all().length);
     const label = newMode.provider
       ? `${newMode.provider}: ${newMode.model}`
       : newMode.model;
@@ -361,6 +372,45 @@ export class AgentLoop implements AgentBackend {
       createDisplayTool({ getCwd, bus: this.bus }),
     );
     this.toolRegistry.register(createListSkillsTool(getCwd));
+
+    // conversation_recall — search/expand evicted conversation turns
+    this.toolRegistry.register({
+      name: "conversation_recall",
+      description:
+        "Browse, search, or expand evicted conversation turns. " +
+        "Use when you need context from earlier in the conversation that was compacted away.",
+      input_schema: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            enum: ["browse", "search", "expand"],
+            description: "browse: list evicted turns, search: regex search, expand: show full turn",
+          },
+          query: {
+            type: "string",
+            description: "Search query (for action=search)",
+          },
+          turn_id: {
+            type: "number",
+            description: "Turn ID to expand (for action=expand)",
+          },
+        },
+        required: ["action"],
+      },
+      execute: async (args) => {
+        const action = args.action as string;
+        let content: string;
+        if (action === "search") {
+          content = this.conversation.search((args.query as string) ?? "");
+        } else if (action === "expand") {
+          content = this.conversation.expand(args.turn_id as number);
+        } else {
+          content = this.conversation.browse();
+        }
+        return { content, exitCode: 0, isError: false };
+      },
+    });
   }
 
   /**
@@ -372,7 +422,11 @@ export class AgentLoop implements AgentBackend {
 
     // Extensions compose additional context (git info, project rules, etc.)
     h.define("dynamic-context:build", () =>
-      buildDynamicContext(this.toolRegistry.all(), this.contextManager),
+      buildDynamicContext(
+        this.toolRegistry.all(),
+        this.contextManager,
+        this.tokenBudget.shellBudgetTokens,
+      ),
     );
 
     // Full control over what the LLM sees: takes messages[], returns messages[].
@@ -535,9 +589,6 @@ export class AgentLoop implements AgentBackend {
     }
   }
 
-  /** Max tokens before auto-compaction (conservative default). */
-  private maxContextTokens = 60_000;
-
   /**
    * Core agent loop: stream LLM response → execute tools → repeat.
    * Returns the final accumulated response text.
@@ -546,10 +597,10 @@ export class AgentLoop implements AgentBackend {
     let fullResponseText = "";
 
     while (!signal.aborted) {
-      // Auto-compact if conversation is getting large
-      const estimatedTokens = Math.ceil(JSON.stringify(this.conversation.getMessages()).length / 4);
-      if (estimatedTokens > this.maxContextTokens) {
-        this.conversation.compact(10);
+      // Auto-compact if conversation exceeds the model-aware budget
+      const budgetTokens = this.tokenBudget.conversationBudgetTokens;
+      if (this.conversation.estimateTokens() > budgetTokens) {
+        this.conversation.compact(budgetTokens);
         this.bus.emit("ui:info", { message: "(conversation compacted)" });
       }
 
@@ -707,9 +758,11 @@ export class AgentLoop implements AgentBackend {
       } catch (e) {
         if (signal.aborted) throw e;
 
-        // Context overflow — compact and retry (no backoff needed)
+        // Context overflow — aggressively compact and retry
         if (this.isContextOverflow(e)) {
-          this.conversation.compact(6);
+          // Use 60% of the budget to leave headroom
+          const aggressiveBudget = Math.floor(this.tokenBudget.conversationBudgetTokens * 0.6);
+          this.conversation.compact(aggressiveBudget, 6);
           this.bus.emit("ui:info", { message: "(context overflow — compacted, retrying)" });
           continue;
         }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -181,9 +181,15 @@ export class AgentLoop implements AgentBackend {
     });
     on("agent:compact-request", () => {
       const budgetTokens = this.tokenBudget.conversationBudgetTokens;
-      this.conversation.compact(budgetTokens);
+      const stats = this.conversation.compact(budgetTokens);
       this.conversation.flush().catch(() => {});
-      this.bus.emit("ui:info", { message: "(conversation compacted)" });
+      if (stats) {
+        this.bus.emit("ui:info", {
+          message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
+        });
+      } else {
+        this.bus.emit("ui:info", { message: "(nothing to compact)" });
+      }
     });
     this.bus.onPipe("context:get-stats", () => {
       return {
@@ -624,9 +630,13 @@ export class AgentLoop implements AgentBackend {
       // Auto-compact if conversation exceeds the model-aware budget
       const budgetTokens = this.tokenBudget.conversationBudgetTokens;
       if (this.conversation.estimateTokens() > budgetTokens) {
-        this.conversation.compact(budgetTokens);
+        const stats = this.conversation.compact(budgetTokens);
         await this.conversation.flush();
-        this.bus.emit("ui:info", { message: "(conversation compacted)" });
+        if (stats) {
+          this.bus.emit("ui:info", {
+            message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
+          });
+        }
       }
 
       // System prompt is static (cacheable); dynamic context uses handler
@@ -787,9 +797,10 @@ export class AgentLoop implements AgentBackend {
         if (this.isContextOverflow(e)) {
           // Use 60% of the budget to leave headroom
           const aggressiveBudget = Math.floor(this.tokenBudget.conversationBudgetTokens * 0.6);
-          this.conversation.compact(aggressiveBudget, 6);
+          const stats = this.conversation.compact(aggressiveBudget, 6);
           await this.conversation.flush();
-          this.bus.emit("ui:info", { message: "(context overflow — compacted, retrying)" });
+          const detail = stats ? ` ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens` : "";
+          this.bus.emit("ui:info", { message: `(context overflow — compacted${detail}, retrying)` });
           continue;
         }
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -153,6 +153,15 @@ export class AgentLoop implements AgentBackend {
       }
       this.bus.emit("config:changed", {});
     });
+    on("config:add-modes", ({ modes: extra }) => {
+      // Remove any existing modes for the same provider, then append
+      const providers = new Set(extra.map((m) => m.provider).filter(Boolean));
+      this.modes = [
+        ...this.modes.filter((m) => !m.provider || !providers.has(m.provider)),
+        ...extra,
+      ];
+      this.bus.emit("config:changed", {});
+    });
     on("agent:reset-session", () => {
       this.cancel();
       this.conversation = new ConversationState();

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -24,6 +24,7 @@ import { computeDiff } from "../utils/diff.js";
 import type { AgentBackend, ToolDefinition } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState } from "./conversation-state.js";
+import { HistoryFile } from "./history-file.js";
 import { STATIC_SYSTEM_PROMPT, buildDynamicContext } from "./system-prompt.js";
 import { TokenBudget } from "../token-budget.js";
 
@@ -49,7 +50,8 @@ interface PendingToolCall {
 export class AgentLoop implements AgentBackend {
   private abortController: AbortController | null = null;
   private toolRegistry = new ToolRegistry();
-  private conversation = new ConversationState();
+  private historyFile = new HistoryFile();
+  private conversation = new ConversationState(this.historyFile);
   private fileReadCache: FileReadCache = new Map();
   private tokenBudget: TokenBudget;
   private modes: AgentMode[];
@@ -174,9 +176,31 @@ export class AgentLoop implements AgentBackend {
     });
     on("agent:reset-session", () => {
       this.cancel();
-      this.conversation = new ConversationState();
+      this.conversation = new ConversationState(this.historyFile);
       this.lastProjectSkillNames.clear();
     });
+    on("agent:compact-request", () => {
+      const budgetTokens = this.tokenBudget.conversationBudgetTokens;
+      this.conversation.compact(budgetTokens);
+      this.conversation.flush().catch(() => {});
+      this.bus.emit("ui:info", { message: "(conversation compacted)" });
+    });
+    this.bus.onPipe("context:get-stats", () => {
+      return {
+        activeTokens: this.conversation.estimateTokens(),
+        nuclearEntries: this.conversation.getNuclearEntryCount(),
+        recallArchiveSize: this.conversation.getRecallArchiveSize(),
+        budgetTokens: this.tokenBudget.conversationBudgetTokens,
+      };
+    });
+
+    // Load prior history from disk (non-blocking)
+    this.historyFile.readRecent().then((entries) => {
+      if (entries.length > 0) {
+        this.conversation.loadPriorHistory(entries);
+      }
+    }).catch(() => {});
+
     on("shell:cwd-change", ({ cwd }) => {
       const projectSkills = discoverProjectSkills(cwd);
       const newNames = new Set(projectSkills.map(s => s.name));
@@ -402,11 +426,11 @@ export class AgentLoop implements AgentBackend {
         const action = args.action as string;
         let content: string;
         if (action === "search") {
-          content = this.conversation.search((args.query as string) ?? "");
+          content = await this.conversation.search((args.query as string) ?? "");
         } else if (action === "expand") {
-          content = this.conversation.expand(args.turn_id as number);
+          content = await this.conversation.expand(args.turn_id as number);
         } else {
-          content = this.conversation.browse();
+          content = await this.conversation.browse();
         }
         return { content, exitCode: 0, isError: false };
       },
@@ -601,6 +625,7 @@ export class AgentLoop implements AgentBackend {
       const budgetTokens = this.tokenBudget.conversationBudgetTokens;
       if (this.conversation.estimateTokens() > budgetTokens) {
         this.conversation.compact(budgetTokens);
+        await this.conversation.flush();
         this.bus.emit("ui:info", { message: "(conversation compacted)" });
       }
 
@@ -763,6 +788,7 @@ export class AgentLoop implements AgentBackend {
           // Use 60% of the budget to leave headroom
           const aggressiveBudget = Math.floor(this.tokenBudget.conversationBudgetTokens * 0.6);
           this.conversation.compact(aggressiveBudget, 6);
+          await this.conversation.flush();
           this.bus.emit("ui:info", { message: "(context overflow — compacted, retrying)" });
           continue;
         }

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -116,11 +116,12 @@ export class ConversationState {
    * them with nuclear one-liner summaries that stay in the conversation.
    * Read-only tool results are dropped entirely.
    */
-  compact(targetTokens: number, recentTurnsToKeep = 10): void {
-    if (this.estimateTokens() <= targetTokens) return;
+  compact(targetTokens: number, recentTurnsToKeep = 10): { before: number; after: number } | null {
+    const before = this.estimateTokens();
+    if (before <= targetTokens) return null;
 
     const turns = this.parseTurns();
-    if (turns.length <= 2) return;
+    if (turns.length <= 2) return null;
 
     // Assign priorities
     const pinnedCount = Math.min(recentTurnsToKeep, turns.length - 1);
@@ -164,7 +165,7 @@ export class ConversationState {
       }
     }
 
-    if (evictedIndices.size === 0) return;
+    if (evictedIndices.size === 0) return null;
 
     // Rebuild: first turn + nuclear summary block + remaining turns
     const rebuilt: ChatCompletionMessageParam[] = [];
@@ -188,6 +189,7 @@ export class ConversationState {
     }
 
     this.messages = rebuilt;
+    return { before, after: this.estimateTokens() };
   }
 
   // ── Tier 2 → Tier 3: Flush ───────────────────────────────────

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -4,9 +4,48 @@ import type { ChatCompletionMessageParam } from "../utils/llm-client.js";
  * Manages the OpenAI chat messages array for the agent loop.
  * Separate from ContextManager — this is the LLM conversation,
  * not the shell history.
+ *
+ * Supports priority-based compaction: when the conversation exceeds the
+ * token budget, low-priority turns are evicted to an archive that the
+ * agent can search/expand via the conversation_recall tool.
  */
+
+// ── Priority tiers (lower number = evicted first) ─────────────────
+
+const enum Priority {
+  /** Large read-only tool results (grep, ls, read_file) — agent can re-read. */
+  LOWEST = 0,
+  /** Successful tool results with no errors. */
+  LOW = 1,
+  /** Tool results from write/edit operations. */
+  MEDIUM = 2,
+  /** User messages, error messages, assistant reasoning. */
+  HIGH = 3,
+  /** First user message (original task) + last N turns — never evicted. */
+  PINNED = 4,
+}
+
+/** Read-only tools whose results are cheap to reproduce. */
+const READ_ONLY_TOOLS = new Set([
+  "grep", "ls", "read_file", "glob", "bash", "search",
+]);
+
+/** Tools that produce durable changes — higher priority. */
+const WRITE_TOOLS = new Set([
+  "write_file", "edit_file", "write", "edit", "patch",
+]);
+
+/** An archived turn that was evicted from the active conversation. */
+export interface EvictedTurn {
+  id: number;
+  messages: ChatCompletionMessageParam[];
+  summary: string;
+}
+
 export class ConversationState {
   private messages: ChatCompletionMessageParam[] = [];
+  private evicted: EvictedTurn[] = [];
+  private nextTurnId = 1;
 
   addUserMessage(text: string): void {
     this.messages.push({ role: "user", content: text });
@@ -51,24 +90,260 @@ export class ConversationState {
     return this.messages;
   }
 
+  // ── Compaction ──────────────────────────────────────────────────
+
   /**
-   * Simple compaction — drop oldest turns, keeping the first user message
-   * (original task context) and the most recent turns.
+   * Estimate token count for the current conversation.
+   * Uses ~4 chars per token heuristic.
    */
-  compact(maxTurns: number): void {
-    if (this.messages.length <= maxTurns * 2) return;
+  estimateTokens(): number {
+    return Math.ceil(JSON.stringify(this.messages).length / 4);
+  }
 
-    const first = this.messages[0];
-    const recent = this.messages.slice(-(maxTurns * 2));
+  /**
+   * Priority-based compaction. Evicts lowest-priority turns until the
+   * estimated token count is under the target budget.
+   *
+   * Pinned content (first user message + recent turns) is never evicted.
+   */
+  compact(targetTokens: number, recentTurnsToKeep = 10): void {
+    if (this.estimateTokens() <= targetTokens) return;
 
-    this.messages = [
-      first,
-      { role: "user", content: "[Earlier conversation turns omitted for context space]" },
-      ...recent,
-    ];
+    // Parse the message array into logical "turns" (boundaries at user messages)
+    const turns = this.parseTurns();
+    if (turns.length <= 2) return; // nothing to evict
+
+    // Assign priorities — pin first turn and recent turns
+    const pinnedCount = Math.min(recentTurnsToKeep, turns.length - 1);
+    for (const turn of turns) {
+      turn.priority = this.inferPriority(turn.messages);
+    }
+    turns[0]!.priority = Priority.PINNED; // original task
+    for (let i = turns.length - pinnedCount; i < turns.length; i++) {
+      turns[i]!.priority = Priority.PINNED;
+    }
+
+    // Build eviction candidates sorted by priority (lowest first), then oldest first
+    const candidates = turns
+      .map((t, idx) => ({ turn: t, idx }))
+      .filter((c) => c.turn.priority !== Priority.PINNED)
+      .sort((a, b) => a.turn.priority - b.turn.priority || a.idx - b.idx);
+
+    // Evict until under budget
+    const evictedIndices = new Set<number>();
+    let currentTokens = this.estimateTokens();
+
+    for (const c of candidates) {
+      if (currentTokens <= targetTokens) break;
+      const turnTokens = Math.ceil(JSON.stringify(c.turn.messages).length / 4);
+      evictedIndices.add(c.idx);
+      currentTokens -= turnTokens;
+
+      // Archive the evicted turn
+      this.evicted.push({
+        id: this.nextTurnId++,
+        messages: c.turn.messages,
+        summary: this.summarizeTurn(c.turn.messages),
+      });
+    }
+
+    if (evictedIndices.size === 0) return;
+
+    // Rebuild messages: kept turns + compaction marker where evicted turns were
+    const rebuilt: ChatCompletionMessageParam[] = [];
+    let inEvictedRun = false;
+
+    for (let i = 0; i < turns.length; i++) {
+      if (evictedIndices.has(i)) {
+        if (!inEvictedRun) {
+          rebuilt.push({
+            role: "user",
+            content: `[Earlier conversation turns evicted for context space — use conversation_recall to search or expand]`,
+          });
+          inEvictedRun = true;
+        }
+      } else {
+        inEvictedRun = false;
+        rebuilt.push(...turns[i]!.messages);
+      }
+    }
+
+    this.messages = rebuilt;
+  }
+
+  // ── Conversation recall (search / expand evicted turns) ────────
+
+  /** Search evicted turns by regex/keyword. */
+  search(query: string): string {
+    if (!query.trim()) return "No query provided.";
+    if (this.evicted.length === 0) return "No evicted turns to search.";
+
+    let regex: RegExp;
+    try {
+      regex = new RegExp(query, "i");
+    } catch {
+      const words = query.split(/\s+/).filter((w) => w.length > 0);
+      const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+      regex = new RegExp(pattern, "i");
+    }
+
+    const matches: { turn: EvictedTurn; excerpts: string[] }[] = [];
+
+    for (const turn of this.evicted) {
+      const text = this.turnToText(turn.messages);
+      const lines = text.split("\n");
+      const matchingLines: number[] = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        if (regex.test(lines[i]!)) matchingLines.push(i);
+      }
+
+      if (matchingLines.length > 0) {
+        const excerpts: string[] = [];
+        for (const idx of matchingLines.slice(0, 5)) {
+          const start = Math.max(0, idx - 2);
+          const end = Math.min(lines.length, idx + 3);
+          excerpts.push(lines.slice(start, end).join("\n"));
+        }
+        matches.push({ turn, excerpts });
+      }
+    }
+
+    if (matches.length === 0) return `No results found for "${query}".`;
+
+    const parts: string[] = [`Search results for "${query}" (${matches.length} turns):\n`];
+    for (const m of matches.slice(0, 20)) {
+      parts.push(`Turn #${m.turn.id}: ${m.turn.summary}`);
+      for (const excerpt of m.excerpts) {
+        parts.push("  " + excerpt.split("\n").join("\n  "));
+      }
+      parts.push("");
+    }
+    return parts.join("\n");
+  }
+
+  /** Expand the full content of an evicted turn by ID. */
+  expand(turnId: number): string {
+    const turn = this.evicted.find((t) => t.id === turnId);
+    if (!turn) return `Turn #${turnId}: not found.`;
+    return `Turn #${turnId}: ${turn.summary}\n\n${this.turnToText(turn.messages)}`;
+  }
+
+  /** Browse summaries of all evicted turns. */
+  browse(): string {
+    if (this.evicted.length === 0) return "No evicted conversation turns.";
+    return this.evicted
+      .map((t) => `#${t.id}: ${t.summary}`)
+      .join("\n");
   }
 
   clear(): void {
     this.messages = [];
+    this.evicted = [];
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────
+
+  private parseTurns(): { messages: ChatCompletionMessageParam[]; priority: Priority }[] {
+    const turns: { messages: ChatCompletionMessageParam[]; priority: Priority }[] = [];
+    let current: ChatCompletionMessageParam[] = [];
+
+    for (const msg of this.messages) {
+      // A user message starts a new turn (unless it's the very first message)
+      if (msg.role === "user" && current.length > 0) {
+        turns.push({ messages: current, priority: Priority.MEDIUM });
+        current = [];
+      }
+      current.push(msg);
+    }
+    if (current.length > 0) {
+      turns.push({ messages: current, priority: Priority.MEDIUM });
+    }
+
+    return turns;
+  }
+
+  private inferPriority(messages: ChatCompletionMessageParam[]): Priority {
+    let hasError = false;
+    let hasWriteTool = false;
+    let allReadOnly = true;
+    let hasToolResult = false;
+
+    for (const msg of messages) {
+      if (msg.role === "user") return Priority.HIGH;
+
+      if (msg.role === "tool") {
+        hasToolResult = true;
+        const content = typeof msg.content === "string" ? msg.content : "";
+        if (content.startsWith("Error:") || content.includes("error")) {
+          hasError = true;
+        }
+      }
+
+      if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
+        for (const tc of msg.tool_calls) {
+          const fn = "function" in tc ? tc.function : undefined;
+          if (!fn) continue;
+          const name = fn.name;
+          if (WRITE_TOOLS.has(name)) hasWriteTool = true;
+          if (!READ_ONLY_TOOLS.has(name)) allReadOnly = false;
+        }
+      }
+    }
+
+    if (hasError) return Priority.HIGH;
+    if (hasWriteTool) return Priority.MEDIUM;
+    if (hasToolResult && allReadOnly) return Priority.LOWEST;
+    if (hasToolResult) return Priority.LOW;
+    return Priority.MEDIUM;
+  }
+
+  /** Generate a one-line heuristic summary of a turn (no LLM call). */
+  private summarizeTurn(messages: ChatCompletionMessageParam[]): string {
+    const parts: string[] = [];
+
+    for (const msg of messages) {
+      if (msg.role === "user" && typeof msg.content === "string") {
+        parts.push(`user: ${msg.content.slice(0, 80)}`);
+      }
+      if (msg.role === "assistant") {
+        if ("tool_calls" in msg && msg.tool_calls) {
+          const tools = msg.tool_calls
+            .map((tc) => "function" in tc ? tc.function.name : "unknown")
+            .filter(Boolean);
+          const unique = [...new Set(tools)];
+          parts.push(`agent called ${unique.join(", ")}`);
+        } else if (typeof msg.content === "string" && msg.content) {
+          parts.push(`agent: ${msg.content.slice(0, 60)}...`);
+        }
+      }
+    }
+
+    return parts.join(" → ") || "(empty turn)";
+  }
+
+  /** Convert messages to a searchable text representation. */
+  private turnToText(messages: ChatCompletionMessageParam[]): string {
+    const lines: string[] = [];
+    for (const msg of messages) {
+      if (msg.role === "user") {
+        lines.push(`[user] ${typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content)}`);
+      } else if (msg.role === "assistant") {
+        if (typeof msg.content === "string" && msg.content) {
+          lines.push(`[assistant] ${msg.content}`);
+        }
+        if ("tool_calls" in msg && msg.tool_calls) {
+          for (const tc of msg.tool_calls) {
+            if ("function" in tc) {
+              lines.push(`[tool_call] ${tc.function.name}(${tc.function.arguments.slice(0, 200)})`);
+            }
+          }
+        }
+      } else if (msg.role === "tool") {
+        const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+        lines.push(`[tool_result] ${content.slice(0, 500)}`);
+      }
+    }
+    return lines.join("\n");
   }
 }

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -1,13 +1,25 @@
 import type { ChatCompletionMessageParam } from "../utils/llm-client.js";
+import { getSettings } from "../settings.js";
+import {
+  type NuclearEntry,
+  toNuclearEntries,
+  formatNuclearLine,
+  isReadOnly,
+  READ_ONLY_TOOLS,
+  WRITE_TOOLS,
+} from "./nuclear-form.js";
+import type { HistoryFile } from "./history-file.js";
 
 /**
- * Manages the OpenAI chat messages array for the agent loop.
- * Separate from ContextManager — this is the LLM conversation,
- * not the shell history.
+ * Three-tier conversation state — works like shell history.
  *
- * Supports priority-based compaction: when the conversation exceeds the
- * token budget, low-priority turns are evicted to an archive that the
- * agent can search/expand via the conversation_recall tool.
+ * Tier 1: Active context   — full content in LLM messages array
+ * Tier 2: Nuclear memory   — one-liner summaries IN the conversation +
+ *                            recall archive (in-memory) for full content
+ * Tier 3: History file     — nuclear entries persisted to disk
+ *
+ * Content flows downward as the context window fills:
+ *   Tier 1 → compact → Tier 2 → flush → Tier 3
  */
 
 // ── Priority tiers (lower number = evicted first) ─────────────────
@@ -21,31 +33,33 @@ const enum Priority {
   MEDIUM = 2,
   /** User messages, error messages, assistant reasoning. */
   HIGH = 3,
-  /** First user message (original task) + last N turns — never evicted. */
+  /** First user message + last N turns — never evicted. */
   PINNED = 4,
 }
 
-/** Read-only tools whose results are cheap to reproduce. */
-const READ_ONLY_TOOLS = new Set([
-  "grep", "ls", "read_file", "glob", "bash", "search",
-]);
-
-/** Tools that produce durable changes — higher priority. */
-const WRITE_TOOLS = new Set([
-  "write_file", "edit_file", "write", "edit", "patch",
-]);
-
-/** An archived turn that was evicted from the active conversation. */
-export interface EvictedTurn {
-  id: number;
-  messages: ChatCompletionMessageParam[];
-  summary: string;
-}
-
 export class ConversationState {
+  // ── Tier 1: Active context ────────────────────────────────────
   private messages: ChatCompletionMessageParam[] = [];
-  private evicted: EvictedTurn[] = [];
-  private nextTurnId = 1;
+
+  // ── Tier 2: Nuclear memory ────────────────────────────────────
+  private nuclearEntries: NuclearEntry[] = [];
+  private recallArchive = new Map<number, ChatCompletionMessageParam[]>();
+
+  // ── Tier 3 reference ──────────────────────────────────────────
+  private historyFile: HistoryFile | null;
+
+  // ── Shared state ──────────────────────────────────────────────
+  private nextSeq = 1;
+
+  constructor(historyFile?: HistoryFile) {
+    this.historyFile = historyFile ?? null;
+  }
+
+  get instanceId(): string {
+    return this.historyFile?.instanceId ?? "0000";
+  }
+
+  // ── Message API (unchanged) ───────────────────────────────────
 
   addUserMessage(text: string): void {
     this.messages.push({ role: "user", content: text });
@@ -81,7 +95,6 @@ export class ConversationState {
     });
   }
 
-  /** Inject a system-level note into the conversation (e.g. context change). */
   addSystemNote(text: string): void {
     this.messages.push({ role: "user", content: text });
   }
@@ -90,40 +103,36 @@ export class ConversationState {
     return this.messages;
   }
 
-  // ── Compaction ──────────────────────────────────────────────────
+  // ── Token estimation ──────────────────────────────────────────
 
-  /**
-   * Estimate token count for the current conversation.
-   * Uses ~4 chars per token heuristic.
-   */
   estimateTokens(): number {
     return Math.ceil(JSON.stringify(this.messages).length / 4);
   }
 
+  // ── Tier 1 → Tier 2: Compaction ───────────────────────────────
+
   /**
-   * Priority-based compaction. Evicts lowest-priority turns until the
-   * estimated token count is under the target budget.
-   *
-   * Pinned content (first user message + recent turns) is never evicted.
+   * Priority-based compaction. Evicts lowest-priority turns, replacing
+   * them with nuclear one-liner summaries that stay in the conversation.
+   * Read-only tool results are dropped entirely.
    */
   compact(targetTokens: number, recentTurnsToKeep = 10): void {
     if (this.estimateTokens() <= targetTokens) return;
 
-    // Parse the message array into logical "turns" (boundaries at user messages)
     const turns = this.parseTurns();
-    if (turns.length <= 2) return; // nothing to evict
+    if (turns.length <= 2) return;
 
-    // Assign priorities — pin first turn and recent turns
+    // Assign priorities
     const pinnedCount = Math.min(recentTurnsToKeep, turns.length - 1);
     for (const turn of turns) {
       turn.priority = this.inferPriority(turn.messages);
     }
-    turns[0]!.priority = Priority.PINNED; // original task
+    turns[0]!.priority = Priority.PINNED;
     for (let i = turns.length - pinnedCount; i < turns.length; i++) {
       turns[i]!.priority = Priority.PINNED;
     }
 
-    // Build eviction candidates sorted by priority (lowest first), then oldest first
+    // Sort candidates: lowest priority first, then oldest
     const candidates = turns
       .map((t, idx) => ({ turn: t, idx }))
       .filter((c) => c.turn.priority !== Priority.PINNED)
@@ -139,117 +148,216 @@ export class ConversationState {
       evictedIndices.add(c.idx);
       currentTokens -= turnTokens;
 
-      // Archive the evicted turn
-      this.evicted.push({
-        id: this.nextTurnId++,
-        messages: c.turn.messages,
-        summary: this.summarizeTurn(c.turn.messages),
-      });
+      // Generate nuclear entries from this turn
+      const entries = toNuclearEntries(c.turn.messages, this.nextSeq, this.instanceId);
+      this.nextSeq += entries.length;
+
+      for (const entry of entries) {
+        if (isReadOnly(entry)) {
+          // Read-only: archive only (dropped from conversation), agent can re-read
+          this.recallArchive.set(entry.seq, c.turn.messages);
+        } else {
+          // State-changing: keep nuclear one-liner in conversation + archive
+          this.nuclearEntries.push(entry);
+          this.recallArchive.set(entry.seq, c.turn.messages);
+        }
+      }
     }
 
     if (evictedIndices.size === 0) return;
 
-    // Rebuild messages: kept turns + compaction marker where evicted turns were
+    // Rebuild: first turn + nuclear summary block + remaining turns
     const rebuilt: ChatCompletionMessageParam[] = [];
-    let inEvictedRun = false;
+    let insertedNuclearBlock = false;
 
     for (let i = 0; i < turns.length; i++) {
       if (evictedIndices.has(i)) {
-        if (!inEvictedRun) {
-          rebuilt.push({
-            role: "user",
-            content: `[Earlier conversation turns evicted for context space — use conversation_recall to search or expand]`,
-          });
-          inEvictedRun = true;
+        if (!insertedNuclearBlock) {
+          rebuilt.push(this.buildNuclearBlock());
+          insertedNuclearBlock = true;
         }
       } else {
-        inEvictedRun = false;
         rebuilt.push(...turns[i]!.messages);
       }
+    }
+
+    // If no nuclear block was inserted but we have entries from prior compactions,
+    // update the existing nuclear block
+    if (!insertedNuclearBlock && this.nuclearEntries.length > 0) {
+      this.updateNuclearBlockInMessages(rebuilt);
     }
 
     this.messages = rebuilt;
   }
 
-  // ── Conversation recall (search / expand evicted turns) ────────
+  // ── Tier 2 → Tier 3: Flush ───────────────────────────────────
 
-  /** Search evicted turns by regex/keyword. */
-  search(query: string): string {
+  /**
+   * Flush oldest nuclear entries to the history file when the
+   * in-context nuclear block grows too large.
+   */
+  async flush(): Promise<void> {
+    const maxEntries = getSettings().nuclearMaxEntries;
+    if (this.nuclearEntries.length <= maxEntries) return;
+
+    const flushCount = this.nuclearEntries.length - maxEntries;
+    const toFlush = this.nuclearEntries.slice(0, flushCount);
+
+    // Write to history file
+    if (this.historyFile) {
+      await this.historyFile.append(toFlush);
+    }
+
+    // Remove flushed entries from memory
+    for (const entry of toFlush) {
+      this.recallArchive.delete(entry.seq);
+    }
+    this.nuclearEntries = this.nuclearEntries.slice(flushCount);
+
+    // Update the nuclear block in messages
+    this.updateNuclearBlockInMessages(this.messages);
+  }
+
+  // ── Startup: Load prior history ───────────────────────────────
+
+  /**
+   * Inject prior session history from the history file as a context note.
+   */
+  loadPriorHistory(entries: NuclearEntry[]): void {
+    if (entries.length === 0) return;
+    // Update nextSeq to avoid collisions
+    const maxSeq = Math.max(...entries.map((e) => e.seq));
+    if (maxSeq >= this.nextSeq) this.nextSeq = maxSeq + 1;
+
+    const lines = entries.map(formatNuclearLine);
+    this.messages.push({
+      role: "user",
+      content: `[Prior session history — loaded from ~/.agent-sh/history]\n${lines.join("\n")}`,
+    });
+  }
+
+  // ── Conversation recall ───────────────────────────────────────
+
+  /** Search Tier 2 archive + Tier 3 history file. */
+  async search(query: string): Promise<string> {
     if (!query.trim()) return "No query provided.";
-    if (this.evicted.length === 0) return "No evicted turns to search.";
 
-    let regex: RegExp;
-    try {
-      regex = new RegExp(query, "i");
-    } catch {
-      const words = query.split(/\s+/).filter((w) => w.length > 0);
-      const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
-      regex = new RegExp(pattern, "i");
-    }
+    const parts: string[] = [];
 
-    const matches: { turn: EvictedTurn; excerpts: string[] }[] = [];
+    // Search Tier 2 (in-memory archive)
+    const archiveResults = this.searchArchive(query);
+    if (archiveResults) parts.push(archiveResults);
 
-    for (const turn of this.evicted) {
-      const text = this.turnToText(turn.messages);
-      const lines = text.split("\n");
-      const matchingLines: number[] = [];
-
-      for (let i = 0; i < lines.length; i++) {
-        if (regex.test(lines[i]!)) matchingLines.push(i);
-      }
-
-      if (matchingLines.length > 0) {
-        const excerpts: string[] = [];
-        for (const idx of matchingLines.slice(0, 5)) {
-          const start = Math.max(0, idx - 2);
-          const end = Math.min(lines.length, idx + 3);
-          excerpts.push(lines.slice(start, end).join("\n"));
+    // Search Tier 3 (history file)
+    if (this.historyFile) {
+      const fileResults = await this.historyFile.search(query);
+      if (fileResults.length > 0) {
+        parts.push(`History file matches (${fileResults.length}):`);
+        for (const r of fileResults.slice(0, 20)) {
+          parts.push(`  ${r.line}`);
         }
-        matches.push({ turn, excerpts });
       }
     }
 
-    if (matches.length === 0) return `No results found for "${query}".`;
+    if (parts.length === 0) return `No results found for "${query}".`;
+    return parts.join("\n\n");
+  }
 
-    const parts: string[] = [`Search results for "${query}" (${matches.length} turns):\n`];
-    for (const m of matches.slice(0, 20)) {
-      parts.push(`Turn #${m.turn.id}: ${m.turn.summary}`);
-      for (const excerpt of m.excerpts) {
-        parts.push("  " + excerpt.split("\n").join("\n  "));
-      }
-      parts.push("");
+  /** Expand full content of a nuclear entry by seq number. */
+  async expand(seq: number): Promise<string> {
+    // Check Tier 2 archive first
+    const archived = this.recallArchive.get(seq);
+    if (archived) {
+      const entry = this.nuclearEntries.find((e) => e.seq === seq);
+      const header = entry ? formatNuclearLine(entry) : `#${seq}`;
+      return `${header}\n\n${this.turnToText(archived)}`;
     }
+
+    return `Entry #${seq}: not found in recall archive (may have been flushed to history file).`;
+  }
+
+  /** Browse nuclear entries (Tier 2) + recent history (Tier 3). */
+  async browse(): Promise<string> {
+    const parts: string[] = [];
+
+    if (this.nuclearEntries.length > 0) {
+      parts.push("In-context nuclear entries:");
+      for (const e of this.nuclearEntries) {
+        parts.push(`  ${formatNuclearLine(e)}`);
+      }
+    }
+
+    if (this.historyFile) {
+      const recent = await this.historyFile.readRecent(25);
+      if (recent.length > 0) {
+        parts.push("\nRecent history file entries:");
+        for (const e of recent) {
+          parts.push(`  ${formatNuclearLine(e)}`);
+        }
+      }
+    }
+
+    if (parts.length === 0) return "No conversation history.";
     return parts.join("\n");
   }
 
-  /** Expand the full content of an evicted turn by ID. */
-  expand(turnId: number): string {
-    const turn = this.evicted.find((t) => t.id === turnId);
-    if (!turn) return `Turn #${turnId}: not found.`;
-    return `Turn #${turnId}: ${turn.summary}\n\n${this.turnToText(turn.messages)}`;
+  // ── Stats ─────────────────────────────────────────────────────
+
+  getNuclearEntryCount(): number {
+    return this.nuclearEntries.length;
   }
 
-  /** Browse summaries of all evicted turns. */
-  browse(): string {
-    if (this.evicted.length === 0) return "No evicted conversation turns.";
-    return this.evicted
-      .map((t) => `#${t.id}: ${t.summary}`)
-      .join("\n");
+  getRecallArchiveSize(): number {
+    return this.recallArchive.size;
   }
+
+  // ── Clear ─────────────────────────────────────────────────────
 
   clear(): void {
     this.messages = [];
-    this.evicted = [];
+    this.nuclearEntries = [];
+    this.recallArchive.clear();
   }
 
-  // ── Internal helpers ──────────────────────────────────────────
+  // ── Internal: Nuclear block management ────────────────────────
+
+  private buildNuclearBlock(): ChatCompletionMessageParam {
+    const lines = this.nuclearEntries.map(formatNuclearLine);
+    return {
+      role: "user",
+      content: `[Conversation history — use conversation_recall to expand any entry]\n${lines.join("\n")}`,
+    };
+  }
+
+  private updateNuclearBlockInMessages(messages: ChatCompletionMessageParam[]): void {
+    if (this.nuclearEntries.length === 0) return;
+    const marker = "[Conversation history — use conversation_recall";
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i]!;
+      if (msg.role === "user" && typeof msg.content === "string" && msg.content.startsWith(marker)) {
+        messages[i] = this.buildNuclearBlock();
+        return;
+      }
+    }
+    // No existing block found — insert after the first turn
+    if (messages.length > 0) {
+      // Find end of first turn (next user message or end)
+      let insertIdx = 1;
+      for (let i = 1; i < messages.length; i++) {
+        if (messages[i]!.role === "user") { insertIdx = i; break; }
+        insertIdx = i + 1;
+      }
+      messages.splice(insertIdx, 0, this.buildNuclearBlock());
+    }
+  }
+
+  // ── Internal: Turn parsing and priority ───────────────────────
 
   private parseTurns(): { messages: ChatCompletionMessageParam[]; priority: Priority }[] {
     const turns: { messages: ChatCompletionMessageParam[]; priority: Priority }[] = [];
     let current: ChatCompletionMessageParam[] = [];
 
     for (const msg of this.messages) {
-      // A user message starts a new turn (unless it's the very first message)
       if (msg.role === "user" && current.length > 0) {
         turns.push({ messages: current, priority: Priority.MEDIUM });
         current = [];
@@ -298,31 +406,33 @@ export class ConversationState {
     return Priority.MEDIUM;
   }
 
-  /** Generate a one-line heuristic summary of a turn (no LLM call). */
-  private summarizeTurn(messages: ChatCompletionMessageParam[]): string {
-    const parts: string[] = [];
+  // ── Internal: Search helpers ──────────────────────────────────
 
-    for (const msg of messages) {
-      if (msg.role === "user" && typeof msg.content === "string") {
-        parts.push(`user: ${msg.content.slice(0, 80)}`);
-      }
-      if (msg.role === "assistant") {
-        if ("tool_calls" in msg && msg.tool_calls) {
-          const tools = msg.tool_calls
-            .map((tc) => "function" in tc ? tc.function.name : "unknown")
-            .filter(Boolean);
-          const unique = [...new Set(tools)];
-          parts.push(`agent called ${unique.join(", ")}`);
-        } else if (typeof msg.content === "string" && msg.content) {
-          parts.push(`agent: ${msg.content.slice(0, 60)}...`);
-        }
+  private searchArchive(query: string): string | null {
+    if (this.recallArchive.size === 0) return null;
+
+    let regex: RegExp;
+    try {
+      regex = new RegExp(query, "i");
+    } catch {
+      const words = query.split(/\s+/).filter((w) => w.length > 0);
+      const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+      regex = new RegExp(pattern, "i");
+    }
+
+    const matches: string[] = [];
+    for (const [seq, msgs] of this.recallArchive) {
+      const text = this.turnToText(msgs);
+      if (regex.test(text)) {
+        const entry = this.nuclearEntries.find((e) => e.seq === seq);
+        matches.push(entry ? formatNuclearLine(entry) : `#${seq}`);
       }
     }
 
-    return parts.join(" → ") || "(empty turn)";
+    if (matches.length === 0) return null;
+    return `Recall archive matches (${matches.length}):\n${matches.map((m) => `  ${m}`).join("\n")}`;
   }
 
-  /** Convert messages to a searchable text representation. */
   private turnToText(messages: ChatCompletionMessageParam[]): string {
     const lines: string[] = [];
     for (const msg of messages) {

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -1,0 +1,177 @@
+/**
+ * Persistent history file — Tier 3 of the three-tier history system.
+ *
+ * Append-only JSONL file at ~/.agent-sh/history. Multiple agent-sh
+ * instances can write concurrently — each line is under PIPE_BUF so
+ * O_APPEND writes are atomic. Only truncation (which rewrites the file)
+ * uses a lock file for safety.
+ */
+import * as fs from "node:fs/promises";
+import * as fss from "node:fs";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
+import { CONFIG_DIR, getSettings } from "../settings.js";
+import {
+  type NuclearEntry,
+  serializeEntry,
+  deserializeEntry,
+  formatNuclearLine,
+} from "./nuclear-form.js";
+
+const HISTORY_PATH = path.join(CONFIG_DIR, "history");
+const LOCK_PATH = HISTORY_PATH + ".lock";
+const LOCK_STALE_MS = 10_000; // consider lock stale after 10s
+
+export class HistoryFile {
+  readonly instanceId: string;
+  private filePath: string;
+
+  constructor(opts?: { filePath?: string; instanceId?: string }) {
+    this.filePath = opts?.filePath ?? HISTORY_PATH;
+    this.instanceId = opts?.instanceId ?? crypto.randomBytes(2).toString("hex");
+  }
+
+  /**
+   * Append entries atomically. Uses O_APPEND for concurrency safety.
+   * Triggers truncation check after writing.
+   */
+  async append(entries: NuclearEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    const lines = entries.map((e) => serializeEntry(e) + "\n").join("");
+    await fs.appendFile(this.filePath, lines, { flag: "a" });
+    await this.maybeTruncate();
+  }
+
+  /**
+   * Read the most recent N entries from the history file.
+   */
+  async readRecent(maxEntries?: number): Promise<NuclearEntry[]> {
+    maxEntries ??= getSettings().historyStartupEntries;
+    let content: string;
+    try {
+      content = await fs.readFile(this.filePath, "utf-8");
+    } catch {
+      return [];
+    }
+    const lines = content.trim().split("\n").filter(Boolean);
+    const recent = lines.slice(-maxEntries);
+    const entries: NuclearEntry[] = [];
+    for (const line of recent) {
+      const entry = deserializeEntry(line);
+      if (entry) entries.push(entry);
+    }
+    return entries;
+  }
+
+  /**
+   * Search history entries by regex/keyword.
+   */
+  async search(query: string): Promise<{ entry: NuclearEntry; line: string }[]> {
+    if (!query.trim()) return [];
+
+    let regex: RegExp;
+    try {
+      regex = new RegExp(query, "i");
+    } catch {
+      const words = query.split(/\s+/).filter((w) => w.length > 0);
+      const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+      regex = new RegExp(pattern, "i");
+    }
+
+    let content: string;
+    try {
+      content = await fs.readFile(this.filePath, "utf-8");
+    } catch {
+      return [];
+    }
+
+    const results: { entry: NuclearEntry; line: string }[] = [];
+    for (const line of content.trim().split("\n")) {
+      const entry = deserializeEntry(line);
+      if (entry && regex.test(entry.sum)) {
+        results.push({ entry, line: formatNuclearLine(entry) });
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Get file size in bytes. Returns 0 if file doesn't exist.
+   */
+  async getSize(): Promise<number> {
+    try {
+      const stat = await fs.stat(this.filePath);
+      return stat.size;
+    } catch {
+      return 0;
+    }
+  }
+
+  // ── Truncation ──────────────────────────────────────────────────
+
+  /**
+   * Truncate from the front if file exceeds historyMaxBytes.
+   * Uses a lock file for the rewrite operation.
+   */
+  private async maybeTruncate(): Promise<void> {
+    const maxBytes = getSettings().historyMaxBytes;
+    const size = await this.getSize();
+    // Only truncate when significantly over (150%) to avoid frequent rewrites
+    if (size <= maxBytes * 1.5) return;
+
+    const acquired = await this.acquireLock();
+    if (!acquired) return; // another process is truncating
+
+    try {
+      let content: string;
+      try {
+        content = await fs.readFile(this.filePath, "utf-8");
+      } catch {
+        return;
+      }
+
+      const lines = content.split("\n").filter(Boolean);
+      // Drop oldest lines until under maxBytes
+      let totalBytes = Buffer.byteLength(content, "utf-8");
+      let dropCount = 0;
+      while (totalBytes > maxBytes && dropCount < lines.length - 1) {
+        totalBytes -= Buffer.byteLength(lines[dropCount]! + "\n", "utf-8");
+        dropCount++;
+      }
+
+      if (dropCount === 0) return;
+
+      const remaining = lines.slice(dropCount).join("\n") + "\n";
+      // Atomic rewrite: write temp → rename
+      const tmpPath = this.filePath + ".tmp." + process.pid;
+      await fs.writeFile(tmpPath, remaining);
+      await fs.rename(tmpPath, this.filePath);
+    } finally {
+      await this.releaseLock();
+    }
+  }
+
+  private async acquireLock(): Promise<boolean> {
+    try {
+      // Check for stale lock
+      try {
+        const stat = await fs.stat(LOCK_PATH);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          await fs.unlink(LOCK_PATH).catch(() => {});
+        }
+      } catch {
+        // Lock doesn't exist — good
+      }
+      // O_EXCL ensures atomicity
+      const fd = await fs.open(LOCK_PATH, fss.constants.O_CREAT | fss.constants.O_EXCL | fss.constants.O_WRONLY);
+      await fd.close();
+      return true;
+    } catch {
+      return false; // lock held by another process
+    }
+  }
+
+  private async releaseLock(): Promise<void> {
+    await fs.unlink(LOCK_PATH).catch(() => {});
+  }
+}

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -1,0 +1,216 @@
+/**
+ * Nuclear form — compact one-liner summaries of conversation actions.
+ *
+ * Used by the three-tier history system:
+ *   Tier 1 (full content) → compacts into → Tier 2 (nuclear one-liners)
+ *   Tier 2 → flushes to → Tier 3 (history file on disk)
+ *
+ * Nuclear entries are the currency of Tier 2 and Tier 3.
+ */
+import type { ChatCompletionMessageParam } from "../utils/llm-client.js";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface NuclearEntry {
+  /** Global sequence number. */
+  seq: number;
+  /** Timestamp (Date.now()). */
+  ts: number;
+  /** Instance ID — 4-char hex identifying the agent-sh process. */
+  iid: string;
+  /** Entry kind. */
+  kind: "user" | "agent" | "tool" | "error";
+  /** Tool name (for kind=tool or kind=error). */
+  tool?: string;
+  /** The one-liner summary. */
+  sum: string;
+}
+
+// ── Tool classification ───────────────────────────────────────────
+
+/** Read-only tools whose results are dropped at Tier 1→2 (agent can re-read). */
+export const READ_ONLY_TOOLS = new Set([
+  "read_file", "grep", "glob", "ls", "search",
+]);
+
+/** State-changing tools whose summaries are kept in nuclear memory. */
+export const WRITE_TOOLS = new Set([
+  "write_file", "edit_file", "write", "edit", "patch",
+]);
+
+// ── Nuclear entry generation ──────────────────────────────────────
+
+/**
+ * Generate nuclear entries from a logical turn (a sequence of messages
+ * starting with a user message, followed by assistant + tool messages).
+ */
+export function toNuclearEntries(
+  messages: ChatCompletionMessageParam[],
+  startSeq: number,
+  instanceId: string,
+): NuclearEntry[] {
+  const entries: NuclearEntry[] = [];
+  let seq = startSeq;
+  const ts = Date.now();
+
+  for (const msg of messages) {
+    if (msg.role === "user") {
+      const text = typeof msg.content === "string" ? msg.content : "";
+      // Skip compaction markers
+      if (text.startsWith("[")) continue;
+      entries.push({
+        seq: seq++, ts, iid: instanceId,
+        kind: "user",
+        sum: `user: "${truncate(text, 80)}"`,
+      });
+    } else if (msg.role === "assistant") {
+      // Process tool calls
+      if ("tool_calls" in msg && msg.tool_calls) {
+        for (const tc of msg.tool_calls) {
+          if (!("function" in tc)) continue;
+          const name = tc.function.name;
+          let args: Record<string, unknown> = {};
+          try { args = JSON.parse(tc.function.arguments); } catch {}
+
+          // Store the tool call — we'll enrich it when we see the result
+          entries.push({
+            seq: seq++, ts, iid: instanceId,
+            kind: "tool",
+            tool: name,
+            sum: summarizeToolCall(name, args),
+          });
+        }
+      } else if (typeof msg.content === "string" && msg.content) {
+        entries.push({
+          seq: seq++, ts, iid: instanceId,
+          kind: "agent",
+          sum: `agent: "${truncate(msg.content, 60)}"`,
+        });
+      }
+    } else if (msg.role === "tool") {
+      // Enrich the most recent tool entry with result info
+      const content = typeof msg.content === "string" ? msg.content : "";
+      const lastTool = findLastTool(entries);
+      if (lastTool) {
+        const isError = content.startsWith("Error:");
+        if (isError) {
+          lastTool.kind = "error";
+          lastTool.sum = `error: ${lastTool.tool} ${truncate(content.slice(7).trim(), 80)}`;
+        } else {
+          lastTool.sum = enrichWithResult(lastTool.tool ?? "", lastTool.sum, content);
+        }
+      }
+    }
+  }
+
+  return entries;
+}
+
+// ── Formatting ────────────────────────────────────────────────────
+
+/** Format a nuclear entry as a display line (for in-context injection). */
+export function formatNuclearLine(entry: NuclearEntry): string {
+  const time = new Date(entry.ts).toLocaleTimeString("en-US", {
+    hour: "2-digit", minute: "2-digit", hour12: false,
+  });
+  return `#${entry.seq} ${time} ${entry.sum}`;
+}
+
+// ── Serialization (JSONL for history file) ────────────────────────
+
+/** Serialize a nuclear entry to a JSONL line. */
+export function serializeEntry(entry: NuclearEntry): string {
+  return JSON.stringify(entry);
+}
+
+/** Deserialize a JSONL line to a nuclear entry. Returns null on parse failure. */
+export function deserializeEntry(line: string): NuclearEntry | null {
+  try {
+    const obj = JSON.parse(line);
+    if (typeof obj.seq === "number" && typeof obj.sum === "string") {
+      return obj as NuclearEntry;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Classification helpers ────────────────────────────────────────
+
+/** Check if a nuclear entry represents a read-only action (should be dropped). */
+export function isReadOnly(entry: NuclearEntry): boolean {
+  return entry.kind === "tool" && entry.tool != null && READ_ONLY_TOOLS.has(entry.tool);
+}
+
+// ── Internal helpers ──────────────────────────────────────────────
+
+function truncate(text: string, maxLen: number): string {
+  const oneLine = text.replace(/\n/g, " ").trim();
+  return oneLine.length > maxLen ? oneLine.slice(0, maxLen) + "..." : oneLine;
+}
+
+function findLastTool(entries: NuclearEntry[]): NuclearEntry | undefined {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i]!.kind === "tool") return entries[i];
+  }
+  return undefined;
+}
+
+function summarizeToolCall(name: string, args: Record<string, unknown>): string {
+  switch (name) {
+    case "bash":
+      return `bash: ${truncate(String(args.command ?? ""), 60)}`;
+    case "user_shell":
+      return `user_shell: ${truncate(String(args.command ?? ""), 60)}`;
+    case "edit_file":
+      return `edit_file ${args.path ?? ""}`;
+    case "write_file":
+    case "write":
+      return `write_file ${args.path ?? args.file_path ?? ""}`;
+    case "read_file":
+      return `read_file ${args.path ?? args.file_path ?? ""}`;
+    case "grep":
+      return `grep "${truncate(String(args.pattern ?? ""), 30)}"`;
+    case "glob":
+      return `glob ${args.pattern ?? ""}`;
+    case "ls":
+      return `ls ${args.path ?? "."}`;
+    case "display":
+      return `display: ${truncate(String(args.command ?? ""), 60)}`;
+    default:
+      return `${name}`;
+  }
+}
+
+function enrichWithResult(toolName: string, summary: string, result: string): string {
+  const lines = result.split("\n");
+  const lineCount = lines.length;
+
+  switch (toolName) {
+    case "bash":
+    case "user_shell": {
+      // Extract exit code from result if present
+      const exitMatch = result.match(/exit code[:\s]*(\d+)/i) ?? result.match(/exit\s+(\d+)/);
+      const exitCode = exitMatch ? exitMatch[1] : "0";
+      return `${summary} (exit ${exitCode}, ${lineCount} lines)`;
+    }
+    case "edit_file":
+    case "edit": {
+      // Try to extract +/- counts from result
+      const addMatch = result.match(/\+(\d+)/);
+      const delMatch = result.match(/-(\d+)/);
+      if (addMatch || delMatch) {
+        return `${summary} (+${addMatch?.[1] ?? 0}/-${delMatch?.[1] ?? 0})`;
+      }
+      return `${summary} (edited)`;
+    }
+    case "write_file":
+    case "write": {
+      const created = result.toLowerCase().includes("created") ? "created" : "written";
+      return `${summary} (${created}, ${lineCount} lines)`;
+    }
+    default:
+      return `${summary} (${lineCount} lines)`;
+  }
+}

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -107,6 +107,7 @@ a program (vim, ssh, a REPL, etc.) or at a shell prompt. In this mode:
 export function buildDynamicContext(
   tools: ToolDefinition[],
   contextManager: ContextManager,
+  shellBudgetTokens?: number,
 ): string {
   const sections: string[] = [];
 
@@ -130,8 +131,9 @@ export function buildDynamicContext(
     );
   }
 
-  // Shell context
-  const shellContext = contextManager.getContext();
+  // Shell context — pass token budget converted to bytes (~4 chars/token)
+  const shellBudgetBytes = shellBudgetTokens != null ? shellBudgetTokens * 4 : undefined;
+  const shellContext = contextManager.getContext(shellBudgetBytes);
   if (shellContext) {
     sections.push(shellContext);
   }

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -62,14 +62,34 @@ output directly, but it is NOT returned to you. Use when:
 - The output is for the user to read, not for you to process
 
 **Live shell** (user_shell):
-Use this to run commands with lasting effects in the user's real shell. Use for:
+Use this to run complete, non-interactive commands in the user's real shell. Use for:
 - Commands that affect shell state (cd, export, source)
 - Installing packages, starting servers, running builds
 - Any command where the user wants real side effects
 - Set return_output=true only if you need to inspect the result
 
+**Terminal interaction** (terminal_read, terminal_keys):
+Use these to observe and interact with what is currently on the user's terminal screen.
+- terminal_read: see what the user sees (current screen contents, cursor position)
+- terminal_keys: send keystrokes as if the user typed them
+Use for: driving interactive programs (vim, htop, less, ssh, REPLs), answering questions
+about what's on screen, or typing at the shell prompt when a program is already running.
+Do NOT use user_shell to interact with an already-running program — use these instead.
+
 Default to scratchpad tools for your own investigation. Use display when the
 user is the intended audience. Use user_shell when the command has real effects.
+Use terminal_read/terminal_keys when interacting with what's already on screen.
+
+# Interactive Overlay Sessions
+
+When the dynamic context includes \`interactive-session: true\`, the user has summoned you
+via a hotkey overlay from inside their live terminal. They may be in the middle of using
+a program (vim, ssh, a REPL, etc.) or at a shell prompt. In this mode:
+- Start with terminal_read if you need to understand what's on screen.
+- Prefer terminal_keys to interact with whatever is currently running.
+- Use user_shell only for running new, standalone commands — not for interacting with
+  what's already on screen.
+- Keep responses concise — the user is in the middle of a workflow.
 
 # Tool Usage Guidelines
 - Use read_file before editing a file you haven't seen

--- a/src/agent/tools/user-shell.ts
+++ b/src/agent/tools/user-shell.ts
@@ -15,7 +15,10 @@ export function createUserShellTool(opts: {
   return {
     name: "user_shell",
     description:
-      "Run a command with lasting effects in the user's live shell (cd, export, install packages, start servers, apply changes). Output is shown directly to the user but NOT returned to you by default — set return_output=true if you need to inspect the result.",
+      "Run a complete, non-interactive command in the user's live shell (cd, export, install packages, start servers, git commands). " +
+      "Use this for commands that have side effects or that the user wants to see. Output is shown directly to the user but NOT returned " +
+      "to you by default — set return_output=true if you need to inspect the result. " +
+      "Do NOT use this to interact with programs that are already running in the terminal — use terminal_keys/terminal_read instead.",
     input_schema: {
       type: "object",
       properties: {

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -1,21 +1,13 @@
 import type { EventBus } from "./event-bus.js";
-import type { Exchange, ToolCallRecord } from "./types.js";
+import type { Exchange } from "./types.js";
 import type { HandlerRegistry } from "./utils/handler-registry.js";
 import { getSettings } from "./settings.js";
-
-// Non-configurable thresholds (agent response and tool output follow shell settings)
-const AGENT_RESPONSE_TRUNCATE_THRESHOLD = 20;
-const AGENT_RESPONSE_HEAD_LINES = 15;
-const TOOL_TRUNCATE_THRESHOLD = 20;
-const TOOL_HEAD_LINES = 5;
-const TOOL_TAIL_LINES = 5;
 
 export class ContextManager {
   private exchanges: Exchange[] = [];
   private nextId = 1;
   private currentCwd: string;
   private sessionStart: number;
-  private pendingToolCalls: ToolCallRecord[] = [];
   private firstPrompt = true;
   private agentShellActive = false; // true while user_shell command is executing
   private handlers: HandlerRegistry | null = null;
@@ -53,49 +45,10 @@ export class ContextManager {
     bus.on("shell:agent-exec-done", () => { this.agentShellActive = false; });
 
     // ── Subscribe to agent events ──
+    // Only track queries (as markers). Agent responses and tool outputs
+    // live exclusively in ConversationState to avoid duplication.
     bus.on("agent:query", (e) => {
-      this.pendingToolCalls = [];
       this.addExchange({ type: "agent_query", query: e.query });
-    });
-
-    bus.on("agent:response-done", (e) => {
-      this.addExchange({
-        type: "agent_response",
-        response: e.response,
-        toolCalls: this.pendingToolCalls,
-      });
-      this.pendingToolCalls = [];
-    });
-
-    bus.on("agent:tool-call", (e) => {
-      // Accumulate tool calls for the agent_response summary
-      this.pendingToolCalls.push({
-        tool: e.tool,
-        args: e.args,
-        output: "",
-        exitCode: null,
-      });
-    });
-
-    bus.on("agent:tool-output", (e) => {
-      // Update the last pending tool call with output
-      const last = this.pendingToolCalls[this.pendingToolCalls.length - 1];
-      if (last) {
-        last.output = e.output;
-        last.exitCode = e.exitCode;
-      }
-
-      // Also store as a separate exchange for chronological log
-      const lines = e.output.split("\n");
-      this.addExchange({
-        type: "tool_execution",
-        tool: e.tool,
-        args: {},
-        output: e.output,
-        exitCode: e.exitCode,
-        outputLines: lines.length,
-        outputBytes: e.output.length,
-      });
     });
   }
 
@@ -266,7 +219,6 @@ export class ContextManager {
    */
   clear(): void {
     this.exchanges = [];
-    this.pendingToolCalls = [];
     this.firstPrompt = true;
     // Don't reset nextId — IDs should be globally unique within a session
   }
@@ -299,22 +251,8 @@ export class ContextManager {
           s.shellTailLines,
           ex.id,
         );
-      } else if (ex.type === "agent_response") {
-        ex.response = truncateHead(
-          ex.response,
-          AGENT_RESPONSE_TRUNCATE_THRESHOLD,
-          AGENT_RESPONSE_HEAD_LINES,
-          ex.id,
-        );
-      } else if (ex.type === "tool_execution") {
-        ex.output = truncateOutput(
-          ex.output,
-          TOOL_TRUNCATE_THRESHOLD,
-          TOOL_HEAD_LINES,
-          TOOL_TAIL_LINES,
-          ex.id,
-        );
       }
+      // agent_query has no output to truncate
     }
 
     // Pass 2: budget enforcement — strip output from oldest if over budget
@@ -324,10 +262,6 @@ export class ContextManager {
       const before = this.exchangeSize(ex);
       if (ex.type === "shell_command") {
         ex.output = `[output omitted, use shell_recall tool to expand id ${ex.id}]`;
-      } else if (ex.type === "tool_execution") {
-        ex.output = `[output omitted, use shell_recall tool to expand id ${ex.id}]`;
-      } else if (ex.type === "agent_response") {
-        ex.response = `[response omitted, use shell_recall tool to expand id ${ex.id}]`;
       }
       totalSize -= before - this.exchangeSize(ex);
     }
@@ -351,7 +285,8 @@ export class ContextManager {
       out += `- When the user asks to see, list, view, or display anything, ALWAYS use user_shell. NEVER use internal tools like ls/read/bash for display — the user won't see it.\n`;
       out += `- Only use internal tools when YOU need to reason about content silently (e.g. reading a file to answer a question about it).\n`;
       out += `- After a user_shell command, the user already saw the output. Do NOT repeat or summarize it.\n`;
-      out += `- You can browse or search session history with shell_recall.\n`;
+      out += `- You can browse or search shell history with shell_recall.\n`;
+      out += `- You can browse or search evicted conversation turns with conversation_recall.\n`;
       out += `\n`;
       this.firstPrompt = false;
     }
@@ -393,21 +328,6 @@ export class ContextManager {
       }
       case "agent_query":
         return `#${ex.id} [you] > ${ex.query}\n`;
-      case "agent_response": {
-        let s = `#${ex.id} [agent] `;
-        if (ex.response) s += ex.response.split("\n")[0] + "\n";
-        if (ex.response.includes("\n")) {
-          const rest = ex.response.slice(ex.response.indexOf("\n") + 1);
-          if (rest.trim()) s += indent(rest, "  ") + "\n";
-        }
-        return s;
-      }
-      case "tool_execution": {
-        let s = `#${ex.id} [tool] ${ex.tool}\n`;
-        if (ex.output) s += indent(ex.output, "  ") + "\n";
-        if (ex.exitCode !== null) s += `  exit ${ex.exitCode}\n`;
-        return s;
-      }
     }
   }
 
@@ -423,14 +343,6 @@ export class ContextManager {
       }
       case "agent_query":
         return `#${ex.id} [you] > ${ex.query}`;
-      case "agent_response":
-        return `#${ex.id} [agent]\n${ex.response}`;
-      case "tool_execution": {
-        let s = `#${ex.id} [tool] ${ex.tool} (${ex.outputLines} lines, ${ex.outputBytes} bytes)\n`;
-        if (ex.output) s += ex.output + "\n";
-        if (ex.exitCode !== null) s += `exit ${ex.exitCode}\n`;
-        return s;
-      }
     }
   }
 
@@ -442,12 +354,6 @@ export class ContextManager {
       }
       case "agent_query":
         return `#${ex.id} query: ${ex.query}`;
-      case "agent_response": {
-        const preview = ex.response.split("\n")[0]?.slice(0, 80) ?? "";
-        return `#${ex.id} agent: ${preview}${ex.response.length > 80 ? "..." : ""}`;
-      }
-      case "tool_execution":
-        return `#${ex.id} tool: ${ex.tool} (${ex.outputLines} lines, exit ${ex.exitCode ?? "?"})`;
     }
   }
 
@@ -457,10 +363,6 @@ export class ContextManager {
         return `${ex.command}\n${ex.output}`;
       case "agent_query":
         return ex.query;
-      case "agent_response":
-        return ex.response;
-      case "tool_execution":
-        return `${ex.tool}\n${ex.output}`;
     }
   }
 
@@ -470,10 +372,6 @@ export class ContextManager {
         return ex.command.length + ex.output.length;
       case "agent_query":
         return ex.query.length;
-      case "agent_response":
-        return ex.response.length;
-      case "tool_execution":
-        return ex.tool.length + ex.output.length;
     }
   }
 }
@@ -495,21 +393,6 @@ function truncateOutput(
     ...lines.slice(0, headLines),
     `[... ${omitted} lines truncated, use shell_recall tool with expand and id ${id} to see full output ...]`,
     ...lines.slice(-tailLines),
-  ].join("\n");
-}
-
-function truncateHead(
-  text: string,
-  threshold: number,
-  headLines: number,
-  id: number,
-): string {
-  const lines = text.split("\n");
-  if (lines.length <= threshold) return text;
-
-  return [
-    ...lines.slice(0, headLines),
-    `[... truncated, use shell_recall tool with expand and id ${id} for full response ...]`,
   ].join("\n");
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -215,6 +215,21 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
       supportsReasoningEffort: p.supportsReasoningEffort,
       modelCapabilities: caps.size > 0 ? caps : undefined,
     });
+
+    // Push registered models into the agent loop so they appear in
+    // autocomplete and are selectable via /model.
+    const addModes: AgentMode[] = modelIds.map((m) => {
+      const mc = caps.get(m);
+      return {
+        model: m,
+        provider: p.id,
+        providerConfig: { apiKey: p.apiKey ?? "", baseURL: p.baseURL },
+        contextWindow: mc?.contextWindow,
+        reasoning: mc?.reasoning,
+        supportsReasoningEffort: p.supportsReasoningEffort,
+      };
+    });
+    bus.emit("config:add-modes", { modes: addModes });
   });
 
   bus.on("config:switch-provider", ({ provider: name }) => {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -27,6 +27,9 @@ export interface ShellEvents {
   // Extensions use this to send keystrokes into the user's live shell.
   "shell:pty-write": { data: string };
 
+  // Resize the PTY (triggers SIGWINCH in the child process).
+  "shell:pty-resize": { cols: number; rows: number };
+
   // Terminal buffer snapshot (request/response pattern via bus)
   "shell:buffer-request": Record<string, never>;
   "shell:buffer-snapshot": {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -176,6 +176,16 @@ export interface ShellEvents {
   // Session reset (slash command → backend: clear conversation state)
   "agent:reset-session": Record<string, never>;
 
+  // Manual compaction request (slash command → backend)
+  "agent:compact-request": Record<string, never>;
+
+  // Context stats query (sync pipe: slash command → backend)
+  "context:get-stats": {
+    activeTokens: number;
+    nuclearEntries: number;
+    recallArchiveSize: number;
+    budgetTokens: number;
+  };
 
   // Extension registers itself as agent backend (extension → core)
   "agent:register-backend": {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -211,6 +211,8 @@ export interface ShellEvents {
 
   // Set modes (core → agent loop: after provider switch)
   "config:set-modes": { modes: AgentMode[] };
+  // Append modes (core → agent loop: after provider register)
+  "config:add-modes": { modes: AgentMode[] };
 
   // Register a provider at runtime (extensions → core)
   "provider:register": {

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -8,49 +8,218 @@
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  */
 import type { ExtensionContext } from "../types.js";
+import { MarkdownRenderer } from "../utils/markdown.js";
+import {
+  renderToolCall,
+  createSpinner,
+  renderSpinnerLine,
+  formatElapsed,
+  type SpinnerState,
+} from "../utils/tool-display.js";
 
 const BOLD = "\x1b[1m";
 const CYAN = "\x1b[36m";
+const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  lines: string[];
+}
 
 export default function activate({ bus, createFloatingPanel }: ExtensionContext): void {
   const panel = createFloatingPanel({
     trigger: "\x1c", // Ctrl+\
     dimBackground: true,
-    autoDismissMs: 2000,
   });
+
+  // ── Conversation state (persists across hide/show) ─────────
+  const messages: ChatMessage[] = [];
+  let renderer: MarkdownRenderer | null = null;
+  let currentAssistantMsg: ChatMessage | null = null;
+
+  // ── Spinner state ──────────────────────────────────────────
+  let spinner: SpinnerState | null = null;
+  let spinnerInterval: ReturnType<typeof setInterval> | null = null;
+  let spinnerStartTime = 0;
+
+  // ── Tool state ─────────────────────────────────────────────
+  let toolStartTime = 0;
+
+  function getContentWidth(): number {
+    return panel.computeGeometry().contentW;
+  }
+
+  /** Rebuild panel content from full message history. */
+  function rebuildContent(): void {
+    panel.clearContent();
+    for (const msg of messages) {
+      for (const line of msg.lines) {
+        panel.appendLine(line);
+      }
+      panel.appendLine(""); // gap between messages
+    }
+  }
+
+  /** Append a line to current assistant message and panel (if visible). */
+  function appendLine(line: string): void {
+    currentAssistantMsg?.lines.push(line);
+    if (panel.visible) panel.appendLine(line);
+  }
+
+  /** Drain rendered markdown lines into message history and panel (if visible). */
+  function drainRenderer(): void {
+    if (!renderer) return;
+    for (const line of renderer.drainLines()) {
+      appendLine(line);
+    }
+  }
+
+  /** Flush the markdown renderer and drain. */
+  function flushRenderer(): void {
+    if (!renderer) {
+      return;
+    }
+    renderer.flush();
+    drainRenderer();
+  }
+
+  /** Start a new assistant message in the conversation. */
+  function startAssistantMessage(): void {
+    flushRenderer();
+    currentAssistantMsg = { role: "assistant", lines: [] };
+    messages.push(currentAssistantMsg);
+    renderer = new MarkdownRenderer(getContentWidth());
+  }
+
+  /** Finalize the current assistant message. */
+  function finalizeAssistantMessage(): void {
+    flushRenderer();
+    renderer = null;
+    currentAssistantMsg = null;
+  }
+
+  // ── Spinner helpers ────────────────────────────────────────
+
+  function startSpinner(label: string): void {
+    stopSpinner();
+    spinnerStartTime = Date.now();
+    spinner = createSpinner({ startTime: spinnerStartTime });
+    spinnerInterval = setInterval(() => {
+      if (!spinner || !panel.visible) return;
+      const line = renderSpinnerLine(spinner, label, { startTime: spinnerStartTime });
+      panel.setFooter(line);
+    }, 80);
+  }
+
+  function stopSpinner(): void {
+    if (spinnerInterval) {
+      clearInterval(spinnerInterval);
+      spinnerInterval = null;
+    }
+    spinner = null;
+    panel.setFooter("");
+  }
 
   // ── Panel lifecycle ────────────────────────────────────────
   panel.handlers.advise("panel:submit", (_next, query: string) => {
+    // Record user message
+    const userMsg: ChatMessage = {
+      role: "user",
+      lines: [`${CYAN}${BOLD}❯${RESET} ${query}`],
+    };
+    messages.push(userMsg);
+
     panel.setActive();
-    panel.appendLine(`${CYAN}${BOLD}❯${RESET} ${query}`);
-    panel.appendLine("");
+    // Rebuild content from history so it's clean
+    rebuildContent();
+
+    startAssistantMessage();
+    startSpinner("Thinking");
+
     bus.emit("agent:submit", { query });
+  });
+
+  panel.handlers.advise("panel:dismiss", (_next) => {
+    // On hide: stop spinner rendering but keep conversation
+    stopSpinner();
+  });
+
+  panel.handlers.advise("panel:show", (_next) => {
+    // On re-show: rebuild content and restart spinner if agent is active
+    rebuildContent();
+    // Re-render any partial content from current assistant message
+    if (renderer) {
+      drainRenderer();
+    }
   });
 
   // ── Stream agent response into panel ───────────────────────
   bus.on("agent:response-chunk", (e) => {
     if (!panel.active) return;
+    if (!currentAssistantMsg) startAssistantMessage();
+
     for (const block of e.blocks) {
       if (block.type === "text" && block.text) {
-        panel.appendText(block.text);
+        renderer!.push(block.text);
+        drainRenderer();
+      } else if (block.type === "code-block") {
+        flushRenderer();
+        // Render code block with language label
+        const label = block.language ? `${DIM}${block.language}${RESET}` : "";
+        if (label) {
+          appendLine(label);
+        }
+        for (const codeLine of block.code.split("\n")) {
+          appendLine(`  ${DIM}${codeLine}${RESET}`);
+        }
       }
     }
   });
 
   bus.on("agent:tool-started", (e) => {
     if (!panel.active) return;
-    panel.appendLine(`▶ ${e.title}${e.displayDetail ? " " + e.displayDetail : ""}`);
+    if (!currentAssistantMsg) startAssistantMessage();
+    flushRenderer();
+    toolStartTime = Date.now();
+
+    const lines = renderToolCall({
+      title: e.title,
+      kind: e.kind,
+      icon: e.icon,
+      locations: e.locations,
+      rawInput: e.rawInput,
+      displayDetail: e.displayDetail,
+    }, getContentWidth());
+
+    for (const line of lines) {
+      appendLine(line);
+    }
+
+    startSpinner(e.title);
   });
 
   bus.on("agent:tool-completed", (e) => {
     if (!panel.active) return;
-    const mark = e.exitCode === 0 ? " ✓" : ` ✗ exit ${e.exitCode}`;
-    panel.updateLastLine((line) => line + mark);
+    stopSpinner();
+
+    const elapsed = toolStartTime ? formatElapsed(Date.now() - toolStartTime) : "";
+    const timer = elapsed ? ` ${DIM}${elapsed}${RESET}` : "";
+    const mark = e.exitCode === 0
+      ? `${GREEN}✓${RESET}${timer}`
+      : `${RED}✗ exit ${e.exitCode}${RESET}${timer}`;
+
+    appendLine(`  ${mark}`);
+
+    startSpinner("Thinking");
   });
 
   bus.on("agent:processing-done", () => {
     if (!panel.active) return;
+    stopSpinner();
+    finalizeAssistantMessage();
     panel.setDone();
   });
 }

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -36,6 +36,13 @@ export default function activate(ctx: ExtensionContext): void {
     return panel.active ? false : next();
   });
 
+  // Signal interactive overlay mode in dynamic context
+  advise("dynamic-context:build", (next) => {
+    const base = next() as string;
+    if (!panel.active) return base;
+    return base + "\ninteractive-session: true\n";
+  });
+
   // ── Conversation state (persists across hide/show) ─────────
   const messages: ChatMessage[] = [];
   let renderer: MarkdownRenderer | null = null;

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -15,10 +15,7 @@ import { MarkdownRenderer } from "../utils/markdown.js";
 import { palette as p } from "../utils/palette.js";
 import {
   renderToolCall,
-  createSpinner,
   formatElapsed,
-  SPINNER_FRAMES,
-  type SpinnerState,
 } from "../utils/tool-display.js";
 
 interface ChatMessage {
@@ -43,10 +40,6 @@ export default function activate(ctx: ExtensionContext): void {
   const messages: ChatMessage[] = [];
   let renderer: MarkdownRenderer | null = null;
   let currentAssistantMsg: ChatMessage | null = null;
-
-  // ── Spinner state ──────────────────────────────────────────
-  let spinner: SpinnerState | null = null;
-  let spinnerInterval: ReturnType<typeof setInterval> | null = null;
 
   // ── Tool state ─────────────────────────────────────────────
   let toolStartTime = 0;
@@ -98,30 +91,6 @@ export default function activate(ctx: ExtensionContext): void {
     currentAssistantMsg = null;
   }
 
-  // ── Spinner — reuses tui:render-spinner handler ────────────
-
-  function startSpinner(label: string): void {
-    stopSpinner();
-    spinner = createSpinner();
-    spinnerInterval = setInterval(() => {
-      if (!spinner || !panel.visible) return;
-      const frame = SPINNER_FRAMES[spinner.frame % SPINNER_FRAMES.length]!;
-      spinner.frame++;
-      const elapsed = formatElapsed(Date.now() - spinner.startTime);
-      const line: string = call("tui:render-spinner", label, frame, elapsed, undefined);
-      panel.setFooter(line);
-    }, 80);
-  }
-
-  function stopSpinner(): void {
-    if (spinnerInterval) {
-      clearInterval(spinnerInterval);
-      spinnerInterval = null;
-    }
-    spinner = null;
-    panel.setFooter("");
-  }
-
   // ── Panel lifecycle ────────────────────────────────────────
 
   panel.handlers.advise("panel:submit", (_next, query: string) => {
@@ -133,12 +102,7 @@ export default function activate(ctx: ExtensionContext): void {
     panel.setActive();
     rebuildContent();
     startAssistantMessage();
-    startSpinner("Thinking");
     bus.emit("agent:submit", { query });
-  });
-
-  panel.handlers.advise("panel:dismiss", (_next) => {
-    stopSpinner();
   });
 
   panel.handlers.advise("panel:show", (_next) => {
@@ -191,22 +155,18 @@ export default function activate(ctx: ExtensionContext): void {
     }, getContentWidth());
 
     for (const line of lines) appendLine(line);
-    startSpinner(e.title);
   });
 
   bus.on("agent:tool-completed", (e) => {
     if (!panel.active) return;
-    stopSpinner();
 
     const elapsed = toolStartTime ? formatElapsed(Date.now() - toolStartTime) : "";
     const mark: string = call("tui:render-tool-complete", e.exitCode, elapsed, undefined);
     appendLine(`  ${mark}`);
-    startSpinner("Thinking");
   });
 
   bus.on("agent:processing-done", () => {
     if (!panel.active) return;
-    stopSpinner();
     finalizeAssistantMessage();
     panel.setDone();
   });

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -23,10 +23,15 @@ interface ChatMessage {
   lines: string[];
 }
 
-export default function activate({ bus, createFloatingPanel }: ExtensionContext): void {
+export default function activate({ bus, advise, createFloatingPanel }: ExtensionContext): void {
   const panel = createFloatingPanel({
     trigger: "\x1c", // Ctrl+\
     dimBackground: true,
+  });
+
+  // Suppress TUI renderer when overlay owns agent output
+  advise("tui:should-render-agent", (next) => {
+    return panel.active ? false : next();
   });
 
   // ── Conversation state (persists across hide/show) ─────────

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -5,6 +5,9 @@
  * inside vim, htop, or ssh. Composites a floating response box on top
  * of the current terminal content.
  *
+ * Rendering reuses the shared tui:render-* handlers so that extensions
+ * advising those handlers affect both the main TUI and the overlay.
+ *
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  */
 import type { ExtensionContext } from "../types.js";
@@ -13,8 +16,8 @@ import { palette as p } from "../utils/palette.js";
 import {
   renderToolCall,
   createSpinner,
-  renderSpinnerLine,
   formatElapsed,
+  SPINNER_FRAMES,
   type SpinnerState,
 } from "../utils/tool-display.js";
 
@@ -23,7 +26,9 @@ interface ChatMessage {
   lines: string[];
 }
 
-export default function activate({ bus, advise, createFloatingPanel }: ExtensionContext): void {
+export default function activate(ctx: ExtensionContext): void {
+  const { bus, advise, call, createFloatingPanel } = ctx;
+
   const panel = createFloatingPanel({
     trigger: "\x1c", // Ctrl+\
     dimBackground: true,
@@ -42,7 +47,6 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
   // ── Spinner state ──────────────────────────────────────────
   let spinner: SpinnerState | null = null;
   let spinnerInterval: ReturnType<typeof setInterval> | null = null;
-  let spinnerStartTime = 0;
 
   // ── Tool state ─────────────────────────────────────────────
   let toolStartTime = 0;
@@ -58,7 +62,7 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
       for (const line of msg.lines) {
         panel.appendLine(line);
       }
-      panel.appendLine(""); // gap between messages
+      panel.appendLine("");
     }
   }
 
@@ -68,7 +72,6 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
     if (panel.visible) panel.appendLine(line);
   }
 
-  /** Drain rendered markdown lines into message history and panel (if visible). */
   function drainRenderer(): void {
     if (!renderer) return;
     for (const line of renderer.drainLines()) {
@@ -76,16 +79,12 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
     }
   }
 
-  /** Flush the markdown renderer and drain. */
   function flushRenderer(): void {
-    if (!renderer) {
-      return;
-    }
+    if (!renderer) return;
     renderer.flush();
     drainRenderer();
   }
 
-  /** Start a new assistant message in the conversation. */
   function startAssistantMessage(): void {
     flushRenderer();
     currentAssistantMsg = { role: "assistant", lines: [] };
@@ -93,22 +92,23 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
     renderer = new MarkdownRenderer(getContentWidth());
   }
 
-  /** Finalize the current assistant message. */
   function finalizeAssistantMessage(): void {
     flushRenderer();
     renderer = null;
     currentAssistantMsg = null;
   }
 
-  // ── Spinner helpers ────────────────────────────────────────
+  // ── Spinner — reuses tui:render-spinner handler ────────────
 
   function startSpinner(label: string): void {
     stopSpinner();
-    spinnerStartTime = Date.now();
-    spinner = createSpinner({ startTime: spinnerStartTime });
+    spinner = createSpinner();
     spinnerInterval = setInterval(() => {
       if (!spinner || !panel.visible) return;
-      const line = renderSpinnerLine(spinner, label, { startTime: spinnerStartTime });
+      const frame = SPINNER_FRAMES[spinner.frame % SPINNER_FRAMES.length]!;
+      spinner.frame++;
+      const elapsed = formatElapsed(Date.now() - spinner.startTime);
+      const line: string = call("tui:render-spinner", label, frame, elapsed, undefined);
       panel.setFooter(line);
     }, 80);
   }
@@ -123,19 +123,17 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
   }
 
   // ── Panel lifecycle ────────────────────────────────────────
+
   panel.handlers.advise("panel:submit", (_next, query: string) => {
-    const userMsg: ChatMessage = {
+    messages.push({
       role: "user",
       lines: [`${p.accent}${p.bold}❯${p.reset} ${query}`],
-    };
-    messages.push(userMsg);
+    });
 
     panel.setActive();
     rebuildContent();
-
     startAssistantMessage();
     startSpinner("Thinking");
-
     bus.emit("agent:submit", { query });
   });
 
@@ -144,12 +142,12 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
   });
 
   panel.handlers.advise("panel:show", (_next) => {
-    // Rebuild from message history to restore content that arrived while hidden
     rebuildContent();
     if (renderer) drainRenderer();
   });
 
   // ── Stream agent response into panel ───────────────────────
+
   bus.on("agent:response-chunk", (e) => {
     if (!panel.active) return;
     if (!currentAssistantMsg) startAssistantMessage();
@@ -160,15 +158,20 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
         drainRenderer();
       } else if (block.type === "code-block") {
         flushRenderer();
-        // Render code block with language label
-        const label = block.language ? `${p.dim}${block.language}${p.reset}` : "";
-        if (label) {
-          appendLine(label);
-        }
-        for (const codeLine of block.code.split("\n")) {
-          appendLine(`  ${p.dim}${codeLine}${p.reset}`);
-        }
+        // Reuse the shared code-block handler
+        call("render:code-block", block.language, block.code, getContentWidth());
       }
+    }
+  });
+
+  // Capture lines emitted by render:code-block into the overlay
+  advise("render:code-block", (next, language: string, code: string, width: number) => {
+    if (!panel.active) return next(language, code, width);
+    // Render code block as indented dim lines for the overlay
+    const label = language ? `${p.dim}${language}${p.reset}` : "";
+    if (label) appendLine(label);
+    for (const codeLine of code.split("\n")) {
+      appendLine(`  ${p.dim}${codeLine}${p.reset}`);
     }
   });
 
@@ -187,10 +190,7 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
       displayDetail: e.displayDetail,
     }, getContentWidth());
 
-    for (const line of lines) {
-      appendLine(line);
-    }
-
+    for (const line of lines) appendLine(line);
     startSpinner(e.title);
   });
 
@@ -199,13 +199,8 @@ export default function activate({ bus, advise, createFloatingPanel }: Extension
     stopSpinner();
 
     const elapsed = toolStartTime ? formatElapsed(Date.now() - toolStartTime) : "";
-    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
-    const mark = e.exitCode === 0
-      ? `${p.success}✓${p.reset}${timer}`
-      : `${p.error}✗ exit ${e.exitCode}${p.reset}${timer}`;
-
+    const mark: string = call("tui:render-tool-complete", e.exitCode, elapsed, undefined);
     appendLine(`  ${mark}`);
-
     startSpinner("Thinking");
   });
 

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -9,6 +9,7 @@
  */
 import type { ExtensionContext } from "../types.js";
 import { MarkdownRenderer } from "../utils/markdown.js";
+import { palette as p } from "../utils/palette.js";
 import {
   renderToolCall,
   createSpinner,
@@ -16,13 +17,6 @@ import {
   formatElapsed,
   type SpinnerState,
 } from "../utils/tool-display.js";
-
-const BOLD = "\x1b[1m";
-const CYAN = "\x1b[36m";
-const DIM = "\x1b[2m";
-const RESET = "\x1b[0m";
-const GREEN = "\x1b[32m";
-const RED = "\x1b[31m";
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -125,15 +119,13 @@ export default function activate({ bus, createFloatingPanel }: ExtensionContext)
 
   // ── Panel lifecycle ────────────────────────────────────────
   panel.handlers.advise("panel:submit", (_next, query: string) => {
-    // Record user message
     const userMsg: ChatMessage = {
       role: "user",
-      lines: [`${CYAN}${BOLD}❯${RESET} ${query}`],
+      lines: [`${p.accent}${p.bold}❯${p.reset} ${query}`],
     };
     messages.push(userMsg);
 
     panel.setActive();
-    // Rebuild content from history so it's clean
     rebuildContent();
 
     startAssistantMessage();
@@ -143,17 +135,13 @@ export default function activate({ bus, createFloatingPanel }: ExtensionContext)
   });
 
   panel.handlers.advise("panel:dismiss", (_next) => {
-    // On hide: stop spinner rendering but keep conversation
     stopSpinner();
   });
 
   panel.handlers.advise("panel:show", (_next) => {
-    // On re-show: rebuild content and restart spinner if agent is active
+    // Rebuild from message history to restore content that arrived while hidden
     rebuildContent();
-    // Re-render any partial content from current assistant message
-    if (renderer) {
-      drainRenderer();
-    }
+    if (renderer) drainRenderer();
   });
 
   // ── Stream agent response into panel ───────────────────────
@@ -168,12 +156,12 @@ export default function activate({ bus, createFloatingPanel }: ExtensionContext)
       } else if (block.type === "code-block") {
         flushRenderer();
         // Render code block with language label
-        const label = block.language ? `${DIM}${block.language}${RESET}` : "";
+        const label = block.language ? `${p.dim}${block.language}${p.reset}` : "";
         if (label) {
           appendLine(label);
         }
         for (const codeLine of block.code.split("\n")) {
-          appendLine(`  ${DIM}${codeLine}${RESET}`);
+          appendLine(`  ${p.dim}${codeLine}${p.reset}`);
         }
       }
     }
@@ -206,10 +194,10 @@ export default function activate({ bus, createFloatingPanel }: ExtensionContext)
     stopSpinner();
 
     const elapsed = toolStartTime ? formatElapsed(Date.now() - toolStartTime) : "";
-    const timer = elapsed ? ` ${DIM}${elapsed}${RESET}` : "";
+    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
     const mark = e.exitCode === 0
-      ? `${GREEN}✓${RESET}${timer}`
-      : `${RED}✗ exit ${e.exitCode}${RESET}${timer}`;
+      ? `${p.success}✓${p.reset}${timer}`
+      : `${p.error}✗ exit ${e.exitCode}${p.reset}${timer}`;
 
     appendLine(`  ${mark}`);
 

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -89,6 +89,36 @@ export default function activate({ bus, contextManager }: ExtensionContext): voi
     },
   });
 
+  register({
+    name: "/compact",
+    description: "Compact conversation (move full content to nuclear summaries)",
+    handler: () => {
+      bus.emit("agent:compact-request", {});
+    },
+  });
+
+  register({
+    name: "/context",
+    description: "Show context budget usage",
+    handler: () => {
+      const stats = bus.emitPipe("context:get-stats", {
+        activeTokens: 0,
+        nuclearEntries: 0,
+        recallArchiveSize: 0,
+        budgetTokens: 0,
+      });
+      const pct = stats.budgetTokens > 0
+        ? Math.round((stats.activeTokens / stats.budgetTokens) * 100)
+        : 0;
+      const lines = [
+        `Active context: ~${stats.activeTokens.toLocaleString()} tokens / ${stats.budgetTokens.toLocaleString()} budget (${pct}%)`,
+        `Nuclear entries: ${stats.nuclearEntries} in-context`,
+        `Recall archive: ${stats.recallArchiveSize} entries`,
+      ];
+      bus.emit("ui:info", { message: lines.join("\n") });
+    },
+  });
+
   // ── Extension registration ────────────────────────────────────
 
   bus.on("command:register", (cmd) => {

--- a/src/extensions/terminal-buffer.ts
+++ b/src/extensions/terminal-buffer.ts
@@ -128,6 +128,7 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
       bus.emit("shell:pty-write", { data: keys });
 
       await settle(settleMs);
+      bus.emit("shell:stdout-hide", {});
 
       const { text, altScreen, cursorX, cursorY } = tb.readScreen();
       const info = [

--- a/src/extensions/terminal-buffer.ts
+++ b/src/extensions/terminal-buffer.ts
@@ -35,9 +35,10 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
   registerTool({
     name: "terminal_read",
     description:
-      "Read the current terminal screen contents. Returns clean text (ANSI stripped) " +
+      "Read what is currently visible on the user's terminal screen. Returns clean text (ANSI stripped) " +
       "with cursor position and whether an alternate-screen program (vim, htop, less) is active. " +
-      "Use this to see what the user sees before sending keystrokes with terminal_keys.",
+      "Use this to observe what the user sees — helpful for answering questions about terminal output, " +
+      "diagnosing errors on screen, or checking state before/after sending keystrokes with terminal_keys.",
     input_schema: {
       type: "object",
       properties: {},
@@ -68,8 +69,11 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
   registerTool({
     name: "terminal_keys",
     description:
-      "Send keystrokes to the user's live terminal. The keys are written directly to the PTY " +
-      "as if the user typed them. Use escape sequences for special keys:\n" +
+      "Send keystrokes directly into the user's live terminal PTY, as if the user typed them. " +
+      "Use this to interact with programs already running in the terminal (vim, htop, less, ssh, REPLs, etc.) " +
+      "or to type commands at the shell prompt. Do NOT use user_shell for this — user_shell runs a new " +
+      "command in a subshell, while terminal_keys types into whatever is currently on screen.\n\n" +
+      "Escape sequences for special keys:\n" +
       "  - Escape: \\x1b\n" +
       "  - Enter/Return: \\r\n" +
       "  - Tab: \\t\n" +

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -17,7 +17,6 @@ import { palette as p } from "../utils/palette.js";
 import {
   renderToolCall,
   createSpinner,
-  renderSpinnerLine,
   formatElapsed,
   SPINNER_FRAMES,
   type SpinnerState,
@@ -195,24 +194,15 @@ export default function activate(ctx: ExtensionContext): void {
   define("tui:render-spinner", (label: string, frame: string, elapsed: string, hint: string | undefined): string => {
     const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
     const hintStr = hint ? ` ${p.dim}${hint}${p.reset}` : "";
-    return `${p.accent}${frame}${p.reset} ${label}...${timer}${hintStr}`;
+    return `${p.accent}${frame} ${label}...${p.reset}${timer}${hintStr}`;
   });
 
   define("tui:render-user-query", (query: string, width: number, modelLabel: string | undefined): string[] => {
     const contentW = width - 4;
     let lines: string[] = [];
     for (const raw of query.split("\n")) {
-      if (raw.length <= contentW) {
-        lines.push(`${p.accent}${raw}${p.reset}`);
-      } else {
-        let remaining = raw;
-        while (remaining.length > contentW) {
-          let breakAt = remaining.lastIndexOf(" ", contentW);
-          if (breakAt <= 0) breakAt = contentW;
-          lines.push(`${p.accent}${remaining.slice(0, breakAt)}${p.reset}`);
-          remaining = remaining.slice(breakAt).trimStart();
-        }
-        if (remaining) lines.push(`${p.accent}${remaining}${p.reset}`);
+      for (const wrapped of wrapLine(`${p.accent}${raw}${p.reset}`, contentW)) {
+        lines.push(wrapped);
       }
     }
     const MAX_QUERY_LINES = 20;
@@ -220,12 +210,11 @@ export default function activate(ctx: ExtensionContext): void {
       const overflow = lines.length - MAX_QUERY_LINES;
       lines = [...lines.slice(0, MAX_QUERY_LINES), `${p.dim}… ${overflow} more lines${p.reset}`];
     }
-    const title = `${p.accent}${p.bold}❯${p.reset}`;
     return renderBoxFrame(lines, {
       width,
       style: "rounded",
       borderColor: p.accent,
-      title,
+      title: `${p.accent}${p.bold}❯${p.reset}`,
       titleRight: modelLabel,
     });
   });
@@ -907,6 +896,10 @@ export default function activate(ctx: ExtensionContext): void {
     s.toolGroupSummaries = [];
   }
 
+  function renderCommandLine(line: string): string {
+    return ctx.call("tui:render-command-output", line, s.currentToolKind) as string;
+  }
+
   function writeCommandOutput(chunk: string): void {
     if (!s.renderer) return;
     closeToolLine();
@@ -916,10 +909,9 @@ export default function activate(ctx: ExtensionContext): void {
     s.commandOutputBuffer += chunk;
     const lines = s.commandOutputBuffer.split("\n");
     s.commandOutputBuffer = lines.pop()!;
-    const renderLine = (l: string) => ctx.call("tui:render-command-output", l, s.currentToolKind) as string;
     for (const line of lines) {
       if (s.commandOutputLineCount < maxLines) {
-        s.renderer.writeLine(renderLine(line));
+        s.renderer.writeLine(renderCommandLine(line));
         s.commandOutputLineCount++;
       } else {
         s.commandOutputOverflow++;
@@ -937,10 +929,9 @@ export default function activate(ctx: ExtensionContext): void {
     const maxLines = s.currentToolKind === "read"
       ? getSettings().readOutputMaxLines
       : getSettings().maxCommandOutputLines;
-    const renderLine = (l: string) => ctx.call("tui:render-command-output", l, s.currentToolKind) as string;
     if (s.commandOutputBuffer) {
       if (s.commandOutputLineCount < maxLines) {
-        s.renderer.writeLine(renderLine(s.commandOutputBuffer));
+        s.renderer.writeLine(renderCommandLine(s.commandOutputBuffer));
         s.commandOutputLineCount++;
       } else {
         s.commandOutputOverflow++;
@@ -955,13 +946,13 @@ export default function activate(ctx: ExtensionContext): void {
       const tail = s.commandOverflowLines.slice(-FAIL_OVERFLOW_MAX);
       const skipped = s.commandOverflowLines.length - tail.length;
       if (skipped > 0) {
-        s.renderer.writeLine(renderLine(`… ${skipped} lines hidden`));
+        s.renderer.writeLine(renderCommandLine(`… ${skipped} lines hidden`));
       }
       for (const line of tail) {
-        s.renderer.writeLine(renderLine(line));
+        s.renderer.writeLine(renderCommandLine(line));
       }
     } else if (s.commandOutputOverflow > 0 && maxLines > 0) {
-      s.renderer.writeLine(renderLine(`… ${s.commandOutputOverflow} more lines`));
+      s.renderer.writeLine(renderCommandLine(`… ${s.commandOutputOverflow} more lines`));
     }
 
     s.commandOutputOverflow = 0;

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -142,6 +142,11 @@ export default function activate(ctx: ExtensionContext): void {
   bus.on("shell:stdout-hold", () => { writer.hold(); });
   bus.on("shell:stdout-release", () => { writer.release(); });
 
+  // Gate: other extensions (e.g. overlay) can advise this to suppress
+  // TUI rendering of agent output while they own the display.
+  define("tui:should-render-agent", (): boolean => true);
+  function shouldRender(): boolean { return ctx.call("tui:should-render-agent"); }
+
   // Track backend/model info for display on response border
   let backendInfo: { name: string; model?: string; provider?: string; contextWindow?: number } | null = null;
   bus.on("agent:info", (info) => { backendInfo = info; });
@@ -159,6 +164,7 @@ export default function activate(ctx: ExtensionContext): void {
   // ── Event subscriptions ─────────────────────────────────────
 
   bus.on("agent:query", (e) => {
+    if (!shouldRender()) return;
     s.spinnerStartTime = 0;
     showUserQuery(e.query);
     startAgentResponse();
@@ -166,6 +172,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:thinking-chunk", (e) => {
+    if (!shouldRender()) return;
     s.thinkingPending = true;
     if (!s.isThinking) {
       s.isThinking = true;
@@ -188,6 +195,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:response-chunk", (e) => {
+    if (!shouldRender()) return;
     const { blocks } = e;
     // Inject spacing: append \n to text blocks that precede non-text blocks
     for (let i = 0; i < blocks.length; i++) {
@@ -220,6 +228,7 @@ export default function activate(ctx: ExtensionContext): void {
   bus.on("agent:usage", (e) => { pendingUsage = e; });
 
   bus.on("agent:response-done", () => {
+    if (!shouldRender()) return;
     s.isThinking = false;
     if (pendingUsage && s.renderer) {
       const { prompt_tokens, completion_tokens } = pendingUsage;
@@ -248,6 +257,7 @@ export default function activate(ctx: ExtensionContext): void {
   let batchGroups = new Map<string, { total: number; rendered: number; headerShown: boolean }>();
 
   bus.on("agent:tool-batch", (e) => {
+    if (!shouldRender()) return;
     fencedTransform.flush();
     finalizeToolGroup();
     batchGroups = new Map();
@@ -261,6 +271,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:tool-started", (e) => {
+    if (!shouldRender()) return;
     fencedTransform.flush();
     stopCurrentSpinner();
     s.currentToolKind = e.kind;
@@ -329,6 +340,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:tool-completed", (e) => {
+    if (!shouldRender()) return;
     s.toolExitCode = e.exitCode;
     if (e.exitCode !== 0) s.toolGroupAllOk = false;
 
@@ -344,10 +356,11 @@ export default function activate(ctx: ExtensionContext): void {
       startThinkingSpinner();
     }
   });
-  bus.on("agent:tool-output-chunk", (e) => writeCommandOutput(e.chunk));
-  bus.on("agent:tool-output", () => flushCommandOutput());
+  bus.on("agent:tool-output-chunk", (e) => { if (shouldRender()) writeCommandOutput(e.chunk); });
+  bus.on("agent:tool-output", () => { if (shouldRender()) flushCommandOutput(); });
 
   bus.on("agent:cancelled", () => {
+    if (!shouldRender()) return;
     s.isThinking = false;
     stopCurrentSpinner();
     showInfo("(cancelled)");
@@ -355,12 +368,14 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:processing-done", () => {
+    if (!shouldRender()) return;
     s.isThinking = false;
     stopCurrentSpinner();
     endAgentResponse();
   });
 
   bus.on("agent:error", (e) => {
+    if (!shouldRender()) return;
     stopCurrentSpinner();
     showCollapsedThinking();
     if (!s.renderer) startAgentResponse();
@@ -371,6 +386,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("permission:request", (e) => {
+    if (!shouldRender()) return;
     stopCurrentSpinner();
     flushCommandOutput();
     if (s.renderer) {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -19,6 +19,7 @@ import {
   createSpinner,
   renderSpinnerLine,
   formatElapsed,
+  SPINNER_FRAMES,
   type SpinnerState,
   type SpinnerOpts,
 } from "../utils/tool-display.js";
@@ -147,6 +148,88 @@ export default function activate(ctx: ExtensionContext): void {
   define("tui:should-render-agent", (): boolean => true);
   function shouldRender(): boolean { return ctx.call("tui:should-render-agent"); }
 
+  // ── Advisable rendering handlers ───────────────────────────────
+  // Extensions advise these to customize how the TUI renders content.
+  // Each handler receives data and returns rendered strings.
+
+  define("tui:response-start", (): void => {});
+  define("tui:response-end", (_hadToolCalls: boolean): void => {});
+
+  define("tui:render-info", (message: string): string =>
+    `${p.muted}${message}${p.reset}`);
+
+  define("tui:render-error", (message: string): string =>
+    `${p.error}Error: ${message}${p.reset}`);
+
+  define("tui:render-usage", (promptTokens: number, completionTokens: number, maxTokens: number): string => {
+    const ctxK = (promptTokens / 1000).toFixed(1);
+    const maxK = (maxTokens / 1000).toFixed(0);
+    const pct = Math.min(100, (promptTokens / maxTokens) * 100).toFixed(0);
+    return `${p.dim}⬆ ${promptTokens}  ⬇ ${completionTokens}  ctx: ${ctxK}k/${maxK}k (${pct}%)${p.reset}`;
+  });
+
+  define("tui:render-content-gap", (fromKind: string, toKind: string): string | null =>
+    fromKind !== toKind ? "\n" : null);
+
+  define("tui:render-tool-complete", (exitCode: number | null, elapsed: string, summary: string | undefined): string => {
+    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
+    const summaryStr = summary ? ` ${p.dim}${summary}${p.reset}` : "";
+    if (exitCode === null) return `${p.muted}(timed out)${p.reset}`;
+    if (exitCode === 0) return `${p.success}✓${p.reset}${summaryStr}${timer}`;
+    return `${p.error}✗ exit ${exitCode}${p.reset}${summaryStr}${timer}`;
+  });
+
+  define("tui:render-tool-group-summary", (count: number, rendered: number, allOk: boolean, summaries: string[]): string => {
+    const mark = allOk ? `${p.success}✓${p.reset}` : `${p.error}✗${p.reset}`;
+    const summaryStr = summaries.length > 0 ? ` ${p.dim}${summaries.join(", ")}${p.reset}` : "";
+    const collapsed = count - rendered;
+    if (collapsed > 0) {
+      return `  ${p.muted}└${p.reset} ${p.dim}+${collapsed} more${p.reset} ${mark}${summaryStr}`;
+    }
+    return `  ${p.muted}└${p.reset} ${mark}${summaryStr}`;
+  });
+
+  define("tui:render-command-output", (line: string, _kind: string | undefined): string =>
+    `${p.dim}  ${line}${p.reset}`);
+
+  define("tui:render-spinner", (label: string, frame: string, elapsed: string, hint: string | undefined): string => {
+    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
+    const hintStr = hint ? ` ${p.dim}${hint}${p.reset}` : "";
+    return `${p.accent}${frame}${p.reset} ${label}...${timer}${hintStr}`;
+  });
+
+  define("tui:render-user-query", (query: string, width: number, modelLabel: string | undefined): string[] => {
+    const contentW = width - 4;
+    let lines: string[] = [];
+    for (const raw of query.split("\n")) {
+      if (raw.length <= contentW) {
+        lines.push(`${p.accent}${raw}${p.reset}`);
+      } else {
+        let remaining = raw;
+        while (remaining.length > contentW) {
+          let breakAt = remaining.lastIndexOf(" ", contentW);
+          if (breakAt <= 0) breakAt = contentW;
+          lines.push(`${p.accent}${remaining.slice(0, breakAt)}${p.reset}`);
+          remaining = remaining.slice(breakAt).trimStart();
+        }
+        if (remaining) lines.push(`${p.accent}${remaining}${p.reset}`);
+      }
+    }
+    const MAX_QUERY_LINES = 20;
+    if (lines.length > MAX_QUERY_LINES) {
+      const overflow = lines.length - MAX_QUERY_LINES;
+      lines = [...lines.slice(0, MAX_QUERY_LINES), `${p.dim}… ${overflow} more lines${p.reset}`];
+    }
+    const title = `${p.accent}${p.bold}❯${p.reset}`;
+    return renderBoxFrame(lines, {
+      width,
+      style: "rounded",
+      borderColor: p.accent,
+      title,
+      titleRight: modelLabel,
+    });
+  });
+
   // Track backend/model info for display on response border
   let backendInfo: { name: string; model?: string; provider?: string; contextWindow?: number } | null = null;
   bus.on("agent:info", (info) => { backendInfo = info; });
@@ -233,15 +316,8 @@ export default function activate(ctx: ExtensionContext): void {
     if (pendingUsage && s.renderer) {
       const { prompt_tokens, completion_tokens } = pendingUsage;
       const maxTokens = backendInfo?.contextWindow ?? 128_000;
-      // prompt_tokens of the latest call = current context usage
-      // (it includes the full conversation history)
-      const ctxK = (prompt_tokens / 1000).toFixed(1);
-      const maxK = (maxTokens / 1000).toFixed(0);
-      const pct = Math.min(100, (prompt_tokens / maxTokens) * 100).toFixed(0);
       s.renderer.writeLine("");
-      s.renderer.writeLine(
-        `${p.dim}⬆ ${prompt_tokens}  ⬇ ${completion_tokens}  ctx: ${ctxK}k/${maxK}k (${pct}%)${p.reset}`,
-      );
+      s.renderer.writeLine(ctx.call("tui:render-usage", prompt_tokens, completion_tokens, maxTokens));
       drain();
       pendingUsage = null;
     }
@@ -433,9 +509,9 @@ export default function activate(ctx: ExtensionContext): void {
   function startAgentResponse(): void {
     s.renderer = new MarkdownRenderer(writer.columns);
     s.hadToolCalls = false;
-    // Preserve lastContentKind across responses so text→tool gaps work
     s.renderer.printTopBorder();
     drain();
+    ctx.call("tui:response-start");
   }
 
   /**
@@ -446,12 +522,12 @@ export default function activate(ctx: ExtensionContext): void {
   let lastEmittedLineBlank = false;
 
   function contentGap(kind: "text" | "tool" | "diff" | "code" | "info"): void {
-    if (s.lastContentKind && s.lastContentKind !== kind) {
-      if (s.renderer) {
-        s.renderer.flush();
-        drain();
+    if (s.lastContentKind) {
+      const gap: string | null = ctx.call("tui:render-content-gap", s.lastContentKind, kind);
+      if (gap) {
+        if (s.renderer) { s.renderer.flush(); drain(); }
+        writer.write(gap);
       }
-      writer.write("\n");
     }
     s.lastContentKind = kind;
   }
@@ -469,6 +545,7 @@ export default function activate(ctx: ExtensionContext): void {
     closeToolLine();
     stopCurrentSpinner();
     if (s.renderer) {
+      ctx.call("tui:response-end", s.hadToolCalls);
       s.renderer.flush();
       s.renderer.printBottomBorder();
       drain();
@@ -478,40 +555,6 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function showUserQuery(query: string): void {
-    const boxW = writer.columns;
-    const contentW = boxW - 4;
-
-    let lines: string[] = [];
-    for (const raw of query.split("\n")) {
-      if (raw.length <= contentW) {
-        lines.push(`${p.accent}${raw}${p.reset}`);
-      } else {
-        let remaining = raw;
-        while (remaining.length > contentW) {
-          let breakAt = remaining.lastIndexOf(" ", contentW);
-          if (breakAt <= 0) breakAt = contentW;
-          lines.push(`${p.accent}${remaining.slice(0, breakAt)}${p.reset}`);
-          remaining = remaining.slice(breakAt).trimStart();
-        }
-        if (remaining) lines.push(`${p.accent}${remaining}${p.reset}`);
-      }
-    }
-
-    // Truncate very long queries to keep the response visible
-    const MAX_QUERY_LINES = 20;
-    if (lines.length > MAX_QUERY_LINES) {
-      const overflow = lines.length - MAX_QUERY_LINES;
-      lines = [
-        ...lines.slice(0, MAX_QUERY_LINES),
-        `${p.dim}… ${overflow} more lines${p.reset}`,
-      ];
-    }
-
-    // Mode-specific border color and title
-    const borderColor = p.accent;
-    const title = `${p.accent}${p.bold}❯${p.reset}`;
-
-    // Backend/model label on the right (backend/model, highlighted)
     const model = backendInfo?.model ?? llmClient?.model;
     const backend = backendInfo?.name;
     let modelLabel: string | undefined;
@@ -523,13 +566,7 @@ export default function activate(ctx: ExtensionContext): void {
       modelLabel = `${p.bold}${backend}${p.reset}`;
     }
 
-    const framed = renderBoxFrame(lines, {
-      width: boxW,
-      style: "rounded",
-      borderColor,
-      title,
-      titleRight: modelLabel,
-    });
+    const framed: string[] = ctx.call("tui:render-user-query", query, writer.columns, modelLabel);
     writer.write("\n");
     for (const line of framed) {
       writer.write(line + "\n");
@@ -773,13 +810,7 @@ export default function activate(ctx: ExtensionContext): void {
     if (!s.renderer) return;
     stopCurrentSpinner();
     const elapsed = s.toolStartTime ? formatElapsed(Date.now() - s.toolStartTime) : "";
-    const timer = elapsed ? ` ${p.dim}${elapsed}${p.reset}` : "";
-    const summary = resultDisplay?.summary ? ` ${p.dim}${resultDisplay.summary}${p.reset}` : "";
-    const mark = exitCode === null
-      ? `${p.muted}(timed out)${p.reset}`
-      : exitCode === 0
-        ? `${p.success}✓${p.reset}${summary}${timer}`
-        : `${p.error}✗ exit ${exitCode}${p.reset}${summary}${timer}`;
+    const mark: string = ctx.call("tui:render-tool-complete", exitCode, elapsed, resultDisplay?.summary);
 
     if (s.toolLineOpen && s.commandOutputLineCount === 0) {
       writer.write(` ${mark}\n`);
@@ -824,7 +855,10 @@ export default function activate(ctx: ExtensionContext): void {
     s.spinner = createSpinner({ startTime: s.spinnerStartTime });
     s.spinnerInterval = setInterval(() => {
       if (s.spinner) {
-        const line = renderSpinnerLine(s.spinner, s.spinnerLabel, s.spinnerOpts);
+        const frame = SPINNER_FRAMES[s.spinner.frame % SPINNER_FRAMES.length]!;
+        s.spinner.frame++;
+        const elapsed = formatElapsed(Date.now() - s.spinner.startTime);
+        const line: string = ctx.call("tui:render-spinner", s.spinnerLabel, frame, elapsed, s.spinnerOpts.hint);
         writer.write(`\r  ${line}\x1b[K`);
       }
     }, 80);
@@ -860,21 +894,11 @@ export default function activate(ctx: ExtensionContext): void {
     }
     closeToolLine();
     if (!s.renderer) startAgentResponse();
-    const mark = s.toolGroupAllOk
-      ? `${p.success}✓${p.reset}`
-      : `${p.error}✗${p.reset}`;
-    const summary = s.toolGroupSummaries.length > 0
-      ? ` ${p.dim}${s.toolGroupSummaries.join(", ")}${p.reset}`
-      : "";
-    const collapsed = s.toolGroupCount - s.toolGroupRendered;
-    if (collapsed > 0) {
-      s.renderer!.writeLine(
-        `  ${p.muted}└${p.reset} ${p.dim}+${collapsed} more${p.reset} ${mark}${summary}`,
-      );
-    } else {
-      // All items visible — close the tree with └ mark + summary
-      s.renderer!.writeLine(`  ${p.muted}└${p.reset} ${mark}${summary}`);
-    }
+    const groupLine: string = ctx.call(
+      "tui:render-tool-group-summary",
+      s.toolGroupCount, s.toolGroupRendered, s.toolGroupAllOk, s.toolGroupSummaries,
+    );
+    s.renderer!.writeLine(groupLine);
     drain();
     s.toolGroupKind = undefined;
     s.toolGroupCount = 0;
@@ -892,9 +916,10 @@ export default function activate(ctx: ExtensionContext): void {
     s.commandOutputBuffer += chunk;
     const lines = s.commandOutputBuffer.split("\n");
     s.commandOutputBuffer = lines.pop()!;
+    const renderLine = (l: string) => ctx.call("tui:render-command-output", l, s.currentToolKind) as string;
     for (const line of lines) {
       if (s.commandOutputLineCount < maxLines) {
-        s.renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
+        s.renderer.writeLine(renderLine(line));
         s.commandOutputLineCount++;
       } else {
         s.commandOutputOverflow++;
@@ -912,9 +937,10 @@ export default function activate(ctx: ExtensionContext): void {
     const maxLines = s.currentToolKind === "read"
       ? getSettings().readOutputMaxLines
       : getSettings().maxCommandOutputLines;
+    const renderLine = (l: string) => ctx.call("tui:render-command-output", l, s.currentToolKind) as string;
     if (s.commandOutputBuffer) {
       if (s.commandOutputLineCount < maxLines) {
-        s.renderer.writeLine(`${p.dim}  ${s.commandOutputBuffer}${p.reset}`);
+        s.renderer.writeLine(renderLine(s.commandOutputBuffer));
         s.commandOutputLineCount++;
       } else {
         s.commandOutputOverflow++;
@@ -929,13 +955,13 @@ export default function activate(ctx: ExtensionContext): void {
       const tail = s.commandOverflowLines.slice(-FAIL_OVERFLOW_MAX);
       const skipped = s.commandOverflowLines.length - tail.length;
       if (skipped > 0) {
-        s.renderer.writeLine(`${p.dim}  … ${skipped} lines hidden${p.reset}`);
+        s.renderer.writeLine(renderLine(`… ${skipped} lines hidden`));
       }
       for (const line of tail) {
-        s.renderer.writeLine(`${p.dim}  ${line}${p.reset}`);
+        s.renderer.writeLine(renderLine(line));
       }
     } else if (s.commandOutputOverflow > 0 && maxLines > 0) {
-      s.renderer.writeLine(`${p.dim}  … ${s.commandOutputOverflow} more lines${p.reset}`);
+      s.renderer.writeLine(renderLine(`… ${s.commandOutputOverflow} more lines`));
     }
 
     s.commandOutputOverflow = 0;
@@ -1057,10 +1083,10 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function showError(message: string): void {
-    writer.write(`\n${p.error}Error: ${message}${p.reset}\n`);
+    writer.write("\n" + ctx.call("tui:render-error", message) + "\n");
   }
 
   function showInfo(message: string): void {
-    writer.write(`${p.muted}${message}${p.reset}\n`);
+    writer.write(ctx.call("tui:render-info", message) + "\n");
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,6 +62,8 @@ export interface Settings {
   shellTailLines?: number;
   /** Max lines for recall expand before requiring line ranges. */
   recallExpandMaxLines?: number;
+  /** Fraction of content budget allocated to shell context (0-1, default 0.35). */
+  shellContextRatio?: number;
 
   // ── Display ───────────────────────────────────────────────
   /** Max command output lines shown inline in TUI. */
@@ -94,6 +96,7 @@ const DEFAULTS: Required<Settings> = {
   shellHeadLines: 5,
   shellTailLines: 5,
   recallExpandMaxLines: 100,
+  shellContextRatio: 0.35,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,
   diffMaxLines: 20,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -65,6 +65,14 @@ export interface Settings {
   /** Fraction of content budget allocated to shell context (0-1, default 0.35). */
   shellContextRatio?: number;
 
+  // ── History ──────────────────────────────────────────────
+  /** Max history file size in bytes (default: 102400 = 100KB). */
+  historyMaxBytes?: number;
+  /** Number of prior history entries to load on startup (default: 50). */
+  historyStartupEntries?: number;
+  /** Max nuclear entries kept in-context before flushing to history file (default: 200). */
+  nuclearMaxEntries?: number;
+
   // ── Display ───────────────────────────────────────────────
   /** Max command output lines shown inline in TUI. */
   maxCommandOutputLines?: number;
@@ -97,6 +105,9 @@ const DEFAULTS: Required<Settings> = {
   shellTailLines: 5,
   recallExpandMaxLines: 100,
   shellContextRatio: 0.35,
+  historyMaxBytes: 102400,
+  historyStartupEntries: 50,
+  nuclearMaxEntries: 200,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,
   diffMaxLines: 20,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,16 @@ import * as os from "node:os";
 export const CONFIG_DIR = path.join(os.homedir(), ".agent-sh");
 const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
 
+/** Per-model capability overrides. */
+export interface ModelCapabilityConfig {
+  /** Model identifier. */
+  id: string;
+  /** Whether the model supports reasoning/thinking tokens. */
+  reasoning?: boolean;
+  /** Context window size in tokens for this specific model. */
+  contextWindow?: number;
+}
+
 /** Provider profile — a named LLM configuration. */
 export interface ProviderConfig {
   /** API key (supports $ENV_VAR syntax for runtime expansion). */
@@ -19,8 +29,8 @@ export interface ProviderConfig {
   baseURL?: string;
   /** Default model to use. Falls back to first entry in models list. */
   defaultModel?: string;
-  /** Models available for cycling. */
-  models?: string[];
+  /** Models available for cycling. Plain strings or objects with capabilities. */
+  models?: (string | ModelCapabilityConfig)[];
   /** Context window size in tokens (e.g. 128000). Used for usage display. */
   contextWindow?: number;
 }
@@ -171,16 +181,30 @@ export function resolveProvider(name: string): ResolvedProvider | null {
   const provider = settings.providers?.[name];
   if (!provider) return null;
 
-  const models = provider.models ?? (provider.defaultModel ? [provider.defaultModel] : []);
-  const defaultModel = provider.defaultModel ?? models[0];
+  const rawModels = provider.models ?? (provider.defaultModel ? [provider.defaultModel] : []);
+  const modelIds: string[] = [];
+  const caps = new Map<string, { reasoning?: boolean; contextWindow?: number }>();
+  for (const m of rawModels) {
+    if (typeof m === "string") {
+      modelIds.push(m);
+    } else {
+      modelIds.push(m.id);
+      if (m.reasoning !== undefined || m.contextWindow !== undefined) {
+        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow });
+      }
+    }
+  }
+
+  const defaultModel = provider.defaultModel ?? modelIds[0];
 
   return {
     id: name,
     apiKey: provider.apiKey ? expandEnvVars(provider.apiKey) : undefined,
     baseURL: provider.baseURL,
     defaultModel,
-    models: models.length ? models : (defaultModel ? [defaultModel] : []),
+    models: modelIds.length ? modelIds : (defaultModel ? [defaultModel] : []),
     contextWindow: provider.contextWindow,
+    modelCapabilities: caps.size > 0 ? caps : undefined,
   };
 }
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -209,6 +209,11 @@ export class Shell implements InputContext {
       this.ptyProcess.write(data);
     });
 
+    // Allow extensions to resize the PTY (sends SIGWINCH to child)
+    this.bus.on("shell:pty-resize", ({ cols, rows }) => {
+      this.ptyProcess.resize(cols, rows);
+    });
+
     // Ref-counted stdout hold — overlay extensions suppress PTY output
     this.bus.on("shell:stdout-hold", () => { this.stdoutHold.increment(); });
     this.bus.on("shell:stdout-release", () => { this.stdoutHold.decrement(); });

--- a/src/token-budget.ts
+++ b/src/token-budget.ts
@@ -1,0 +1,57 @@
+/**
+ * Unified token budget manager.
+ *
+ * Splits a model's context window between two streams:
+ *   - Shell context (user shell commands and outputs — situational awareness)
+ *   - Conversation (agent messages and tool results — task continuity)
+ *
+ * The budget accounts for fixed overhead (system prompt, tool definitions,
+ * response reserve) and divides the remaining space by a configurable ratio.
+ */
+import { getSettings } from "./settings.js";
+
+/** Overhead estimates (tokens). */
+const SYSTEM_PROMPT_OVERHEAD = 800;
+const DYNAMIC_CONTEXT_OVERHEAD = 500; // conventions, metadata, skills list
+const TOKENS_PER_TOOL_DEFINITION = 50;
+const RESPONSE_RESERVE = 8192; // matches llm-client.ts default max_tokens
+
+/** Fallback when contextWindow is unknown. */
+const DEFAULT_CONTEXT_WINDOW = 60_000;
+
+export class TokenBudget {
+  private contextWindow: number;
+  private toolCount: number;
+
+  constructor(contextWindow?: number, toolCount = 0) {
+    this.contextWindow = contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+    this.toolCount = toolCount;
+  }
+
+  /** Update when model or tool set changes. */
+  update(contextWindow?: number, toolCount?: number): void {
+    if (contextWindow != null) this.contextWindow = contextWindow;
+    if (toolCount != null) this.toolCount = toolCount;
+  }
+
+  /** Total tokens available for shell context + conversation content. */
+  get contentBudget(): number {
+    const overhead =
+      SYSTEM_PROMPT_OVERHEAD +
+      DYNAMIC_CONTEXT_OVERHEAD +
+      this.toolCount * TOKENS_PER_TOOL_DEFINITION +
+      RESPONSE_RESERVE;
+    return Math.max(0, this.contextWindow - overhead);
+  }
+
+  /** Token budget for the shell context stream. */
+  get shellBudgetTokens(): number {
+    const ratio = getSettings().shellContextRatio;
+    return Math.floor(this.contentBudget * ratio);
+  }
+
+  /** Token budget for the conversation messages stream. */
+  get conversationBudgetTokens(): number {
+    return this.contentBudget - this.shellBudgetTokens;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,13 +118,10 @@ export interface TerminalSession {
 }
 
 // ── Exchange types (used by ContextManager) ──────────────────────
-
-export interface ToolCallRecord {
-  tool: string;
-  args: Record<string, unknown>;
-  output: string;
-  exitCode: number | null;
-}
+//
+// Shell context tracks only user-initiated activity (shell commands and
+// agent queries). Agent tool outputs and responses live exclusively in
+// the ConversationState messages array to avoid duplication.
 
 export type Exchange =
   | {
@@ -145,22 +142,4 @@ export type Exchange =
       id: number;
       timestamp: number;
       query: string;
-    }
-  | {
-      type: "agent_response";
-      id: number;
-      timestamp: number;
-      response: string;
-      toolCalls: ToolCallRecord[];
-    }
-  | {
-      type: "tool_execution";
-      id: number;
-      timestamp: number;
-      tool: string;
-      args: Record<string, unknown>;
-      output: string;
-      exitCode: number | null;
-      outputLines: number;
-      outputBytes: number;
     };

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -63,6 +63,35 @@ export function visibleLen(str: string): number {
   return width;
 }
 
+/**
+ * Truncate a string to fit within `maxWidth` visible columns.
+ * Accounts for CJK double-width characters. Appends `…` if truncated.
+ */
+export function truncateToWidth(str: string, maxWidth: number): string {
+  const clean = str.replace(/\x1b\[[^m]*m/g, "");
+  let width = 0;
+  let i = 0;
+  for (const char of clean) {
+    const cw = charWidth(char.codePointAt(0) ?? 0);
+    if (width + cw > maxWidth - 1) {
+      // Need room for the "…" (1 column wide)
+      return clean.slice(0, i) + "…";
+    }
+    width += cw;
+    i += char.length;
+  }
+  return clean;
+}
+
+/**
+ * Pad a string with spaces to fill `targetWidth` visible columns.
+ * Accounts for CJK double-width characters.
+ */
+export function padEndToWidth(str: string, targetWidth: number): string {
+  const gap = targetWidth - visibleLen(str);
+  return gap > 0 ? str + " ".repeat(gap) : str;
+}
+
 /** Strip all ANSI escape sequences (SGR, OSC, CSI, private mode) and carriage returns. */
 export function stripAnsi(str: string): string {
   return str

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -533,9 +533,8 @@ export class FloatingPanel {
 
     this.restoreScreen();
 
-    // If we restored from the TerminalBuffer, it already has all PTY
-    // data processed — don't replay raw ptyBuffer (would double-apply).
-    // Only replay when there's no buffer (fallback case).
+    // Replay buffered PTY output when no TerminalBuffer is available
+    // (SIGWINCH handles redraw for interactive programs).
     if (!this.buffer && this.ptyBuffer) {
       process.stdout.write(this.ptyBuffer);
     }
@@ -892,17 +891,21 @@ export class FloatingPanel {
     if (this.usedAltScreen) {
       process.stdout.write("\x1b[?1049l");
     }
-    // Rewrite screen from terminal buffer — it has the latest state
-    // including draws from background programs while the overlay was up.
-    // Write the serialized output as a continuous stream (don't split —
-    // it contains cursor positioning and SGR sequences).
+    // The overlay drew composite rows on the terminal. Repaint from
+    // the TerminalBuffer which has the true screen state.
     if (this.buffer) {
       this.buffer.flush();
       const serialized = this.buffer.serialize();
       if (serialized) {
+        // Clear screen then write the full terminal state.
+        // Sync markers prevent tearing during the repaint.
         process.stdout.write(`${SYNC_START}\x1b[H\x1b[2J${serialized}${SYNC_END}`);
+        return;
       }
     }
+    // No buffer — just clear and let SIGWINCH handle it
+    process.stdout.write("\x1b[2J\x1b[H");
+    process.stdout.emit("resize");
   }
 
   private resolveSize(spec: number | string, available: number): number {

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -888,14 +888,13 @@ export class FloatingPanel {
 
   private restoreScreen(): void {
     if (this.usedAltScreen) {
-      // Leave alt screen — the terminal restores the saved main buffer.
       process.stdout.write("\x1b[?1049l");
-    } else {
-      // We were already on alt screen (vim, htop, etc.) so we didn't
-      // enter our own.  Restore by rewriting the screen content from
-      // the xterm buffer, which mirrors what the foreground program
-      // had rendered.
-      const raw = this.buffer?.serialize() ?? "";
+    }
+    // Rewrite screen from terminal buffer to ensure it reflects
+    // the latest state (background programs may have drawn while
+    // the overlay was up — the alt screen snapshot would be stale).
+    if (this.buffer) {
+      const raw = this.buffer.serialize() ?? "";
       const rows = process.stdout.rows || 24;
       const lines = raw.split("\n");
       const out: string[] = [SYNC_START];

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -31,6 +31,7 @@
  *   import { FloatingPanel } from "agent-sh/utils/floating-panel.js";
  */
 import { stripAnsi } from "./ansi.js";
+import { wrapLine } from "./markdown.js";
 import { LineEditor } from "./line-editor.js";
 import { TerminalBuffer } from "./terminal-buffer.js";
 import { HandlerRegistry } from "./handler-registry.js";
@@ -222,6 +223,7 @@ export class FloatingPanel {
    *   - `{prefix}:composite-row(content: string, bgLine: string|null, boxLeft: number, boxW: number, cols: number) -> string`
    *   - `{prefix}:submit(query: string) -> void`
    *   - `{prefix}:dismiss() -> void`
+   *   - `{prefix}:show() -> void`
    *   - `{prefix}:input(data: string) -> boolean`
    *   - `{prefix}:build-row(content: string, width: number) -> string`
    */
@@ -237,6 +239,7 @@ export class FloatingPanel {
 
   // ── State ───────────────────────────────────────────────────
   private phase: Phase = "idle";
+  private _visible = false;  // whether the panel is currently shown on screen
   private editor = new LineEditor();
   private contentLines: string[] = [];
   private currentPartialLine = "";
@@ -282,14 +285,21 @@ export class FloatingPanel {
 
     // Default content renderer: uses built-in appendText/appendLine buffer
     this.handlers.define(`${p}:render-content`, (ctx: RenderContext): RenderResult => {
-      if (ctx.phase === "input") {
-        return {
-          lines: [`\x1b[36m${this.config.promptIcon}${RESET} ${ctx.inputBuffer}`],
-          cursor: { row: 0, col: this.config.promptIcon.length + 1 + ctx.inputCursor },
-        };
+      const raw = [...ctx.contentLines, ...(ctx.partialLine ? [ctx.partialLine] : [])];
+      // Wrap long lines to fit within the content width
+      const all: string[] = [];
+      for (const line of raw) {
+        const wrapped = wrapLine(line, ctx.width);
+        all.push(...wrapped);
       }
-      const all = [...ctx.contentLines, ...(ctx.partialLine ? [ctx.partialLine] : [])];
-      // Auto-scroll
+
+      // In input phase, append the prompt line at the bottom of content
+      if (ctx.phase === "input") {
+        const promptLine = `\x1b[36m${this.config.promptIcon}${RESET} ${ctx.inputBuffer}`;
+        all.push(promptLine);
+      }
+
+      // Auto-scroll to bottom
       let offset = ctx.scrollOffset;
       if (all.length > ctx.height) {
         offset = all.length - ctx.height;
@@ -297,7 +307,22 @@ export class FloatingPanel {
         offset = 0;
       }
       this.scrollOffset = offset;
-      return { lines: all.slice(offset, offset + ctx.height) };
+
+      const visible = all.slice(offset, offset + ctx.height);
+
+      // Cursor position for input mode
+      if (ctx.phase === "input") {
+        const promptRow = visible.length - 1;
+        // If prompt is visible, set cursor
+        if (promptRow >= 0) {
+          return {
+            lines: visible,
+            cursor: { row: promptRow, col: this.config.promptIcon.length + 1 + ctx.inputCursor },
+          };
+        }
+      }
+
+      return { lines: visible };
     });
 
     // Default submit: no-op (extension overrides)
@@ -305,6 +330,9 @@ export class FloatingPanel {
 
     // Default dismiss: no-op
     this.handlers.define(`${p}:dismiss`, () => {});
+
+    // Default show: no-op (extension overrides to rebuild content on re-show)
+    this.handlers.define(`${p}:show`, () => {});
 
     // Default custom input handler: don't consume
     this.handlers.define(`${p}:input`, (_data: string): boolean => false);
@@ -399,15 +427,15 @@ export class FloatingPanel {
   // ── Bus event wiring ───────────────────────────────────────
 
   private wireEvents(): void {
-    // Buffer PTY output while overlay is open so we can replay it on dismiss.
+    // Buffer PTY output while overlay is visible so we can replay it on hide.
     // Alt screen restore discards anything written while it was active.
     this.bus.on("shell:pty-data", ({ raw }) => {
-      if (this.phase !== "idle") this.ptyBuffer += raw;
+      if (this._visible) this.ptyBuffer += raw;
     });
 
     this.bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
     this.bus.onPipe("shell:redraw-prompt", (payload) => {
-      if (this.phase !== "idle") {
+      if (this._visible) {
         return { ...payload, handled: true };
       }
       // After dismiss, suppress one redraw — restoreScreen already
@@ -444,14 +472,21 @@ export class FloatingPanel {
 
   // ── Public lifecycle ────────────────────────────────────────
 
+  /** Whether the panel has an active conversation (may be hidden). */
   get active(): boolean {
     return this.phase !== "idle";
+  }
+
+  /** Whether the panel is currently visible on screen. */
+  get visible(): boolean {
+    return this._visible;
   }
 
   get terminalBuffer(): TerminalBuffer | null {
     return this.buffer;
   }
 
+  /** Open a fresh panel with a new conversation. */
   open(): void {
     if (this.phase !== "idle") return;
     this.ensureBuffer();
@@ -465,13 +500,64 @@ export class FloatingPanel {
     this.footer = "";
     this.prevFrame = [];
 
+    this.enterScreen();
+  }
+
+  /** Hide the panel without destroying conversation state. */
+  hide(): void {
+    if (!this._visible) return;
+    if (this.renderTimer) { clearTimeout(this.renderTimer); this.renderTimer = null; }
+    if (this.resizeHandler) { process.stdout.off("resize", this.resizeHandler); this.resizeHandler = null; }
+
+    this._visible = false;
+    this.suppressNextRedraw = true;
+    this.prevFrame = [];
+
+    this.restoreScreen();
+
+    // Replay any PTY output that arrived while the overlay was visible.
+    if (this.ptyBuffer) {
+      process.stdout.write(this.ptyBuffer);
+      this.ptyBuffer = "";
+    }
+
+    this.bus.emit("shell:stdout-hide", {});
+    this.bus.emit("shell:stdout-release", {});
+
+    this.handlers.call(`${this.prefix}:dismiss`);
+  }
+
+  /** Show the panel again after hide(), preserving conversation. */
+  show(): void {
+    if (this._visible || this.phase === "idle") return;
+    this.prevFrame = [];
+    this.enterScreen();
+    this.handlers.call(`${this.prefix}:show`);
+  }
+
+  /** Fully destroy the panel, resetting all state. */
+  dismiss(): void {
+    if (this.phase === "idle") return;
+    if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
+
+    // Hide first if visible
+    if (this._visible) this.hide();
+
+    this.phase = "idle";
+    this.editor.clear();
+    this.contentLines = [];
+    this.currentPartialLine = "";
+    this.scrollOffset = 0;
+    this.title = "";
+    this.footer = "";
+  }
+
+  /** Common screen enter logic shared by open() and show(). */
+  private enterScreen(): void {
+    this._visible = true;
     this.ptyBuffer = "";
     this.bus.emit("shell:stdout-hold", {});
 
-    // If a foreground program (vim, htop) is already on alt screen,
-    // don't enter a second alt screen — it doesn't nest.  Instead,
-    // render directly on the current screen and restore from the
-    // xterm buffer on dismiss.
     this.usedAltScreen = !(this.buffer?.altScreen);
     if (this.usedAltScreen) {
       process.stdout.write("\x1b[?1049h");
@@ -481,34 +567,6 @@ export class FloatingPanel {
     process.stdout.on("resize", this.resizeHandler);
 
     this.render();
-  }
-
-  dismiss(): void {
-    if (this.phase === "idle") return;
-    if (this.renderTimer) { clearTimeout(this.renderTimer); this.renderTimer = null; }
-    if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
-    if (this.resizeHandler) { process.stdout.off("resize", this.resizeHandler); this.resizeHandler = null; }
-
-    this.suppressNextRedraw = true;
-    this.phase = "idle";
-    this.editor.clear();
-    this.prevFrame = [];
-
-    this.restoreScreen();
-
-    // Replay any PTY output that arrived while the overlay was open.
-    // Alt screen restore discarded it, but it represents real work
-    // the agent did (commands run, output produced).
-    if (this.ptyBuffer) {
-      process.stdout.write(this.ptyBuffer);
-      this.ptyBuffer = "";
-    }
-
-    // Reset any accumulated stdout-show refs, then release hold.
-    this.bus.emit("shell:stdout-hide", {});
-    this.bus.emit("shell:stdout-release", {});
-
-    this.handlers.call(`${this.prefix}:dismiss`);
   }
 
   // ── Public content API ──────────────────────────────────────
@@ -563,13 +621,10 @@ export class FloatingPanel {
   }
 
   setDone(): void {
-    this.phase = "done";
+    // Auto-prompt: transition to input for follow-up conversation
+    this.phase = "input";
+    this.editor.clear();
     this.render();
-    if (this.config.autoDismissMs > 0) {
-      this.autoDismissTimer = setTimeout(() => {
-        if (this.phase === "done") this.dismiss();
-      }, this.config.autoDismissMs);
-    }
   }
 
   getInput(): string {
@@ -586,19 +641,30 @@ export class FloatingPanel {
     const consumed = { ...payload, consumed: true };
     const { data } = payload;
 
-    switch (this.phase) {
-      case "done":
-        this.dismiss();
-        return consumed;
+    // Toggle visibility when trigger is pressed and panel is hidden but active
+    if (this.isTrigger(data) && this.phase !== "idle" && !this._visible) {
+      this.show();
+      return consumed;
+    }
 
+    // When not visible, only intercept the trigger key
+    if (!this._visible && this.phase !== "idle") {
+      return payload;
+    }
+
+    switch (this.phase) {
       case "input":
         this.handleInputKey(data);
         return consumed;
 
       case "active":
-        if (data === "\x03") this.bus.emit("agent:cancel-request", {});
-        else if (data === "\x1b" || this.isTrigger(data)) this.dismiss();
-        else this.handlers.call(`${this.prefix}:input`, data);
+        if (data === "\x03") {
+          this.bus.emit("agent:cancel-request", {});
+        } else if (data === "\x1b" || this.isTrigger(data)) {
+          this.hide();
+        } else {
+          this.handlers.call(`${this.prefix}:input`, data);
+        }
         return consumed;
 
       default: // idle
@@ -612,12 +678,12 @@ export class FloatingPanel {
 
   private handleInputKey(data: string): void {
     // Check full data string against trigger sequences (may be multi-byte)
-    if (this.isTrigger(data)) { this.dismiss(); return; }
+    if (this.isTrigger(data)) { this.hide(); return; }
 
     for (let i = 0; i < data.length; i++) {
       const ch = data[i]!;
-      if (ch === "\x1b" && data[i + 1] == null) { this.dismiss(); return; }
-      if (ch.charCodeAt(0) === 0x03) { this.dismiss(); return; }
+      if (ch === "\x1b" && data[i + 1] == null) { this.hide(); return; }
+      if (ch.charCodeAt(0) === 0x03) { this.hide(); return; }
     }
 
     const actions = this.editor.feed(data);
@@ -625,20 +691,29 @@ export class FloatingPanel {
       switch (action.action) {
         case "submit": {
           const query = this.editor.buffer.trim();
-          if (!query) { this.dismiss(); return; }
+          if (!query) { this.hide(); return; }
+          this.editor.pushHistory(query);
           this.phase = "active";
           this.editor.clear();
           this.handlers.call(`${this.prefix}:submit`, query);
           return;
         }
         case "cancel":
-          this.dismiss();
+          this.hide();
           return;
+        case "arrow-up": {
+          const hist = this.editor.historyBack();
+          if (hist) this.render();
+          break;
+        }
+        case "arrow-down": {
+          const hist = this.editor.historyForward();
+          if (hist) this.render();
+          break;
+        }
         case "changed":
         case "tab":
         case "shift+tab":
-        case "arrow-up":
-        case "arrow-down":
         case "delete-empty":
           this.render();
           break;
@@ -708,7 +783,7 @@ export class FloatingPanel {
   }
 
   private render(): void {
-    if (this.phase === "idle") return;
+    if (this.phase === "idle" || !this._visible) return;
 
     const { rows: frame, cursorSeq } = this.buildFrame();
 

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -533,11 +533,13 @@ export class FloatingPanel {
 
     this.restoreScreen();
 
-    // Replay any PTY output that arrived while the overlay was visible.
-    if (this.ptyBuffer) {
+    // If we restored from the TerminalBuffer, it already has all PTY
+    // data processed — don't replay raw ptyBuffer (would double-apply).
+    // Only replay when there's no buffer (fallback case).
+    if (!this.buffer && this.ptyBuffer) {
       process.stdout.write(this.ptyBuffer);
-      this.ptyBuffer = "";
     }
+    this.ptyBuffer = "";
 
     this.bus.emit("shell:stdout-hide", {});
     this.bus.emit("shell:stdout-release", {});

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -531,8 +531,8 @@ export class FloatingPanel {
     this._visible = false;
     this.prevFrame = [];
 
-    if (this.phase !== "idle" && this.buffer) {
-      // Session still active — enter passthrough mode.
+    if (this.phase === "active" && this.buffer) {
+      // Agent still working — enter passthrough mode.
       // Keep alt screen + stdout held. Render TerminalBuffer directly
       // so the background program's screen stays correct without
       // handing rendering control back to ncurses.
@@ -540,7 +540,7 @@ export class FloatingPanel {
       this.ptyBuffer = "";
       this.startPassthrough();
     } else {
-      // No active session or no buffer — full teardown.
+      // Agent idle or done — full teardown, hand back control.
       this.teardownScreen();
     }
 
@@ -660,6 +660,11 @@ export class FloatingPanel {
   }
 
   setDone(): void {
+    if (this._passthrough) {
+      // Agent finished while hidden — session over, hand back control.
+      this.dismiss();
+      return;
+    }
     if (this.config.autoDismissMs > 0) {
       // Legacy behavior: enter done state, auto-dismiss after delay
       this.phase = "done";

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -894,6 +894,7 @@ export class FloatingPanel {
     // the latest state (background programs may have drawn while
     // the overlay was up — the alt screen snapshot would be stale).
     if (this.buffer) {
+      this.buffer.flush();
       const raw = this.buffer.serialize() ?? "";
       const rows = process.stdout.rows || 24;
       const lines = raw.split("\n");

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -373,7 +373,8 @@ export class FloatingPanel {
     this.handlers.define(`${p}:render-border-bottom`, (ctx: FrameContext): string => {
       const { geo, border: b } = ctx;
       if (ctx.footer) {
-        const footerPad = Math.max(0, geo.boxW - ctx.footer.length - 3);
+        const visLen = stripAnsi(ctx.footer).length;
+        const footerPad = Math.max(0, geo.boxW - visLen - 3);
         return `${b.bl}${b.h.repeat(footerPad)}${DIM}${ctx.footer}${RESET}${b.h}${b.br}`;
       }
       return `${b.bl}${b.h.repeat(geo.boxW - 2)}${b.br}`;

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -892,21 +892,16 @@ export class FloatingPanel {
     if (this.usedAltScreen) {
       process.stdout.write("\x1b[?1049l");
     }
-    // Rewrite screen from terminal buffer to ensure it reflects
-    // the latest state (background programs may have drawn while
-    // the overlay was up — the alt screen snapshot would be stale).
+    // Rewrite screen from terminal buffer — it has the latest state
+    // including draws from background programs while the overlay was up.
+    // Write the serialized output as a continuous stream (don't split —
+    // it contains cursor positioning and SGR sequences).
     if (this.buffer) {
       this.buffer.flush();
-      const raw = this.buffer.serialize() ?? "";
-      const rows = process.stdout.rows || 24;
-      const lines = raw.split("\n");
-      const out: string[] = [SYNC_START];
-      for (let i = 0; i < rows; i++) {
-        out.push(`\x1b[${i + 1};1H\x1b[2K`);
-        if (i < lines.length) out.push(lines[i]!);
+      const serialized = this.buffer.serialize();
+      if (serialized) {
+        process.stdout.write(`${SYNC_START}\x1b[H\x1b[2J${serialized}${SYNC_END}`);
       }
-      out.push(SYNC_END);
-      process.stdout.write(out.join(""));
     }
   }
 

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -253,7 +253,6 @@ export class FloatingPanel {
   private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
   private ptyBuffer = "";  // PTY output accumulated while overlay is open
   private usedAltScreen = false;  // whether we entered our own alt screen
-  private holdKept = false;  // stdout hold maintained while hidden (agent still active)
   private wrapCache = new Map<string, string[]>();  // line → wrapped lines (invalidated on width change)
   private wrapCacheWidth = 0;
 
@@ -534,16 +533,8 @@ export class FloatingPanel {
       this.ptyBuffer = "";
     }
 
-    if (this.phase === "active") {
-      // Agent still running — keep stdout hold so TUI renderer stays
-      // suppressed, but use stdout-show to let PTY output through.
-      this.bus.emit("shell:stdout-show", {});
-      this.holdKept = true;
-    } else {
-      this.bus.emit("shell:stdout-hide", {});
-      this.bus.emit("shell:stdout-release", {});
-      this.holdKept = false;
-    }
+    this.bus.emit("shell:stdout-hide", {});
+    this.bus.emit("shell:stdout-release", {});
 
     this.handlers.call(`${this.prefix}:dismiss`);
   }
@@ -552,25 +543,7 @@ export class FloatingPanel {
   show(): void {
     if (this._visible || this.phase === "idle") return;
     this.prevFrame = [];
-
-    if (this.holdKept) {
-      // Hold was maintained — undo the stdout-show and re-enter screen
-      // without a second hold (already held).
-      this.bus.emit("shell:stdout-hide", {});
-      this.holdKept = false;
-
-      this._visible = true;
-      this.ptyBuffer = "";
-      this.usedAltScreen = !(this.buffer?.altScreen);
-      if (this.usedAltScreen) process.stdout.write("\x1b[?1049h");
-      this.resizeHandler = () => { this.prevFrame = []; this.render(); };
-      process.stdout.on("resize", this.resizeHandler);
-      this.render();
-    } else {
-      // Hold was released — fresh enter with new hold.
-      this.enterScreen();
-    }
-
+    this.enterScreen();
     this.handlers.call(`${this.prefix}:show`);
   }
 
@@ -578,14 +551,6 @@ export class FloatingPanel {
   dismiss(): void {
     if (this.phase === "idle") return;
     if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
-
-    // If hold was kept from a previous hide, release it before cleanup
-    if (this.holdKept) {
-      this.bus.emit("shell:stdout-hide", {});
-      this.bus.emit("shell:stdout-release", {});
-      this.holdKept = false;
-    }
-
     if (this._visible) this.hide();
 
     this.phase = "idle";
@@ -666,13 +631,6 @@ export class FloatingPanel {
   }
 
   setDone(): void {
-    // If hidden with hold kept, release now — agent work is done.
-    if (this.holdKept) {
-      this.bus.emit("shell:stdout-hide", {});
-      this.bus.emit("shell:stdout-release", {});
-      this.holdKept = false;
-    }
-
     if (this.config.autoDismissMs > 0) {
       // Legacy behavior: enter done state, auto-dismiss after delay
       this.phase = "done";

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -239,7 +239,8 @@ export class FloatingPanel {
 
   // ── State ───────────────────────────────────────────────────
   private phase: Phase = "idle";
-  private _visible = false;  // whether the panel is currently shown on screen
+  private _visible = false;  // whether the panel box is shown on screen
+  private _passthrough = false;  // hidden but still rendering TerminalBuffer
   private editor = new LineEditor();
   private contentLines: string[] = [];
   private currentPartialLine = "";
@@ -256,6 +257,8 @@ export class FloatingPanel {
   private usedAltScreen = false;  // whether we entered our own alt screen
   private wrapCache = new Map<string, string[]>();  // line → wrapped lines (invalidated on width change)
   private wrapCacheWidth = 0;
+  private passthroughTimer: ReturnType<typeof setInterval> | null = null;
+  private prevSerialized = "";
 
   constructor(bus: EventBus, config: FloatingPanelConfig, handlers?: HandlerRegistry) {
     this.bus = bus;
@@ -452,7 +455,7 @@ export class FloatingPanel {
 
     this.bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
     this.bus.onPipe("shell:redraw-prompt", (payload) => {
-      if (this._visible) {
+      if (this._visible || this._passthrough) {
         return { ...payload, handled: true };
       }
       // After dismiss, suppress one redraw — restoreScreen already
@@ -525,23 +528,21 @@ export class FloatingPanel {
   hide(): void {
     if (!this._visible) return;
     if (this.renderTimer) { clearTimeout(this.renderTimer); this.renderTimer = null; }
-    if (this.resizeHandler) { process.stdout.off("resize", this.resizeHandler); this.resizeHandler = null; }
-
     this._visible = false;
-    this.suppressNextRedraw = true;
     this.prevFrame = [];
 
-    this.restoreScreen();
-
-    // Replay buffered PTY output when no TerminalBuffer is available
-    // (SIGWINCH handles redraw for interactive programs).
-    if (!this.buffer && this.ptyBuffer) {
-      process.stdout.write(this.ptyBuffer);
+    if (this.phase !== "idle" && this.buffer) {
+      // Session still active — enter passthrough mode.
+      // Keep alt screen + stdout held. Render TerminalBuffer directly
+      // so the background program's screen stays correct without
+      // handing rendering control back to ncurses.
+      this._passthrough = true;
+      this.ptyBuffer = "";
+      this.startPassthrough();
+    } else {
+      // No active session or no buffer — full teardown.
+      this.teardownScreen();
     }
-    this.ptyBuffer = "";
-
-    this.bus.emit("shell:stdout-hide", {});
-    this.bus.emit("shell:stdout-release", {});
 
     this.handlers.call(`${this.prefix}:dismiss`);
   }
@@ -549,8 +550,19 @@ export class FloatingPanel {
   /** Show the panel again after hide(), preserving conversation. */
   show(): void {
     if (this._visible || this.phase === "idle") return;
-    this.prevFrame = [];
-    this.enterScreen();
+
+    if (this._passthrough) {
+      // Resume from passthrough — alt screen + stdout hold already active.
+      this.stopPassthrough();
+      this._passthrough = false;
+      this._visible = true;
+      this.prevFrame = [];
+      this.render();
+    } else {
+      // Cold show — need full screen setup.
+      this.prevFrame = [];
+      this.enterScreen();
+    }
     this.handlers.call(`${this.prefix}:show`);
   }
 
@@ -558,7 +570,17 @@ export class FloatingPanel {
   dismiss(): void {
     if (this.phase === "idle") return;
     if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
-    if (this._visible) this.hide();
+
+    if (this._passthrough) {
+      this.stopPassthrough();
+      this._passthrough = false;
+      this.teardownScreen();
+    } else if (this._visible) {
+      this._visible = false;
+      if (this.renderTimer) { clearTimeout(this.renderTimer); this.renderTimer = null; }
+      this.prevFrame = [];
+      this.teardownScreen();
+    }
 
     this.phase = "idle";
     this.editor.clear();
@@ -887,25 +909,60 @@ export class FloatingPanel {
 
   // ── Screen helpers ────────────────────────────────────────
 
-  private restoreScreen(): void {
+  /** Full screen teardown: exit alt screen, release stdout, force redraw. */
+  private teardownScreen(): void {
+    if (this.resizeHandler) {
+      process.stdout.off("resize", this.resizeHandler);
+      this.resizeHandler = null;
+    }
+    this.suppressNextRedraw = true;
+
     if (this.usedAltScreen) {
       process.stdout.write("\x1b[?1049l");
     }
-    // The overlay drew composite rows on the terminal. Repaint from
-    // the TerminalBuffer which has the true screen state.
-    if (this.buffer) {
-      this.buffer.flush();
-      const serialized = this.buffer.serialize();
-      if (serialized) {
-        // Clear screen then write the full terminal state.
-        // Sync markers prevent tearing during the repaint.
-        process.stdout.write(`${SYNC_START}\x1b[H\x1b[2J${serialized}${SYNC_END}`);
-        return;
-      }
+    // ncurses's curscr is stale — only a real dimension change triggers
+    // clearok + full repaint (same-size SIGWINCH is a no-op).
+    const cols = process.stdout.columns || 80;
+    const rows = process.stdout.rows || 24;
+    this.bus.emit("shell:pty-resize", { cols, rows: rows - 1 });
+    setTimeout(() => {
+      this.bus.emit("shell:pty-resize", { cols, rows });
+    }, 50);
+
+    if (!this.buffer && this.ptyBuffer) {
+      process.stdout.write(this.ptyBuffer);
     }
-    // No buffer — just clear and let SIGWINCH handle it
-    process.stdout.write("\x1b[2J\x1b[H");
-    process.stdout.emit("resize");
+    this.ptyBuffer = "";
+    this.bus.emit("shell:stdout-hide", {});
+    this.bus.emit("shell:stdout-release", {});
+  }
+
+  // ── Passthrough rendering ─────────────────────────────────
+
+  /** Start rendering TerminalBuffer directly (no overlay box). */
+  private startPassthrough(): void {
+    this.prevSerialized = "";
+    this.renderPassthrough();
+    this.passthroughTimer = setInterval(() => this.renderPassthrough(), 50);
+  }
+
+  private stopPassthrough(): void {
+    if (this.passthroughTimer) {
+      clearInterval(this.passthroughTimer);
+      this.passthroughTimer = null;
+    }
+    this.prevSerialized = "";
+  }
+
+  /** Render the TerminalBuffer's screen content directly (no overlay). */
+  private renderPassthrough(): void {
+    if (!this.buffer) return;
+    this.buffer.flush();
+    const serialized = this.buffer.serialize();
+    if (serialized && serialized !== this.prevSerialized) {
+      this.prevSerialized = serialized;
+      process.stdout.write(`${SYNC_START}\x1b[H${serialized}${SYNC_END}`);
+    }
   }
 
   private resolveSize(spec: number | string, available: number): number {

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -98,7 +98,7 @@ export interface FloatingPanelConfig {
    * Requires @xterm/headless — falls back to blank background if unavailable.
    */
   dimBackground?: boolean;
-  /** Auto-dismiss delay in ms when done (0 = disabled). Default: 0. */
+  /** Auto-dismiss delay in ms when done (0 = auto-prompt for follow-up). Default: 0. */
   autoDismissMs?: number;
   /** Icon shown before the input cursor. Default: "\u276f". */
   promptIcon?: string;
@@ -247,12 +247,15 @@ export class FloatingPanel {
   private title = "";
   private footer = "";
   private renderTimer: ReturnType<typeof setTimeout> | null = null;
-  private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
   private resizeHandler: (() => void) | null = null;
   private prevFrame: string[] = [];
   private suppressNextRedraw = false;
+  private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
   private ptyBuffer = "";  // PTY output accumulated while overlay is open
   private usedAltScreen = false;  // whether we entered our own alt screen
+  private holdKept = false;  // stdout hold maintained while hidden (agent still active)
+  private wrapCache = new Map<string, string[]>();  // line → wrapped lines (invalidated on width change)
+  private wrapCacheWidth = 0;
 
   constructor(bus: EventBus, config: FloatingPanelConfig, handlers?: HandlerRegistry) {
     this.bus = bus;
@@ -286,10 +289,20 @@ export class FloatingPanel {
     // Default content renderer: uses built-in appendText/appendLine buffer
     this.handlers.define(`${p}:render-content`, (ctx: RenderContext): RenderResult => {
       const raw = [...ctx.contentLines, ...(ctx.partialLine ? [ctx.partialLine] : [])];
-      // Wrap long lines to fit within the content width
+
+      // Invalidate wrap cache if width changed
+      if (ctx.width !== this.wrapCacheWidth) {
+        this.wrapCache.clear();
+        this.wrapCacheWidth = ctx.width;
+      }
+
       const all: string[] = [];
       for (const line of raw) {
-        const wrapped = wrapLine(line, ctx.width);
+        let wrapped = this.wrapCache.get(line);
+        if (!wrapped) {
+          wrapped = wrapLine(line, ctx.width);
+          this.wrapCache.set(line, wrapped);
+        }
         all.push(...wrapped);
       }
 
@@ -427,8 +440,8 @@ export class FloatingPanel {
   // ── Bus event wiring ───────────────────────────────────────
 
   private wireEvents(): void {
-    // Buffer PTY output while overlay is visible so we can replay it on hide.
-    // Alt screen restore discards anything written while it was active.
+    // Buffer PTY output while overlay is visible (alt screen discards it).
+    // Don't buffer when hidden — PTY flows to terminal directly via stdout-show.
     this.bus.on("shell:pty-data", ({ raw }) => {
       if (this._visible) this.ptyBuffer += raw;
     });
@@ -521,8 +534,16 @@ export class FloatingPanel {
       this.ptyBuffer = "";
     }
 
-    this.bus.emit("shell:stdout-hide", {});
-    this.bus.emit("shell:stdout-release", {});
+    if (this.phase === "active") {
+      // Agent still running — keep stdout hold so TUI renderer stays
+      // suppressed, but use stdout-show to let PTY output through.
+      this.bus.emit("shell:stdout-show", {});
+      this.holdKept = true;
+    } else {
+      this.bus.emit("shell:stdout-hide", {});
+      this.bus.emit("shell:stdout-release", {});
+      this.holdKept = false;
+    }
 
     this.handlers.call(`${this.prefix}:dismiss`);
   }
@@ -531,7 +552,25 @@ export class FloatingPanel {
   show(): void {
     if (this._visible || this.phase === "idle") return;
     this.prevFrame = [];
-    this.enterScreen();
+
+    if (this.holdKept) {
+      // Hold was maintained — undo the stdout-show and re-enter screen
+      // without a second hold (already held).
+      this.bus.emit("shell:stdout-hide", {});
+      this.holdKept = false;
+
+      this._visible = true;
+      this.ptyBuffer = "";
+      this.usedAltScreen = !(this.buffer?.altScreen);
+      if (this.usedAltScreen) process.stdout.write("\x1b[?1049h");
+      this.resizeHandler = () => { this.prevFrame = []; this.render(); };
+      process.stdout.on("resize", this.resizeHandler);
+      this.render();
+    } else {
+      // Hold was released — fresh enter with new hold.
+      this.enterScreen();
+    }
+
     this.handlers.call(`${this.prefix}:show`);
   }
 
@@ -540,7 +579,13 @@ export class FloatingPanel {
     if (this.phase === "idle") return;
     if (this.autoDismissTimer) { clearTimeout(this.autoDismissTimer); this.autoDismissTimer = null; }
 
-    // Hide first if visible
+    // If hold was kept from a previous hide, release it before cleanup
+    if (this.holdKept) {
+      this.bus.emit("shell:stdout-hide", {});
+      this.bus.emit("shell:stdout-release", {});
+      this.holdKept = false;
+    }
+
     if (this._visible) this.hide();
 
     this.phase = "idle";
@@ -621,10 +666,26 @@ export class FloatingPanel {
   }
 
   setDone(): void {
-    // Auto-prompt: transition to input for follow-up conversation
-    this.phase = "input";
-    this.editor.clear();
-    this.render();
+    // If hidden with hold kept, release now — agent work is done.
+    if (this.holdKept) {
+      this.bus.emit("shell:stdout-hide", {});
+      this.bus.emit("shell:stdout-release", {});
+      this.holdKept = false;
+    }
+
+    if (this.config.autoDismissMs > 0) {
+      // Legacy behavior: enter done state, auto-dismiss after delay
+      this.phase = "done";
+      this.render();
+      this.autoDismissTimer = setTimeout(() => {
+        if (this.phase === "done") this.dismiss();
+      }, this.config.autoDismissMs);
+    } else {
+      // Auto-prompt: transition to input for follow-up conversation
+      this.phase = "input";
+      this.editor.clear();
+      this.render();
+    }
   }
 
   getInput(): string {
@@ -653,6 +714,10 @@ export class FloatingPanel {
     }
 
     switch (this.phase) {
+      case "done":
+        this.dismiss();
+        return consumed;
+
       case "input":
         this.handleInputKey(data);
         return consumed;

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -244,6 +244,7 @@ export class FloatingPanel {
   private contentLines: string[] = [];
   private currentPartialLine = "";
   private scrollOffset = 0;
+  private userScrolled = false;  // true when user manually scrolled away from bottom
   private title = "";
   private footer = "";
   private renderTimer: ReturnType<typeof setTimeout> | null = null;
@@ -311,12 +312,15 @@ export class FloatingPanel {
         all.push(promptLine);
       }
 
-      // Auto-scroll to bottom
+      // Scroll: auto-scroll to bottom unless user manually scrolled
       let offset = ctx.scrollOffset;
-      if (all.length > ctx.height) {
-        offset = all.length - ctx.height;
+      const maxOffset = Math.max(0, all.length - ctx.height);
+      if (this.userScrolled) {
+        offset = Math.min(offset, maxOffset);
+        // Resume auto-scroll if user scrolled back to bottom
+        if (offset >= maxOffset) this.userScrolled = false;
       } else {
-        offset = 0;
+        offset = maxOffset;
       }
       this.scrollOffset = offset;
 
@@ -509,6 +513,7 @@ export class FloatingPanel {
     this.contentLines = [];
     this.currentPartialLine = "";
     this.scrollOffset = 0;
+    this.userScrolled = false;
     this.title = "";
     this.footer = "";
     this.prevFrame = [];
@@ -647,6 +652,18 @@ export class FloatingPanel {
     }
   }
 
+  scrollUp(lines = 3): void {
+    this.scrollOffset = Math.max(0, this.scrollOffset - lines);
+    this.userScrolled = true;
+    this.render();
+  }
+
+  scrollDown(lines = 3): void {
+    this.scrollOffset += lines;
+    this.userScrolled = true;
+    this.render();
+  }
+
   getInput(): string {
     return this.editor.buffer;
   }
@@ -686,6 +703,8 @@ export class FloatingPanel {
           this.bus.emit("agent:cancel-request", {});
         } else if (data === "\x1b" || this.isTrigger(data)) {
           this.hide();
+        } else if (this.handleScroll(data)) {
+          // scroll handled
         } else {
           this.handlers.call(`${this.prefix}:input`, data);
         }
@@ -700,6 +719,31 @@ export class FloatingPanel {
     }
   }
 
+  /** Handle scroll input. Returns true if consumed. */
+  private handleScroll(data: string): boolean {
+    // Arrow up / mouse wheel up
+    if (data === "\x1b[A" || data === "\x1bOA") { this.scrollUp(1); return true; }
+    // Arrow down / mouse wheel down
+    if (data === "\x1b[B" || data === "\x1bOB") { this.scrollDown(1); return true; }
+    // Page up (CSI 5~)
+    if (data === "\x1b[5~") { this.scrollUp(this.computeGeometry().contentH - 1); return true; }
+    // Page down (CSI 6~)
+    if (data === "\x1b[6~") { this.scrollDown(this.computeGeometry().contentH - 1); return true; }
+    // Mouse wheel: CSI M followed by button byte (64 = wheel up, 65 = wheel down)
+    if (data.length >= 6 && data.startsWith("\x1b[M")) {
+      const button = data.charCodeAt(3);
+      if (button === 96) { this.scrollUp(3); return true; }   // wheel up
+      if (button === 97) { this.scrollDown(3); return true; }  // wheel down
+    }
+    // SGR mouse: CSI < 64;x;yM (wheel up) / CSI < 65;x;yM (wheel down)
+    const sgr = data.match(/^\x1b\[<(64|65);\d+;\d+M$/);
+    if (sgr) {
+      if (sgr[1] === "64") { this.scrollUp(3); return true; }
+      if (sgr[1] === "65") { this.scrollDown(3); return true; }
+    }
+    return false;
+  }
+
   private handleInputKey(data: string): void {
     // Check full data string against trigger sequences (may be multi-byte)
     if (this.isTrigger(data)) { this.hide(); return; }
@@ -709,6 +753,9 @@ export class FloatingPanel {
       if (ch === "\x1b" && data[i + 1] == null) { this.hide(); return; }
       if (ch.charCodeAt(0) === 0x03) { this.hide(); return; }
     }
+
+    // Page Up/Down and mouse wheel scroll even in input phase
+    if (this.handleScroll(data)) return;
 
     const actions = this.editor.feed(data);
     for (const action of actions) {

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -31,6 +31,11 @@ export class LineEditor {
   cursor = 0;
   private pendingSeq = ""; // buffered incomplete escape sequence
 
+  // ── History ──────────────────────────────────────────────────
+  private history: string[] = [];
+  private historyIndex = -1;  // -1 = current input, 0..N = history entries (newest first)
+  private savedBuffer = "";   // saves current input when browsing history
+
   /** Process raw terminal input, return actions for the consumer. */
   feed(data: string): LineEditAction[] {
     // If we had a pending incomplete escape sequence, prepend it
@@ -151,6 +156,43 @@ export class LineEditor {
     this.buffer = "";
     this.cursor = 0;
     this.pendingSeq = "";
+    this.historyIndex = -1;
+    this.savedBuffer = "";
+  }
+
+  /** Add a line to history (most recent first). */
+  pushHistory(line: string): void {
+    if (!line.trim()) return;
+    // Deduplicate: remove if already at top
+    if (this.history.length > 0 && this.history[0] === line) return;
+    this.history.unshift(line);
+    // Cap history size
+    if (this.history.length > 100) this.history.pop();
+  }
+
+  /** Navigate to a previous history entry. Returns changed action or null. */
+  historyBack(): LineEditAction | null {
+    if (this.historyIndex + 1 >= this.history.length) return null;
+    if (this.historyIndex === -1) {
+      this.savedBuffer = this.buffer; // save current input
+    }
+    this.historyIndex++;
+    this.buffer = this.history[this.historyIndex]!;
+    this.cursor = this.buffer.length;
+    return { action: "changed" };
+  }
+
+  /** Navigate to a more recent history entry. Returns changed action or null. */
+  historyForward(): LineEditAction | null {
+    if (this.historyIndex <= -1) return null;
+    this.historyIndex--;
+    if (this.historyIndex === -1) {
+      this.buffer = this.savedBuffer;
+    } else {
+      this.buffer = this.history[this.historyIndex]!;
+    }
+    this.cursor = this.buffer.length;
+    return { action: "changed" };
   }
 
   // ── Key bindings ────────────────────────────────────────────

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { visibleLen } from "./ansi.js";
+import { visibleLen, truncateToWidth, padEndToWidth } from "./ansi.js";
 import { palette as p } from "./palette.js";
 
 const MAX_CONTENT_WIDTH = 90;
@@ -193,7 +193,7 @@ export class MarkdownRenderer {
     const colWidths: number[] = new Array(numCols).fill(0);
     for (const row of dataRows) {
       for (let c = 0; c < numCols; c++) {
-        colWidths[c] = Math.max(colWidths[c]!, row[c]!.length);
+        colWidths[c] = Math.max(colWidths[c]!, visibleLen(row[c]!));
       }
     }
 
@@ -221,7 +221,7 @@ export class MarkdownRenderer {
       const isHeader = hasHeader && i === 0;
       const cells = row.map((cell, c) => {
         const w = colWidths[c]!;
-        const text = cell.length > w ? cell.slice(0, w - 1) + "…" : cell.padEnd(w);
+        const text = visibleLen(cell) > w ? truncateToWidth(cell, w) : padEndToWidth(cell, w);
         return isHeader ? `${p.bold}${text}${p.reset}` : text;
       });
       this.writeLine(`${p.dim}│${p.reset} ${cells.join(` ${p.dim}│${p.reset} `)} ${p.dim}│${p.reset}`);

--- a/src/utils/terminal-buffer.ts
+++ b/src/utils/terminal-buffer.ts
@@ -100,6 +100,9 @@ export class TerminalBuffer {
   private readonly term: any;
   private readonly serializeAddon: any;
 
+  /** Flush pending drip-feed data (set by createWired). */
+  _flushPending: (() => void) | null = null;
+
   private constructor(term: any, serialize: any) {
     this.term = term;
     this.serializeAddon = serialize;
@@ -135,10 +138,18 @@ export class TerminalBuffer {
     setInterval(() => {
       if (pending) { const d = pending; pending = ""; tb.write(d); }
     }, 50);
+    tb._flushPending = () => {
+      if (pending) { const d = pending; pending = ""; tb.write(d); }
+    };
     process.stdout.on("resize", () => {
       tb.resize(process.stdout.columns || 80, process.stdout.rows || 24);
     });
     return tb;
+  }
+
+  /** Flush any pending drip-feed data into the virtual terminal. */
+  flush(): void {
+    this._flushPending?.();
   }
 
   /** Write raw data into the virtual terminal. */

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -255,7 +255,7 @@ export function formatElapsed(ms: number): string {
 
 // ── Spinner with elapsed timer ───────────────────────────────────
 
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 export interface SpinnerState {
   frame: number;


### PR DESCRIPTION
## Summary

This branch covers three areas of work:

### Overlay: persistent chat panel + composable TUI rendering
- Floating overlay panel (Ctrl+\) with markdown rendering, input history, scrolling
- Composable TUI rendering: `tui:should-render-agent` gate lets overlay suppress main TUI
- Terminal buffer tools (`terminal_read`, `terminal_keys`) for bridge extensions
- Screen restore fixes (flush buffer, skip double replay, handle background programs)
- Passthrough rendering: keep TerminalBuffer active when overlay is hidden

### Context management: unified budget + three-tier history
- **Separate streams**: shell context tracks only user activity; agent tool outputs live only in conversation (no duplication)
- **Token budget**: `TokenBudget` splits model's actual `contextWindow` between shell (35%) and conversation (65%), replacing hardcoded 60k threshold
- **Three-tier history** (like shell history — continuous, no sessions):
  - Tier 1: full content in LLM conversation
  - Tier 2: nuclear one-liner summaries stay in-context, read-only items dropped, full content in recall archive
  - Tier 3: `~/.agent-sh/history` JSONL file, persists across restarts, shared across shells
- **Priority-based compaction**: read-only tool results evicted first, user messages and errors last
- **`conversation_recall` tool**: search/expand across all tiers
- **`/compact` and `/context` slash commands**
- Documentation: `docs/context-management.md`

### Provider capabilities
- `ProviderConfig.models` accepts objects with `id`, `reasoning`, `contextWindow` (not just strings)
- `resolveProvider()` populates `modelCapabilities` from settings

## Test plan
- [ ] Type check: `npx tsc --noEmit`
- [ ] Overlay: Ctrl+\ opens panel, markdown renders, scrolling works, screen restores cleanly
- [ ] Context: run commands, ask agent questions, verify compaction produces nuclear one-liners
- [ ] History file: `~/.agent-sh/history` populated after compaction, loads on restart
- [ ] `/compact` triggers manual compaction, `/context` shows stats
- [ ] Model switch: token budget recalculates when switching between models with different context windows
- [ ] Multi-shell: two instances append to same history file without corruption