### PR TITLE
fixes, extension system, compositor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Configure via `~/.agent-sh/settings.json`. See the [Usage Guide](docs/usage.md#c
 - [Context Management](docs/context-management.md) — three-tier history, token budget, design philosophy
 - [Architecture](docs/architecture.md) — design philosophy, component overview, project structure
 - [Extensions](docs/extensions.md) — event bus, content transforms, custom backends, theming
+- [TUI Composition](docs/tui-composition.md) — compositor, render surfaces, stream routing
 - [Library Usage](docs/library.md) — embedding agent-sh in your own apps
 - [Troubleshooting](docs/troubleshooting.md) — common errors and debug mode
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -681,15 +681,26 @@ open() → [input] → submit → [active] → setDone() → [input] (follow-up)
 
 ## Rendering Architecture
 
-The tui-renderer turns content blocks into terminal output. All output flows through an **OutputWriter** (`write(text)` + `columns`). Extensions should never call `process.stdout.write` directly.
+The tui-renderer turns content blocks into terminal output. All output flows through the **compositor**, which routes named streams (`"agent"`, `"query"`, `"status"`) to **render surfaces**. Extensions should never call `process.stdout.write` directly.
 
 ```
 ContentBlock (from transform pipeline)
-    ├── text        → MarkdownRenderer.push(chunk) → drainLines() → writer
-    ├── code-block  → ctx.call("render:code-block") → drainLines() → writer
-    ├── image       → ctx.call("render:image")       → writer
-    └── raw         → writer.write(escape)
+    ├── text        → MarkdownRenderer.push(chunk) → drainLines() → compositor
+    ├── code-block  → ctx.call("render:code-block") → drainLines() → compositor
+    ├── image       → ctx.call("render:image")       → compositor
+    └── raw         → compositor.surface("agent").write(escape)
 ```
+
+Extensions can redirect any stream to a different surface (e.g. a floating panel):
+
+```typescript
+// Redirect agent output to a panel
+const restore = ctx.compositor.redirect("agent", panelSurface);
+// ... later ...
+restore(); // back to stdout
+```
+
+Streams are hierarchical: `"agent:diff"` falls back to `"agent"` if no override exists. See [TUI Composition](tui-composition.md) for the full compositor design, surface API, and examples.
 
 Rendering components follow a **return lines, don't write** convention — each returns `string[]`, making them testable in isolation:
 

--- a/docs/tui-composition.md
+++ b/docs/tui-composition.md
@@ -1,0 +1,256 @@
+# TUI Composition
+
+How agent-sh routes rendered output to different surfaces (stdout, floating panels, test buffers) and how extensions intercept or redirect that output.
+
+## Overview
+
+The TUI rendering pipeline has three layers:
+
+1. **Components** — know *what* to render. Pure functions that turn state into `string[]`. Examples: `renderBoxFrame()`, `renderDiff()`, `renderToolCall()`.
+
+2. **Surfaces** — know *where* output goes. A surface accepts lines and raw writes. Stdout is a surface. A floating panel's content area is a surface.
+
+3. **Compositor** — knows *how to route*. Maps named streams to surfaces. Extensions override routing with `redirect()` to capture output.
+
+```
+                    ┌─────────────────┐
+ EventBus events    │  tui-renderer   │  (subscribes to agent:* events,
+  agent:query  ───► │                 │   manages state, calls components)
+  agent:chunk  ───► │  RenderState    │
+  agent:tool-* ───► │  MarkdownRender │
+                    └───────┬─────────┘
+                            │ writes to named streams
+                            ▼
+                    ┌─────────────────┐
+                    │   Compositor    │  routes streams → surfaces
+                    │                 │
+                    │ "agent"  ──► ?  │
+                    │ "query"  ──► ?  │
+                    │ "status" ──► ?  │
+                    └───────┬─────────┘
+                            │ resolves to active surface
+                    ┌───────┴─────────────────────┐
+                    ▼                             ▼
+             ┌─────────────┐              ┌──────────────┐
+             │ StdoutSurface│              │ PanelSurface │
+             │ (default)    │              │ (override)   │
+             └─────────────┘              └──────────────┘
+```
+
+## Surfaces
+
+A `RenderSurface` is anything that can accept rendered output:
+
+```typescript
+interface RenderSurface {
+  write(text: string): void;    // raw — supports \r, escape codes
+  writeLine(line: string): void; // line + newline
+  readonly columns: number;      // available width
+}
+```
+
+Built-in surfaces:
+
+| Surface | Description |
+|---|---|
+| `StdoutSurface` | Default. Writes to `process.stdout`. |
+| `nullSurface` | Drops all output silently. Used when no route exists. |
+
+Extensions create their own surfaces. For example, a floating panel surface:
+
+```typescript
+const panelSurface: RenderSurface = {
+  write(text) {
+    if (text.startsWith("\r")) {
+      // Handle spinner \r overwrites
+      const cleaned = text.replace(/^\r/, "").replace(/\x1b\[\d*K/g, "");
+      if (cleaned.trim()) panel.updateLastLine(() => cleaned);
+      return;
+    }
+    panel.appendText(text);
+  },
+  writeLine(line) { panel.appendLine(line); },
+  get columns() { return panel.computeGeometry().contentW; },
+};
+```
+
+## Compositor
+
+The compositor maps named streams to surfaces. Components write to streams — they never know (or care) which surface they end up on.
+
+```typescript
+interface Compositor {
+  surface(stream: string): RenderSurface;
+  redirect(stream: string, target: RenderSurface): () => void;
+  setDefault(stream: string, target: RenderSurface): void;
+}
+```
+
+### Default streams
+
+| Stream | Content |
+|---|---|
+| `"agent"` | Agent response: markdown, tool calls, spinner, diffs, code blocks |
+| `"query"` | User query display (the bordered input box) |
+| `"status"` | Info messages, errors, suggestions |
+
+All three default to `StdoutSurface`.
+
+### Redirecting a stream
+
+`redirect()` returns a restore function. Redirects are stack-based — multiple redirects on the same stream nest correctly:
+
+```typescript
+const restore = compositor.redirect("agent", panelSurface);
+// ... agent output now goes to the panel ...
+restore(); // back to previous surface
+```
+
+### Hierarchical streams
+
+Stream names are hierarchical, separated by `:`. When resolving a surface, the compositor walks up the hierarchy until it finds an override or default:
+
+```
+"agent:sub:abc123"  →  "agent:sub"  →  "agent"  →  nullSurface
+```
+
+This enables fine-grained interception without registering defaults for every sub-stream:
+
+```typescript
+// All agent output goes to stdout (the "agent" default)
+compositor.setDefault("agent", stdoutSurface);
+
+// Redirect just diffs to a viewer panel — everything else unaffected
+compositor.redirect("agent:diff", diffPanelSurface);
+
+// Redirect a specific subagent to its own panel
+compositor.redirect("agent:sub:abc123", subagentPanelSurface);
+```
+
+The tui-renderer writes to the appropriate sub-stream. If no override exists for that sub-stream, output falls through to the parent — which is typically stdout.
+
+## Writing an extension that uses the compositor
+
+### Example: overlay agent (full redirect)
+
+The overlay agent redirects *all* render streams to a floating panel when active. This is the simplest pattern — whole-sale capture:
+
+```typescript
+export default function activate(ctx: ExtensionContext): void {
+  const { bus, compositor, createFloatingPanel } = ctx;
+
+  const panel = createFloatingPanel({ trigger: "\x1c" });
+  const panelSurface = createPanelSurface(panel);
+
+  let restoreAgent: (() => void) | null = null;
+  let restoreQuery: (() => void) | null = null;
+
+  panel.handlers.advise("panel:submit", (_next, query: string) => {
+    restoreAgent = compositor.redirect("agent", panelSurface);
+    restoreQuery = compositor.redirect("query", panelSurface);
+    panel.setActive();
+    bus.emit("agent:submit", { query });
+  });
+
+  panel.handlers.advise("panel:dismiss", (next) => {
+    next();
+    restoreAgent?.(); restoreAgent = null;
+    restoreQuery?.(); restoreQuery = null;
+  });
+}
+```
+
+Because the full tui-renderer pipeline still runs — it just writes to the panel surface instead of stdout — the overlay gets markdown rendering, tool grouping, diffs, and syntax highlighting for free.
+
+### Example: diff viewer (sub-stream redirect)
+
+An extension that captures just diff output into a separate panel:
+
+```typescript
+export default function activate(ctx: ExtensionContext): void {
+  const { compositor, createFloatingPanel } = ctx;
+
+  const panel = createFloatingPanel({ trigger: "\x04" }); // Ctrl+D
+  const surface = createPanelSurface(panel);
+
+  panel.handlers.advise("panel:show", (_next) => {
+    // Redirect just the diff sub-stream
+    compositor.redirect("agent:diff", surface);
+  });
+}
+```
+
+Main agent output (text, tools, spinner) continues on stdout. Only diffs route to the panel.
+
+### Example: subagent panel
+
+A panel that shows a subagent's work separately from the main agent:
+
+```typescript
+function onSubagentSpawn(id: string, ctx: ExtensionContext): void {
+  const panel = ctx.createFloatingPanel({ dimBackground: false });
+  const surface = createPanelSurface(panel);
+
+  // This subagent's output goes to its own panel
+  const restore = ctx.compositor.redirect(`agent:sub:${id}`, surface);
+
+  panel.open();
+  // When done, restore routing
+  ctx.bus.on("agent:processing-done", () => {
+    restore();
+    panel.setDone();
+  });
+}
+```
+
+## How tui-renderer uses the compositor
+
+The tui-renderer gets the compositor from `ExtensionContext` and writes to named streams instead of stdout directly:
+
+```typescript
+export default function activate(ctx: ExtensionContext): void {
+  const { compositor } = ctx;
+
+  // Shorthand — get the current agent surface
+  function out(): RenderSurface {
+    return compositor.surface("agent");
+  }
+
+  // Drain markdown renderer lines to the active surface
+  function drain(): void {
+    const surface = out();
+    for (const line of renderer.drainLines()) {
+      surface.writeLine(line);
+    }
+  }
+
+  // Spinner writes directly to the surface
+  setInterval(() => {
+    out().write(`\r  ${spinnerLine}\x1b[K`);
+  }, 80);
+}
+```
+
+The renderer doesn't know whether it's writing to stdout or a panel. The compositor resolves the target on each `surface()` call, so redirects take effect immediately — even mid-response.
+
+## Relationship to other systems
+
+| System | Role | Compositor interaction |
+|---|---|---|
+| **EventBus** | Delivers agent events to tui-renderer | None — events flow regardless of where output goes |
+| **Handler registry** | Advisable render functions (`render:code-block`, etc.) | Handlers produce lines; compositor routes them to surfaces |
+| **FloatingPanel** | Screen compositing, input routing, alt-screen management | Panel provides the surface; compositor routes to it |
+| **MarkdownRenderer** | Streaming markdown → lines | Produces lines; tui-renderer drains them to compositor surface |
+
+The compositor sits between "produce lines" and "display lines". It doesn't affect *what* gets rendered — only *where*.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `src/utils/compositor.ts` | `RenderSurface`, `Compositor`, `DefaultCompositor`, `StdoutSurface` |
+| `src/extensions/tui-renderer.ts` | Main renderer — writes to compositor streams |
+| `src/extensions/overlay-agent.ts` | Redirects streams to floating panel |
+| `src/utils/floating-panel.ts` | Panel screen management and content API |
+| `src/core.ts` | Creates compositor, registers default surfaces |
+| `src/types.ts` | `ExtensionContext.compositor` type |

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -30,7 +30,7 @@ export default function activate({ bus, advise, createFloatingPanel, terminalBuf
   // ── Inject terminal buffer into agent context ──────────────
   if (terminalBuffer) {
     advise("context:build-extra", (next: () => string) =>
-      formatScreenContext(terminalBuffer.readScreen(), 80, next()),
+      formatScreenContext(terminalBuffer.readScreen({ includeScrollback: true }), 80, next()),
     );
   }
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -406,6 +406,7 @@ export class AgentLoop implements AgentBackend {
     // conversation_recall — search/expand evicted conversation turns
     this.toolRegistry.register({
       name: "conversation_recall",
+      displayName: "recall",
       description:
         "Browse, search, or expand evicted conversation turns. " +
         "Use when you need context from earlier in the conversation that was compacted away.",

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -240,9 +240,37 @@ export class AgentLoop implements AgentBackend {
     this.toolRegistry.register(tool);
   }
 
+  /** Unregister a tool by name. */
+  unregisterTool(name: string): void {
+    this.toolRegistry.unregister(name);
+  }
+
   /** Get all registered tools. */
   getTools(): ToolDefinition[] {
     return this.toolRegistry.all();
+  }
+
+  // ── Extension instructions & tool tracking ──────────────────────
+
+  private instructions = new Map<string, string>();
+
+  /** Register a named instruction block for the system prompt. */
+  registerInstruction(name: string, text: string): void {
+    this.instructions.set(name, text);
+  }
+
+  /** Remove a named instruction block. */
+  removeInstruction(name: string): void {
+    this.instructions.delete(name);
+  }
+
+  /** Get instruction blocks registered by extensions. */
+  getInstructionSections(): string[] {
+    const sections: string[] = [];
+    for (const [name, text] of this.instructions) {
+      sections.push(`## ${name}\n${text}`);
+    }
+    return sections;
   }
 
   kill(): void {
@@ -451,10 +479,18 @@ export class AgentLoop implements AgentBackend {
   private registerHandlers(): void {
     const h = this.handlers;
 
+    // System prompt: static identity + behavioral instructions.
+    // Extensions can use registerInstruction() for a managed section,
+    // or advise this handler directly for full control.
+    h.define("system-prompt:build", () => {
+      const instructions = this.getInstructionSections();
+      if (instructions.length === 0) return STATIC_SYSTEM_PROMPT;
+      return STATIC_SYSTEM_PROMPT + "\n\n# Extension Instructions\n\n" + instructions.join("\n\n");
+    });
+
     // Extensions compose additional context (git info, project rules, etc.)
     h.define("dynamic-context:build", () =>
       buildDynamicContext(
-        this.toolRegistry.all(),
         this.contextManager,
         this.tokenBudget.shellBudgetTokens,
       ),
@@ -640,9 +676,9 @@ export class AgentLoop implements AgentBackend {
         }
       }
 
-      // System prompt is static (cacheable); dynamic context uses handler
-      // so extensions can compose additional context via advise()
-      const systemPrompt = STATIC_SYSTEM_PROMPT;
+      // System prompt uses handler so extensions can append instructions (cacheable);
+      // dynamic context uses handler for per-query state via advise()
+      const systemPrompt = this.handlers.call("system-prompt:build") as string;
       const dynamicContext = this.handlers.call("dynamic-context:build");
 
       // Stream LLM response with retry

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -27,6 +27,7 @@ import { ConversationState } from "./conversation-state.js";
 import { HistoryFile } from "./history-file.js";
 import { STATIC_SYSTEM_PROMPT, buildDynamicContext } from "./system-prompt.js";
 import { TokenBudget } from "../token-budget.js";
+import { getSettings } from "../settings.js";
 
 // Core tool factories
 import { createBashTool } from "./tools/bash.js";
@@ -180,8 +181,8 @@ export class AgentLoop implements AgentBackend {
       this.lastProjectSkillNames.clear();
     });
     on("agent:compact-request", () => {
-      const budgetTokens = this.tokenBudget.conversationBudgetTokens;
-      const stats = this.conversation.compact(budgetTokens);
+      // Force compaction: use target of 0 so every non-pinned turn is evicted
+      const stats = this.conversation.compact(0, 10, true);
       this.conversation.flush().catch(() => {});
       if (stats) {
         this.bus.emit("ui:info", {
@@ -664,10 +665,11 @@ export class AgentLoop implements AgentBackend {
     let fullResponseText = "";
 
     while (!signal.aborted) {
-      // Auto-compact if conversation exceeds the model-aware budget
+      // Auto-compact when conversation exceeds threshold fraction of budget
       const budgetTokens = this.tokenBudget.conversationBudgetTokens;
-      if (this.conversation.estimateTokens() > budgetTokens) {
-        const stats = this.conversation.compact(budgetTokens);
+      const autoCompactThreshold = Math.floor(budgetTokens * getSettings().autoCompactThreshold);
+      if (this.conversation.estimateTokens() > autoCompactThreshold) {
+        const stats = this.conversation.compact(autoCompactThreshold);
         await this.conversation.flush();
         if (stats) {
           this.bus.emit("ui:info", {

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -116,9 +116,9 @@ export class ConversationState {
    * them with nuclear one-liner summaries that stay in the conversation.
    * Read-only tool results are dropped entirely.
    */
-  compact(targetTokens: number, recentTurnsToKeep = 10): { before: number; after: number } | null {
+  compact(targetTokens: number, recentTurnsToKeep = 10, force = false): { before: number; after: number } | null {
     const before = this.estimateTokens();
-    if (before <= targetTokens) return null;
+    if (!force && before <= targetTokens) return null;
 
     const turns = this.parseTurns();
     if (turns.length <= 2) return null;

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -110,10 +110,11 @@ export function toNuclearEntries(
 
 /** Format a nuclear entry as a display line (for in-context injection). */
 export function formatNuclearLine(entry: NuclearEntry): string {
-  const time = new Date(entry.ts).toLocaleTimeString("en-US", {
-    hour: "2-digit", minute: "2-digit", hour12: false,
-  });
-  return `#${entry.seq} ${time} ${entry.sum}`;
+  const d = new Date(entry.ts);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  // ISO-ish compact: 2026-04-13 14:05
+  const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `#${entry.seq} [${stamp}] ${entry.sum}`;
 }
 
 // ── Serialization (JSONL for history file) ────────────────────────

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ToolDefinition } from "./types.js";
 import type { ContextManager } from "../context-manager.js";
 import { discoverSkills } from "./skills.js";
 
@@ -68,28 +67,8 @@ Use this to run complete, non-interactive commands in the user's real shell. Use
 - Any command where the user wants real side effects
 - Set return_output=true only if you need to inspect the result
 
-**Terminal interaction** (terminal_read, terminal_keys):
-Use these to observe and interact with what is currently on the user's terminal screen.
-- terminal_read: see what the user sees (current screen contents, cursor position)
-- terminal_keys: send keystrokes as if the user typed them
-Use for: driving interactive programs (vim, htop, less, ssh, REPLs), answering questions
-about what's on screen, or typing at the shell prompt when a program is already running.
-Do NOT use user_shell to interact with an already-running program — use these instead.
-
 Default to scratchpad tools for your own investigation. Use display when the
 user is the intended audience. Use user_shell when the command has real effects.
-Use terminal_read/terminal_keys when interacting with what's already on screen.
-
-# Interactive Overlay Sessions
-
-When the dynamic context includes \`interactive-session: true\`, the user has summoned you
-via a hotkey overlay from inside their live terminal. They may be in the middle of using
-a program (vim, ssh, a REPL, etc.) or at a shell prompt. In this mode:
-- Start with terminal_read if you need to understand what's on screen.
-- Prefer terminal_keys to interact with whatever is currently running.
-- Use user_shell only for running new, standalone commands — not for interacting with
-  what's already on screen.
-- Keep responses concise — the user is in the middle of a workflow.
 
 # Tool Usage Guidelines
 - Use read_file before editing a file you haven't seen
@@ -100,22 +79,15 @@ a program (vim, ssh, a REPL, etc.) or at a shell prompt. In this mode:
 
 /**
  * Build the dynamic context — injected as a user message before each query.
- * Contains everything that changes: tools, shell context, conventions, cwd.
+ * Contains everything that changes: shell context, conventions, cwd.
  *
- * Runs through the "agent:dynamic-context" pipe so extensions can append.
+ * Runs through the "dynamic-context:build" handler so extensions can advise.
  */
 export function buildDynamicContext(
-  tools: ToolDefinition[],
   contextManager: ContextManager,
   shellBudgetTokens?: number,
 ): string {
   const sections: string[] = [];
-
-  // Tools
-  sections.push(
-    "# Available Tools\n" +
-      tools.map((t) => `- ${t.name}: ${t.description}`).join("\n"),
-  );
 
   // Project conventions (CLAUDE.md / AGENT.md)
   const conventions = loadConventionFiles(contextManager.getCwd());

--- a/src/core.ts
+++ b/src/core.ts
@@ -360,7 +360,10 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         registerCommand: (name, description, handler) =>
           bus.emit("command:register", { name, description, handler }),
         registerTool: (tool) => agentLoop?.registerTool(tool),
+        unregisterTool: (name) => agentLoop?.unregisterTool(name),
         getTools: () => agentLoop?.getTools() ?? [],
+        registerInstruction: (name, text) => agentLoop?.registerInstruction(name, text),
+        removeInstruction: (name) => agentLoop?.removeInstruction(name),
         define: (name, fn) => handlers.define(name, fn),
         advise: (name, wrapper) => handlers.advise(name, wrapper),
         call: (name, ...args) => handlers.call(name, ...args),

--- a/src/core.ts
+++ b/src/core.ts
@@ -28,6 +28,7 @@ import { resolveProvider, getProviderNames, type ResolvedProvider } from "./sett
 import { HandlerRegistry } from "./utils/handler-registry.js";
 import { TerminalBuffer } from "./utils/terminal-buffer.js";
 import { FloatingPanel, type FloatingPanelConfig } from "./utils/floating-panel.js";
+import { DefaultCompositor, StdoutSurface } from "./utils/compositor.js";
 
 // Re-export types that library consumers need
 export { EventBus } from "./event-bus.js";
@@ -278,6 +279,13 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     bus.emit("config:changed", {});
   });
 
+  // ── Compositor ──────────────────────────────────────────────
+  const compositor = new DefaultCompositor();
+  const stdoutSurface = new StdoutSurface();
+  compositor.setDefault("agent", stdoutSurface);
+  compositor.setDefault("query", stdoutSurface);
+  compositor.setDefault("status", stdoutSurface);
+
   // ── Lazy singleton terminal buffer ──────────────────────────
   let terminalBufferSingleton: TerminalBuffer | null | undefined; // undefined = not yet created
   const getTerminalBuffer = (): TerminalBuffer | null => {
@@ -372,6 +380,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           const tb = config.dimBackground !== false ? getTerminalBuffer() : null;
           return new FloatingPanel(bus, { ...config, terminalBuffer: tb ?? undefined });
         },
+        compositor,
       };
     },
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -341,7 +341,16 @@ export class EventBus {
     if (!listeners) return payload;
     let result = payload;
     for (const fn of listeners) {
-      result = fn(result);
+      try {
+        const out = fn(result);
+        if (out && typeof (out as any).then === "function") {
+          console.error(`[event-bus] Warning: async handler in sync pipe "${String(event)}" — use onPipeAsync instead`);
+          continue;
+        }
+        result = out;
+      } catch (err) {
+        console.error(`[event-bus] Pipe handler error in "${String(event)}":`, err instanceof Error ? err.message : err);
+      }
     }
     return result;
   }

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -328,6 +328,17 @@ export class EventBus {
     listeners.push(fn);
   }
 
+  /** Remove a transform listener from a pipeline event. */
+  offPipe<K extends keyof ShellEvents>(
+    event: K,
+    fn: PipeListener<ShellEvents[K]>,
+  ): void {
+    const listeners = this.pipeListeners.get(event);
+    if (!listeners) return;
+    const idx = listeners.indexOf(fn);
+    if (idx !== -1) listeners.splice(idx, 1);
+  }
+
   /**
    * Emit a pipeline event — each registered pipe listener receives the
    * output of the previous one. Returns the final transformed payload.

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtensionContext } from "./types.js";
+import type { EventBus } from "./event-bus.js";
 import { CONFIG_DIR, getSettings } from "./settings.js";
 
 const EXT_DIR = path.join(CONFIG_DIR, "extensions");
@@ -20,6 +21,75 @@ async function ensureTsSupport(): Promise<void> {
     // tsx not available — TS extensions will fail with a clear error
   }
 }
+
+// ── Scoped context for reloadable extensions ────────────────────
+
+type Cleanup = () => void;
+
+/**
+ * Wrap an ExtensionContext to track all registrations (bus.on, bus.onPipe,
+ * advise, command:register). Returns the wrapped context and a dispose()
+ * function that tears down everything registered through it.
+ */
+function createScopedContext(ctx: ExtensionContext): { scoped: ExtensionContext; dispose: () => void } {
+  const cleanups: Cleanup[] = [];
+  const bus = ctx.bus;
+
+  const scopedBus: EventBus = Object.create(bus);
+
+  // Track bus.on registrations
+  scopedBus.on = ((event: any, fn: any) => {
+    bus.on(event, fn);
+    cleanups.push(() => bus.off(event, fn));
+  }) as typeof bus.on;
+
+  // Track bus.onPipe registrations
+  scopedBus.onPipe = ((event: any, fn: any) => {
+    bus.onPipe(event, fn);
+    cleanups.push(() => bus.offPipe(event, fn));
+  }) as typeof bus.onPipe;
+
+  // Track advise registrations
+  const scopedAdvise: typeof ctx.advise = (name, wrapper) => {
+    const unadvise = ctx.advise(name, wrapper);
+    cleanups.push(unadvise);
+    return unadvise;
+  };
+
+  // Track instruction registrations
+  const scopedRegisterInstruction: typeof ctx.registerInstruction = (name, text) => {
+    ctx.registerInstruction(name, text);
+    cleanups.push(() => ctx.removeInstruction(name));
+  };
+
+  // Track tool registrations
+  const scopedRegisterTool: typeof ctx.registerTool = (tool) => {
+    ctx.registerTool(tool);
+    cleanups.push(() => ctx.unregisterTool(tool.name));
+  };
+
+  const scoped: ExtensionContext = {
+    ...ctx,
+    bus: scopedBus,
+    advise: scopedAdvise,
+    registerInstruction: scopedRegisterInstruction,
+    removeInstruction: ctx.removeInstruction,
+    registerTool: scopedRegisterTool,
+    unregisterTool: ctx.unregisterTool,
+  };
+
+  const dispose = () => {
+    for (const fn of cleanups) {
+      try { fn(); } catch { /* ignore */ }
+    }
+    cleanups.length = 0;
+  };
+
+  return { scoped, dispose };
+}
+
+// Track disposers for user extensions so reload can tear them down
+const extensionDisposers = new Map<string, () => void>();
 
 
 /**
@@ -54,26 +124,8 @@ export async function loadExtensions(
   }
 
   // 3. ~/.agent-sh/extensions/ directory
-  try {
-    const entries = await fs.readdir(EXT_DIR, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(EXT_DIR, entry.name);
-      // Resolve symlinks to check if they point to directories
-      const isDir = entry.isDirectory() ||
-        (entry.isSymbolicLink() && (await fs.stat(fullPath)).isDirectory());
-      if (isDir) {
-        // Directory extension: look for index.{ts,js,mjs,...}
-        const indexFile = await findIndex(fullPath);
-        if (indexFile) {
-          specifiers.push(indexFile);
-        }
-      } else if (SCRIPT_EXTS.some((ext) => entry.name.endsWith(ext))) {
-        specifiers.push(fullPath);
-      }
-    }
-  } catch {
-    // Directory doesn't exist — no user extensions
-  }
+  const userSpecifiers = await discoverUserExtensions();
+  specifiers.push(...userSpecifiers);
 
   // Deduplicate
   const seen = new Set<string>();
@@ -83,14 +135,51 @@ export async function loadExtensions(
     return true;
   });
 
-  // Load each extension
+  // Load each extension (user extensions get scoped contexts for reloadability)
+  const loaded = await loadSpecifiers(unique, ctx, false, userSpecifiers);
+  return loaded;
+}
+
+async function discoverUserExtensions(): Promise<string[]> {
+  const specifiers: string[] = [];
+  try {
+    const entries = await fs.readdir(EXT_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(EXT_DIR, entry.name);
+      const isDir = entry.isDirectory() ||
+        (entry.isSymbolicLink() && (await fs.stat(fullPath)).isDirectory());
+      if (isDir) {
+        const indexFile = await findIndex(fullPath);
+        if (indexFile) specifiers.push(indexFile);
+      } else if (SCRIPT_EXTS.some((ext) => entry.name.endsWith(ext))) {
+        specifiers.push(fullPath);
+      }
+    }
+  } catch {
+    // Directory doesn't exist — no user extensions
+  }
+  return specifiers;
+}
+
+async function loadSpecifiers(
+  specifiers: string[],
+  ctx: ExtensionContext,
+  bustCache: boolean,
+  userSpecifiers?: string[],
+): Promise<string[]> {
+  const userSet = new Set(userSpecifiers ?? []);
   const loaded: string[] = [];
-  for (const specifier of unique) {
+  for (const specifier of specifiers) {
     try {
-      const importPath = await resolveSpecifier(specifier);
+      let importPath = await resolveSpecifier(specifier);
 
       if (TS_EXTS.some((ext) => importPath.endsWith(ext))) {
         await ensureTsSupport();
+      }
+      // Append timestamp query to bust Node's module cache on reload
+      if (bustCache) {
+        const sep = importPath.includes("?") ? "&" : "?";
+        importPath += `${sep}t=${Date.now()}`;
       }
       const mod = await import(importPath);
       // tsx may double-wrap default exports: mod.default.default
@@ -100,10 +189,20 @@ export async function loadExtensions(
           ? mod.default.default
           : mod.activate;
       if (typeof activate === "function") {
-        activate(ctx);
-        // Extract a short name from the specifier
         const base = path.basename(specifier).replace(/\.(ts|js|mjs|mts|tsx)$/, "");
         const name = base === "index" ? path.basename(path.dirname(specifier)) : base;
+
+        // User extensions get a scoped context so /reload can tear them down
+        if (userSet.has(specifier)) {
+          // Dispose previous load if reloading
+          extensionDisposers.get(name)?.();
+
+          const { scoped, dispose } = createScopedContext(ctx);
+          activate(scoped);
+          extensionDisposers.set(name, dispose);
+        } else {
+          activate(ctx);
+        }
         loaded.push(name);
       }
     } catch (err) {
@@ -112,8 +211,16 @@ export async function loadExtensions(
       });
     }
   }
-
   return loaded;
+}
+
+/**
+ * Reload user extensions (from ~/.agent-sh/extensions/).
+ * Tears down old registrations, busts the module cache, and re-activates.
+ */
+export async function reloadExtensions(ctx: ExtensionContext): Promise<string[]> {
+  const specifiers = await discoverUserExtensions();
+  return loadSpecifiers(specifiers, ctx, true, specifiers);
 }
 
 /**

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -5,33 +5,78 @@
  * inside vim, htop, or ssh. Composites a floating response box on top
  * of the current terminal content.
  *
- * Rendering reuses the shared tui:render-* handlers so that extensions
- * advising those handlers affect both the main TUI and the overlay.
+ * Uses the compositor to redirect agent output into the floating panel.
+ * The full tui-renderer pipeline (markdown, tool grouping, spinner, diffs)
+ * applies — the overlay just changes *where* the output goes.
  *
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  */
 import type { ExtensionContext } from "../types.js";
-import { MarkdownRenderer } from "../utils/markdown.js";
-import { palette as p } from "../utils/palette.js";
-import {
-  renderToolCall,
-  formatElapsed,
-} from "../utils/tool-display.js";
+import type { RenderSurface } from "../utils/compositor.js";
+import type { FloatingPanel } from "../utils/floating-panel.js";
 
-interface ChatMessage {
-  role: "user" | "assistant";
-  lines: string[];
+/** Adapt a FloatingPanel to the RenderSurface interface. */
+function createPanelSurface(panel: FloatingPanel): RenderSurface {
+  return {
+    write(text: string): void {
+      // Handle \r (carriage return) — overwrite the current line.
+      // The spinner uses "\r  <content>\x1b[K" to update in-place.
+      if (text.startsWith("\r")) {
+        // Strip \r and any erase-line sequences
+        const cleaned = text.replace(/^\r/, "").replace(/\x1b\[\d*K/g, "");
+        if (cleaned.trim()) {
+          panel.updateLastLine(() => cleaned);
+        }
+        return;
+      }
+
+      // Regular text — may contain newlines
+      panel.appendText(text);
+    },
+    writeLine(line: string): void {
+      panel.appendLine(line);
+    },
+    get columns(): number {
+      return panel.computeGeometry().contentW;
+    },
+  };
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, advise, call, createFloatingPanel, registerInstruction } = ctx;
+  const { bus, compositor, advise, registerInstruction, createFloatingPanel } = ctx;
 
   const panel = createFloatingPanel({
     trigger: "\x1c", // Ctrl+\
     dimBackground: true,
   });
 
-  // Suppress TUI renderer when overlay owns agent output
+  const panelSurface = createPanelSurface(panel);
+
+  // ── Compositor routing ────────────────────────────────────────
+  // When the panel is active, redirect all render streams to it.
+  let restoreAgent: (() => void) | null = null;
+  let restoreQuery: (() => void) | null = null;
+  let restoreStatus: (() => void) | null = null;
+
+  function redirectToPanel(): void {
+    if (restoreAgent) return; // already redirected
+    restoreAgent = compositor.redirect("agent", panelSurface);
+    restoreQuery = compositor.redirect("query", panelSurface);
+    restoreStatus = compositor.redirect("status", panelSurface);
+  }
+
+  function restoreRouting(): void {
+    restoreAgent?.();
+    restoreQuery?.();
+    restoreStatus?.();
+    restoreAgent = restoreQuery = restoreStatus = null;
+  }
+
+  // Suppress TUI renderer when overlay owns agent output.
+  // TODO: Once tui-renderer fully uses compositor routing, remove this gate
+  // and let the compositor redirect handle everything. The tui-renderer's
+  // full pipeline (markdown, tool grouping, diffs) would then apply to the
+  // overlay too — which is the desired end state.
   advise("tui:should-render-agent", (next) => {
     return panel.active ? false : next();
   });
@@ -54,138 +99,29 @@ export default function activate(ctx: ExtensionContext): void {
     return base + "\ninteractive-session: true\n";
   });
 
-  // ── Conversation state (persists across hide/show) ─────────
-  const messages: ChatMessage[] = [];
-  let renderer: MarkdownRenderer | null = null;
-  let currentAssistantMsg: ChatMessage | null = null;
-
-  // ── Tool state ─────────────────────────────────────────────
-  let toolStartTime = 0;
-
-  function getContentWidth(): number {
-    return panel.computeGeometry().contentW;
-  }
-
-  /** Rebuild panel content from full message history. */
-  function rebuildContent(): void {
-    panel.clearContent();
-    for (const msg of messages) {
-      for (const line of msg.lines) {
-        panel.appendLine(line);
-      }
-      panel.appendLine("");
-    }
-  }
-
-  /** Append a line to current assistant message and panel (if visible). */
-  function appendLine(line: string): void {
-    currentAssistantMsg?.lines.push(line);
-    if (panel.visible) panel.appendLine(line);
-  }
-
-  function drainRenderer(): void {
-    if (!renderer) return;
-    for (const line of renderer.drainLines()) {
-      appendLine(line);
-    }
-  }
-
-  function flushRenderer(): void {
-    if (!renderer) return;
-    renderer.flush();
-    drainRenderer();
-  }
-
-  function startAssistantMessage(): void {
-    flushRenderer();
-    currentAssistantMsg = { role: "assistant", lines: [] };
-    messages.push(currentAssistantMsg);
-    renderer = new MarkdownRenderer(getContentWidth());
-  }
-
-  function finalizeAssistantMessage(): void {
-    flushRenderer();
-    renderer = null;
-    currentAssistantMsg = null;
-  }
-
-  // ── Panel lifecycle ────────────────────────────────────────
+  // ── Panel lifecycle ────────────────────────────────────────────
 
   panel.handlers.advise("panel:submit", (_next, query: string) => {
-    messages.push({
-      role: "user",
-      lines: [`${p.accent}${p.bold}❯${p.reset} ${query}`],
-    });
-
+    redirectToPanel();
     panel.setActive();
-    rebuildContent();
-    startAssistantMessage();
     bus.emit("agent:submit", { query });
   });
 
   panel.handlers.advise("panel:show", (_next) => {
-    rebuildContent();
-    if (renderer) drainRenderer();
+    if (panel.active) redirectToPanel();
   });
 
-  // ── Stream agent response into panel ───────────────────────
-
-  bus.on("agent:response-chunk", (e) => {
-    if (!panel.active) return;
-    if (!currentAssistantMsg) startAssistantMessage();
-
-    for (const block of e.blocks) {
-      if (block.type === "text" && block.text) {
-        renderer!.push(block.text);
-        drainRenderer();
-      } else if (block.type === "code-block") {
-        flushRenderer();
-        // Reuse the shared code-block handler
-        call("render:code-block", block.language, block.code, getContentWidth());
-      }
-    }
-  });
-
-  // Capture lines emitted by render:code-block into the overlay
-  advise("render:code-block", (next, language: string, code: string, width: number) => {
-    if (!panel.active) return next(language, code, width);
-    // Render code block as indented dim lines for the overlay
-    const label = language ? `${p.dim}${language}${p.reset}` : "";
-    if (label) appendLine(label);
-    for (const codeLine of code.split("\n")) {
-      appendLine(`  ${p.dim}${codeLine}${p.reset}`);
-    }
-  });
-
-  bus.on("agent:tool-started", (e) => {
-    if (!panel.active) return;
-    if (!currentAssistantMsg) startAssistantMessage();
-    flushRenderer();
-    toolStartTime = Date.now();
-
-    const lines = renderToolCall({
-      title: e.title,
-      kind: e.kind,
-      icon: e.icon,
-      locations: e.locations,
-      rawInput: e.rawInput,
-      displayDetail: e.displayDetail,
-    }, getContentWidth());
-
-    for (const line of lines) appendLine(line);
-  });
-
-  bus.on("agent:tool-completed", (e) => {
-    if (!panel.active) return;
-
-    const elapsed = toolStartTime ? formatElapsed(Date.now() - toolStartTime) : "";
-    const mark: string = call("tui:render-tool-complete", e.exitCode, elapsed, undefined);
-    appendLine(`  ${mark}`);
+  // Restore routing on hide (panel:dismiss is the hide handler)
+  panel.handlers.advise("panel:dismiss", (next) => {
+    next();
+    restoreRouting();
   });
 
   bus.on("agent:processing-done", () => {
     if (!panel.active) return;
-    finalizeAssistantMessage();
     panel.setDone();
+    // setDone() may trigger dismiss() which resets phase to idle.
+    // If that happened, restore routing now (dismiss() doesn't call panel:dismiss).
+    if (!panel.active) restoreRouting();
   });
 }

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -24,7 +24,7 @@ interface ChatMessage {
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, advise, call, createFloatingPanel } = ctx;
+  const { bus, advise, call, createFloatingPanel, registerInstruction } = ctx;
 
   const panel = createFloatingPanel({
     trigger: "\x1c", // Ctrl+\
@@ -35,6 +35,17 @@ export default function activate(ctx: ExtensionContext): void {
   advise("tui:should-render-agent", (next) => {
     return panel.active ? false : next();
   });
+
+  registerInstruction("Interactive Overlay Sessions", [
+    "When the dynamic context includes `interactive-session: true`, the user has summoned you",
+    "via a hotkey overlay from inside their live terminal. They may be in the middle of using",
+    "a program (vim, ssh, a REPL, etc.) or at a shell prompt. In this mode:",
+    "- Start with terminal_read if you need to understand what's on screen.",
+    "- Prefer terminal_keys to interact with whatever is currently running.",
+    "- Use user_shell only for running new, standalone commands — not for interacting with",
+    "  what's already on screen.",
+    "- Keep responses concise — the user is in the middle of a workflow.",
+  ].join("\n"));
 
   // Signal interactive overlay mode in dynamic context
   advise("dynamic-context:build", (next) => {

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -13,6 +13,7 @@
 import { palette as p } from "../utils/palette.js";
 import type { ExtensionContext } from "../types.js";
 import { discoverSkills, loadSkillContent, type Skill } from "../agent/skills.js";
+import { reloadExtensions } from "../extension-loader.js";
 
 interface SlashCommand {
   name: string;
@@ -20,7 +21,8 @@ interface SlashCommand {
   handler: (args: string) => Promise<void> | void;
 }
 
-export default function activate({ bus, contextManager }: ExtensionContext): void {
+export default function activate(ctx: ExtensionContext): void {
+  const { bus, contextManager } = ctx;
   const commands = new Map<string, SlashCommand>();
 
   const register = (cmd: SlashCommand) => {
@@ -116,6 +118,19 @@ export default function activate({ bus, contextManager }: ExtensionContext): voi
         `Recall archive: ${stats.recallArchiveSize} entries`,
       ];
       bus.emit("ui:info", { message: lines.join("\n") });
+    },
+  });
+
+  register({
+    name: "/reload",
+    description: "Reload user extensions from ~/.agent-sh/extensions/",
+    handler: async () => {
+      const names = await reloadExtensions(ctx);
+      if (names.length > 0) {
+        bus.emit("ui:info", { message: `Reloaded: ${names.join(", ")}` });
+      } else {
+        bus.emit("ui:info", { message: "No extensions to reload." });
+      }
     },
   });
 

--- a/src/extensions/terminal-buffer.ts
+++ b/src/extensions/terminal-buffer.ts
@@ -29,7 +29,8 @@ function settle(ms = 100): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export default function activate({ bus, terminalBuffer: tb, registerTool }: ExtensionContext): void {
+export default function activate(ctx: ExtensionContext): void {
+  const { bus, terminalBuffer: tb, registerTool, registerInstruction } = ctx;
   if (!tb) return; // @xterm/headless not installed
 
   registerTool({
@@ -41,7 +42,15 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
       "diagnosing errors on screen, or checking state before/after sending keystrokes with terminal_keys.",
     input_schema: {
       type: "object",
-      properties: {},
+      properties: {
+        include_scrollback: {
+          type: "boolean",
+          description:
+            "If true, include scrollback buffer (content that scrolled off screen) " +
+            "in addition to the visible viewport. Useful for capturing output from " +
+            "long-running or streaming commands. Default: false.",
+        },
+      },
     },
     showOutput: true,
 
@@ -51,8 +60,9 @@ export default function activate({ bus, terminalBuffer: tb, registerTool }: Exte
       locations: [],
     }),
 
-    async execute() {
-      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
+    async execute(args) {
+      const includeScrollback = (args.include_scrollback as boolean) ?? false;
+      const { text, altScreen, cursorX, cursorY } = tb.readScreen({ includeScrollback });
       const info = [
         altScreen ? "mode: alternate screen" : "mode: normal",
         `cursor: row=${cursorY} col=${cursorX}`,

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -654,7 +654,7 @@ export default function activate(ctx: ExtensionContext): void {
   /** Render a diff as framed box lines (pure — no TUI state side effects). */
   function renderDiffBody(diff: DiffResult, filePath: string, width: number): string[] {
     if (diff.isIdentical) return [];
-    const boxW = Math.min(120, width);
+    const boxW = Math.min(120, width - 2);  // -2 for writeLine indent
     const contentW = boxW - 4;
 
     const diffLines = renderDiff(diff, {
@@ -998,7 +998,7 @@ export default function activate(ctx: ExtensionContext): void {
 
     if (!entry.expandedLines) {
       const { filePath, diff } = entry;
-      const boxW = Math.min(120, writer.columns);
+      const boxW = Math.min(120, writer.columns - 2);  // -2 for writeLine indent
       const contentW = boxW - 4;
 
       const diffLines = renderDiff(diff, {

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -28,7 +28,7 @@ import type { DiffResult } from "../utils/diff.js";
 import { getSettings } from "../settings.js";
 import type { ExtensionContext } from "../types.js";
 import type { ToolResultDisplay, ToolResultBody } from "../agent/types.js";
-import { StdoutWriter } from "../utils/output-writer.js";
+import type { RenderSurface } from "../utils/compositor.js";
 
 /** Encode a PNG buffer as a terminal inline image escape sequence. */
 function encodeImageForTerminal(data: Buffer): string | null {
@@ -134,13 +134,11 @@ function createRenderState(): RenderState {
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, llmClient, define } = ctx;
-  const writer = new StdoutWriter();
+  const { bus, llmClient, define, compositor } = ctx;
   const s = createRenderState();
 
-  // Suppress all TUI output while stdout is held (overlay extensions)
-  bus.on("shell:stdout-hold", () => { writer.hold(); });
-  bus.on("shell:stdout-release", () => { writer.release(); });
+  /** Shorthand — get the current agent surface. */
+  function out(): RenderSurface { return compositor.surface("agent"); }
 
   // Gate: other extensions (e.g. overlay) can advise this to suppress
   // TUI rendering of agent output while they own the display.
@@ -290,7 +288,7 @@ export default function activate(ctx: ExtensionContext): void {
           break;
         case "raw":
           flushForRaw();
-          writer.write(block.escape);
+          out().write(block.escape);
           break;
       }
     }
@@ -480,7 +478,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
   bus.on("ui:error", (e) => showError(e.message));
   bus.on("ui:suggestion", (e) => {
-    writer.write(`${p.dim}💡 ${e.text}${p.reset}\n`);
+    compositor.surface("status").writeLine(`${p.dim}💡 ${e.text}${p.reset}`);
   });
 
   // ── Rendering functions ─────────────────────────────────────
@@ -488,7 +486,7 @@ export default function activate(ctx: ExtensionContext): void {
   function drain(): void {
     if (!s.renderer) return;
     for (const line of s.renderer.drainLines()) {
-      writer.write(line + "\n");
+      out().write(line + "\n");
       // Track whether we just emitted a blank line (for contentGap dedup).
       // Lines from the renderer are indented ("  "), so a blank line is "  " or empty.
       lastEmittedLineBlank = line.trimEnd() === "" || line.trimEnd().replace(/\x1b\[[^m]*m/g, "").trim() === "";
@@ -496,7 +494,7 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function startAgentResponse(): void {
-    s.renderer = new MarkdownRenderer(writer.columns);
+    s.renderer = new MarkdownRenderer(out().columns);
     s.hadToolCalls = false;
     s.renderer.printTopBorder();
     drain();
@@ -515,7 +513,7 @@ export default function activate(ctx: ExtensionContext): void {
       const gap: string | null = ctx.call("tui:render-content-gap", s.lastContentKind, kind);
       if (gap) {
         if (s.renderer) { s.renderer.flush(); drain(); }
-        writer.write(gap);
+        out().write(gap);
       }
     }
     s.lastContentKind = kind;
@@ -538,7 +536,7 @@ export default function activate(ctx: ExtensionContext): void {
       s.renderer.flush();
       s.renderer.printBottomBorder();
       drain();
-      writer.write("\n");
+      out().write("\n");
       s.renderer = null;
     }
   }
@@ -555,10 +553,11 @@ export default function activate(ctx: ExtensionContext): void {
       modelLabel = `${p.bold}${backend}${p.reset}`;
     }
 
-    const framed: string[] = ctx.call("tui:render-user-query", query, writer.columns, modelLabel);
-    writer.write("\n");
+    const querySurface = compositor.surface("query");
+    const framed: string[] = ctx.call("tui:render-user-query", query, querySurface.columns, modelLabel);
+    querySurface.write("\n");
     for (const line of framed) {
-      writer.write(line + "\n");
+      querySurface.writeLine(line);
     }
   }
 
@@ -570,7 +569,7 @@ export default function activate(ctx: ExtensionContext): void {
       s.isThinking = false;
       if (s.showThinkingText && s.renderer) {
         s.renderer.flush();
-        const w = Math.min(80, writer.columns);
+        const w = Math.min(80, out().columns);
         s.renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
         drain();
       }
@@ -609,7 +608,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   function writeCodeBlock(language: string, code: string): void {
-    ctx.call("render:code-block", language, code, writer.columns);
+    ctx.call("render:code-block", language, code, out().columns);
   }
 
   function flushForRaw(): void {
@@ -624,7 +623,7 @@ export default function activate(ctx: ExtensionContext): void {
     flushForRaw();
     const escape = encodeImageForTerminal(data);
     if (escape) {
-      writer.write("  " + escape + "\n");
+      out().write("  " + escape + "\n");
     }
   });
 
@@ -760,13 +759,13 @@ export default function activate(ctx: ExtensionContext): void {
       locations: extra?.locations,
       rawInput: extra?.rawInput,
       displayDetail: extra?.displayDetail,
-    }, writer.columns);
+    }, out().columns);
 
     if (extra?.groupContinuation && lines.length > 0) {
       // Swap the colored kind icon for a muted tree connector,
       // and strip the tool name prefix — show detail only.
       const detail = extra.displayDetail || extractDetail(extra);
-      const maxW = Math.max(1, writer.columns - 6);
+      const maxW = Math.max(1, out().columns - 6);
       const text = detail.length > maxW ? detail.slice(0, maxW - 1) + "…" : detail;
       lines[0] = detail
         ? `${p.muted}├${p.reset} ${p.dim}${text}${p.reset}`
@@ -786,7 +785,7 @@ export default function activate(ctx: ExtensionContext): void {
         drain();
         s.toolLineOpen = false;
       } else {
-        writer.write(`  ${batchPrefix}${lines[lines.length - 1]}`);
+        out().write(`  ${batchPrefix}${lines[lines.length - 1]}`);
         s.toolLineOpen = true;
       }
     }
@@ -802,7 +801,7 @@ export default function activate(ctx: ExtensionContext): void {
     const mark: string = ctx.call("tui:render-tool-complete", exitCode, elapsed, resultDisplay?.summary);
 
     if (s.toolLineOpen && s.commandOutputLineCount === 0) {
-      writer.write(` ${mark}\n`);
+      out().write(` ${mark}\n`);
       s.toolLineOpen = false;
     } else {
       closeToolLine();
@@ -819,7 +818,7 @@ export default function activate(ctx: ExtensionContext): void {
 
   function renderResultBody(body: ToolResultBody): void {
     if (!s.renderer) return;
-    const lines: string[] = ctx.call("render:result-body", body, writer.columns) ?? [];
+    const lines: string[] = ctx.call("render:result-body", body, out().columns) ?? [];
     for (const line of lines) {
       s.renderer!.writeLine(line);
     }
@@ -848,7 +847,7 @@ export default function activate(ctx: ExtensionContext): void {
         s.spinner.frame++;
         const elapsed = formatElapsed(Date.now() - s.spinner.startTime);
         const line: string = ctx.call("tui:render-spinner", s.spinnerLabel, frame, elapsed, s.spinnerOpts.hint);
-        writer.write(`\r  ${line}\x1b[K`);
+        out().write(`\r  ${line}\x1b[K`);
       }
     }, 80);
   }
@@ -859,14 +858,14 @@ export default function activate(ctx: ExtensionContext): void {
       s.spinnerInterval = null;
     }
     if (s.spinner) {
-      writer.write("\r\x1b[2K");
+      out().write("\r\x1b[2K");
       s.spinner = null;
     }
   }
 
   function closeToolLine(): void {
     if (s.toolLineOpen) {
-      writer.write("\n");
+      out().write("\n");
       s.toolLineOpen = false;
     }
   }
@@ -975,7 +974,7 @@ export default function activate(ctx: ExtensionContext): void {
     const lines: string[] = ctx.call(
       "render:result-body",
       { kind: "diff", diff, filePath } satisfies ToolResultBody,
-      writer.columns,
+      out().columns,
     ) ?? [];
 
     if (!s.renderer) startAgentResponse();
@@ -998,7 +997,7 @@ export default function activate(ctx: ExtensionContext): void {
 
     if (!entry.expandedLines) {
       const { filePath, diff } = entry;
-      const boxW = Math.min(120, writer.columns - 2);  // -2 for writeLine indent
+      const boxW = Math.min(120, out().columns - 2);  // -2 for writeLine indent
       const contentW = boxW - 4;
 
       const diffLines = renderDiff(diff, {
@@ -1019,9 +1018,9 @@ export default function activate(ctx: ExtensionContext): void {
       });
     }
 
-    writer.write("\n");
+    out().write("\n");
     for (const line of entry.expandedLines) {
-      writer.write(line + "\n");
+      out().write(line + "\n");
     }
   }
 
@@ -1029,12 +1028,12 @@ export default function activate(ctx: ExtensionContext): void {
     const lines: string[] = ctx.call(
       "render:result-body",
       { kind: "diff", diff: entry.diff, filePath: entry.filePath } satisfies ToolResultBody,
-      writer.columns,
+      out().columns,
     ) ?? [];
 
-    writer.write("\n");
+    out().write("\n");
     for (const line of lines) {
-      writer.write(line + "\n");
+      out().write(line + "\n");
     }
   }
 
@@ -1065,7 +1064,7 @@ export default function activate(ctx: ExtensionContext): void {
     } else {
       if (s.renderer) {
         s.renderer.flush();
-        const w = Math.min(80, writer.columns);
+        const w = Math.min(80, out().columns);
         s.renderer.writeLine(`${p.dim}${"─".repeat(w)}${p.reset}`);
         drain();
       }
@@ -1074,10 +1073,11 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function showError(message: string): void {
-    writer.write("\n" + ctx.call("tui:render-error", message) + "\n");
+    const s = compositor.surface("status");
+    s.write("\n" + ctx.call("tui:render-error", message) + "\n");
   }
 
   function showInfo(message: string): void {
-    writer.write(ctx.call("tui:render-info", message) + "\n");
+    compositor.surface("status").writeLine(ctx.call("tui:render-info", message));
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,13 @@ async function main(): Promise<void> {
     const shellEnv = await captureShellEnvAsync(shellPath);
     if (Object.keys(shellEnv).length > 0) {
       Object.assign(baseEnv, mergeShellEnv(baseEnv, shellEnv));
+      // Expose captured env vars to process.env so extensions can read them.
+      // Only add vars not already present to avoid clobbering runtime state.
+      for (const [k, v] of Object.entries(baseEnv)) {
+        if (process.env[k] === undefined) {
+          process.env[k] = v;
+        }
+      }
       if (process.env.DEBUG) {
         console.error('[agent-sh] Shell environment captured');
       }

--- a/src/input-handler.ts
+++ b/src/input-handler.ts
@@ -149,7 +149,7 @@ export class InputHandler {
       }
       this.promptWrappedLines = totalTermLines - 1;
 
-      // Position cursor: find which line and column the cursor is on
+      // Position cursor: find which logical line and column the cursor is on
       let charsRemaining = this.editor.cursor;
       let cursorLine = 0;
       for (let li = 0; li < lines.length; li++) {
@@ -161,13 +161,33 @@ export class InputHandler {
         cursorLine = li + 1;
       }
 
-      // Move from end position to cursor position
-      const linesFromEnd = lines.length - 1 - cursorLine;
-      if (linesFromEnd > 0) {
-        process.stdout.write(`\x1b[${linesFromEnd}A`);
+      // Compute terminal rows for cursor positioning (not logical lines)
+      // Each logical line may wrap across multiple terminal rows.
+      const cursorColAbs = promptVisLen + charsRemaining;
+      const cursorTermRow = Math.floor(cursorColAbs / termW);
+
+      // Count terminal rows occupied by lines after cursor's logical line
+      let termRowsAfterCursor = 0;
+      for (let li = cursorLine + 1; li < lines.length; li++) {
+        const lineVisLen = promptVisLen + lines[li]!.length;
+        termRowsAfterCursor += lineVisLen > 0 ? Math.ceil(lineVisLen / termW) : 1;
       }
-      const cursorCol = (cursorLine === 0 ? promptVisLen : promptVisLen) + charsRemaining;
-      process.stdout.write(`\r\x1b[${cursorCol}C`);
+
+      // Also count remaining terminal rows on cursor's own logical line
+      const cursorLineVisLen = promptVisLen + lines[cursorLine]!.length;
+      const cursorLineTotalRows = cursorLineVisLen > 0 ? Math.ceil(cursorLineVisLen / termW) : 1;
+      const rowsAfterCursorInLine = cursorLineTotalRows - 1 - cursorTermRow;
+
+      const totalRowsFromEnd = termRowsAfterCursor + rowsAfterCursorInLine;
+      if (totalRowsFromEnd > 0) {
+        process.stdout.write(`\x1b[${totalRowsFromEnd}A`);
+      }
+      const cursorCol = cursorColAbs % termW;
+      if (cursorCol > 0) {
+        process.stdout.write(`\r\x1b[${cursorCol}C`);
+      } else {
+        process.stdout.write(`\r`);
+      }
     }
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,6 +72,8 @@ export interface Settings {
   historyStartupEntries?: number;
   /** Max nuclear entries kept in-context before flushing to history file (default: 200). */
   nuclearMaxEntries?: number;
+  /** Auto-compact threshold as fraction of conversation budget (0-1, default 0.5). */
+  autoCompactThreshold?: number;
 
   // ── Display ───────────────────────────────────────────────
   /** Max command output lines shown inline in TUI. */
@@ -108,6 +110,7 @@ const DEFAULTS: Required<Settings> = {
   historyMaxBytes: 102400,
   historyStartupEntries: 50,
   nuclearMaxEntries: 200,
+  autoCompactThreshold: 0.5,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,
   diffMaxLines: 20,

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -272,14 +272,16 @@ export class Shell implements InputContext {
    * Routed through shell:redraw-prompt pipe so extensions (e.g. overlay)
    * can suppress it by setting `handled: true`.
    */
-  freshPrompt(): void {
+  freshPrompt(): boolean {
     const result = this.bus.emitPipe("shell:redraw-prompt", {
       cwd: this.outputParser.getCwd(),
       handled: false,
     });
     if (!result.handled) {
       this.ptyProcess.write("\n");
+      return true;
     }
+    return false;
   }
 
   onCommandEntered(command: string, cwd: string): void {
@@ -331,9 +333,12 @@ export class Shell implements InputContext {
     this.bus.on("agent:processing-done", () => {
       this.paused = false;
       this.agentActive = false;
-      this.echoSkip = true;
       if (!this.inputHandler.handleProcessingDone()) {
-        this.freshPrompt();
+        // echoSkip only when freshPrompt actually wrote \n to the PTY.
+        // When the overlay suppresses freshPrompt, no echo to skip.
+        if (this.freshPrompt()) {
+          this.echoSkip = true;
+        }
       }
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils
 import type { ToolDefinition } from "./agent/types.js";
 import type { TerminalBuffer } from "./utils/terminal-buffer.js";
 import type { FloatingPanel, FloatingPanelConfig } from "./utils/floating-panel.js";
+import type { Compositor } from "./utils/compositor.js";
 
 export type { ContentBlock } from "./event-bus.js";
 export type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
@@ -100,6 +101,13 @@ export interface ExtensionContext {
    * handler-based customization.
    */
   createFloatingPanel: (config: FloatingPanelConfig) => FloatingPanel;
+
+  // ── Compositor ─────────────────────────────────────────────────
+  /**
+   * Routes named render streams ("agent", "query", "status") to surfaces.
+   * Extensions use `compositor.redirect()` to capture output (e.g. overlay panels).
+   */
+  compositor: Compositor;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,14 +69,22 @@ export interface ExtensionContext {
   // ── Tool registration (agent-sh backend only) ─────────────
   /** Register a tool for the built-in agent. No-op when using bridge backends. */
   registerTool: (tool: ToolDefinition) => void;
+  /** Unregister a tool by name. */
+  unregisterTool: (name: string) => void;
   /** Get all registered tools (for subagent tool subsets). Returns [] when using bridge backends. */
   getTools: () => ToolDefinition[];
+
+  // ── System prompt instructions ────────────────────────────
+  /** Register a named instruction block for the agent's system prompt. */
+  registerInstruction: (name: string, text: string) => void;
+  /** Remove a named instruction block from the system prompt. */
+  removeInstruction: (name: string) => void;
 
   // ── Named handler registry (Emacs-style advice) ───────────
   /** Register a named handler. */
   define: (name: string, fn: (...args: any[]) => any) => void;
-  /** Wrap a named handler. Receives `next` (original) + args. */
-  advise: (name: string, wrapper: (next: (...args: any[]) => any, ...args: any[]) => any) => void;
+  /** Wrap a named handler. Receives `next` (original) + args. Returns an unadvise function. */
+  advise: (name: string, wrapper: (next: (...args: any[]) => any, ...args: any[]) => any) => () => void;
   /** Call a named handler. */
   call: (name: string, ...args: any[]) => any;
 

--- a/src/utils/compositor.ts
+++ b/src/utils/compositor.ts
@@ -1,0 +1,115 @@
+/**
+ * Compositor — routes named render streams to surfaces.
+ *
+ * Components write to named streams ("agent", "query", "status").
+ * The compositor decides where each stream actually goes based on
+ * the current routing table.  Extensions override routing with
+ * `redirect()` to capture output (e.g. overlay panels).
+ *
+ * Streams are hierarchical: "agent:diff" falls back to "agent" if
+ * no override or default is registered for "agent:diff" specifically.
+ * This enables fine-grained interception — redirect just diffs into
+ * a panel, or just a subagent's output ("agent:sub:abc123"), while
+ * everything else flows to the parent stream's surface.
+ *
+ *   // tui-renderer registers default surfaces
+ *   compositor.setDefault("agent", stdoutSurface);
+ *
+ *   // overlay-agent redirects when active
+ *   const restore = compositor.redirect("agent", panelSurface);
+ *   // ... later ...
+ *   restore();  // back to stdout
+ *
+ *   // fine-grained: redirect only diffs to a viewer panel
+ *   compositor.redirect("agent:diff", diffPanelSurface);
+ *   // "agent:text", "agent:tool" etc. still go to stdout
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * A surface accepts rendered output.  Stdout is a surface.
+ * A floating panel's content area is a surface.  A test buffer is a surface.
+ */
+export interface RenderSurface {
+  /** Raw write — supports \r, partial lines, escape codes. */
+  write(text: string): void;
+  /** Convenience: write + newline. */
+  writeLine(line: string): void;
+  /** Available width in columns. */
+  readonly columns: number;
+}
+
+export interface Compositor {
+  /** Get the currently active surface for a stream. */
+  surface(stream: string): RenderSurface;
+
+  /** Override routing: redirect a stream to a different surface.
+   *  Returns a restore function that undoes the redirect. */
+  redirect(stream: string, target: RenderSurface): () => void;
+
+  /** Register the default surface for a stream. */
+  setDefault(stream: string, target: RenderSurface): void;
+}
+
+/** Silent sink — drops all output. Used when no surface is registered. */
+export const nullSurface: RenderSurface = {
+  write() {},
+  writeLine() {},
+  get columns() { return 80; },
+};
+
+/** Surface backed by process.stdout. */
+export class StdoutSurface implements RenderSurface {
+  write(text: string): void {
+    if (process.stdout.writable) {
+      try { process.stdout.write(text); } catch { /* ignore */ }
+    }
+  }
+  writeLine(line: string): void {
+    this.write(line + "\n");
+  }
+  get columns(): number {
+    return process.stdout.columns || 80;
+  }
+}
+
+export class DefaultCompositor implements Compositor {
+  private defaults = new Map<string, RenderSurface>();
+  private overrides = new Map<string, RenderSurface[]>();
+
+  surface(stream: string): RenderSurface {
+    const stack = this.overrides.get(stream);
+    if (stack && stack.length > 0) return stack[stack.length - 1]!;
+    if (this.defaults.has(stream)) return this.defaults.get(stream)!;
+
+    // Hierarchical fallback: "agent:diff" → "agent"
+    const colon = stream.lastIndexOf(":");
+    if (colon !== -1) return this.surface(stream.slice(0, colon));
+
+    return nullSurface;
+  }
+
+  redirect(stream: string, target: RenderSurface): () => void {
+    let stack = this.overrides.get(stream);
+    if (!stack) {
+      stack = [];
+      this.overrides.set(stream, stack);
+    }
+    stack.push(target);
+
+    let restored = false;
+    return () => {
+      if (restored) return;
+      restored = true;
+      const s = this.overrides.get(stream);
+      if (!s) return;
+      const idx = s.indexOf(target);
+      if (idx !== -1) s.splice(idx, 1);
+    };
+  }
+
+  setDefault(stream: string, target: RenderSurface): void {
+    this.defaults.set(stream, target);
+  }
+}

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -332,7 +332,9 @@ function renderUnified(diff: DiffResult, opts: DiffRenderOptions): string[] {
 
     for (let i = 0; i < hunk.lines.length; i++) {
       const line = hunk.lines[i];
-      const no = String(line.oldNo ?? line.newNo ?? "").padStart(noW);
+      const no = String(
+        line.type === "removed" ? (line.oldNo ?? "") : (line.newNo ?? line.oldNo ?? ""),
+      ).padStart(noW);
 
       if (line.type === "context") {
         const raw = truncateText(line.text, lineTextW);

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -925,21 +925,28 @@ export class FloatingPanel {
     if (this.usedAltScreen) {
       process.stdout.write("\x1b[?1049l");
     }
-    // ncurses's curscr is stale — only a real dimension change triggers
-    // clearok + full repaint (same-size SIGWINCH is a no-op).
-    const cols = process.stdout.columns || 80;
-    const rows = process.stdout.rows || 24;
-    this.bus.emit("shell:pty-resize", { cols, rows: rows - 1 });
-    setTimeout(() => {
-      this.bus.emit("shell:pty-resize", { cols, rows });
-    }, 50);
 
-    if (!this.buffer && this.ptyBuffer) {
+    // Replay PTY output that arrived while the overlay was active.
+    // Without this, commands run by the agent (e.g. user_shell ls)
+    // would vanish — the alt screen exit restores the saved screen
+    // from before the overlay opened, losing any shell output produced
+    // during the session.
+    if (this.ptyBuffer) {
       process.stdout.write(this.ptyBuffer);
     }
     this.ptyBuffer = "";
-    this.bus.emit("shell:stdout-hide", {});
     this.bus.emit("shell:stdout-release", {});
+
+    if (!this.usedAltScreen) {
+      // TUI app was running (vim, htop, etc.) — we didn't enter our own
+      // alt screen, so the app needs SIGWINCH to repaint its UI.
+      const cols = process.stdout.columns || 80;
+      const rows = process.stdout.rows || 24;
+      this.bus.emit("shell:pty-resize", { cols, rows: rows - 1 });
+      setTimeout(() => {
+        this.bus.emit("shell:pty-resize", { cols, rows });
+      }, 50);
+    }
   }
 
   // ── Passthrough rendering ─────────────────────────────────

--- a/src/utils/handler-registry.ts
+++ b/src/utils/handler-registry.ts
@@ -11,48 +11,90 @@
  *     if (lang === "latex") return renderLatex(code);
  *     return next(lang, code);  // call original
  *   });
+ *
+ * Internally, each handler is stored as a base function plus an ordered
+ * list of advisors. `call` builds the chain on invocation, so advisors
+ * can be added or removed at any time without closure entanglement.
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+type HandlerFn = (...args: any[]) => any;
+type Advisor = (next: HandlerFn, ...args: any[]) => any;
+
+interface HandlerEntry {
+  base: HandlerFn;
+  advisors: Advisor[];
+}
+
 export class HandlerRegistry {
-  private handlers = new Map<string, (...args: any[]) => any>();
+  private entries = new Map<string, HandlerEntry>();
 
   /**
-   * Register a named handler. If one already exists, it's replaced.
+   * Register a named handler. If one already exists, its base is replaced
+   * but existing advisors are preserved.
    */
-  define(name: string, fn: (...args: any[]) => any): void {
-    this.handlers.set(name, fn);
+  define(name: string, fn: HandlerFn): void {
+    const existing = this.entries.get(name);
+    if (existing) {
+      existing.base = fn;
+    } else {
+      this.entries.set(name, { base: fn, advisors: [] });
+    }
   }
 
   /**
-   * Wrap a named handler with advice. The wrapper receives the
-   * previous handler as `next` and all original arguments.
+   * Add an advisor to a named handler. The advisor receives `next`
+   * (the rest of the chain) and all original arguments.
    *
-   * - Call `next(...args)` to invoke the original (around/before/after)
+   * - Call `next(...args)` to invoke the rest of the chain
    * - Don't call `next` to replace entirely (override)
    * - Call `next` conditionally to wrap (around)
    *
-   * Multiple advisors chain: each wraps the previous one.
-   * If no handler exists yet, `next` is a no-op.
+   * Advisors run outermost-first (last added = outermost).
+   * Returns an unadvise function that cleanly removes this advisor.
    */
-  advise(name: string, wrapper: (next: (...args: any[]) => any, ...args: any[]) => any): void {
-    const original = this.handlers.get(name) ?? ((() => undefined) as any);
-    this.handlers.set(name, (...args: any[]) => wrapper(original, ...args));
+  advise(name: string, advisor: Advisor): () => void {
+    let entry = this.entries.get(name);
+    if (!entry) {
+      entry = { base: (() => undefined) as any, advisors: [] };
+      this.entries.set(name, entry);
+    }
+    entry.advisors.push(advisor);
+
+    let removed = false;
+    return () => {
+      if (removed) return;
+      removed = true;
+      const e = this.entries.get(name);
+      if (!e) return;
+      const idx = e.advisors.indexOf(advisor);
+      if (idx !== -1) e.advisors.splice(idx, 1);
+    };
   }
 
   /**
-   * Call a named handler. Returns undefined if no handler is registered.
+   * Call a named handler. Builds the advisor chain on each call:
+   * outermost advisor wraps the next, down to the base handler.
+   * Returns undefined if no handler is registered.
    */
   call(name: string, ...args: any[]): any {
-    const fn = this.handlers.get(name);
-    return fn?.(...args);
+    const entry = this.entries.get(name);
+    if (!entry) return undefined;
+
+    // Build chain: base ← advisor[0] ← advisor[1] ← ... ← advisor[n-1]
+    let fn: HandlerFn = entry.base;
+    for (const advisor of entry.advisors) {
+      const next = fn;
+      fn = (...a: any[]) => advisor(next, ...a);
+    }
+    return fn(...args);
   }
 
   /**
    * Check if a named handler exists.
    */
   has(name: string): boolean {
-    return this.handlers.has(name);
+    return this.entries.has(name);
   }
 }

--- a/src/utils/message-utils.ts
+++ b/src/utils/message-utils.ts
@@ -1,0 +1,84 @@
+/**
+ * Utilities for manipulating OpenAI-format message arrays.
+ *
+ * Used by extensions advising `conversation:prepare` to transform
+ * the message array before it's sent to the LLM.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Find tool call IDs matching a tool name and optional argument filter.
+ *
+ * Scans assistant messages for tool_calls where `function.name` matches
+ * and parsed arguments satisfy the filter (shallow key/value match).
+ *
+ * Returns call IDs in message order (earliest first).
+ */
+export function findToolCallIds(
+  messages: any[],
+  toolName: string,
+  argFilter?: Record<string, unknown>,
+): string[] {
+  const ids: string[] = [];
+  for (const msg of messages) {
+    if (msg.role !== "assistant" || !msg.tool_calls) continue;
+    for (const tc of msg.tool_calls) {
+      const fn = tc.function ?? tc.fn;
+      if (!fn || fn.name !== toolName) continue;
+      if (argFilter) {
+        let args: Record<string, unknown>;
+        try { args = JSON.parse(fn.arguments); } catch { continue; }
+        const match = Object.entries(argFilter).every(([k, v]) => args[k] === v);
+        if (!match) continue;
+      }
+      ids.push(tc.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Replace tool result content for specific call IDs.
+ *
+ * Returns a new array (shallow copy) with matching tool messages
+ * replaced. Non-matching messages are passed through by reference.
+ */
+export function stubToolResults(
+  messages: any[],
+  callIds: Set<string>,
+  stub: string,
+): any[] {
+  return messages.map((msg) => {
+    if (msg.role === "tool" && callIds.has(msg.tool_call_id)) {
+      return { ...msg, content: stub };
+    }
+    return msg;
+  });
+}
+
+/**
+ * Deduplicate tool results: keep only the latest result for a given
+ * tool name + argument filter, replace all older results with a stub.
+ *
+ * Common use case: a file that's read repeatedly (e.g. a live transcript)
+ * — only the most recent read matters.
+ *
+ * Example:
+ *   dedupeToolResults(messages, "read_file",
+ *     { path: "/path/to/transcript.txt" },
+ *     "[stale — superseded by later read]")
+ */
+export function dedupeToolResults(
+  messages: any[],
+  toolName: string,
+  argFilter?: Record<string, unknown>,
+  stub = "[superseded by later call]",
+): any[] {
+  const callIds = findToolCallIds(messages, toolName, argFilter);
+  if (callIds.length <= 1) return messages;
+
+  // Keep the last one, stub the rest
+  const staleIds = new Set(callIds.slice(0, -1));
+  return stubToolResults(messages, staleIds, stub);
+}

--- a/src/utils/terminal-buffer.ts
+++ b/src/utils/terminal-buffer.ts
@@ -163,9 +163,11 @@ export class TerminalBuffer {
   }
 
   /** Read clean screen text with metadata. */
-  readScreen(): ScreenSnapshot {
+  readScreen(opts?: { includeScrollback?: boolean }): ScreenSnapshot {
     const buf = this.term.buffer.active;
-    const lines = this.readViewportLines(buf);
+    const lines = opts?.includeScrollback
+      ? this.readAllLines(buf)
+      : this.readViewportLines(buf);
     return {
       text: lines.join("\n"),
       altScreen: buf.type === "alternate",
@@ -193,6 +195,21 @@ export class TerminalBuffer {
     for (let y = 0; y < targetRows; y++) {
       const line = buf.getLine(base + y);
       lines.push(line ? line.translateToString(true) : "");
+    }
+    return lines;
+  }
+
+  /** Read all lines including scrollback from a buffer. */
+  private readAllLines(buf: any): string[] {
+    const total = (buf.baseY ?? 0) + buf.length;
+    const lines: string[] = [];
+    for (let y = 0; y < total; y++) {
+      const line = buf.getLine(y);
+      lines.push(line ? line.translateToString(true) : "");
+    }
+    // Trim trailing empty lines
+    while (lines.length > 0 && lines[lines.length - 1] === "") {
+      lines.pop();
     }
     return lines;
   }


### PR DESCRIPTION
## Summary

- **Diff rendering, input cursor, pipe resilience, env capture** — assorted UI and robustness fixes
- **Extension system** — system prompt injection, scrollback capture, scoped cleanup for reloadable extensions
- **Compositor** — new TUI composition layer that routes named render streams (`"agent"`, `"query"`, `"status"`) to pluggable surfaces (stdout, floating panels, test buffers). Hierarchical stream names (`"agent:diff"`, `"agent:sub:<id>"`) enable fine-grained interception. Overlay agent simplified from 191 to 130 lines by using compositor redirect instead of manual event wiring.
- **Compaction** — configurable auto-compact threshold (`autoCompactThreshold`, default 0.5), force-compact on manual `/compact`
- **Nuclear timestamps** — deterministic `YYYY-MM-DD HH:MM` format replacing locale-dependent `toLocaleTimeString`

## Commits

- `d375b47` fix: diff rendering, input cursor, pipe resilience, env capture
- `e84762f` extension system: system prompt injection, scrollback capture, scoped cleanup
- `448e461` compositor: route TUI output through named streams and surfaces
- `f1d3be8` compaction: configurable threshold, force-compact on manual request
- `8c17ab4` fix: use deterministic ISO timestamp in nuclear summary lines

## New docs

- [`docs/tui-composition.md`](docs/tui-composition.md) — compositor design, surface API, hierarchical streams, extension examples

## Test plan

- [ ] Verify normal TUI rendering unchanged (text, tools, diffs, spinner)
- [ ] Verify overlay agent (Ctrl+\) renders output in floating panel
- [ ] Verify `/compact` force-evicts all non-pinned turns
- [ ] Verify auto-compact triggers at 50% of budget (or configured threshold)
- [ ] Verify nuclear summary timestamps show `YYYY-MM-DD HH:MM` format
- [ ] Verify extension reload (`/reload`) cleans up scoped registrations