### PR TITLE
feat: extension system prompt sections + recall fixes + diff refactor

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -100,7 +100,7 @@ Key behaviors:
 
 ### Tier 3: History File
 
-When nuclear entries accumulate past `nuclearMaxEntries` (default 200), oldest entries flush to `~/.agent-sh/history` — a JSONL file that persists across restarts.
+Nuclear entries are eagerly written to `~/.agent-sh/history` — a JSONL file that persists across restarts — as they arrive. They also stay in memory for the nuclear block injected into context.
 
 On startup, the last `historyStartupEntries` (default 100) non-read-only entries are loaded so the agent knows what happened in prior terminal sessions. Read-only tools (`read_file`, `grep`, `glob`, `ls`) are filtered out at load time to maximize the number of meaningful entries.
 
@@ -165,15 +165,14 @@ All settings in `~/.agent-sh/settings.json`:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `contextWindowSize` | 20 | Max recent shell exchanges in context |
-| `contextBudget` | 16384 | Byte budget for shell context |
-| `shellTruncateThreshold` | 10 | Shell output lines before truncation |
-| `shellHeadLines` | 5 | Lines kept from start of truncated output |
-| `shellTailLines` | 5 | Lines kept from end |
+| `contextBudget` | 32768 | Byte budget for shell context |
+| `shellTruncateThreshold` | 20 | Shell output lines before truncation |
+| `shellHeadLines` | 10 | Lines kept from start of truncated output |
+| `shellTailLines` | 10 | Lines kept from end |
 | `shellContextRatio` | 0.35 | Fraction of content budget for shell context |
-| `recallExpandMaxLines` | 100 | Max lines shell_recall returns without line ranges |
-| `historyMaxBytes` | 102400 | Max history file size (100KB) |
+| `recallExpandMaxLines` | 500 | Max lines recall expand returns without line ranges |
+| `historyMaxBytes` | 104857600 | Max history file size (100MB) |
 | `historyStartupEntries` | 100 | Prior history entries loaded on startup (read-only tools filtered) |
-| `nuclearMaxEntries` | 200 | Max nuclear entries in-context before flushing to disk |
 
 ## Key Files
 

--- a/package.json
+++ b/package.json
@@ -98,12 +98,14 @@
   },
   "dependencies": {
     "cli-highlight": "^2.1.11",
+    "diff": "^9.0.0",
     "marked": "^17.0.6",
     "node-pty": "^1.2.0-beta.12",
     "openai": "^6.34.0",
     "tsx": "^4.19.0"
   },
   "devDependencies": {
+    "@types/diff": "^8.0.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
   }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -806,6 +806,12 @@ export class AgentLoop implements AgentBackend {
   private async executeLoop(signal: AbortSignal): Promise<string> {
     let fullResponseText = "";
 
+    // System prompt and dynamic context are constant within a single agent
+    // query — no new shell commands arrive between tool-call iterations, and
+    // extension instructions don't change mid-flight. Build once.
+    const systemPrompt = this.handlers.call("system-prompt:build") as string;
+    const dynamicContext = this.handlers.call("dynamic-context:build");
+
     while (!signal.aborted) {
       // Auto-compact when total context approaches the window limit.
       const totalEstimate = this.conversation.estimatePromptTokens();
@@ -817,11 +823,6 @@ export class AgentLoop implements AgentBackend {
         this.conversation.compact(threshold);
         // Auto-compaction is silent — no ui:info emitted
       }
-
-      // System prompt uses handler so extensions can append instructions (cacheable);
-      // dynamic context uses handler for per-query state via advise()
-      const systemPrompt = this.handlers.call("system-prompt:build") as string;
-      const dynamicContext = this.handlers.call("dynamic-context:build");
 
       // Stream LLM response with retry
       const result = await this.streamWithRetry(systemPrompt, dynamicContext, signal);

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -20,7 +20,7 @@ import type { HandlerFunctions } from "../utils/handler-registry.js";
 import { setMaxListeners } from "node:events";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { computeDiff, computeInputDiff } from "../utils/diff.js";
+import { computeDiff, computeEditDiff, computeInputDiff } from "../utils/diff.js";
 import type { AgentBackend, ToolDefinition } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState } from "./conversation-state.js";
@@ -68,6 +68,7 @@ export class AgentLoop implements AgentBackend {
   private ctorListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
   private ctorPipeListeners: Array<{ event: string; fn: (...args: any[]) => any }> = [];
   private lastProjectSkillNames = new Set<string>();
+
   private static readonly THINKING_LEVELS = ["off", "low", "medium", "high"];
 
   private bus: EventBus;
@@ -113,10 +114,18 @@ export class AgentLoop implements AgentBackend {
       this.bus.on(event, fn);
       this.ctorListeners.push({ event, fn });
     };
-    onCtor("agent:register-tool", ({ tool }) => this.registerTool(tool));
-    onCtor("agent:unregister-tool", ({ name }) => this.unregisterTool(name));
-    onCtor("agent:register-instruction", ({ name, text }) => this.registerInstruction(name, text));
+    onCtor("agent:register-tool", ({ tool, extensionName }) => {
+      this.registerTool(tool);
+      if (extensionName) this.toolExtensions.set(tool.name, extensionName);
+    });
+    onCtor("agent:unregister-tool", ({ name }) => {
+      this.unregisterTool(name);
+      this.toolExtensions.delete(name);
+    });
+    onCtor("agent:register-instruction", ({ name, text, extensionName }) => this.registerInstruction(name, text, extensionName));
     onCtor("agent:remove-instruction", ({ name }) => this.removeInstruction(name));
+    onCtor("agent:register-skill", ({ name, description, filePath, extensionName }) => this.registerSkill(name, description, filePath, extensionName));
+    onCtor("agent:remove-skill", ({ name }) => this.removeSkill(name));
     const getToolsPipe = () => ({ tools: this.getTools() });
     this.bus.onPipe("agent:get-tools", getToolsPipe);
     this.ctorPipeListeners.push({ event: "agent:get-tools", fn: getToolsPipe });
@@ -216,8 +225,10 @@ export class AgentLoop implements AgentBackend {
       this.lastProjectSkillNames.clear();
     });
     on("agent:compact-request", () => {
-      // Force compaction: use target of 0 so every non-pinned turn is evicted
-      const stats = this.conversation.compact(0, 10, true);
+      // Force compaction: nucleate everything. No recent window preservation —
+      // conversation_recall can recover any evicted content, so there's no reason
+      // to keep verbatim turns when the user explicitly requests compaction.
+      const stats = this.conversation.compact(0, 0, true);
       if (stats) {
         this.bus.emit("ui:info", {
           message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
@@ -286,13 +297,20 @@ export class AgentLoop implements AgentBackend {
     return this.toolRegistry.all();
   }
 
-  // ── Extension instructions & tool tracking ──────────────────────
+  // ── Extension instructions, skills & tool tracking ──────────────────
 
-  private instructions = new Map<string, string>();
+  /** Instructions keyed by name, with extension attribution. */
+  private instructions = new Map<string, { text: string; extensionName: string }>();
+
+  /** Skills keyed by name, with extension attribution. */
+  private skills = new Map<string, { description: string; filePath: string; extensionName: string }>();
+
+  /** Tool → extension name attribution. */
+  private toolExtensions = new Map<string, string>();
 
   /** Register a named instruction block for the system prompt. */
-  registerInstruction(name: string, text: string): void {
-    this.instructions.set(name, text);
+  registerInstruction(name: string, text: string, extensionName: string): void {
+    this.instructions.set(name, { text, extensionName });
   }
 
   /** Remove a named instruction block. */
@@ -300,13 +318,71 @@ export class AgentLoop implements AgentBackend {
     this.instructions.delete(name);
   }
 
-  /** Get instruction blocks registered by extensions. */
-  getInstructionSections(): string[] {
-    const sections: string[] = [];
-    for (const [name, text] of this.instructions) {
-      sections.push(`## ${name}\n${text}`);
+  /** Register a named skill (on-demand reference material). */
+  registerSkill(name: string, description: string, filePath: string, extensionName: string): void {
+    this.skills.set(name, { description, filePath, extensionName });
+  }
+
+  /** Remove a registered skill. */
+  removeSkill(name: string): void {
+    this.skills.delete(name);
+  }
+
+  /**
+   * Build the system prompt grouped by extension.
+   *
+   * Each extension gets a unified block:
+   *   ## extension-name
+   *   ### Tools
+   *   ### Skills
+   *   ### Instructions
+   */
+  buildExtensionSections(): string[] {
+    interface ExtensionGroup {
+      tools: Array<{ name: string; description: string }>;
+      skills: Array<{ name: string; description: string; filePath: string }>;
+      instructions: Array<{ text: string }>;
     }
-    return sections;
+
+    const groups = new Map<string, ExtensionGroup>();
+    const ensure = (name: string): ExtensionGroup =>
+      groups.get(name) ?? (groups.set(name, { tools: [], skills: [], instructions: [] }).get(name)!);
+
+    // Attribute instructions
+    for (const { text, extensionName } of this.instructions.values()) {
+      ensure(extensionName).instructions.push({ text });
+    }
+
+    // Attribute skills
+    for (const [skillName, { description, filePath, extensionName }] of this.skills) {
+      ensure(extensionName).skills.push({ name: skillName, description, filePath });
+    }
+
+    // Attribute tools (skip built-in scratchpad tools)
+    const builtinTools = new Set([
+      "bash", "read_file", "write_file", "edit_file", "grep", "glob", "ls",
+      "list_skills", "conversation_recall",
+    ]);
+    for (const tool of this.toolRegistry.all()) {
+      if (builtinTools.has(tool.name)) continue;
+      const extName = this.toolExtensions.get(tool.name);
+      if (!extName) continue;
+      ensure(extName).tools.push({ name: tool.name, description: tool.description.split("\n")[0] });
+    }
+
+    // Render
+    return [...groups.entries()]
+      .filter(([, g]) => g.tools.length + g.skills.length + g.instructions.length > 0)
+      .map(([name, g]) => {
+        const parts: string[] = [];
+        if (g.tools.length > 0)
+          parts.push("### Tools\n" + g.tools.map(t => `${t.name} — ${t.description}`).join("\n"));
+        if (g.skills.length > 0)
+          parts.push("### Skills\n" + g.skills.map(s => `${s.name}: ${s.description}\n  → ${s.filePath}`).join("\n\n"));
+        if (g.instructions.length > 0)
+          parts.push("### Instructions\n" + g.instructions.map(i => i.text).join("\n\n"));
+        return `## ${name}\n${parts.join("\n\n")}`;
+      });
   }
 
   kill(): void {
@@ -477,7 +553,9 @@ export class AgentLoop implements AgentBackend {
       displayName: "recall",
       description:
         "Browse, search, or expand evicted conversation turns. " +
-        "Use when you need context from earlier in the conversation that was compacted away.",
+        "Use when you need context from earlier in the conversation that was compacted away. " +
+        "Search is regex-based and covers both summaries and full body text. " +
+        "If search doesn't find what you expect, try broader/shorter terms or browse to scan the timeline.",
       input_schema: {
         type: "object",
         properties: {
@@ -514,9 +592,12 @@ export class AgentLoop implements AgentBackend {
     // System instruction: proactively search history for prior preferences
     this.registerInstruction(
       "recall-guidance",
-      "When starting a task that may have been discussed before (conventions, preferences, corrections), " +
+      "When starting a task that may have been discussed before (conventions, preferences, corrections, prior examples), " +
       "use conversation_recall to search history for relevant prior entries. " +
-      "Treat recurring user guidance as standing preferences.",
+      "Treat recurring user guidance as standing preferences. " +
+      "If a search returns nothing useful, try: shorter queries, alternate terms, or browse to scan the full timeline. " +
+      "Recall only covers this and recent sessions — for older context, also search the filesystem (grep, glob).",
+      "core",
     );
   }
 
@@ -531,9 +612,9 @@ export class AgentLoop implements AgentBackend {
     // Extensions can use registerInstruction() for a managed section,
     // or advise this handler directly for full control.
     h.define("system-prompt:build", () => {
-      const instructions = this.getInstructionSections();
-      if (instructions.length === 0) return STATIC_SYSTEM_PROMPT;
-      return STATIC_SYSTEM_PROMPT + "\n\n# Extension Instructions\n\n" + instructions.join("\n\n");
+      const sections = this.buildExtensionSections();
+      if (sections.length === 0) return STATIC_SYSTEM_PROMPT;
+      return STATIC_SYSTEM_PROMPT + "\n\n# Extension Instructions\n\n" + sections.join("\n\n");
     });
 
     // Extensions compose additional context (git info, project rules, etc.)
@@ -580,10 +661,19 @@ export class AgentLoop implements AgentBackend {
             let diff: ReturnType<typeof computeDiff> | undefined;
 
             if (typeof args.old_text === "string" && typeof args.new_text === "string") {
-              // edit_file — diff the edit inputs directly, no file read needed
+              // edit_file — read the file so line numbers are real (not relative to the edit region)
               const normalizedOld = (args.old_text as string).replace(/\r\n/g, "\n");
               const normalizedNew = (args.new_text as string).replace(/\r\n/g, "\n");
-              diff = computeInputDiff(normalizedOld, normalizedNew);
+              try {
+                const oldFileContent = await fs.readFile(absPath, "utf-8");
+                diff = computeEditDiff(
+                  oldFileContent, normalizedOld, normalizedNew,
+                  args.replace_all === true,
+                );
+              } catch {
+                // File doesn't exist yet — fall back to input-only diff
+                diff = computeInputDiff(normalizedOld, normalizedNew);
+              }
             } else if (typeof args.content === "string") {
               // write_file — still need to read the old file for comparison
               let oldContent: string | null = null;

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -179,9 +179,13 @@ export class ConversationState {
   }
 
   private appendToFile(entries: NuclearEntry[]): void {
-    if (this.historyFile && entries.length > 0) {
+    if (!this.historyFile || entries.length === 0) return;
+    // Skip read-only tools (read_file, grep, glob, ls) — they bloat the
+    // file without adding searchable value since the agent can re-run them.
+    const writable = entries.filter((e) => !isReadOnly(e));
+    if (writable.length > 0) {
       // Fire-and-forget — don't block the conversation flow
-      this.historyFile.append(entries).catch(() => {});
+      this.historyFile.append(writable).catch(() => {});
     }
   }
 

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -254,8 +254,13 @@ export class ConversationState {
     const turns = this.parseTurns();
     if (turns.length <= 2) return null;
 
-    // Assign priorities with recency weighting
-    const pinnedCount = Math.min(recentTurnsToKeep, turns.length - 1);
+    // Cap the pinned window so at least ~40% of turns are evictable.
+    // Without this, sessions with few turns but large tool outputs would have
+    // everything pinned and nothing to compact — the user sees high usage but
+    // gets "nothing to compact". When force=true, be more aggressive (60% evictable).
+    const maxPinnedFraction = force ? 0.4 : 0.6;
+    const maxPinned = Math.max(2, Math.floor(turns.length * maxPinnedFraction));
+    const pinnedCount = Math.min(recentTurnsToKeep, turns.length - 1, maxPinned);
     for (let i = 0; i < turns.length; i++) {
       turns[i]!.priority = this.inferPriority(turns[i]!.messages);
     }
@@ -505,7 +510,7 @@ export class ConversationState {
    * - Keeps user/assistant messages intact
    */
   private slimTurn(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
-    const MAX_RESULT_LEN = 500;
+    const MAX_RESULT_LEN = 1500;
     const result: ChatCompletionMessageParam[] = [];
 
     // Collect tool_call ids that are read-only so we can skip their results

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -91,7 +91,11 @@ export class HistoryFile {
     const results: { entry: NuclearEntry; line: string }[] = [];
     for (const line of content.trim().split("\n")) {
       const entry = deserializeEntry(line);
-      if (entry && !isReadOnly(entry) && regex.test(entry.sum)) {
+      if (!entry || isReadOnly(entry)) continue;
+      // Search both the summary and the body — the body can contain up to
+      // 4000 chars of the original content that the summary truncates away.
+      const searchText = [entry.sum, entry.body].filter(Boolean).join("\n");
+      if (regex.test(searchText)) {
         results.push({ entry, line: formatNuclearLine(entry) });
       }
     }

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -42,12 +42,14 @@ export const WRITE_TOOLS = new Set([
 
 // ── Eager nucleation ──────────────────────────────────────────────
 
-/** Body caps by entry kind (in characters). 0 = no body stored. */
+/** Body caps by entry kind (in characters). 0 = no body stored.
+ *  These are only recovered via conversation_recall expand — they
+ *  never enter the context window automatically, so be generous. */
 const BODY_CAPS: Record<string, number> = {
-  user: 2000,
-  agent: 2000,
-  tool: 4000,
-  error: 2000,
+  user: 8000,
+  agent: 8000,
+  tool: 16000,
+  error: 8000,
 };
 
 /**
@@ -85,7 +87,7 @@ export function nucleate(
     const text = textOrTool;
     const iid = arg2 as string;
     const seq = arg3 as number;
-    const maxSum = kindOrName === "user" ? 80 : 60;
+    const maxSum = kindOrName === "user" ? 200 : 150;
     const cap = BODY_CAPS[kindOrName]!;
     return {
       seq, ts: Date.now(), iid,
@@ -132,7 +134,7 @@ function buildToolBody(toolName: string, args: Record<string, unknown>, result: 
   const argStr = toolName === "bash" || toolName === "user_shell"
     ? String(args.command ?? "")
     : JSON.stringify(args);
-  const maxResult = 3000;
+  const maxResult = 12000;
   const truncated = result.length > maxResult
     ? result.slice(0, Math.floor(maxResult * 0.6))
       + `\n[… truncated …]\n`

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -93,7 +93,7 @@ export function buildDynamicContext(
     sections.push("# Project Conventions\n\n" + conventions.join("\n\n"));
   }
 
-  // Skills hint
+  // Skills hint (folder-based discovery for backward compatibility)
   const skills = discoverSkills(contextManager.getCwd());
   if (skills.length > 0) {
     sections.push(

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -283,7 +283,7 @@ export class ContextManager {
       out += `- Your internal tools (bash, read, write, ls, etc.) run in an isolated subprocess. The user CANNOT see their output.\n`;
       out += `- Only use internal tools when YOU need to reason about content silently (e.g. reading a file to answer a question about it).\n`;
       out += `- You can browse or search shell history with shell_recall.\n`;
-      out += `- You can browse or search evicted conversation turns with conversation_recall.\n`;
+      out += `- You can browse or search evicted conversation turns with conversation_recall (search covers summaries and full body text).\n`;
       out += `\n`;
       this.firstPrompt = false;
     }

--- a/src/core.ts
+++ b/src/core.ts
@@ -184,7 +184,9 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     },
 
     extensionContext(opts) {
-      return {
+      // Mutable extension name — set by extension-loader before activate()
+      let _extensionName = "";
+      const ctx: ExtensionContext = {
         bus,
         contextManager,
         instanceId,
@@ -196,16 +198,20 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         getExtensionSettings: settingsMod.getExtensionSettings,
         registerCommand: (name, description, handler) =>
           bus.emit("command:register", { name, description, handler }),
-        registerTool: (tool) => bus.emit("agent:register-tool", { tool }),
+        registerTool: (tool) => bus.emit("agent:register-tool", { tool, extensionName: _extensionName }),
         unregisterTool: (name) => bus.emit("agent:unregister-tool", { name }),
         getTools: () => bus.emitPipe("agent:get-tools", { tools: [] }).tools,
-        registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text }),
+        registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text, extensionName: _extensionName }),
         removeInstruction: (name) => bus.emit("agent:remove-instruction", { name }),
+        registerSkill: (name, description, filePath) => bus.emit("agent:register-skill", { name, description, filePath, extensionName: _extensionName }),
+        removeSkill: (name) => bus.emit("agent:remove-skill", { name }),
         define: (name, fn) => handlers.define(name, fn),
         advise: (name, wrapper) => handlers.advise(name, wrapper),
         call: (name, ...args) => handlers.call(name, ...args),
         get terminalBuffer() { return getTerminalBuffer(); },
         compositor,
+        get _extensionName() { return _extensionName; },
+        set _extensionName(n: string) { _extensionName = n; }, // set by extension-loader before activate()
         createRemoteSession: (opts: RemoteSessionOptions): RemoteSession => {
           const { surface } = opts;
           const cleanups: (() => void)[] = [];
@@ -250,6 +256,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           };
         },
       };
+      return ctx;
     },
 
     kill() {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -245,12 +245,14 @@ export interface ShellEvents {
   };
 
   // Tool/instruction registration (extension → active agent backend)
-  "agent:register-tool": { tool: import("./agent/types.js").ToolDefinition };
+  "agent:register-tool": { tool: import("./agent/types.js").ToolDefinition; extensionName?: string };
   "agent:unregister-tool": { name: string };
   "agent:get-tools": { tools: import("./agent/types.js").ToolDefinition[] };
   "agent:get-nuclear-summary": { summary: string | null };
-  "agent:register-instruction": { name: string; text: string };
+  "agent:register-instruction": { name: string; text: string; extensionName: string };
   "agent:remove-instruction": { name: string };
+  "agent:register-skill": { name: string; description: string; filePath: string; extensionName: string };
+  "agent:remove-skill": { name: string };
 
   // Banner section collection (sync pipe: extensions contribute labeled items to startup banner)
   "banner:collect": {

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -62,6 +62,12 @@ function createScopedContext(ctx: ExtensionContext): { scoped: ExtensionContext;
     cleanups.push(() => ctx.removeInstruction(name));
   };
 
+  // Track skill registrations
+  const scopedRegisterSkill: typeof ctx.registerSkill = (name, description, filePath) => {
+    ctx.registerSkill(name, description, filePath);
+    cleanups.push(() => ctx.removeSkill(name));
+  };
+
   // Track tool registrations
   const scopedRegisterTool: typeof ctx.registerTool = (tool) => {
     ctx.registerTool(tool);
@@ -74,6 +80,8 @@ function createScopedContext(ctx: ExtensionContext): { scoped: ExtensionContext;
     advise: scopedAdvise,
     registerInstruction: scopedRegisterInstruction,
     removeInstruction: ctx.removeInstruction,
+    registerSkill: scopedRegisterSkill,
+    removeSkill: ctx.removeSkill,
     registerTool: scopedRegisterTool,
     unregisterTool: ctx.unregisterTool,
   };
@@ -198,9 +206,11 @@ async function loadSpecifiers(
           extensionDisposers.get(name)?.();
 
           const { scoped, dispose } = createScopedContext(ctx);
+          scoped._extensionName = name;
           activate(scoped);
           extensionDisposers.set(name, dispose);
         } else {
+          ctx._extensionName = name;
           activate(ctx);
         }
         loaded.push(name);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,8 +70,6 @@ export interface Settings {
   historyMaxBytes?: number;
   /** Number of prior history entries to load on startup (default: 50). */
   historyStartupEntries?: number;
-  /** Max nuclear entries kept in-context before flushing to history file (default: 200). */
-  nuclearMaxEntries?: number;
   /** Auto-compact threshold as fraction of conversation budget (0-1, default 0.5). */
   autoCompactThreshold?: number;
 
@@ -108,15 +106,14 @@ const DEFAULTS: Required<Settings> = {
   defaultBackend: "ash",
   toolMode: "api" as "api" | "deferred" | "inline",
   contextWindowSize: 20,
-  contextBudget: 16384,
-  shellTruncateThreshold: 10,
-  shellHeadLines: 5,
-  shellTailLines: 5,
-  recallExpandMaxLines: 100,
+  contextBudget: 32768,
+  shellTruncateThreshold: 20,
+  shellHeadLines: 10,
+  shellTailLines: 10,
+  recallExpandMaxLines: 500,
   shellContextRatio: 0.35,
-  historyMaxBytes: 102400,
+  historyMaxBytes: 104857600, // 100MB — history is only accessed via search/expand, never loaded wholesale
   historyStartupEntries: 100,
-  nuclearMaxEntries: 200,
   autoCompactThreshold: 0.5,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,16 @@ export interface ExtensionContext {
   /** Remove a named instruction block from the system prompt. */
   removeInstruction: (name: string) => void;
 
+  // ── Skill registration ────────────────────────────────────
+  /** Register a skill (on-demand reference material) for the agent. */
+  registerSkill: (name: string, description: string, filePath: string) => void;
+  /** Remove a registered skill by name. */
+  removeSkill: (name: string) => void;
+
+  // ── Internal ──────────────────────────────────────────────
+  /** @internal Extension name set by the loader before activate(). */
+  _extensionName?: string;
+
   // ── Named handler registry (Emacs-style advice) ───────────
   /** Register a named handler. */
   define: (name: string, fn: (...args: any[]) => any) => void;

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,9 +1,17 @@
 /**
- * Myers' O(ND) diff algorithm for line-level diffs.
+ * Line-level diff computation, powered by the `diff` npm package.
  *
- * Replaces the previous O(m×n) LCS implementation — for a file with
- * 1000 lines where 3 lines change, this runs ~300× faster.
+ * Exposes a unified `DiffResult` interface consumed by the diff renderer.
+ * Three entry points cover the main use cases:
+ *
+ *   computeDiff       — full-file diff (write_file, or when edit region can't be located)
+ *   computeEditDiff   — edit_file: locates the edit region, builds the new file, full diff
+ *   computeInputDiff  — fast preview: diffs only old_text vs new_text, no file I/O
  */
+
+import * as Diff from "diff";
+
+// ── Types ────────────────────────────────────────────────────────────
 
 export interface DiffLine {
   type: "context" | "added" | "removed";
@@ -24,10 +32,80 @@ export interface DiffResult {
   isNewFile: boolean;
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Convert a `diff` library Change[] into our DiffLine[], tracking real
+ * old/new line numbers.
+ */
+function changesToDiffLines(changes: Diff.Change[]): DiffLine[] {
+  const result: DiffLine[] = [];
+  let oldNo = 0;
+  let newNo = 0;
+
+  for (const change of changes) {
+    const lines = change.value.replace(/\n$/, "").split("\n");
+    for (const text of lines) {
+      if (change.added) {
+        newNo++;
+        result.push({ type: "added", oldNo: null, newNo, text });
+      } else if (change.removed) {
+        oldNo++;
+        result.push({ type: "removed", oldNo, newNo: null, text });
+      } else {
+        oldNo++;
+        newNo++;
+        result.push({ type: "context", oldNo, newNo, text });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Group raw DiffLines into hunks with `context` lines of surrounding context.
+ */
+function groupHunks(lines: DiffLine[], ctx: number): DiffHunk[] {
+  const changeIdx: number[] = [];
+  for (let i = 0; i < lines.length; i++)
+    if (lines[i].type !== "context") changeIdx.push(i);
+
+  if (changeIdx.length === 0) return [];
+
+  const hunks: DiffHunk[] = [];
+  let start = Math.max(0, changeIdx[0]! - ctx);
+  let end = Math.min(lines.length - 1, changeIdx[0]! + ctx);
+
+  for (let k = 1; k < changeIdx.length; k++) {
+    const ns = Math.max(0, changeIdx[k]! - ctx);
+    const ne = Math.min(lines.length - 1, changeIdx[k]! + ctx);
+    if (ns <= end + 1) {
+      end = ne;
+    } else {
+      hunks.push({ lines: lines.slice(start, end + 1) });
+      start = ns;
+      end = ne;
+    }
+  }
+  hunks.push({ lines: lines.slice(start, end + 1) });
+  return hunks;
+}
+
+function countChanges(lines: DiffLine[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const l of lines) {
+    if (l.type === "added") added++;
+    else if (l.type === "removed") removed++;
+  }
+  return { added, removed };
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
 /**
  * Compute a line-level diff between old and new file content.
- * Uses Myers' O(ND) algorithm — proportional to the edit distance,
- * not the file size.
  */
 export function computeDiff(
   oldText: string | null,
@@ -56,38 +134,12 @@ export function computeDiff(
 
   // Identical — nothing to show
   if (oldText === newText) {
-    return {
-      hunks: [],
-      added: 0,
-      removed: 0,
-      isIdentical: true,
-      isNewFile: false,
-    };
+    return { hunks: [], added: 0, removed: 0, isIdentical: true, isNewFile: false };
   }
 
-  const a = oldText.split("\n");
-  const b = newText.split("\n");
-
-  // For very large files, fall back to a simple line-count diff
-  if (a.length + b.length > 2_000_000) {
-    return {
-      hunks: [],
-      added: b.length,
-      removed: a.length,
-      isIdentical: false,
-      isNewFile: false,
-    };
-  }
-
-  const ses = myersSES(a, b);
-  const raw = sesToDiffLines(ses, a, b);
-
-  let added = 0;
-  let removed = 0;
-  for (const l of raw) {
-    if (l.type === "added") added++;
-    else if (l.type === "removed") removed++;
-  }
+  const changes = Diff.diffLines(oldText, newText);
+  const raw = changesToDiffLines(changes);
+  const { added, removed } = countChanges(raw);
 
   return {
     hunks: groupHunks(raw, 3),
@@ -100,7 +152,8 @@ export function computeDiff(
 
 /**
  * Compute a diff for an edit operation where we know the old/new text.
- * Only diffs a window around the edit region — O(window²) instead of O(file²).
+ * Locates the edit region(s) in the file, constructs the full new file,
+ * then diffs the whole thing so line numbers are file-relative.
  */
 export function computeEditDiff(
   oldFileText: string,
@@ -109,14 +162,12 @@ export function computeEditDiff(
   replaceAll = false,
 ): DiffResult {
   const a = oldFileText.split("\n");
-
   const editOldLines = editOld.split("\n");
   const editNewLines = editNew.split("\n");
 
   // Find all occurrences of editOld in the file
   const regions: { start: number; end: number }[] = [];
   if (replaceAll) {
-    // Find all non-overlapping occurrences
     let i = 0;
     while (i <= a.length - editOldLines.length) {
       let match = true;
@@ -125,13 +176,12 @@ export function computeEditDiff(
       }
       if (match) {
         regions.push({ start: i, end: i + editOldLines.length });
-        i += editOldLines.length; // skip past
+        i += editOldLines.length;
       } else {
         i++;
       }
     }
   } else {
-    // Find the single occurrence
     for (let i = 0; i <= a.length - editOldLines.length; i++) {
       let match = true;
       for (let k = 0; k < editOldLines.length; k++) {
@@ -144,7 +194,7 @@ export function computeEditDiff(
     }
   }
 
-  // Build the full new file to compute correct line numbers
+  // Build the full new file
   let newFile: string[];
   if (replaceAll && regions.length > 0) {
     const parts: string[] = [];
@@ -160,7 +210,7 @@ export function computeEditDiff(
     const r = regions[0]!;
     newFile = [...a.slice(0, r.start), ...editNewLines, ...a.slice(r.end)];
   } else {
-    // Couldn't locate edit — fall back to full diff
+    // Couldn't locate edit — fall back to string replace + full diff
     const newContent = replaceAll
       ? oldFileText.split(editOld).join(editNew)
       : oldFileText.replace(editOld, editNew);
@@ -180,18 +230,9 @@ export function computeInputDiff(
   oldText: string,
   newText: string,
 ): DiffResult {
-  const a = oldText.split("\n");
-  const b = newText.split("\n");
-
-  const ses = myersSES(a, b);
-  const raw = sesToDiffLines(ses, a, b);
-
-  let added = 0;
-  let removed = 0;
-  for (const l of raw) {
-    if (l.type === "added") added++;
-    else if (l.type === "removed") removed++;
-  }
+  const changes = Diff.diffLines(oldText, newText);
+  const raw = changesToDiffLines(changes);
+  const { added, removed } = countChanges(raw);
 
   return {
     hunks: groupHunks(raw, 3),
@@ -200,202 +241,4 @@ export function computeInputDiff(
     isIdentical: false,
     isNewFile: false,
   };
-}
-
-// ── Myers' algorithm ──────────────────────────────────────────────
-
-interface SESEntry {
-  type: "keep" | "insert" | "delete";
-  text: string;
-}
-
-/**
- * Myers' shortest edit script (O(ND) where D = edit distance).
- * Returns the minimal edit script transforming `a` into `b`.
- */
-function myersSES(a: string[], b: string[]): SESEntry[] {
-  const n = a.length;
-  const m = b.length;
-
-  if (n === 0) return b.map(text => ({ type: "insert" as const, text }));
-  if (m === 0) return a.map(text => ({ type: "delete" as const, text }));
-
-  const max = n + m;
-  // V[k] = furthest-reaching x on diagonal k; use offset to handle negative indices
-  const size = 2 * max + 1;
-  const v = new Int32Array(size);
-  const offset = max;
-  v[offset + 1] = 0; // V[1] = 0
-
-  // Store traces for backtracking
-  const traces: Int32Array[] = [];
-
-  let foundD = -1;
-
-  for (let d = 0; d <= max; d++) {
-    // Snapshot V for backtracking
-    const trace = new Int32Array(size);
-    trace.set(v);
-    traces.push(trace);
-
-    for (let k = -d; k <= d; k += 2) {
-      // Decide whether to move down (insert) or right (delete)
-      let x: number;
-      if (k === -d || (k !== d && v[offset + k - 1] < v[offset + k + 1])) {
-        x = v[offset + k + 1]; // move down — insert from b
-      } else {
-        x = v[offset + k - 1] + 1; // move right — delete from a
-      }
-
-      let y = x - k;
-
-      // Extend along diagonal (matching lines)
-      while (x < n && y < m && a[x] === b[y]) {
-        x++;
-        y++;
-      }
-
-      v[offset + k] = x;
-
-      if (x >= n && y >= m) {
-        foundD = d;
-        break;
-      }
-    }
-
-    if (foundD >= 0) break;
-  }
-
-  // Backtrack through traces to produce the edit script
-  return backtrackMyers(traces, a, b, foundD, offset);
-}
-
-function backtrackMyers(
-  traces: Int32Array[],
-  a: string[],
-  b: string[],
-  d: number,
-  offset: number,
-): SESEntry[] {
-  const n = a.length;
-  const m = b.length;
-
-  // Collect (x, y) at each step
-  const path: Array<{ x: number; y: number }> = [];
-  let x = n;
-  let y = m;
-
-  for (let dd = d; dd > 0; dd--) {
-    const v = traces[dd]!;
-    const k = x - y;
-
-    let prevK: number;
-    if (k === -dd || (k !== dd && v[offset + k - 1] < v[offset + k + 1])) {
-      prevK = k + 1; // came from insert
-    } else {
-      prevK = k - 1; // came from delete
-    }
-
-    const prevX = v[offset + prevK];
-    const prevY = prevX - prevK;
-
-    // Diagonal runs between (prevX, prevY) and the start of the diagonal run to (x,y)
-    // First, unwind diagonal from (x,y) back to where the snake starts
-    const trace = traces[dd - 1]!;
-    let midX = prevK === k + 1 ? prevX : prevX + 1;
-    let midY = midX - k;
-
-    // Diagonal from midX,midY to x,y
-    path.push({ x, y });
-
-    // Walk diagonal back
-    while (midX < x && midY < y) {
-      x--;
-      y--;
-      path.push({ x, y });
-    }
-
-    // The move itself
-    path.push({ x: prevX, y: prevY });
-
-    x = prevX;
-    y = prevY;
-  }
-
-  // d=0: just the initial diagonal
-  path.push({ x: 0, y: 0 });
-  path.reverse();
-
-  // Convert path to SES
-  const ses: SESEntry[] = [];
-  for (let i = 1; i < path.length; i++) {
-    const prev = path[i - 1]!;
-    const curr = path[i]!;
-    const dx = curr.x - prev.x;
-    const dy = curr.y - prev.y;
-
-    if (dx === 1 && dy === 1) {
-      ses.push({ type: "keep", text: a[prev.x]! });
-    } else if (dx === 1 && dy === 0) {
-      ses.push({ type: "delete", text: a[prev.x]! });
-    } else if (dx === 0 && dy === 1) {
-      ses.push({ type: "insert", text: b[prev.y]! });
-    } else {
-      // Multiple diagonal steps already handled individually
-    }
-  }
-
-  return ses;
-}
-
-function sesToDiffLines(ses: SESEntry[], a: string[], b: string[]): DiffLine[] {
-  const result: DiffLine[] = [];
-  let oi = 0; // old line number (1-based)
-  let ni = 0; // new line number (1-based)
-
-  for (const entry of ses) {
-    switch (entry.type) {
-      case "keep":
-        oi++;
-        ni++;
-        result.push({ type: "context", oldNo: oi, newNo: ni, text: entry.text });
-        break;
-      case "delete":
-        oi++;
-        result.push({ type: "removed", oldNo: oi, newNo: null, text: entry.text });
-        break;
-      case "insert":
-        ni++;
-        result.push({ type: "added", oldNo: null, newNo: ni, text: entry.text });
-        break;
-    }
-  }
-
-  return result;
-}
-
-function groupHunks(lines: DiffLine[], ctx: number): DiffHunk[] {
-  const changeIdx: number[] = [];
-  for (let i = 0; i < lines.length; i++)
-    if (lines[i].type !== "context") changeIdx.push(i);
-
-  if (changeIdx.length === 0) return [];
-
-  const hunks: DiffHunk[] = [];
-  let start = Math.max(0, changeIdx[0]! - ctx);
-  let end = Math.min(lines.length - 1, changeIdx[0]! + ctx);
-
-  for (let k = 1; k < changeIdx.length; k++) {
-    const ns = Math.max(0, changeIdx[k]! - ctx);
-    const ne = Math.min(lines.length - 1, changeIdx[k]! + ctx);
-    if (ns <= end + 1) {
-      end = ne;
-    } else {
-      hunks.push({ lines: lines.slice(start, end + 1) });
-      start = ns;
-      end = ne;
-    }
-  }
-  hunks.push({ lines: lines.slice(start, end + 1) });
-  return hunks;
 }


### PR DESCRIPTION
## Changes

### feat: group extension tools, skills, and instructions in system prompt (`5766e48`)
- Extensions can register instructions, skills, and tools that appear as grouped sections in the system prompt
- Adds event bus events and types for extension registration (`agent:register-instruction`, `agent:register-skill`)
- Extension loader wires up the new hooks

### fix: recall search misses content truncated from summary (`586778c`)
- History file search now includes the `body` field, not just the 60–80 char summary — prevents searches from missing key nouns that were truncated away
- Dials back truncation across the board (modern models have large context windows, and history/expand content never enters context automatically):
  - Nuclear summaries: 80→200 (user), 60→150 (agent) chars
  - Body caps: 2K→8K (user/agent), 4K→16K (tool)
  - History file: 100KB→100MB (regex-searched, never loaded wholesale)
  - Shell context: 16KB→32KB budget, 20-line threshold, 10+10 head/tail
  - slimTurn tool result cap: 500→1500 chars, expand: 100→500 lines
- Hoists system prompt and dynamic context build out of the agent loop (constant within a single query)
- Removes dead `nuclearMaxEntries` setting
- Improves recall tool description and guidance instructions

### fix: skip read-only tools in history file writes (`3f6de87`)
- `read_file`, `grep`, `glob`, `ls`, and other read-only tool calls are now omitted from the history file
- Reduces noise and file size — only mutation commands (`edit_file`, `write_file`, `bash`, etc.) are persisted

### refactor: replace custom Myers diff with `diff` npm package (`a732c43`)
- Removes ~250 lines of hand-rolled Myers diff implementation in favor of the well-tested [`diff`](https://www.npmjs.com/package/diff) package
- Preserves the same `computeEditScript` API and output format
- Simpler, more maintainable, and handles edge cases correctly out of the box

## Files changed (14)
`docs/context-management.md` · `package.json` · `src/agent/agent-loop.ts` · `src/agent/conversation-state.ts` · `src/agent/history-file.ts` · `src/agent/nuclear-form.ts` · `src/agent/system-prompt.ts` · `src/context-manager.ts` · `src/core.ts` · `src/event-bus.ts` · `src/extension-loader.ts` · `src/settings.ts` · `src/types.ts` · `src/utils/diff.ts`