### PR TITLE
feat: eager nucleation — persistent context history like zsh

### DIFF
--- a/examples/extensions/ash-mcp-bridge/index.ts
+++ b/examples/extensions/ash-mcp-bridge/index.ts
@@ -95,6 +95,7 @@ async function connectServer(
     command: config.command,
     args: config.args,
     env: { ...process.env, ...config.env } as Record<string, string>,
+    stderr: "pipe",
   });
 
   const client = new Client({ name: `ash-${name}`, version: "0.1.0" });
@@ -157,9 +158,7 @@ async function connectServer(
     });
   }
 
-  ctx.bus.emit("ui:info", {
-    message: `mcp-bridge: "${name}" connected (${tools.length} tools)`,
-  });
+  // ui:info suppressed — connection is silent by default
 
   return { name, client, transport };
 }

--- a/examples/extensions/ash-mcp-bridge/index.ts
+++ b/examples/extensions/ash-mcp-bridge/index.ts
@@ -65,6 +65,17 @@ export default async function activate(ctx: any): Promise<void> {
     }
   }
 
+  // Contribute connected servers to the startup banner
+  bus.onPipe("banner:collect", (e) => {
+    if (connected.length > 0) {
+      e.sections.push({
+        label: "MCP Servers",
+        items: connected.map((s) => s.name),
+      });
+    }
+    return e;
+  });
+
   // Clean up on exit
   bus.on("app:quit", () => {
     for (const server of connected) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "types": "./dist/core.d.ts",
       "default": "./dist/core.js"
     },
-    "./utils/*": "./dist/utils/*.js",
+    "./utils/*": "./dist/utils/*",
     "./types": {
       "types": "./dist/types.d.ts",
       "default": "./dist/types.js"

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -719,12 +719,8 @@ export class AgentLoop implements AgentBackend {
       const budgetTokens = this.tokenBudget.conversationBudgetTokens;
       const autoCompactThreshold = Math.floor(budgetTokens * getSettings().autoCompactThreshold);
       if (this.conversation.estimateTokens() > autoCompactThreshold) {
-        const stats = this.conversation.compact(autoCompactThreshold);
-        if (stats) {
-          this.bus.emit("ui:info", {
-            message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
-          });
-        }
+        this.conversation.compact(autoCompactThreshold);
+        // Auto-compaction is silent — no ui:info emitted
       }
 
       // System prompt uses handler so extensions can append instructions (cacheable);

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -217,7 +217,6 @@ export class AgentLoop implements AgentBackend {
     on("agent:compact-request", () => {
       // Force compaction: use target of 0 so every non-pinned turn is evicted
       const stats = this.conversation.compact(0, 10, true);
-      this.conversation.flush().catch(() => {});
       if (stats) {
         this.bus.emit("ui:info", {
           message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
@@ -721,7 +720,6 @@ export class AgentLoop implements AgentBackend {
       const autoCompactThreshold = Math.floor(budgetTokens * getSettings().autoCompactThreshold);
       if (this.conversation.estimateTokens() > autoCompactThreshold) {
         const stats = this.conversation.compact(autoCompactThreshold);
-        await this.conversation.flush();
         if (stats) {
           this.bus.emit("ui:info", {
             message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
@@ -749,7 +747,10 @@ export class AgentLoop implements AgentBackend {
       this.toolProtocol.recordAssistant(this.conversation, text, toolCalls);
 
       // No tool calls → agent is done
-      if (toolCalls.length === 0) break;
+      if (toolCalls.length === 0) {
+        this.conversation.eagerNucleateAgent(fullResponseText);
+        break;
+      }
 
       // Emit batch info so the TUI can render group headers upfront
       {
@@ -879,6 +880,17 @@ export class AgentLoop implements AgentBackend {
       // Record all tool results via protocol
       this.toolProtocol.recordResults(this.conversation, collectedResults);
 
+      // Eager nucleation: write tool results to history file
+      this.conversation.eagerNucleateTools(
+        collectedResults.map((r) => {
+          // Find the original args for this tool call
+          const tc = toolCalls.find(t => t.id === r.callId || t.name === r.toolName);
+          let args: Record<string, unknown> = {};
+          try { args = tc ? JSON.parse(tc.argumentsJson) : {}; } catch {}
+          return { toolName: r.toolName, args, content: r.content, isError: !!r.isError };
+        }),
+      );
+
       // Loop back — LLM sees tool results
     }
 
@@ -909,7 +921,6 @@ export class AgentLoop implements AgentBackend {
           // Use 60% of the budget to leave headroom
           const aggressiveBudget = Math.floor(this.tokenBudget.conversationBudgetTokens * 0.6);
           const stats = this.conversation.compact(aggressiveBudget, 6);
-          await this.conversation.flush();
           const detail = stats ? ` ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens` : "";
           this.bus.emit("ui:info", { message: `(context overflow — compacted${detail}, retrying)` });
           continue;

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -2,6 +2,7 @@ import type { ChatCompletionMessageParam } from "../utils/llm-client.js";
 import { getSettings } from "../settings.js";
 import {
   type NuclearEntry,
+  nucleate,
   toNuclearEntries,
   formatNuclearLine,
   isReadOnly,
@@ -11,15 +12,16 @@ import {
 import type { HistoryFile } from "./history-file.js";
 
 /**
- * Three-tier conversation state — works like shell history.
+ * Conversation state with eager nucleation — works like shell history.
  *
- * Tier 1: Active context   — full content in LLM messages array
- * Tier 2: Nuclear memory   — one-liner summaries IN the conversation +
- *                            recall archive (in-memory) for full content
- * Tier 3: History file     — nuclear entries persisted to disk
+ * Three stores:
+ *   LLM context   — full messages + nuclear block (session-only)
+ *   In-session mem — full original messages in recallArchive (session-only)
+ *   History file   — nuclear entries (JSONL, persistent)
  *
- * Content flows downward as the context window fills:
- *   Tier 1 → compact → Tier 2 → flush → Tier 3
+ * Every message is nucleated eagerly on arrival → appended to disk.
+ * Compaction evicts from LLM context, replacing with pre-computed nuclear
+ * entries. Session end → nuclear entries survive on disk, memory is lost.
  */
 
 // ── Priority tiers (lower number = evicted first) ─────────────────
@@ -38,14 +40,18 @@ const enum Priority {
 }
 
 export class ConversationState {
-  // ── Tier 1: Active context ────────────────────────────────────
+  // ── LLM context ───────────────────────────────────────────────
   private messages: ChatCompletionMessageParam[] = [];
 
-  // ── Tier 2: Nuclear memory ────────────────────────────────────
+  // ── Nuclear entries (pre-computed, used by compact) ────────────
   private nuclearEntries: NuclearEntry[] = [];
+  /** Map from seq → nuclear entry for lookup during compact. */
+  private nuclearBySeq = new Map<number, NuclearEntry>();
+
+  // ── In-session memory (ephemeral) ─────────────────────────────
   private recallArchive = new Map<number, ChatCompletionMessageParam[]>();
 
-  // ── Tier 3 reference ──────────────────────────────────────────
+  // ── History file reference ────────────────────────────────────
   private historyFile: HistoryFile | null;
 
   // ── Shared state ──────────────────────────────────────────────
@@ -59,10 +65,11 @@ export class ConversationState {
     return this.historyFile?.instanceId ?? "0000";
   }
 
-  // ── Message API (unchanged) ───────────────────────────────────
+  // ── Message API (with eager nucleation) ───────────────────────
 
   addUserMessage(text: string): void {
     this.messages.push({ role: "user", content: text });
+    this.eagerNucleateUser(text);
   }
 
   addAssistantMessage(
@@ -108,18 +115,82 @@ export class ConversationState {
     return this.messages;
   }
 
+  // ── Eager nucleation ──────────────────────────────────────────
+
+  /** Nucleate a user query — called from addUserMessage. */
+  private eagerNucleateUser(text: string): void {
+    const seq = this.nextSeq++;
+    const entry = nucleate("user", text, this.instanceId, seq);
+    this.nuclearEntries.push(entry);
+    this.nuclearBySeq.set(seq, entry);
+    this.recallArchive.set(seq, [{ role: "user", content: text }]);
+    this.appendToFile([entry]);
+  }
+
+  /**
+   * Nucleate an agent text response. Called by agent-loop when the loop
+   * finishes without tool calls.
+   */
+  eagerNucleateAgent(text: string): void {
+    if (!text) return;
+    const seq = this.nextSeq++;
+    const entry = nucleate("agent", text, this.instanceId, seq);
+    this.nuclearEntries.push(entry);
+    this.nuclearBySeq.set(seq, entry);
+    this.recallArchive.set(seq, [{ role: "assistant", content: text }]);
+    this.appendToFile([entry]);
+  }
+
+  /**
+   * Nucleate tool call results. Called by agent-loop after all tool results
+   * are collected. One entry per tool call, enriched with result.
+   */
+  eagerNucleateTools(
+    results: Array<{ toolName: string; args: Record<string, unknown>; content: string; isError: boolean }>,
+  ): void {
+    const entries: NuclearEntry[] = [];
+    for (const r of results) {
+      const seq = this.nextSeq++;
+      const entry = nucleate(
+        r.isError ? "error" : "tool",
+        r.toolName,
+        r.args,
+        r.content,
+        r.isError,
+        this.instanceId,
+        seq,
+      );
+      entries.push(entry);
+      this.nuclearEntries.push(entry);
+      this.nuclearBySeq.set(seq, entry);
+      // Store minimal turn in recall archive
+      this.recallArchive.set(seq, [
+        { role: "assistant", content: null, tool_calls: [{ id: `seq_${seq}`, type: "function", function: { name: r.toolName, arguments: JSON.stringify(r.args) } }] },
+        { role: "tool", tool_call_id: `seq_${seq}`, content: r.content },
+      ]);
+    }
+    this.appendToFile(entries);
+  }
+
+  private appendToFile(entries: NuclearEntry[]): void {
+    if (this.historyFile && entries.length > 0) {
+      // Fire-and-forget — don't block the conversation flow
+      this.historyFile.append(entries).catch(() => {});
+    }
+  }
+
   // ── Token estimation ──────────────────────────────────────────
 
   estimateTokens(): number {
     return Math.ceil(JSON.stringify(this.messages).length / 4);
   }
 
-  // ── Tier 1 → Tier 2: Compaction ───────────────────────────────
+  // ── Compaction (uses pre-computed nuclear entries) ─────────────
 
   /**
    * Priority-based compaction. Evicts lowest-priority turns, replacing
-   * them with nuclear one-liner summaries that stay in the conversation.
-   * Read-only tool results are dropped entirely.
+   * them with their pre-computed nuclear one-liner summaries.
+   * Read-only tool results are dropped entirely from context.
    */
   compact(targetTokens: number, recentTurnsToKeep = 10, force = false): { before: number; after: number } | null {
     const before = this.estimateTokens();
@@ -128,23 +199,27 @@ export class ConversationState {
     const turns = this.parseTurns();
     if (turns.length <= 2) return null;
 
-    // Assign priorities
+    // Assign priorities with recency weighting
     const pinnedCount = Math.min(recentTurnsToKeep, turns.length - 1);
-    for (const turn of turns) {
-      turn.priority = this.inferPriority(turn.messages);
+    for (let i = 0; i < turns.length; i++) {
+      turns[i]!.priority = this.inferPriority(turns[i]!.messages);
     }
     turns[0]!.priority = Priority.PINNED;
     for (let i = turns.length - pinnedCount; i < turns.length; i++) {
       turns[i]!.priority = Priority.PINNED;
     }
 
-    // Sort candidates: lowest priority first, then oldest
+    // Sort candidates: lowest effective priority first (base * recency), then oldest
     const candidates = turns
       .map((t, idx) => ({ turn: t, idx }))
       .filter((c) => c.turn.priority !== Priority.PINNED)
-      .sort((a, b) => a.turn.priority - b.turn.priority || a.idx - b.idx);
+      .sort((a, b) => {
+        const effA = a.turn.priority * recencyWeight(a.idx, turns.length);
+        const effB = b.turn.priority * recencyWeight(b.idx, turns.length);
+        return effA - effB || a.idx - b.idx;
+      });
 
-    // Evict until under budget
+    // Evict until under budget — use pre-computed nuclear entries
     const evictedIndices = new Set<number>();
     let currentTokens = this.estimateTokens();
 
@@ -154,17 +229,20 @@ export class ConversationState {
       evictedIndices.add(c.idx);
       currentTokens -= turnTokens;
 
-      // Generate nuclear entries from this turn
-      const entries = toNuclearEntries(c.turn.messages, this.nextSeq, this.instanceId);
-      this.nextSeq += entries.length;
+      // Generate nuclear entries from this turn ONLY if not already nucleated.
+      // This handles the case where messages were added before eager nucleation
+      // was wired up (e.g. loadPriorHistory).
+      const turnEntries = toNuclearEntries(c.turn.messages, this.nextSeq, this.instanceId);
+      this.nextSeq += turnEntries.length;
 
-      for (const entry of entries) {
+      for (const entry of turnEntries) {
         if (isReadOnly(entry)) {
           // Read-only: archive only (dropped from conversation), agent can re-read
           this.recallArchive.set(entry.seq, c.turn.messages);
         } else {
           // State-changing: keep nuclear one-liner in conversation + archive
           this.nuclearEntries.push(entry);
+          this.nuclearBySeq.set(entry.seq, entry);
           this.recallArchive.set(entry.seq, c.turn.messages);
         }
       }
@@ -197,34 +275,6 @@ export class ConversationState {
     return { before, after: this.estimateTokens() };
   }
 
-  // ── Tier 2 → Tier 3: Flush ───────────────────────────────────
-
-  /**
-   * Flush oldest nuclear entries to the history file when the
-   * in-context nuclear block grows too large.
-   */
-  async flush(): Promise<void> {
-    const maxEntries = getSettings().nuclearMaxEntries;
-    if (this.nuclearEntries.length <= maxEntries) return;
-
-    const flushCount = this.nuclearEntries.length - maxEntries;
-    const toFlush = this.nuclearEntries.slice(0, flushCount);
-
-    // Write to history file
-    if (this.historyFile) {
-      await this.historyFile.append(toFlush);
-    }
-
-    // Remove flushed entries from memory
-    for (const entry of toFlush) {
-      this.recallArchive.delete(entry.seq);
-    }
-    this.nuclearEntries = this.nuclearEntries.slice(flushCount);
-
-    // Update the nuclear block in messages
-    this.updateNuclearBlockInMessages(this.messages);
-  }
-
   // ── Startup: Load prior history ───────────────────────────────
 
   /**
@@ -245,17 +295,17 @@ export class ConversationState {
 
   // ── Conversation recall ───────────────────────────────────────
 
-  /** Search Tier 2 archive + Tier 3 history file. */
+  /** Search in-memory archive + history file. */
   async search(query: string): Promise<string> {
     if (!query.trim()) return "No query provided.";
 
     const parts: string[] = [];
 
-    // Search Tier 2 (in-memory archive)
+    // Search in-memory archive
     const archiveResults = this.searchArchive(query);
     if (archiveResults) parts.push(archiveResults);
 
-    // Search Tier 3 (history file)
+    // Search history file
     if (this.historyFile) {
       const fileResults = await this.historyFile.search(query);
       if (fileResults.length > 0) {
@@ -272,18 +322,24 @@ export class ConversationState {
 
   /** Expand full content of a nuclear entry by seq number. */
   async expand(seq: number): Promise<string> {
-    // Check Tier 2 archive first
+    // Try in-session memory first (full content)
     const archived = this.recallArchive.get(seq);
     if (archived) {
-      const entry = this.nuclearEntries.find((e) => e.seq === seq);
+      const entry = this.nuclearBySeq.get(seq);
       const header = entry ? formatNuclearLine(entry) : `#${seq}`;
       return `${header}\n\n${this.turnToText(archived)}`;
     }
 
-    return `Entry #${seq}: not found in recall archive (may have been flushed to history file).`;
+    // Fall back to history file body field
+    if (this.historyFile) {
+      const entry = await this.historyFile.findBySeq(seq);
+      if (entry?.body) return `${formatNuclearLine(entry)}\n\n${entry.body}`;
+    }
+
+    return `Entry #${seq}: no expanded content available.`;
   }
 
-  /** Browse nuclear entries (Tier 2) + recent history (Tier 3). */
+  /** Browse nuclear entries (in-context) + recent history file. */
   async browse(): Promise<string> {
     const parts: string[] = [];
 
@@ -323,6 +379,7 @@ export class ConversationState {
   clear(): void {
     this.messages = [];
     this.nuclearEntries = [];
+    this.nuclearBySeq.clear();
     this.recallArchive.clear();
   }
 
@@ -431,7 +488,7 @@ export class ConversationState {
     for (const [seq, msgs] of this.recallArchive) {
       const text = this.turnToText(msgs);
       if (regex.test(text)) {
-        const entry = this.nuclearEntries.find((e) => e.seq === seq);
+        const entry = this.nuclearBySeq.get(seq);
         matches.push(entry ? formatNuclearLine(entry) : `#${seq}`);
       }
     }
@@ -463,4 +520,10 @@ export class ConversationState {
     }
     return lines.join("\n");
   }
+}
+
+// ── Recency weighting ────────────────────────────────────────────
+
+function recencyWeight(idx: number, total: number): number {
+  return Math.max(0.1, 1 - idx / total);
 }

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -1,10 +1,9 @@
 /**
- * Persistent history file — Tier 3 of the three-tier history system.
+ * Persistent history file — append-only JSONL at ~/.agent-sh/history.
  *
- * Append-only JSONL file at ~/.agent-sh/history. Multiple agent-sh
- * instances can write concurrently — each line is under PIPE_BUF so
- * O_APPEND writes are atomic. Only truncation (which rewrites the file)
- * uses a lock file for safety.
+ * Multiple agent-sh instances can write concurrently — each line is under
+ * PIPE_BUF so O_APPEND writes are atomic. Only truncation (which rewrites
+ * the file) uses a lock file for safety.
  */
 import * as fs from "node:fs/promises";
 import * as fss from "node:fs";
@@ -93,6 +92,25 @@ export class HistoryFile {
       }
     }
     return results;
+  }
+
+  /**
+   * Find a single entry by sequence number. Returns null if not found.
+   * Searches from the end of the file (most recent first).
+   */
+  async findBySeq(seq: number): Promise<NuclearEntry | null> {
+    let content: string;
+    try {
+      content = await fs.readFile(this.filePath, "utf-8");
+    } catch {
+      return null;
+    }
+    const lines = content.trim().split("\n").filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const entry = deserializeEntry(lines[i]!);
+      if (entry && entry.seq === seq) return entry;
+    }
+    return null;
   }
 
   /**

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -22,8 +22,10 @@ export interface NuclearEntry {
   kind: "user" | "agent" | "tool" | "error";
   /** Tool name (for kind=tool or kind=error). */
   tool?: string;
-  /** The one-liner summary. */
+  /** The one-liner summary — injected in startup context. */
   sum: string;
+  /** Expanded content — on disk only, fetched by conversation_recall expand. */
+  body?: string;
 }
 
 // ── Tool classification ───────────────────────────────────────────
@@ -37,6 +39,107 @@ export const READ_ONLY_TOOLS = new Set([
 export const WRITE_TOOLS = new Set([
   "write_file", "edit_file", "write", "edit", "patch",
 ]);
+
+// ── Eager nucleation ──────────────────────────────────────────────
+
+/** Body caps by entry kind (in characters). 0 = no body stored. */
+const BODY_CAPS: Record<string, number> = {
+  user: 2000,
+  agent: 2000,
+  tool: 4000,
+  error: 2000,
+};
+
+/**
+ * Produce a nuclear entry eagerly — called at each hook point as messages
+ * arrive, not during compaction. Returns { sum, body }.
+ */
+export function nucleate(
+  kind: "user" | "agent",
+  text: string,
+  iid: string,
+  seq: number,
+): NuclearEntry;
+
+export function nucleate(
+  kind: "tool" | "error",
+  toolName: string,
+  args: Record<string, unknown>,
+  resultContent: string,
+  isError: boolean,
+  iid: string,
+  seq: number,
+): NuclearEntry;
+
+export function nucleate(
+  kindOrName: "user" | "agent" | "tool" | "error",
+  textOrTool: string,
+  arg2: string | Record<string, unknown>,
+  arg3?: string | number,
+  arg4?: boolean | string,
+  arg5?: number | string,
+  arg6?: number,
+): NuclearEntry {
+  if (kindOrName === "user" || kindOrName === "agent") {
+    // Simple overload: nucleate("user", text, iid, seq)
+    const text = textOrTool;
+    const iid = arg2 as string;
+    const seq = arg3 as number;
+    const maxSum = kindOrName === "user" ? 80 : 60;
+    const cap = BODY_CAPS[kindOrName]!;
+    return {
+      seq, ts: Date.now(), iid,
+      kind: kindOrName,
+      sum: `${kindOrName}: "${truncate(text, maxSum)}"`,
+      body: text.length > cap ? truncate(text, cap) : text,
+    };
+  } else {
+    // Tool/error overload: nucleate("tool", toolName, args, resultContent, isError, iid, seq)
+    const toolName = textOrTool;
+    const args = arg2 as Record<string, unknown>;
+    const resultContent = arg3 as string;
+    const isError = arg4 as boolean;
+    const iid = arg5 as string;
+    const seq = arg6 as number;
+    const kind = isError ? "error" : "tool";
+    const summary = summarizeToolCall(toolName, args);
+    const enriched = isError
+      ? `error: ${toolName} ${truncate(resultContent, 80)}`
+      : enrichWithResult(toolName, summary, resultContent);
+
+    let body: string | undefined;
+    if (READ_ONLY_TOOLS.has(toolName)) {
+      // Read-only tools: no body (agent can re-read the file)
+      body = undefined;
+    } else {
+      const cap = BODY_CAPS[kind]!;
+      const fullBody = buildToolBody(toolName, args, resultContent);
+      body = fullBody.length > cap ? truncate(fullBody, cap) : fullBody;
+    }
+
+    return {
+      seq, ts: Date.now(), iid,
+      kind,
+      tool: toolName,
+      sum: enriched,
+      body,
+    };
+  }
+}
+
+/** Build body text for a tool result — command + truncated output. */
+function buildToolBody(toolName: string, args: Record<string, unknown>, result: string): string {
+  const argStr = toolName === "bash" || toolName === "user_shell"
+    ? String(args.command ?? "")
+    : JSON.stringify(args);
+  const maxResult = 3000;
+  const truncated = result.length > maxResult
+    ? result.slice(0, Math.floor(maxResult * 0.6))
+      + `\n[… truncated …]\n`
+      + result.slice(result.length - Math.floor(maxResult * 0.4))
+    : result;
+  return `$ ${argStr}\n${truncated}`;
+}
 
 // ── Nuclear entry generation ──────────────────────────────────────
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -251,6 +251,11 @@ export interface ShellEvents {
   "agent:register-instruction": { name: string; text: string };
   "agent:remove-instruction": { name: string };
 
+  // Banner section collection (sync pipe: extensions contribute labeled items to startup banner)
+  "banner:collect": {
+    sections: Array<{ label: string; items: string[] }>;
+  };
+
   // Autocomplete (sync pipe: extensions inspect buffer and append items)
   "autocomplete:request": {
     buffer: string;

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -54,13 +54,6 @@ function encodeImageForTerminal(data: Buffer): string | null {
 // All mutable TUI state in one place for clarity and future
 // migration to a frame-based rendering model.
 
-interface TruncatedDiff {
-  filePath: string;
-  diff: DiffResult;
-  expandedLines?: string[];
-  expanded: boolean;
-}
-
 interface RenderState {
   // ── Response rendering ──
   renderer: MarkdownRenderer | null;
@@ -99,8 +92,6 @@ interface RenderState {
   showThinkingText: boolean;
   thinkingPending: boolean;
 
-  // ── Diff expansion ──
-  lastTruncatedDiff: TruncatedDiff | null;
 }
 
 function createRenderState(): RenderState {
@@ -129,7 +120,6 @@ function createRenderState(): RenderState {
     isThinking: false,
     showThinkingText: false,
     thinkingPending: false,
-    lastTruncatedDiff: null,
   };
 }
 
@@ -473,7 +463,6 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("input:keypress", (e) => {
-    if (e.key === "\x0f") expandLastDiff();       // Ctrl+O
     if (e.key === "\x14") toggleThinkingDisplay(); // Ctrl+T
   });
   // Interactive tool UI — stop spinner while tool has control
@@ -676,19 +665,8 @@ export default function activate(ctx: ExtensionContext): void {
       trueColor: true,
     });
 
-    const lastLine = diffLines[diffLines.length - 1] ?? "";
-    const isTruncated = lastLine.includes("… ");
-
-    if (isTruncated) {
-      s.lastTruncatedDiff = { filePath, diff, expanded: false };
-    } else {
-      s.lastTruncatedDiff = null;
-    }
-
     const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
-    const footer = isTruncated
-      ? [`  ${p.dim}ctrl+o to expand${p.reset}`]
-      : undefined;
+    const footer = undefined;
 
     return renderBoxFrame(body, {
       width: boxW,
@@ -1003,59 +981,6 @@ export default function activate(ctx: ExtensionContext): void {
       s.renderer!.writeLine(line);
     }
     drain();
-  }
-
-  function expandLastDiff(): void {
-    if (!s.lastTruncatedDiff) return;
-
-    const entry = s.lastTruncatedDiff;
-    entry.expanded = !entry.expanded;
-
-    if (!entry.expanded) {
-      showFileDiffCached(entry);
-      return;
-    }
-
-    if (!entry.expandedLines) {
-      const { filePath, diff } = entry;
-      const boxW = Math.min(cappedW() - 2, out().columns - 2);  // -2 for writeLine indent
-      const contentW = boxW - 4;
-
-      const diffLines = renderDiff(diff, {
-        width: contentW,
-        filePath,
-        maxLines: 500,
-        trueColor: true,
-      });
-
-      const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
-
-      entry.expandedLines = renderBoxFrame(body, {
-        width: boxW,
-        style: "rounded",
-        borderColor: p.dim,
-        title: diffTitle(filePath, diff),
-        footer: [`  ${p.dim}ctrl+o to collapse${p.reset}`],
-      });
-    }
-
-    out().write("\n");
-    for (const line of entry.expandedLines) {
-      out().write(line + "\n");
-    }
-  }
-
-  function showFileDiffCached(entry: TruncatedDiff): void {
-    const lines: string[] = ctx.call(
-      "render:result-body",
-      { kind: "diff", diff: entry.diff, filePath: entry.filePath } satisfies ToolResultBody,
-      cappedW(),
-    ) ?? [];
-
-    out().write("\n");
-    for (const line of lines) {
-      out().write(line + "\n");
-    }
   }
 
   function toggleThinkingDisplay(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,6 +309,14 @@ async function main(): Promise<void> {
       }
     }
 
+    const extSections = bus.emitPipe("banner:collect", { sections: [] }).sections;
+    for (const sec of extSections) {
+      sections += `\n\n  ${p.muted}${sec.label}:${p.reset}`;
+      for (const item of sec.items) {
+        sections += `\n    ${p.dim}${item}${p.reset}`;
+      }
+    }
+
     const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}>/help${p.muted} for commands${p.reset}`;
     const borderLine = `${p.muted}${"─".repeat(bannerW)}${p.reset}`;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -120,7 +120,7 @@ const DEFAULTS: Required<Settings> = {
   autoCompactThreshold: 0.5,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,
-  diffMaxLines: 20,
+  diffMaxLines: Infinity,
   skillPaths: [],
   startupBanner: true,
   promptIndicator: true,

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -525,7 +525,11 @@ export class InputHandler {
             const name = spaceIdx === -1 ? query : query.slice(0, spaceIdx);
             const args = spaceIdx === -1 ? "" : query.slice(spaceIdx + 1).trim();
             this.bus.emit("command:execute", { name, args });
-            this.ctx.freshPrompt();
+            if (currentMode.returnToSelf) {
+              this.enterMode(currentMode);
+            } else {
+              this.ctx.freshPrompt();
+            }
           } else if (query) {
             this.pendingReturnMode = currentMode.returnToSelf ? currentMode.id : null;
             currentMode.onSubmit(query, this.bus);

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -7,7 +7,7 @@ import { CONFIG_DIR, getSettings } from "../settings.js";
 import type { EventBus } from "../event-bus.js";
 import type { InputModeConfig } from "../types.js";
 
-const HISTORY_FILE = path.join(CONFIG_DIR, "history");
+const HISTORY_FILE = path.join(CONFIG_DIR, "input-history");
 
 /**
  * Narrow contract between InputHandler and its host (Shell).


### PR DESCRIPTION
## Summary

Redesign the context persistence system to write nuclear entries eagerly on every message arrival — like zsh appends every command to `~/.zsh_history`.

### Key changes

- **Eager nucleation**: every user query, agent response, and tool result is nucleated immediately and appended to `~/.agent-sh/history` (JSONL). No shutdown hook needed.
- **`body` field on `NuclearEntry`**: stores expandable content on disk alongside the one-liner `sum`. Caps per type: user/agent ~2KB, tools ~4KB, read-only tools dropped entirely.
- **`flush()` removed**: no second write path. Compaction is purely about evicting from the LLM context window.
- **Recency-weighted priority**: compaction now factors in recency when deciding what to evict (older entries get lower weight).
- **Cross-session `expand` fallback**: `conversation_recall expand` now falls back to the `body` field from disk for entries from prior sessions.
- **`HistoryFile.findBySeq()`**: efficient lookup for on-demand entry retrieval.
- **Banner collect pipe**: extensions can contribute labeled sections to the startup banner via `banner:collect`.
- **Input history fix**: `InputHandler` no longer clobbers the nuclear history file (now uses `~/.agent-sh/input-history`).

### Commits

| Commit | Description |
|--------|-------------|
| `ab4e479` | `feat: banner:collect pipe — extensions contribute labeled sections to startup banner` |
| `2d05f31` | `fix: separate input-history from nuclear history — InputHandler no longer clobbers agent memory` |
| `78051b8` | `fix package export` |
| `b98f88e` | `feat: eager nucleation — persistent context history like zsh` |

### Design doc

See `260414_context.org` (in dev notes) for the full implementation guide.