### PR TITLE
tmux split pane, advisable shell lifecycle, overlay rendering

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -62,6 +62,8 @@ TypeScript and JavaScript are both supported (`.ts`, `.tsx`, `.mts`, `.js`, `.mj
 | `call` | `(name, ...args) => any` | Call a named handler |
 | `terminalBuffer` | `TerminalBuffer \| null` | Shared headless xterm.js buffer mirroring PTY output (lazy singleton, null if `@xterm/headless` not installed) |
 | `createFloatingPanel` | `(config: FloatingPanelConfig) => FloatingPanel` | Create a floating panel overlay with composited rendering, input routing, and handler-based customization |
+| `compositor` | `Compositor` | Routes named render streams to surfaces. See [TUI Composition](tui-composition.md) |
+| `createRemoteSession` | `(opts: RemoteSessionOptions) => RemoteSession` | Create a remote session that routes agent output to a surface. See [Remote Sessions](#remote-sessions) |
 
 ## Extension Settings
 
@@ -678,6 +680,101 @@ open() → [input] → submit → [active] → setDone() → [input] (follow-up)
 **Screen restore**: On dismiss, the panel uses a SIGWINCH double-resize (resize to `rows-1`, then back to `rows`) to force the foreground program to fully repaint. This is necessary because ncurses ignores same-size SIGWINCH (`resizeterm` returns early when dimensions haven't changed), and ncurses's `curscr` is stale after the overlay drew on the terminal — a simple exit from alt screen would leave overlay artifacts in cells that ncurses considers unchanged.
 
 **Keyboard protocol support**: The trigger key is recognized in all encodings — raw control byte, xterm modifyOtherKeys (`\e[27;5;code~`), and kitty keyboard protocol (`\e[code;5u`). This ensures the trigger works inside vim and other programs that enable extended keyboard protocols.
+
+## Remote Sessions
+
+A remote session bundles all the wiring needed to route agent output away from stdout — compositor redirects, shell lifecycle advisors, and chrome suppression — into a single call. Use it when building side panes, web UIs, remote displays, or any extension where agent output should appear somewhere other than the main terminal.
+
+```typescript
+const session = ctx.createRemoteSession({
+  surface: mySurface,          // where output goes (RenderSurface)
+  suppressQueryBox: true,      // hide query box (session has own input)
+  interactive: true,           // set interactive-session context
+});
+
+session.submit("what's on screen?");  // submit a query
+session.close();                       // restore everything
+```
+
+### RemoteSessionOptions
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `surface` | `RenderSurface` | (required) | The surface to render agent output to |
+| `suppressBorders` | `boolean` | `true` | Suppress response top/bottom borders |
+| `suppressQueryBox` | `boolean` | `false` | Suppress the user query box (use when the session has its own input) |
+| `suppressUsage` | `boolean` | `true` | Suppress token usage stats line |
+| `interactive` | `boolean` | `false` | Add `interactive-session: true` to dynamic context (tells agent to use terminal_read/terminal_keys) |
+
+### What createRemoteSession handles
+
+Internally, a remote session:
+
+1. **Redirects render streams** — `"agent"`, `"query"`, `"status"` all route to the provided surface
+2. **Keeps the shell interactive** — advises `shell:on-processing-start` and `shell:on-processing-done` to skip pause/unpause
+3. **Suppresses chrome** — advises `tui:response-border`, `tui:render-user-query`, `tui:render-usage` based on options
+4. **Sets dynamic context** — advises `dynamic-context:build` to inject `interactive-session: true` when `interactive` is set
+
+Calling `session.close()` removes all advisors and restores all compositor routing in one call.
+
+### Example: tmux side pane
+
+```typescript
+// Output-only: queries from main shell, output in side pane
+const session = ctx.createRemoteSession({ surface });
+// session.close() when done
+
+// Interactive: side pane has own input prompt
+const session = ctx.createRemoteSession({
+  surface,
+  suppressQueryBox: true,
+  interactive: true,
+});
+conn.on("data", (d) => session.submit(d.toString().trim()));
+```
+
+### Example: overlay agent
+
+```typescript
+const session = ctx.createRemoteSession({
+  surface: panelSurface,
+  suppressQueryBox: true,
+  interactive: true,
+});
+session.submit(query);
+// ... later, on dismiss ...
+session.close();
+```
+
+## Shell Lifecycle Handlers
+
+The shell's behavior during agent processing is controlled by two advisable handlers. Extensions advise these to change how the shell responds when the agent starts and stops working.
+
+### `shell:on-processing-start`
+
+Default: pauses the shell (blocks PTY output and input) while the agent works. This is correct when agent output shares stdout with the terminal.
+
+```typescript
+// Skip pause — agent output goes to a separate surface
+ctx.advise("shell:on-processing-start", (next) => {
+  if (mySessionActive) return;  // don't pause
+  return next();                // default: pause
+});
+```
+
+### `shell:on-processing-done`
+
+Default: unpauses the shell, re-enters agent input mode or redraws the shell prompt.
+
+```typescript
+// Skip prompt redraw — already handled by the extension
+ctx.advise("shell:on-processing-done", (next) => {
+  if (mySessionActive) return;  // skip
+  return next();                // default: unpause + redraw
+});
+```
+
+> **Note:** `createRemoteSession()` advises both of these automatically. You only need to advise them directly if you're building custom lifecycle behavior without using remote sessions.
 
 ## Rendering Architecture
 

--- a/docs/tui-composition.md
+++ b/docs/tui-composition.md
@@ -233,6 +233,25 @@ export default function activate(ctx: ExtensionContext): void {
 
 The renderer doesn't know whether it's writing to stdout or a panel. The compositor resolves the target on each `surface()` call, so redirects take effect immediately — even mid-response.
 
+## Remote sessions
+
+For most extensions that route output to a different surface, use `createRemoteSession()` instead of manual compositor redirects. It bundles compositor routing, shell lifecycle advisors, and chrome suppression into one call:
+
+```typescript
+const session = ctx.createRemoteSession({
+  surface: panelSurface,
+  suppressQueryBox: true,   // session has own input
+  interactive: true,         // enable terminal_read/terminal_keys context
+});
+
+session.submit("what's on screen?");
+session.close();  // restores everything
+```
+
+See [Extensions: Remote Sessions](extensions.md#remote-sessions) for the full API.
+
+Use the compositor directly only when you need fine-grained control — e.g. redirecting a single sub-stream like `"agent:diff"` without affecting the rest.
+
 ## Relationship to other systems
 
 | System | Role | Compositor interaction |
@@ -241,6 +260,7 @@ The renderer doesn't know whether it's writing to stdout or a panel. The composi
 | **Handler registry** | Advisable render functions (`render:code-block`, etc.) | Handlers produce lines; compositor routes them to surfaces |
 | **FloatingPanel** | Screen compositing, input routing, alt-screen management | Panel provides the surface; compositor routes to it |
 | **MarkdownRenderer** | Streaming markdown → lines | Produces lines; tui-renderer drains them to compositor surface |
+| **RemoteSession** | High-level "route output elsewhere" primitive | Creates compositor redirects + lifecycle advisors in one call |
 
 The compositor sits between "produce lines" and "display lines". It doesn't affect *what* gets rendered — only *where*.
 
@@ -250,7 +270,8 @@ The compositor sits between "produce lines" and "display lines". It doesn't affe
 |---|---|
 | `src/utils/compositor.ts` | `RenderSurface`, `Compositor`, `DefaultCompositor`, `StdoutSurface` |
 | `src/extensions/tui-renderer.ts` | Main renderer — writes to compositor streams |
-| `src/extensions/overlay-agent.ts` | Redirects streams to floating panel |
+| `src/extensions/overlay-agent.ts` | Uses `createRemoteSession` to route to floating panel |
 | `src/utils/floating-panel.ts` | Panel screen management and content API |
-| `src/core.ts` | Creates compositor, registers default surfaces |
-| `src/types.ts` | `ExtensionContext.compositor` type |
+| `src/core.ts` | Creates compositor, registers default surfaces, implements `createRemoteSession` |
+| `src/types.ts` | `ExtensionContext.compositor`, `RemoteSession`, `RemoteSessionOptions` |
+| `examples/extensions/tmux-pane.ts` | Tmux side pane — `/split` and `/rsplit` using `createRemoteSession` |

--- a/examples/extensions/tmux-pane.ts
+++ b/examples/extensions/tmux-pane.ts
@@ -1,0 +1,232 @@
+/**
+ * Tmux side-pane extension.
+ *
+ * When running inside tmux, provides `/split` to open a side pane
+ * where all agent output is rendered. The user's shell stays
+ * undisturbed in the original pane. Uses the compositor to redirect
+ * the "agent" stream to a tmux pane surface.
+ *
+ * The side pane runs `cat` to stay alive and accepts writes via its tty.
+ *
+ * Usage:
+ *   # Load directly
+ *   ash -e ./examples/extensions/tmux-pane.ts
+ *
+ *   # Or install permanently
+ *   cp examples/extensions/tmux-pane.ts ~/.agent-sh/extensions/
+ *
+ * Commands:
+ *   /split        — toggle side pane on/off
+ *   /split open   — open the side pane
+ *   /split close  — close the side pane
+ */
+import * as fs from "node:fs";
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import type { ExtensionContext, RenderSurface } from "agent-sh/types";
+
+function inTmux(): boolean {
+  return !!process.env.TMUX;
+}
+
+function tmux(...args: string[]): string {
+  return execSync("tmux " + args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" "), { encoding: "utf-8" }).trim();
+}
+
+interface TmuxPane {
+  paneId: string;
+  tty: string;
+  fd: fs.WriteStream;
+  process: ChildProcess;
+}
+
+function createTmuxPane(widthPercent = 45, onError?: () => void): TmuxPane {
+  // Split horizontally, get pane id and tty
+  const output = tmux(
+    "split-window", "-h",
+    "-l", `${widthPercent}%`,
+    "-P", "-F", "#{pane_id}",
+    // Run cat to keep pane alive
+    "cat",
+  );
+  const paneId = output.trim();
+
+  // Small delay for pane to initialize its tty
+  execSync("sleep 0.1");
+
+  const tty = tmux("display-message", "-p", "-t", paneId, "#{pane_tty}");
+  const fd = fs.createWriteStream(tty, { flags: "w" });
+
+  // When the pane is killed externally, the fd gets an EIO error.
+  // Trigger cleanup so the compositor stops routing to the dead surface.
+  fd.on("error", () => { onError?.(); });
+
+  // Get the cat process — we spawned it via tmux, so we don't have a
+  // direct handle. We'll track the pane id for cleanup instead.
+  const proc = spawn("true", [], { stdio: "ignore", detached: true });
+  proc.unref();
+
+  return { paneId, tty, fd, process: proc };
+}
+
+function getPaneWidth(paneId: string): number {
+  try {
+    return parseInt(tmux("display-message", "-p", "-t", paneId, "#{pane_width}"), 10) || 80;
+  } catch {
+    return 80;
+  }
+}
+
+function killPane(pane: TmuxPane): void {
+  try { pane.fd.end(); } catch { /* ignore */ }
+  try { tmux("kill-pane", "-t", pane.paneId); } catch { /* ignore */ }
+}
+
+function createTmuxSurface(pane: TmuxPane): RenderSurface {
+  // Cache pane width — refreshed on SIGWINCH via tmux, but we only
+  // need to query it occasionally (not on every line).
+  let cachedWidth = getPaneWidth(pane.paneId);
+  let lastWidthCheck = Date.now();
+
+  return {
+    write(text: string): void {
+      if (pane.fd.destroyed) return;
+      try { pane.fd.write(text); } catch { /* pane may be gone */ }
+    },
+    writeLine(line: string): void {
+      this.write(line + "\n");
+    },
+    get columns(): number {
+      const now = Date.now();
+      if (now - lastWidthCheck > 2000) {
+        cachedWidth = getPaneWidth(pane.paneId);
+        lastWidthCheck = now;
+      }
+      return cachedWidth;
+    },
+  };
+}
+
+export default function activate(ctx: ExtensionContext): void {
+  const { bus, compositor, advise, registerCommand } = ctx;
+
+  if (!inTmux()) return; // silently no-op outside tmux
+
+  let pane: TmuxPane | null = null;
+  let surface: RenderSurface | null = null;
+  let restoreAgent: (() => void) | null = null;
+  let restoreQuery: (() => void) | null = null;
+  let restoreStatus: (() => void) | null = null;
+
+  // In split mode, don't pause the shell — agent output goes to a
+  // separate pane so the user can keep working.
+  advise("shell:on-processing-start", (next) => {
+    if (pane) return; // skip pause — user keeps their shell
+    return next();
+  });
+
+  advise("shell:on-processing-done", (next) => {
+    if (pane) return; // skip prompt redraw — already redrawn on query
+    return next();
+  });
+
+  // Suppress response borders in the side pane — the pane itself
+  // provides visual separation between queries.
+  advise("tui:response-border", (next, position: string, width: number) => {
+    if (pane) return null;
+    return next(position, width);
+  });
+
+  function openSplit(): void {
+    if (pane) return; // already open
+
+    try {
+      pane = createTmuxPane(45, () => destroyStalePane());
+      surface = createTmuxSurface(pane);
+
+      // Redirect all render streams to the side pane.
+      restoreAgent = compositor.redirect("agent", surface);
+      restoreQuery = compositor.redirect("query", surface);
+      restoreStatus = compositor.redirect("status", surface);
+
+      // Write a subtle header
+      surface.writeLine("\x1b[2m── agent output ──\x1b[0m\n");
+
+      bus.emit("ui:info", { message: "Side pane opened. Agent output redirected." });
+    } catch (e) {
+      bus.emit("ui:error", {
+        message: `Failed to create tmux pane: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      pane = null;
+      surface = null;
+    }
+  }
+
+  function closeSplit(): void {
+    if (!pane) return;
+
+    restoreAgent?.();
+    restoreQuery?.();
+    restoreStatus?.();
+    restoreAgent = restoreQuery = restoreStatus = null;
+
+    killPane(pane);
+    pane = null;
+    surface = null;
+
+    bus.emit("ui:info", { message: "Side pane closed." });
+  }
+
+  function toggle(): void {
+    if (pane) closeSplit();
+    else openSplit();
+  }
+
+  registerCommand("split", "Toggle tmux side pane for agent output", (args) => {
+    const cmd = args.trim().toLowerCase();
+    if (cmd === "close") return closeSplit();
+    if (cmd === "open") return openSplit();
+    toggle();
+  });
+
+  // In split mode, give the user their shell prompt back immediately
+  // after submitting a query — don't wait for the agent to finish.
+  bus.on("agent:query", () => {
+    if (!pane) return;
+    // Send a newline to the PTY to trigger the shell's precmd hook,
+    // which redraws the prompt. setImmediate ensures the query box
+    // renders to the side pane first.
+    setImmediate(() => {
+      bus.emit("shell:pty-write", { data: "\n" });
+    });
+  });
+
+  bus.on("agent:processing-done", () => {
+    if (!pane) return;
+
+    // Check if pane was closed externally
+    try {
+      tmux("display-message", "-p", "-t", pane.paneId, "#{pane_id}");
+    } catch {
+      destroyStalePane();
+      return;
+    }
+
+    // Separate responses visually in the side pane
+    surface?.writeLine("");
+  });
+
+  // Clean up on exit
+  process.on("exit", () => {
+    if (pane) killPane(pane);
+  });
+
+  function destroyStalePane(): void {
+    restoreAgent?.();
+    restoreQuery?.();
+    restoreStatus?.();
+    restoreAgent = restoreQuery = restoreStatus = null;
+    try { pane?.fd.end(); } catch { /* ignore */ }
+    pane = null;
+    surface = null;
+  }
+}

--- a/examples/extensions/tmux-pane.ts
+++ b/examples/extensions/tmux-pane.ts
@@ -1,71 +1,40 @@
 /**
  * Tmux side-pane extension.
  *
- * When running inside tmux, provides `/split` to open a side pane
- * where all agent output is rendered. The user's shell stays
- * undisturbed in the original pane. Uses the compositor to redirect
- * the "agent" stream to a tmux pane surface.
+ * Two modes:
+ *   /split  — agent output renders in the side pane, queries typed
+ *             in the main shell (> prompt).
+ *   /rsplit — reverse split: the side pane has its own input prompt,
+ *             the agent can see and control the main pane via
+ *             terminal_read / terminal_keys.
  *
- * The side pane runs `cat` to stay alive and accepts writes via its tty.
+ * Both modes use createRemoteSession() which handles compositor
+ * routing, shell lifecycle, and chrome suppression automatically.
  *
  * Usage:
- *   # Load directly
  *   ash -e ./examples/extensions/tmux-pane.ts
  *
  *   # Or install permanently
  *   cp examples/extensions/tmux-pane.ts ~/.agent-sh/extensions/
- *
- * Commands:
- *   /split        — toggle side pane on/off
- *   /split open   — open the side pane
- *   /split close  — close the side pane
  */
 import * as fs from "node:fs";
-import { execSync, spawn, type ChildProcess } from "node:child_process";
-import type { ExtensionContext, RenderSurface } from "agent-sh/types";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execSync, spawn } from "node:child_process";
+import type { ExtensionContext, RenderSurface, RemoteSession } from "agent-sh/types";
+
+// ── Helpers ─────────────────────────────────────────────────────
 
 function inTmux(): boolean {
   return !!process.env.TMUX;
 }
 
 function tmux(...args: string[]): string {
-  return execSync("tmux " + args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" "), { encoding: "utf-8" }).trim();
-}
-
-interface TmuxPane {
-  paneId: string;
-  tty: string;
-  fd: fs.WriteStream;
-  process: ChildProcess;
-}
-
-function createTmuxPane(widthPercent = 45, onError?: () => void): TmuxPane {
-  // Split horizontally, get pane id and tty
-  const output = tmux(
-    "split-window", "-h",
-    "-l", `${widthPercent}%`,
-    "-P", "-F", "#{pane_id}",
-    // Run cat to keep pane alive
-    "cat",
-  );
-  const paneId = output.trim();
-
-  // Small delay for pane to initialize its tty
-  execSync("sleep 0.1");
-
-  const tty = tmux("display-message", "-p", "-t", paneId, "#{pane_tty}");
-  const fd = fs.createWriteStream(tty, { flags: "w" });
-
-  // When the pane is killed externally, the fd gets an EIO error.
-  // Trigger cleanup so the compositor stops routing to the dead surface.
-  fd.on("error", () => { onError?.(); });
-
-  // Get the cat process — we spawned it via tmux, so we don't have a
-  // direct handle. We'll track the pane id for cleanup instead.
-  const proc = spawn("true", [], { stdio: "ignore", detached: true });
-  proc.unref();
-
-  return { paneId, tty, fd, process: proc };
+  return execSync(
+    "tmux " + args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" "),
+    { encoding: "utf-8" },
+  ).trim();
 }
 
 function getPaneWidth(paneId: string): number {
@@ -76,21 +45,70 @@ function getPaneWidth(paneId: string): number {
   }
 }
 
-function killPane(pane: TmuxPane): void {
-  try { pane.fd.end(); } catch { /* ignore */ }
-  try { tmux("kill-pane", "-t", pane.paneId); } catch { /* ignore */ }
+function paneExists(paneId: string): boolean {
+  try {
+    tmux("display-message", "-p", "-t", paneId, "#{pane_id}");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-function createTmuxSurface(pane: TmuxPane): RenderSurface {
-  // Cache pane width — refreshed on SIGWINCH via tmux, but we only
-  // need to query it occasionally (not on every line).
-  let cachedWidth = getPaneWidth(pane.paneId);
+// ── Chat client script (runs in rsplit pane) ────────────────────
+
+const CHAT_CLIENT_SCRIPT = `
+const net = require("net");
+const readline = require("readline");
+
+const sockPath = process.argv[2];
+if (!sockPath) { console.error("No socket path"); process.exit(1); }
+
+const sock = net.createConnection(sockPath);
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+sock.on("data", (data) => {
+  readline.clearLine(process.stdout, 0);
+  readline.cursorTo(process.stdout, 0);
+  process.stdout.write(data.toString());
+  rl.prompt(true);
+});
+
+sock.on("end", () => process.exit(0));
+sock.on("error", () => process.exit(1));
+
+rl.setPrompt("\\x1b[36m❯\\x1b[0m ");
+rl.prompt();
+
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) { rl.prompt(); return; }
+  sock.write(trimmed + "\\n");
+});
+
+rl.on("close", () => { sock.end(); process.exit(0); });
+`;
+
+// ── Surface factory ─────────────────────────────────────────────
+
+function createSurface(
+  paneId: string,
+  ttyFd: fs.WriteStream,
+  socketClient: () => net.Socket | undefined,
+): RenderSurface {
+  let cachedWidth = getPaneWidth(paneId);
   let lastWidthCheck = Date.now();
 
   return {
     write(text: string): void {
-      if (pane.fd.destroyed) return;
-      try { pane.fd.write(text); } catch { /* pane may be gone */ }
+      // In rsplit mode, route through socket so client can manage prompt
+      const c = socketClient();
+      if (c && !c.destroyed) {
+        try { c.write(text); } catch {}
+        return;
+      }
+      // In split mode (or fallback), write directly to tty
+      if (ttyFd.destroyed) return;
+      try { ttyFd.write(text); } catch {}
     },
     writeLine(line: string): void {
       this.write(line + "\n");
@@ -98,7 +116,7 @@ function createTmuxSurface(pane: TmuxPane): RenderSurface {
     get columns(): number {
       const now = Date.now();
       if (now - lastWidthCheck > 2000) {
-        cachedWidth = getPaneWidth(pane.paneId);
+        cachedWidth = getPaneWidth(paneId);
         lastWidthCheck = now;
       }
       return cachedWidth;
@@ -106,127 +124,184 @@ function createTmuxSurface(pane: TmuxPane): RenderSurface {
   };
 }
 
+// ── Pane state ──────────────────────────────────────────────────
+
+type PaneMode = "split" | "rsplit";
+
+interface PaneState {
+  mode: PaneMode;
+  paneId: string;
+  ttyFd: fs.WriteStream;
+  session: RemoteSession;
+  // rsplit-mode only
+  server?: net.Server;
+  client?: net.Socket;
+  sockPath?: string;
+  scriptPath?: string;
+}
+
+// ── Extension ───────────────────────────────────────────────────
+
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, compositor, advise, registerCommand } = ctx;
+  const { bus, registerCommand, registerInstruction, createRemoteSession } = ctx;
 
-  if (!inTmux()) return; // silently no-op outside tmux
+  if (!inTmux()) return;
 
-  let pane: TmuxPane | null = null;
-  let surface: RenderSurface | null = null;
-  let restoreAgent: (() => void) | null = null;
-  let restoreQuery: (() => void) | null = null;
-  let restoreStatus: (() => void) | null = null;
+  let state: PaneState | null = null;
 
-  // In split mode, don't pause the shell — agent output goes to a
-  // separate pane so the user can keep working.
-  advise("shell:on-processing-start", (next) => {
-    if (pane) return; // skip pause — user keeps their shell
-    return next();
-  });
+  registerInstruction("Tmux Interactive Session", [
+    "When the dynamic context includes `interactive-session: true`, the user is chatting",
+    "with you in a side pane next to their terminal. They may have a program running in",
+    "the other pane (vim, htop, a REPL, etc.). In this mode:",
+    "- Use terminal_read to see what's on their screen.",
+    "- Use terminal_keys to interact with their running program.",
+    "- Use user_shell only for standalone commands, not for interacting with what's on screen.",
+    "- Keep responses concise.",
+  ].join("\n"));
 
-  advise("shell:on-processing-done", (next) => {
-    if (pane) return; // skip prompt redraw — already redrawn on query
-    return next();
-  });
-
-  // Suppress response borders in the side pane — the pane itself
-  // provides visual separation between queries.
-  advise("tui:response-border", (next, position: string, width: number) => {
-    if (pane) return null;
-    return next(position, width);
-  });
+  // ── Open / close ──────────────────────────────────────────────
 
   function openSplit(): void {
-    if (pane) return; // already open
+    if (state) close();
 
     try {
-      pane = createTmuxPane(45, () => destroyStalePane());
-      surface = createTmuxSurface(pane);
+      const paneId = tmux(
+        "split-window", "-h", "-l", "45%",
+        "-P", "-F", "#{pane_id}", "cat",
+      ).trim();
+      execSync("sleep 0.1");
 
-      // Redirect all render streams to the side pane.
-      restoreAgent = compositor.redirect("agent", surface);
-      restoreQuery = compositor.redirect("query", surface);
-      restoreStatus = compositor.redirect("status", surface);
+      const tty = tmux("display-message", "-p", "-t", paneId, "#{pane_tty}");
+      const ttyFd = fs.createWriteStream(tty, { flags: "w" });
+      ttyFd.on("error", () => destroyStale());
 
-      // Write a subtle header
+      const surface = createSurface(paneId, ttyFd, () => undefined);
+      const session = createRemoteSession({ surface });
+
+      state = { mode: "split", paneId, ttyFd, session };
       surface.writeLine("\x1b[2m── agent output ──\x1b[0m\n");
-
-      bus.emit("ui:info", { message: "Side pane opened. Agent output redirected." });
+      bus.emit("ui:info", { message: "Split pane opened (/split to close, /rsplit for interactive)." });
     } catch (e) {
       bus.emit("ui:error", {
-        message: `Failed to create tmux pane: ${e instanceof Error ? e.message : String(e)}`,
+        message: `Failed to open split: ${e instanceof Error ? e.message : String(e)}`,
       });
-      pane = null;
-      surface = null;
     }
   }
 
-  function closeSplit(): void {
-    if (!pane) return;
+  function openRsplit(): void {
+    if (state) close();
 
-    restoreAgent?.();
-    restoreQuery?.();
-    restoreStatus?.();
-    restoreAgent = restoreQuery = restoreStatus = null;
+    try {
+      const sockPath = path.join(os.tmpdir(), `agent-sh-chat-${process.pid}.sock`);
+      try { fs.unlinkSync(sockPath); } catch {}
 
-    killPane(pane);
-    pane = null;
-    surface = null;
+      let client: net.Socket | undefined;
 
-    bus.emit("ui:info", { message: "Side pane closed." });
+      const server = net.createServer((conn) => {
+        client = conn;
+        if (state) state.client = conn;
+        conn.on("data", (data) => {
+          for (const line of data.toString().split("\n")) {
+            const trimmed = line.trim();
+            if (trimmed) session.submit(trimmed);
+          }
+        });
+        conn.on("end", () => { client = undefined; if (state) state.client = undefined; });
+        conn.on("error", () => { client = undefined; if (state) state.client = undefined; });
+      });
+      server.listen(sockPath);
+
+      const scriptPath = path.join(os.tmpdir(), `agent-sh-chat-${process.pid}.js`);
+      fs.writeFileSync(scriptPath, CHAT_CLIENT_SCRIPT);
+
+      const paneId = tmux(
+        "split-window", "-h", "-l", "45%",
+        "-P", "-F", "#{pane_id}",
+        "node", scriptPath, sockPath,
+      ).trim();
+      execSync("sleep 0.2");
+
+      const tty = tmux("display-message", "-p", "-t", paneId, "#{pane_tty}");
+      const ttyFd = fs.createWriteStream(tty, { flags: "w" });
+      ttyFd.on("error", () => destroyStale());
+
+      const surface = createSurface(paneId, ttyFd, () => client);
+      const session = createRemoteSession({
+        surface,
+        suppressQueryBox: true,
+        interactive: true,
+      });
+
+      state = { mode: "rsplit", paneId, ttyFd, session, server, client, sockPath, scriptPath };
+      bus.emit("ui:info", { message: "Reverse split opened (/rsplit to close, /split for output-only)." });
+    } catch (e) {
+      bus.emit("ui:error", {
+        message: `Failed to open rsplit: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      if (state) close();
+    }
   }
 
-  function toggle(): void {
-    if (pane) closeSplit();
-    else openSplit();
+  function close(): void {
+    if (!state) return;
+    const s = state;
+    state = null;
+
+    s.session.close();
+    if (s.client) { try { s.client.end(); } catch {} }
+    if (s.server) { try { s.server.close(); } catch {} }
+    try { s.ttyFd.end(); } catch {}
+    try { tmux("kill-pane", "-t", s.paneId); } catch {}
+    if (s.sockPath) { try { fs.unlinkSync(s.sockPath); } catch {} }
+    if (s.scriptPath) { try { fs.unlinkSync(s.scriptPath); } catch {} }
   }
+
+  function destroyStale(): void {
+    if (!state) return;
+    const s = state;
+    state = null;
+
+    s.session.close();
+    if (s.client) { try { s.client.end(); } catch {} }
+    if (s.server) { try { s.server.close(); } catch {} }
+    try { s.ttyFd.end(); } catch {}
+    if (s.sockPath) { try { fs.unlinkSync(s.sockPath); } catch {} }
+    if (s.scriptPath) { try { fs.unlinkSync(s.scriptPath); } catch {} }
+  }
+
+  // ── Commands ──────────────────────────────────────────────────
 
   registerCommand("split", "Toggle tmux side pane for agent output", (args) => {
     const cmd = args.trim().toLowerCase();
-    if (cmd === "close") return closeSplit();
+    if (cmd === "close") return close();
     if (cmd === "open") return openSplit();
-    toggle();
+    if (state?.mode === "split") close(); else openSplit();
   });
 
-  // In split mode, give the user their shell prompt back immediately
-  // after submitting a query — don't wait for the agent to finish.
+  registerCommand("rsplit", "Toggle interactive tmux side pane (reverse split)", (args) => {
+    const cmd = args.trim().toLowerCase();
+    if (cmd === "close") return close();
+    if (cmd === "open") return openRsplit();
+    if (state?.mode === "rsplit") close(); else openRsplit();
+  });
+
+  // ── Lifecycle events ──────────────────────────────────────────
+
+  // In split mode, redraw prompt immediately after query submit.
   bus.on("agent:query", () => {
-    if (!pane) return;
-    // Send a newline to the PTY to trigger the shell's precmd hook,
-    // which redraws the prompt. setImmediate ensures the query box
-    // renders to the side pane first.
-    setImmediate(() => {
-      bus.emit("shell:pty-write", { data: "\n" });
-    });
+    if (state?.mode !== "split") return;
+    setImmediate(() => bus.emit("shell:pty-write", { data: "\n" }));
   });
 
+  // In rsplit mode, re-prompt the client after agent finishes.
   bus.on("agent:processing-done", () => {
-    if (!pane) return;
-
-    // Check if pane was closed externally
-    try {
-      tmux("display-message", "-p", "-t", pane.paneId, "#{pane_id}");
-    } catch {
-      destroyStalePane();
-      return;
+    if (!state) return;
+    if (!paneExists(state.paneId)) { destroyStale(); return; }
+    if (state.mode === "rsplit" && state.client && !state.client.destroyed) {
+      state.client.write("\n");
     }
-
-    // Separate responses visually in the side pane
-    surface?.writeLine("");
+    state.session.surface.writeLine("");
   });
 
-  // Clean up on exit
-  process.on("exit", () => {
-    if (pane) killPane(pane);
-  });
-
-  function destroyStalePane(): void {
-    restoreAgent?.();
-    restoreQuery?.();
-    restoreStatus?.();
-    restoreAgent = restoreQuery = restoreStatus = null;
-    try { pane?.fd.end(); } catch { /* ignore */ }
-    pane = null;
-    surface = null;
-  }
+  process.on("exit", () => { if (state) close(); });
 }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -623,8 +623,8 @@ export class AgentLoop implements AgentBackend {
     this.abortController = new AbortController();
     const signal = this.abortController.signal;
     // Each loop iteration adds an abort listener (via OpenAI SDK stream);
-    // raise the limit to avoid spurious warnings on multi-tool queries.
-    setMaxListeners(50, signal);
+    // disable the limit — long-running tool loops can easily exceed any cap.
+    setMaxListeners(0, signal);
 
     this.bus.emit("agent:query", { query });
     this.bus.emit("agent:processing-start", {});

--- a/src/core.ts
+++ b/src/core.ts
@@ -43,6 +43,8 @@ export { LlmClient } from "./utils/llm-client.js";
 export interface AgentShellCore {
   bus: EventBus;
   contextManager: ContextManager;
+  /** Handler registry for define/advise/call. */
+  handlers: HandlerRegistry;
   /** LLM client for fast-path features (null when no provider configured). */
   llmClient: LlmClient | null;
   /** Activate the agent backend (call after extensions load). */
@@ -297,6 +299,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
   return {
     bus,
     contextManager,
+    handlers,
     llmClient,
 
     activateBackend() {

--- a/src/core.ts
+++ b/src/core.ts
@@ -20,7 +20,7 @@ import { EventBus, type ContentBlock } from "./event-bus.js";
 import { ContextManager } from "./context-manager.js";
 import { AgentLoop } from "./agent/agent-loop.js";
 import { LlmClient } from "./utils/llm-client.js";
-import type { AgentShellConfig, AgentMode, ExtensionContext } from "./types.js";
+import type { AgentShellConfig, AgentMode, ExtensionContext, RemoteSessionOptions, RemoteSession } from "./types.js";
 import { setPalette } from "./utils/palette.js";
 import * as streamTransform from "./utils/stream-transform.js";
 import * as settingsMod from "./settings.js";
@@ -384,6 +384,49 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           return new FloatingPanel(bus, { ...config, terminalBuffer: tb ?? undefined });
         },
         compositor,
+        createRemoteSession: (opts: RemoteSessionOptions): RemoteSession => {
+          const { surface } = opts;
+          const cleanups: (() => void)[] = [];
+          let active = true;
+
+          // Redirect all render streams
+          cleanups.push(compositor.redirect("agent", surface));
+          cleanups.push(compositor.redirect("query", surface));
+          cleanups.push(compositor.redirect("status", surface));
+
+          // Keep shell interactive
+          cleanups.push(handlers.advise("shell:on-processing-start", (next) => active ? undefined : next()));
+          cleanups.push(handlers.advise("shell:on-processing-done", (next) => active ? undefined : next()));
+
+          // Suppress chrome
+          if (opts.suppressBorders !== false) {
+            cleanups.push(handlers.advise("tui:response-border", (next, ...a) => active ? null : next(...a)));
+          }
+          if (opts.suppressQueryBox) {
+            cleanups.push(handlers.advise("tui:render-user-query", (next, ...a) => active ? [] : next(...a)));
+          }
+          if (opts.suppressUsage !== false) {
+            cleanups.push(handlers.advise("tui:render-usage", (next, ...a) => active ? "" : next(...a)));
+          }
+          if (opts.interactive) {
+            cleanups.push(handlers.advise("dynamic-context:build", (next) => {
+              const base = next() as string;
+              return active ? base + "\ninteractive-session: true\n" : base;
+            }));
+          }
+
+          return {
+            submit(query: string) { bus.emit("agent:submit", { query }); },
+            get surface() { return surface; },
+            get active() { return active; },
+            close() {
+              if (!active) return;
+              active = false;
+              for (const fn of cleanups.reverse()) fn();
+              cleanups.length = 0;
+            },
+          };
+        },
       };
     },
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -140,6 +140,7 @@ export interface ShellEvents {
   "shell:stdout-hold": Record<string, never>;
   "shell:stdout-release": Record<string, never>;
 
+
   // Temporarily force PTY output visible even while agent is processing
   // (ref-counted). Used by tools like terminal_keys that need the user
   // to see the foreground program's response to injected keystrokes.

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -72,13 +72,18 @@ export default function activate(ctx: ExtensionContext): void {
     restoreAgent = restoreQuery = restoreStatus = null;
   }
 
-  // Suppress TUI renderer when overlay owns agent output.
-  // TODO: Once tui-renderer fully uses compositor routing, remove this gate
-  // and let the compositor redirect handle everything. The tui-renderer's
-  // full pipeline (markdown, tool grouping, diffs) would then apply to the
-  // overlay too — which is the desired end state.
-  advise("tui:should-render-agent", (next) => {
-    return panel.active ? false : next();
+  // Suppress query box and response borders in overlay — the panel has its own frame.
+  advise("tui:render-user-query", (next, query: string, width: number, modelLabel: string | undefined) => {
+    if (panel.active) return [];
+    return next(query, width, modelLabel);
+  });
+  advise("tui:response-border", (next, position: string, width: number) => {
+    if (panel.active) return null;
+    return next(position, width);
+  });
+  advise("tui:render-usage", (next, prompt: number, completion: number, max: number) => {
+    if (panel.active) return "";
+    return next(prompt, completion, max);
   });
 
   registerInstruction("Interactive Overlay Sessions", [

--- a/src/extensions/overlay-agent.ts
+++ b/src/extensions/overlay-agent.ts
@@ -5,13 +5,12 @@
  * inside vim, htop, or ssh. Composites a floating response box on top
  * of the current terminal content.
  *
- * Uses the compositor to redirect agent output into the floating panel.
- * The full tui-renderer pipeline (markdown, tool grouping, spinner, diffs)
- * applies — the overlay just changes *where* the output goes.
+ * Uses createRemoteSession() to route the full tui-renderer pipeline
+ * (markdown, tool grouping, spinner, diffs) into the floating panel.
  *
  * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
  */
-import type { ExtensionContext } from "../types.js";
+import type { ExtensionContext, RemoteSession } from "../types.js";
 import type { RenderSurface } from "../utils/compositor.js";
 import type { FloatingPanel } from "../utils/floating-panel.js";
 
@@ -43,7 +42,7 @@ function createPanelSurface(panel: FloatingPanel): RenderSurface {
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, compositor, advise, registerInstruction, createFloatingPanel } = ctx;
+  const { bus, registerInstruction, createFloatingPanel, createRemoteSession } = ctx;
 
   const panel = createFloatingPanel({
     trigger: "\x1c", // Ctrl+\
@@ -51,40 +50,7 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   const panelSurface = createPanelSurface(panel);
-
-  // ── Compositor routing ────────────────────────────────────────
-  // When the panel is active, redirect all render streams to it.
-  let restoreAgent: (() => void) | null = null;
-  let restoreQuery: (() => void) | null = null;
-  let restoreStatus: (() => void) | null = null;
-
-  function redirectToPanel(): void {
-    if (restoreAgent) return; // already redirected
-    restoreAgent = compositor.redirect("agent", panelSurface);
-    restoreQuery = compositor.redirect("query", panelSurface);
-    restoreStatus = compositor.redirect("status", panelSurface);
-  }
-
-  function restoreRouting(): void {
-    restoreAgent?.();
-    restoreQuery?.();
-    restoreStatus?.();
-    restoreAgent = restoreQuery = restoreStatus = null;
-  }
-
-  // Suppress query box and response borders in overlay — the panel has its own frame.
-  advise("tui:render-user-query", (next, query: string, width: number, modelLabel: string | undefined) => {
-    if (panel.active) return [];
-    return next(query, width, modelLabel);
-  });
-  advise("tui:response-border", (next, position: string, width: number) => {
-    if (panel.active) return null;
-    return next(position, width);
-  });
-  advise("tui:render-usage", (next, prompt: number, completion: number, max: number) => {
-    if (panel.active) return "";
-    return next(prompt, completion, max);
-  });
+  let session: RemoteSession | null = null;
 
   registerInstruction("Interactive Overlay Sessions", [
     "When the dynamic context includes `interactive-session: true`, the user has summoned you",
@@ -97,36 +63,46 @@ export default function activate(ctx: ExtensionContext): void {
     "- Keep responses concise — the user is in the middle of a workflow.",
   ].join("\n"));
 
-  // Signal interactive overlay mode in dynamic context
-  advise("dynamic-context:build", (next) => {
-    const base = next() as string;
-    if (!panel.active) return base;
-    return base + "\ninteractive-session: true\n";
-  });
-
   // ── Panel lifecycle ────────────────────────────────────────────
 
   panel.handlers.advise("panel:submit", (_next, query: string) => {
-    redirectToPanel();
+    if (!session) {
+      session = createRemoteSession({
+        surface: panelSurface,
+        suppressQueryBox: true,
+        interactive: true,
+      });
+    }
     panel.setActive();
-    bus.emit("agent:submit", { query });
+    session.submit(query);
   });
 
   panel.handlers.advise("panel:show", (_next) => {
-    if (panel.active) redirectToPanel();
+    // Re-establish session if panel is shown while agent is still working
+    if (panel.active && !session) {
+      session = createRemoteSession({
+        surface: panelSurface,
+        suppressQueryBox: true,
+        interactive: true,
+      });
+    }
   });
 
   // Restore routing on hide (panel:dismiss is the hide handler)
   panel.handlers.advise("panel:dismiss", (next) => {
     next();
-    restoreRouting();
+    session?.close();
+    session = null;
   });
 
   bus.on("agent:processing-done", () => {
     if (!panel.active) return;
     panel.setDone();
     // setDone() may trigger dismiss() which resets phase to idle.
-    // If that happened, restore routing now (dismiss() doesn't call panel:dismiss).
-    if (!panel.active) restoreRouting();
+    // If that happened, close the session now.
+    if (!panel.active) {
+      session?.close();
+      session = null;
+    }
   });
 }

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -149,6 +149,9 @@ export default function activate(ctx: ExtensionContext): void {
   // Extensions advise these to customize how the TUI renders content.
   // Each handler receives data and returns rendered strings.
 
+  define("tui:response-border", (position: "top" | "bottom", width: number): string | null => {
+    return `${p.dim}${p.accent}${"─".repeat(width)}${p.reset}`;
+  });
   define("tui:response-start", (): void => {});
   define("tui:response-end", (_hadToolCalls: boolean): void => {});
 
@@ -496,7 +499,8 @@ export default function activate(ctx: ExtensionContext): void {
   function startAgentResponse(): void {
     s.renderer = new MarkdownRenderer(out().columns);
     s.hadToolCalls = false;
-    s.renderer.printTopBorder();
+    const border: string | null = ctx.call("tui:response-border", "top", out().columns);
+    if (border) s.renderer.writeLine(border);
     drain();
     ctx.call("tui:response-start");
   }
@@ -534,7 +538,8 @@ export default function activate(ctx: ExtensionContext): void {
     if (s.renderer) {
       ctx.call("tui:response-end", s.hadToolCalls);
       s.renderer.flush();
-      s.renderer.printBottomBorder();
+      const border: string | null = ctx.call("tui:response-border", "bottom", out().columns);
+      if (border) s.renderer.writeLine(border);
       drain();
       out().write("\n");
       s.renderer = null;
@@ -555,9 +560,11 @@ export default function activate(ctx: ExtensionContext): void {
 
     const querySurface = compositor.surface("query");
     const framed: string[] = ctx.call("tui:render-user-query", query, querySurface.columns, modelLabel);
-    querySurface.write("\n");
-    for (const line of framed) {
-      querySurface.writeLine(line);
+    if (framed.length > 0) {
+      querySurface.write("\n");
+      for (const line of framed) {
+        querySurface.writeLine(line);
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ async function main(): Promise<void> {
 
   const shell = new Shell({
     bus,
+    handlers: core.handlers,
     cols,
     rows,
     shell: config.shell || process.env.SHELL || "/bin/bash",

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -8,9 +8,16 @@ import { OutputParser } from "./output-parser.js";
 import { getSettings } from "./settings.js";
 import { RefCounter } from "./utils/output-writer.js";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface ShellHandlers {
+  define: (name: string, fn: (...args: any[]) => any) => void;
+  call: (name: string, ...args: any[]) => any;
+}
+
 export class Shell implements InputContext {
   private ptyProcess: pty.IPty;
   private bus: EventBus;
+  private handlers: ShellHandlers;
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
   private paused = false;
@@ -23,6 +30,7 @@ export class Shell implements InputContext {
 
   constructor(opts: {
     bus: EventBus;
+    handlers: ShellHandlers;
     onShowAgentInfo?: () => { info: string; model?: string };
     cols: number;
     rows: number;
@@ -183,6 +191,7 @@ export class Shell implements InputContext {
     }
 
     this.bus = opts.bus;
+    this.handlers = opts.handlers;
     this.outputParser = new OutputParser(opts.bus, opts.cwd);
 
     // Ensure temp dir cleanup on abnormal exit (SIGKILL won't fire this,
@@ -325,21 +334,30 @@ export class Shell implements InputContext {
    * zero frontend knowledge; any frontend can subscribe to the same events.
    */
   private setupAgentLifecycle(): void {
-    this.bus.on("agent:processing-start", () => {
+    // Default agent lifecycle: pause the shell while the agent works,
+    // then redraw the prompt when done. Extensions advise these handlers
+    // to change behavior (e.g. tmux split keeps the shell interactive).
+    this.handlers.define("shell:on-processing-start", () => {
       this.agentActive = true;
       this.paused = true;
     });
 
-    this.bus.on("agent:processing-done", () => {
+    this.handlers.define("shell:on-processing-done", () => {
       this.paused = false;
       this.agentActive = false;
       if (!this.inputHandler.handleProcessingDone()) {
-        // echoSkip only when freshPrompt actually wrote \n to the PTY.
-        // When the overlay suppresses freshPrompt, no echo to skip.
         if (this.freshPrompt()) {
           this.echoSkip = true;
         }
       }
+    });
+
+    this.bus.on("agent:processing-start", () => {
+      this.handlers.call("shell:on-processing-start");
+    });
+
+    this.bus.on("agent:processing-done", () => {
+      this.handlers.call("shell:on-processing-done");
     });
 
     // Permission prompts need stdout unpaused so the interactive UI renders,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import type { Compositor } from "./utils/compositor.js";
 
 export type { ContentBlock } from "./event-bus.js";
 export type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
+export type { RenderSurface } from "./utils/compositor.js";
 
 /** A model entry in the cycling list, optionally tied to a provider. */
 export interface AgentMode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,34 @@ export type { ContentBlock } from "./event-bus.js";
 export type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
 export type { RenderSurface } from "./utils/compositor.js";
 
+// ── Remote sessions ──────────────────────────────────────────────
+
+export interface RemoteSessionOptions {
+  /** The surface to render agent output to. */
+  surface: import("./utils/compositor.js").RenderSurface;
+  /** Suppress response borders (default: true). */
+  suppressBorders?: boolean;
+  /** Suppress user query box (default: false).
+   *  True for sessions with their own input (rsplit, overlay).
+   *  False for sessions where input comes from the main shell (split). */
+  suppressQueryBox?: boolean;
+  /** Suppress usage stats line (default: true). */
+  suppressUsage?: boolean;
+  /** Set interactive-session dynamic context (default: false). */
+  interactive?: boolean;
+}
+
+export interface RemoteSession {
+  /** Submit a query to the agent from this session. */
+  submit(query: string): void;
+  /** The surface this session renders to. */
+  readonly surface: import("./utils/compositor.js").RenderSurface;
+  /** Whether this session is currently active. */
+  readonly active: boolean;
+  /** Tear down — restores all routing and advisors. */
+  close(): void;
+}
+
 /** A model entry in the cycling list, optionally tied to a provider. */
 export interface AgentMode {
   model: string;
@@ -109,6 +137,18 @@ export interface ExtensionContext {
    * Extensions use `compositor.redirect()` to capture output (e.g. overlay panels).
    */
   compositor: Compositor;
+
+  // ── Remote sessions ────────────────────────────────────────────
+  /**
+   * Create a remote session that routes agent output to a surface and
+   * optionally accepts queries. Handles all compositor routing, shell
+   * lifecycle advisors, and chrome suppression.
+   *
+   *   const session = ctx.createRemoteSession({ surface, interactive: true });
+   *   session.submit("what's on screen?");
+   *   session.close();  // restores everything
+   */
+  createRemoteSession: (opts: RemoteSessionOptions) => RemoteSession;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Tmux side pane** (`examples/extensions/tmux-pane.ts`) — `/split` opens a tmux side pane where all agent output renders via compositor redirect. The shell stays interactive while the agent works. Handles pane cleanup on external kill (EIO error detection), immediate prompt redraw on query submit, and graceful fallback to inline mode.

- **Advisable shell lifecycle** — Shell's `agent:processing-start` and `agent:processing-done` behavior is now driven by two advisable handlers (`shell:on-processing-start`, `shell:on-processing-done`). Extensions advise these to control pause/unpause/prompt behavior rather than patching boolean flags. Shell gets access to the HandlerRegistry.

- **Overlay rendering fixes** — Removed the `shouldRender()` gate that suppressed tui-renderer during overlay. The full tui-renderer pipeline (markdown, tool grouping, diffs, syntax highlighting) now flows through the compositor to the overlay panel. Query box, response borders, and usage stats are suppressed via handler advice.

- **Advisable response borders** — New `tui:response-border` handler replaces direct `MarkdownRenderer.printTopBorder()`/`printBottomBorder()` calls. Extensions return `null` to suppress borders.

- **RenderSurface export** — `RenderSurface` type exported from `agent-sh/types` for extension authors.

- **MaxListeners fix** — `setMaxListeners(0)` on AbortSignal to prevent warnings on long tool loops.

## Test plan

- [ ] Normal inline TUI rendering unchanged (text, tools, diffs, spinner, borders)
- [ ] Overlay agent (Ctrl+\) renders full tui-renderer output (no shouldRender gate)
- [ ] In tmux: `/split` opens side pane, agent output routes there
- [ ] In tmux: shell stays interactive during agent processing (can type commands)
- [ ] In tmux: prompt redraws immediately after query submit
- [ ] In tmux: killing side pane externally restores inline routing (no crash)
- [ ] In tmux: `/split close` cleans up pane and restores routing
- [ ] Outside tmux: `/split` command not registered (silent no-op)
- [ ] No MaxListenersExceededWarning on long agent runs