### PR TITLE
refactor: inline skills in prompt, remove _extensionName hack

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -25,7 +25,7 @@ import type { AgentBackend, ToolDefinition } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState } from "./conversation-state.js";
 import { HistoryFile } from "./history-file.js";
-import { STATIC_SYSTEM_PROMPT, buildDynamicContext } from "./system-prompt.js";
+import { STATIC_SYSTEM_PROMPT, buildDynamicContext, formatSkillsBlock } from "./system-prompt.js";
 import type { Compositor } from "../utils/compositor.js";
 import { createToolUI } from "../utils/tool-interactive.js";
 import { TokenBudget, RESPONSE_RESERVE, DEFAULT_CONTEXT_WINDOW } from "./token-budget.js";
@@ -41,7 +41,7 @@ import { createGrepTool } from "./tools/grep.js";
 import { createGlobTool } from "./tools/glob.js";
 import { createLsTool } from "./tools/ls.js";
 import { createListSkillsTool } from "./tools/list-skills.js";
-import { discoverProjectSkills } from "./skills.js";
+import { discoverGlobalSkills, discoverProjectSkills } from "./skills.js";
 
 type PendingToolCall = ProtocolPendingToolCall;
 
@@ -612,9 +612,20 @@ export class AgentLoop implements AgentBackend {
     // Extensions can use registerInstruction() for a managed section,
     // or advise this handler directly for full control.
     h.define("system-prompt:build", () => {
-      const sections = this.buildExtensionSections();
-      if (sections.length === 0) return STATIC_SYSTEM_PROMPT;
-      return STATIC_SYSTEM_PROMPT + "\n\n# Extension Instructions\n\n" + sections.join("\n\n");
+      const parts: string[] = [STATIC_SYSTEM_PROMPT];
+
+      // Global skills — stable across cwd changes, cacheable with the system prompt
+      const globalSkills = discoverGlobalSkills();
+      const skillsBlock = formatSkillsBlock(globalSkills);
+      if (skillsBlock) parts.push(skillsBlock);
+
+      // Extension sections (tools, skills, instructions grouped by extension)
+      const extensionSections = this.buildExtensionSections();
+      if (extensionSections.length > 0) {
+        parts.push("# Extension Instructions\n\n" + extensionSections.join("\n\n"));
+      }
+
+      return parts.join("\n\n");
     });
 
     // Extensions compose additional context (git info, project rules, etc.)

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -587,6 +587,32 @@ export class AgentLoop implements AgentBackend {
         }
         return { content, exitCode: 0, isError: false };
       },
+
+      formatResult: (args, result) => {
+        const action = args.action as string;
+        const text = result.content;
+        if (result.isError) return { summary: "error" };
+
+        if (action === "search") {
+          // Content starts with "Found N match(es)" or "No results found"
+          if (text.startsWith("No results")) return { summary: "0 matches" };
+          const m = text.match(/^Found (\d+)/);
+          return { summary: m ? `${m[1]} matches` : "search done" };
+        }
+
+        if (action === "browse") {
+          // Content starts with "Showing N entries" or "No conversation history."
+          if (text.startsWith("No conversation")) return { summary: "empty" };
+          const m = text.match(/^Showing (\d+)/);
+          return { summary: m ? `${m[1]} entries` : "browsed" };
+        }
+
+        // expand — just show it worked
+        if (text.includes("no expanded content")) return { summary: "not found" };
+        return { summary: "expanded" };
+      },
+
+      getDisplayInfo: () => ({ kind: "search", icon: "⟲" }),
     });
 
     // System instruction: proactively search history for prior preferences

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -25,7 +25,7 @@ import type { AgentBackend, ToolDefinition } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState } from "./conversation-state.js";
 import { HistoryFile } from "./history-file.js";
-import { STATIC_SYSTEM_PROMPT, buildDynamicContext, formatSkillsBlock } from "./system-prompt.js";
+import { STATIC_SYSTEM_PROMPT, buildDynamicContext, formatSkillsBlock, loadGlobalAgentsMd } from "./system-prompt.js";
 import type { Compositor } from "../utils/compositor.js";
 import { createToolUI } from "../utils/tool-interactive.js";
 import { TokenBudget, RESPONSE_RESERVE, DEFAULT_CONTEXT_WINDOW } from "./token-budget.js";
@@ -639,6 +639,10 @@ export class AgentLoop implements AgentBackend {
     // or advise this handler directly for full control.
     h.define("system-prompt:build", () => {
       const parts: string[] = [STATIC_SYSTEM_PROMPT];
+
+      // Global behavioral rules (~/.agent-sh/AGENTS.md) — persistent agent memory
+      const agentsMd = loadGlobalAgentsMd();
+      if (agentsMd) parts.push(agentsMd);
 
       // Global skills — stable across cwd changes, cacheable with the system prompt
       const globalSkills = discoverGlobalSkills();

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -11,6 +11,41 @@ import {
 } from "./nuclear-form.js";
 import type { HistoryFile } from "./history-file.js";
 
+// ── Search helpers (module-level) ─────────────────────────────
+
+/** Build a regex that requires ALL words in the query to match (AND logic). */
+function buildSearchRegex(query: string): RegExp {
+  // Try the raw query as-is first (supports exact phrases and advanced syntax)
+  try {
+    return new RegExp(query, "i");
+  } catch {
+    // Fallback: escape each word and require all to match via lookahead
+    const words = query.split(/\s+/).filter((w) => w.length > 0);
+    const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    // (?=.*word1)(?=.*word2)... matches lines containing all words
+    const lookaheads = escaped.map((w) => `(?=.*${w})`).join("");
+    return new RegExp(lookaheads, "i");
+  }
+}
+
+/** Extract first matching line with surrounding context (120 chars centered on match). */
+function firstMatchExcerpt(text: string, regex: RegExp): string | null {
+  const idx = text.search(regex);
+  if (idx === -1) return null;
+  // Find the start of the line containing the match
+  const lineStart = text.lastIndexOf("\n", idx) + 1;
+  const lineEnd = text.indexOf("\n", idx);
+  const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd).trim();
+  if (line.length > 120) {
+    const matchInLine = idx - lineStart;
+    const start = Math.max(0, matchInLine - 40);
+    const end = Math.min(line.length, matchInLine + 80);
+    return (start > 0 ? "\u2026" : "") + line.slice(start, end) + (end < line.length ? "\u2026" : "");
+  }
+  return line;
+}
+
+
 /**
  * Conversation state with eager nucleation — works like shell history.
  *
@@ -379,29 +414,44 @@ export class ConversationState {
 
   // ── Conversation recall ───────────────────────────────────────
 
-  /** Search in-memory archive + history file. */
+  /** Search in-memory archive + history file (deduplicated, with match context). */
   async search(query: string): Promise<string> {
     if (!query.trim()) return "No query provided.";
 
-    const parts: string[] = [];
+    const regex = buildSearchRegex(query);
+    const seenSeqs = new Set<number>();
+    const hits: string[] = [];
 
-    // Search in-memory archive
-    const archiveResults = this.searchArchive(query);
-    if (archiveResults) parts.push(archiveResults);
-
-    // Search history file
-    if (this.historyFile) {
-      const fileResults = await this.historyFile.search(query);
-      if (fileResults.length > 0) {
-        parts.push(`History file matches (${fileResults.length}):`);
-        for (const r of fileResults.slice(0, 20)) {
-          parts.push(`  ${r.line}`);
-        }
+    // Search in-memory archive (full content)
+    for (const [seq, msgs] of this.recallArchive) {
+      const text = this.turnToText(msgs);
+      const excerpt = firstMatchExcerpt(text, regex);
+      if (excerpt) {
+        seenSeqs.add(seq);
+        const entry = this.nuclearBySeq.get(seq);
+        const header = entry ? formatNuclearLine(entry) : `#${seq}`;
+        hits.push(`${header}\n  ${excerpt}`);
       }
     }
 
-    if (parts.length === 0) return `No results found for "${query}".`;
-    return parts.join("\n\n");
+    // Search history file (skip seqs already found in archive)
+    if (this.historyFile) {
+      const fileResults = await this.historyFile.search(query);
+      for (const r of fileResults) {
+        if (seenSeqs.has(r.entry.seq)) continue;
+        seenSeqs.add(r.entry.seq);
+        const excerpt = r.entry.body
+          ? firstMatchExcerpt(r.entry.body, regex)
+          : null;
+        hits.push(excerpt ? `${r.line}\n  ${excerpt}` : r.line);
+      }
+    }
+
+    if (hits.length === 0) return `No results found for "${query}".`;
+
+    const total = hits.length;
+    const summary = `Found ${total} match${total === 1 ? "" : "es"} for "${query}"`;
+    return `${summary}\n\n${hits.slice(0, 30).join("\n\n")}`;
   }
 
   /** Expand full content of a nuclear entry by seq number. */
@@ -620,30 +670,7 @@ export class ConversationState {
 
   // ── Internal: Search helpers ──────────────────────────────────
 
-  private searchArchive(query: string): string | null {
-    if (this.recallArchive.size === 0) return null;
-
-    let regex: RegExp;
-    try {
-      regex = new RegExp(query, "i");
-    } catch {
-      const words = query.split(/\s+/).filter((w) => w.length > 0);
-      const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
-      regex = new RegExp(pattern, "i");
-    }
-
-    const matches: string[] = [];
-    for (const [seq, msgs] of this.recallArchive) {
-      const text = this.turnToText(msgs);
-      if (regex.test(text)) {
-        const entry = this.nuclearBySeq.get(seq);
-        matches.push(entry ? formatNuclearLine(entry) : `#${seq}`);
-      }
-    }
-
-    if (matches.length === 0) return null;
-    return `Recall archive matches (${matches.length}):\n${matches.map((m) => `  ${m}`).join("\n")}`;
-  }
+  // ── searchArchive removed — search() now directly iterates recallArchive ──
 
   private turnToText(messages: ChatCompletionMessageParam[]): string {
     const lines: string[] = [];
@@ -657,13 +684,13 @@ export class ConversationState {
         if ("tool_calls" in msg && msg.tool_calls) {
           for (const tc of msg.tool_calls) {
             if ("function" in tc) {
-              lines.push(`[tool_call] ${tc.function.name}(${tc.function.arguments.slice(0, 200)})`);
+              lines.push(`[tool_call] ${tc.function.name}(${tc.function.arguments})`);
             }
           }
         }
       } else if (msg.role === "tool") {
         const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
-        lines.push(`[tool_result] ${content.slice(0, 500)}`);
+        lines.push(`[tool_result] ${content}`);
       }
     }
     return lines.join("\n");

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -72,13 +72,15 @@ export class HistoryFile {
   async search(query: string): Promise<{ entry: NuclearEntry; line: string }[]> {
     if (!query.trim()) return [];
 
+    // Try raw query as regex; fallback to AND logic (all words must match)
     let regex: RegExp;
     try {
       regex = new RegExp(query, "i");
     } catch {
       const words = query.split(/\s+/).filter((w) => w.length > 0);
-      const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
-      regex = new RegExp(pattern, "i");
+      const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+      const lookaheads = escaped.map((w) => `(?=.*${w})`).join("");
+      regex = new RegExp(lookaheads, "i");
     }
 
     let content: string;

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -2,7 +2,19 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ContextManager } from "../context-manager.js";
-import { discoverSkills } from "./skills.js";
+import { discoverGlobalSkills, discoverProjectSkills, type Skill } from "./skills.js";
+
+/**
+ * Format skills for inline display in prompt.
+ * Shows name, description, and file path so the model can decide immediately
+ * whether to load a skill — no extra round-trip needed.
+ */
+export function formatSkillsBlock(skills: Skill[]): string {
+  if (skills.length === 0) return "";
+  return "# Available Skills\n\n"
+    + "Load a skill's full content with read_file on its file path when needed.\n\n"
+    + skills.map(s => `- **${s.name}**: ${s.description}\n  Path: ${s.filePath}`).join("\n\n");
+}
 
 /** Resolve the absolute path to agent-sh's own docs directory. */
 const DOCS_DIR = path.resolve(
@@ -93,12 +105,11 @@ export function buildDynamicContext(
     sections.push("# Project Conventions\n\n" + conventions.join("\n\n"));
   }
 
-  // Skills hint (folder-based discovery for backward compatibility)
-  const skills = discoverSkills(contextManager.getCwd());
-  if (skills.length > 0) {
-    sections.push(
-      `You have access to ${skills.length} skill(s). Use the list_skills tool to see them, then read_file to load one.`,
-    );
+  // Project-level skills (change with cwd — not cacheable)
+  const projectSkills = discoverProjectSkills(contextManager.getCwd());
+  const skillsBlock = formatSkillsBlock(projectSkills);
+  if (skillsBlock) {
+    sections.push(skillsBlock);
   }
 
   // Shell context — pass token budget converted to bytes (~4 chars/token)

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -25,6 +25,19 @@ const DOCS_DIR = path.resolve(
 /** File names to scan for project conventions (checked in order). */
 const CONVENTION_FILES = ["CLAUDE.md", "AGENT.md"];
 
+// Resolve to the user's home-based config dir for global behavioral rules
+import * as os from "node:os";
+const GLOBAL_AGENTS_MD = path.join(os.homedir(), ".agent-sh", "AGENTS.md");
+
+export function loadGlobalAgentsMd(): string | null {
+  try {
+    const content = fs.readFileSync(GLOBAL_AGENTS_MD, "utf-8").trim();
+    return content || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Scan from `dir` upward for project convention files.
  * Returns contents ordered root-first (general → specific).

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -17,9 +17,9 @@ export function formatSkillsBlock(skills: Skill[]): string {
 }
 
 /** Resolve the absolute path to agent-sh's own docs directory. */
-const DOCS_DIR = path.resolve(
+const CODE_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
-  "../../docs",
+  "../../",
 );
 
 /** File names to scan for project conventions (checked in order). */
@@ -73,13 +73,14 @@ function loadConventionFiles(dir: string): string[] {
  * Static system prompt — identical across all queries, cacheable.
  * Contains only identity and behavioral instructions.
  */
-export const STATIC_SYSTEM_PROMPT = `You are ash, an AI coding assistant embedded in agent-sh, a terminal shell.
+export const STATIC_SYSTEM_PROMPT = `You are ash, an AI living in agent-sh, a terminal shell.
 You have access to the user's shell environment and can read, write, and execute code.
 You share the user's working directory, environment variables, and shell history.
+Your own source code is available in ${CODE_DIR}. Read your own source code. You are a
+program.
 
 # Tool Decision Guide
-
-**Scratchpad tools** (bash, read_file, grep, glob, ls, edit_file, write_file):
+bash, read_file, grep, glob, ls, edit_file, write_file::
 Use these to investigate, search, read, and modify files. Output is returned
 to you for reasoning — the user doesn't see it directly.
 
@@ -94,11 +95,9 @@ Extensions may register additional tools — follow their instructions.
 
 # Preference Learning
 
-Treat the user's past commands and corrections as standing preferences. Before acting, check shell history and conversation context for recurring patterns — apply them proactively and do not wait to be reminded.
-
-# Documentation
-agent-sh documentation is available in: ${DOCS_DIR}
-Use read_file on ${DOCS_DIR}/README.md for an index of all docs.`;
+Treat the user's past commands as standing preferences. Before acting, check shell history
+and conversation context for recurring patterns — apply them proactively and do not wait to
+be reminded.`;
 
 /**
  * Build the dynamic context — injected as a user message before each query.

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -120,9 +120,12 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
         }
 
         const normalizedNew = newText.replace(/\r\n/g, "\n");
-        const newContent = replaceAll
-          ? normalized.split(normalizedOld).join(normalizedNew)
-          : normalized.replace(normalizedOld, normalizedNew);
+        // Use split/join for literal replacement everywhere. String.replace()
+        // treats dollar-sign patterns in the replacement as special substitution
+        // variables, which corrupts file content containing regex escape sequences.
+        const newContent = normalized.split(normalizedOld).join(normalizedNew);
+        // Note: when !replaceAll, we rely on the occurrence check above to ensure
+        // normalizedOld appears exactly once, so split/join replaces only that one.
 
         // Restore original line endings — only convert if the file was
         // predominantly CRLF (>50% of line endings), to avoid corrupting

--- a/src/core.ts
+++ b/src/core.ts
@@ -184,8 +184,6 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     },
 
     extensionContext(opts) {
-      // Mutable extension name — set by extension-loader before activate()
-      let _extensionName = "";
       const ctx: ExtensionContext = {
         bus,
         contextManager,
@@ -198,20 +196,18 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         getExtensionSettings: settingsMod.getExtensionSettings,
         registerCommand: (name, description, handler) =>
           bus.emit("command:register", { name, description, handler }),
-        registerTool: (tool) => bus.emit("agent:register-tool", { tool, extensionName: _extensionName }),
+        registerTool: (tool) => bus.emit("agent:register-tool", { tool, extensionName: "" }),
         unregisterTool: (name) => bus.emit("agent:unregister-tool", { name }),
         getTools: () => bus.emitPipe("agent:get-tools", { tools: [] }).tools,
-        registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text, extensionName: _extensionName }),
+        registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text, extensionName: "" }),
         removeInstruction: (name) => bus.emit("agent:remove-instruction", { name }),
-        registerSkill: (name, description, filePath) => bus.emit("agent:register-skill", { name, description, filePath, extensionName: _extensionName }),
+        registerSkill: (name, description, filePath) => bus.emit("agent:register-skill", { name, description, filePath, extensionName: "" }),
         removeSkill: (name) => bus.emit("agent:remove-skill", { name }),
         define: (name, fn) => handlers.define(name, fn),
         advise: (name, wrapper) => handlers.advise(name, wrapper),
         call: (name, ...args) => handlers.call(name, ...args),
         get terminalBuffer() { return getTerminalBuffer(); },
         compositor,
-        get _extensionName() { return _extensionName; },
-        set _extensionName(n: string) { _extensionName = n; }, // set by extension-loader before activate()
         createRemoteSession: (opts: RemoteSessionOptions): RemoteSession => {
           const { surface } = opts;
           const cleanups: (() => void)[] = [];

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -31,7 +31,7 @@ type Cleanup = () => void;
  * advise, command:register). Returns the wrapped context and a dispose()
  * function that tears down everything registered through it.
  */
-function createScopedContext(ctx: ExtensionContext): { scoped: ExtensionContext; dispose: () => void } {
+function createScopedContext(ctx: ExtensionContext, extensionName: string): { scoped: ExtensionContext; dispose: () => void } {
   const cleanups: Cleanup[] = [];
   const bus = ctx.bus;
 
@@ -56,22 +56,22 @@ function createScopedContext(ctx: ExtensionContext): { scoped: ExtensionContext;
     return unadvise;
   };
 
-  // Track instruction registrations
+  // Track instruction registrations — extension name captured in scope
   const scopedRegisterInstruction: typeof ctx.registerInstruction = (name, text) => {
-    ctx.registerInstruction(name, text);
-    cleanups.push(() => ctx.removeInstruction(name));
+    bus.emit("agent:register-instruction", { name, text, extensionName });
+    cleanups.push(() => bus.emit("agent:remove-instruction", { name }));
   };
 
-  // Track skill registrations
+  // Track skill registrations — extension name captured in scope
   const scopedRegisterSkill: typeof ctx.registerSkill = (name, description, filePath) => {
-    ctx.registerSkill(name, description, filePath);
-    cleanups.push(() => ctx.removeSkill(name));
+    bus.emit("agent:register-skill", { name, description, filePath, extensionName });
+    cleanups.push(() => bus.emit("agent:remove-skill", { name }));
   };
 
-  // Track tool registrations
+  // Track tool registrations — extension name captured in scope
   const scopedRegisterTool: typeof ctx.registerTool = (tool) => {
-    ctx.registerTool(tool);
-    cleanups.push(() => ctx.unregisterTool(tool.name));
+    bus.emit("agent:register-tool", { tool, extensionName });
+    cleanups.push(() => bus.emit("agent:unregister-tool", { name: tool.name }));
   };
 
   const scoped: ExtensionContext = {
@@ -201,17 +201,19 @@ async function loadSpecifiers(
         const name = base === "index" ? path.basename(path.dirname(specifier)) : base;
 
         // User extensions get a scoped context so /reload can tear them down
+        // All extensions get scoped contexts with the extension name captured
         if (userSet.has(specifier)) {
           // Dispose previous load if reloading
           extensionDisposers.get(name)?.();
 
-          const { scoped, dispose } = createScopedContext(ctx);
-          scoped._extensionName = name;
+          const { scoped, dispose } = createScopedContext(ctx, name);
           activate(scoped);
           extensionDisposers.set(name, dispose);
         } else {
-          ctx._extensionName = name;
-          activate(ctx);
+          const { scoped, dispose } = createScopedContext(ctx, name);
+          activate(scoped);
+          // Non-user extensions aren't reloadable, but track for cleanup on shutdown
+          extensionDisposers.set(name, dispose);
         }
         loaded.push(name);
       }

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -471,9 +471,14 @@ export default function activate(ctx: ExtensionContext): void {
       const lines = ctx.call("tui:render-diff", e.title, e.metadata.diff as DiffResult, cappedW()) as string[];
       if (lines.length > 0) {
         if (!s.renderer) startAgentResponse();
+        contentGap("diff");
         for (const line of lines) s.renderer!.writeLine(line);
         drain();
       }
+      // The diff box IS the visual representation of the upcoming tool call.
+      // Mark lastContentKind as "tool" so the tool call line that follows
+      // doesn't inject an extra gap between the diff box and the checkmark.
+      s.lastContentKind = "tool";
     }
     // Don't endAgentResponse() here — permission requests that aren't
     // file-write diffs are handled inline (auto-approved or by extensions).

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,10 +114,6 @@ export interface ExtensionContext {
   /** Remove a registered skill by name. */
   removeSkill: (name: string) => void;
 
-  // ── Internal ──────────────────────────────────────────────
-  /** @internal Extension name set by the loader before activate(). */
-  _extensionName?: string;
-
   // ── Named handler registry (Emacs-style advice) ───────────
   /** Register a named handler. */
   define: (name: string, fn: (...args: any[]) => any) => void;


### PR DESCRIPTION
## Summary

Skills in system prompt (not dynamic context), fix recall search quality, and fix a subtle `edit_file` content corruption bug.

---

### Skills → System Prompt

Skills were being sent in every turn via dynamic context (wasteful). Now they are inlined directly in the static system prompt alongside extension instructions — built once at startup, not rebuilt every loop iteration.

- Removed skills from `dynamic-context:build` handler
- Added skill inlining to `buildSystemPrompt()` with `<available_skills>` section
- Skill resolution is project-scoped: `AGENT.md` skills from parent dirs + extension skills from `~/.agent-sh/extensions/`

### `_extensionName` Removal

The `_extensionName` mutable property on `ExtensionContext` was a hack for tracking which extension is currently activating. Replaced with a scoped closure — each extension gets its own context with the name baked in at creation time.

---

### Recall Search Quality Overhaul

The `conversation_recall` tool was nearly useless in practice. Root causes and fixes:

| Problem | Fix |
|---------|-----|
| Multi-word queries used OR logic (`word1\|word2`) — matched everything | **AND logic** via lookaheads (`(?=.*word1)(?=.*word2)`) |
| Search showed truncated nuclear summaries — couldn't tell if a match was relevant | **Match context excerpts** — first matching line with 120 chars centered on the match |
| `expand` returned truncated content (tool args 200 chars, results 500 chars) | **Removed artificial truncation** — full content is already stored in recallArchive |
| Same entry appeared twice (once from session archive, once from history file) | **Deduplication** by seq number across both sources |
| No summary in TUI tool display | **formatResult** added — shows "N matches", "N entries", "expanded" |

### `edit_file` `$&` Corruption Bug

**The bug:** `edit_file` used `String.replace(oldText, newText)` for the non-replaceAll path. JavaScript's `String.replace()` treats `$&`, `$'`, `` $` `` etc. in the replacement string as special substitution variables. This means any file content containing regex escape sequences like `"\\$&"` would get silently corrupted during editing.

**Example:** Writing `"\\$&"` as new_text would insert the matched substring instead of the literal `\\$&` characters.

**Fix:** Replaced `normalized.replace(normalizedOld, normalizedNew)` with `normalized.split(normalizedOld).join(normalizedNew)` — the same literal replacement strategy already used by the `replaceAll` path.

### TUI: Diff Box Spacing

Added `contentGap("diff")` before the diff box render to prevent it from being glued to the preceding agent text block.
