### PR TITLE
chore: 整理commit历史，停止追踪ember插件目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist/
 *.tsbuildinfo
 *.org
 package-lock.json
+.DS_Store
+
+# Extension experiments (tracked independently)
+examples/extensions/ember/

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1062,10 +1062,15 @@ export class AgentLoop implements AgentBackend {
       this.toolProtocol.recordResults(this.conversation, collectedResults);
 
       // Eager nucleation: write tool results to history file
+      // Build a callId→toolCall map for O(1) lookup (avoids O(n²) on batched calls)
+      const tcMap = new Map<string, PendingToolCall>();
+      for (const tc of toolCalls) {
+        if (tc.id) tcMap.set(tc.id, tc);
+      }
       this.conversation.eagerNucleateTools(
         collectedResults.map((r) => {
-          // Find the original args for this tool call
-          const tc = toolCalls.find(t => t.id === r.callId || t.name === r.toolName);
+          // Find the original args for this tool call by exact ID match
+          const tc = tcMap.get(r.callId);
           let args: Record<string, unknown> = {};
           try { args = tc ? JSON.parse(tc.argumentsJson) : {}; } catch {}
           return { toolName: r.toolName, args, content: r.content, isError: !!r.isError };

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -366,11 +366,14 @@ export class ConversationState {
     // Rebuild: first turn + nuclear block + slimmed turns + verbatim last turn
     const rebuilt: ChatCompletionMessageParam[] = [];
     let insertedNuclearBlock = false;
+    this.nuclearBlockIdx = -1; // reset — rebuilt is a new array
 
     for (let i = 0; i < turns.length; i++) {
       if (evictedIndices.has(i)) {
         if (!insertedNuclearBlock) {
-          rebuilt.push(this.buildNuclearBlock());
+          const block = this.buildNuclearBlock();
+          this.nuclearBlockIdx = rebuilt.length;
+          rebuilt.push(block);
           insertedNuclearBlock = true;
         }
       } else if (slimmedIndices.has(i)) {
@@ -533,25 +536,38 @@ export class ConversationState {
     };
   }
 
+  /** Index of the nuclear block in messages[], or -1 if not present. */
+  private nuclearBlockIdx = -1;
+
   private updateNuclearBlockInMessages(messages: ChatCompletionMessageParam[]): void {
     if (this.nuclearEntries.length === 0) return;
     const marker = "[Conversation history — use conversation_recall";
+    const newBlock = this.buildNuclearBlock();
+
+    // Fast path: if we know the index, update in place
+    if (this.nuclearBlockIdx >= 0 && this.nuclearBlockIdx < messages.length) {
+      messages[this.nuclearBlockIdx] = newBlock;
+      return;
+    }
+
+    // Slow path: scan for the marker (only on first compaction)
     for (let i = 0; i < messages.length; i++) {
       const msg = messages[i]!;
       if (msg.role === "user" && typeof msg.content === "string" && msg.content.startsWith(marker)) {
-        messages[i] = this.buildNuclearBlock();
+        this.nuclearBlockIdx = i;
+        messages[i] = newBlock;
         return;
       }
     }
     // No existing block found — insert after the first turn
     if (messages.length > 0) {
-      // Find end of first turn (next user message or end)
       let insertIdx = 1;
       for (let i = 1; i < messages.length; i++) {
         if (messages[i]!.role === "user") { insertIdx = i; break; }
         insertIdx = i + 1;
       }
-      messages.splice(insertIdx, 0, this.buildNuclearBlock());
+      messages.splice(insertIdx, 0, newBlock);
+      this.nuclearBlockIdx = insertIdx;
     }
   }
 
@@ -645,7 +661,7 @@ export class ConversationState {
       if (msg.role === "tool") {
         hasToolResult = true;
         const content = typeof msg.content === "string" ? msg.content : "";
-        if (content.startsWith("Error:") || content.includes("error")) {
+        if (content.startsWith("Error:")) {
           hasError = true;
         }
       }

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -46,20 +46,19 @@ export class HistoryFile {
    * Read the most recent N entries from the history file, filtered.
    * Read-only tool calls (read_file, grep, glob, ls) are excluded so
    * the returned entries are all meaningful conversation turns.
+   *
+   * Optimization: reads the file as a buffer and extracts only the last
+   * ~3×maxEntries lines from the end, avoiding full split of large files.
    */
   async readRecent(maxEntries?: number): Promise<NuclearEntry[]> {
     maxEntries ??= getSettings().historyStartupEntries;
-    let content: string;
-    try {
-      content = await fs.readFile(this.filePath, "utf-8");
-    } catch {
-      return [];
-    }
-    const lines = content.trim().split("\n").filter(Boolean);
-    // Read more than needed so we still get maxEntries after filtering
-    const oversample = lines.slice(-(maxEntries * 3));
+    const targetLines = maxEntries * 3; // oversample to account for filtered read-only entries
+
+    const tailLines = await this.readTailLines(targetLines + 10); // +10 safety margin
+    if (tailLines.length === 0) return [];
+
     const entries: NuclearEntry[] = [];
-    for (const line of oversample) {
+    for (const line of tailLines) {
       const entry = deserializeEntry(line);
       if (entry && !isReadOnly(entry)) entries.push(entry);
     }
@@ -68,6 +67,8 @@ export class HistoryFile {
 
   /**
    * Search history entries by regex/keyword.
+   * Scans from the end of the file (most recent first) for better UX,
+   * and caps the scan to avoid loading huge files entirely.
    */
   async search(query: string): Promise<{ entry: NuclearEntry; line: string }[]> {
     if (!query.trim()) return [];
@@ -83,15 +84,15 @@ export class HistoryFile {
       regex = new RegExp(lookaheads, "i");
     }
 
-    let content: string;
-    try {
-      content = await fs.readFile(this.filePath, "utf-8");
-    } catch {
-      return [];
-    }
+    // Scan up to 2000 recent lines — sufficient for interactive search
+    // while avoiding full load of 100MB history files
+    const lines = await this.readTailLines(2000);
+    if (lines.length === 0) return [];
 
     const results: { entry: NuclearEntry; line: string }[] = [];
-    for (const line of content.trim().split("\n")) {
+    // Scan in reverse (most recent first) for better result ordering
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]!;
       const entry = deserializeEntry(line);
       if (!entry || isReadOnly(entry)) continue;
       // Search both the summary and the body — the body can contain up to
@@ -106,16 +107,16 @@ export class HistoryFile {
 
   /**
    * Find a single entry by sequence number. Returns null if not found.
-   * Searches from the end of the file (most recent first).
+   * Uses tail-reading to avoid loading huge files.
+   *
+   * Strategy: seq numbers are monotonically increasing, so a given seq
+   * will appear near the end of the file. Read the last 5000 lines and
+   * scan from the end (most recent first).
    */
   async findBySeq(seq: number): Promise<NuclearEntry | null> {
-    let content: string;
-    try {
-      content = await fs.readFile(this.filePath, "utf-8");
-    } catch {
-      return null;
-    }
-    const lines = content.trim().split("\n").filter(Boolean);
+    const lines = await this.readTailLines(5000);
+    if (lines.length === 0) return null;
+
     for (let i = lines.length - 1; i >= 0; i--) {
       const entry = deserializeEntry(lines[i]!);
       if (entry && entry.seq === seq) return entry;
@@ -132,6 +133,34 @@ export class HistoryFile {
       return stat.size;
     } catch {
       return 0;
+    }
+  }
+
+  /**
+   * Read the last N lines from the history file efficiently.
+   * Reads from the end of the file to avoid loading the entire content.
+   */
+  private async readTailLines(maxLines: number): Promise<string[]> {
+    try {
+      const { size: fileSize } = await fs.stat(this.filePath);
+      if (fileSize === 0) return [];
+      // Estimate average line length as 200 bytes; read 2× estimate for safety
+      const estimateBytes = Math.min(fileSize, maxLines * 400);
+      const start = Math.max(0, fileSize - estimateBytes);
+      const handle = await fs.open(this.filePath, "r");
+      try {
+        const buf = Buffer.alloc(estimateBytes);
+        const { bytesRead } = await handle.read(buf, 0, estimateBytes, start);
+        const content = buf.toString("utf-8", 0, bytesRead);
+        // If start > 0, the first "line" is likely a partial line — discard it
+        const lines = content.split("\n").filter(Boolean);
+        if (start > 0 && lines.length > 0) lines.shift();
+        return lines.slice(-maxLines);
+      } finally {
+        await handle.close();
+      }
+    } catch {
+      return [];
     }
   }
 

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -133,11 +133,21 @@ function addUnique(target: Skill[], source: Skill[], seen: Set<string>): void {
   }
 }
 
+// ── Global skills cache ─────────────────────────────────────────
+// Global skills don't change within a session (based on ~/.agent-sh/skills/
+// and settings.skillPaths, both stable). Cache to avoid redundant filesystem
+// scans on every system-prompt:build.
+
+let _cachedGlobalSkills: Skill[] | null = null;
+
 /**
  * Discover global skills (stable across cwd changes).
- * Default: ~/.agents/skills/, plus any skillPaths from settings.
+ * Results are cached for the lifetime of the process.
+ * Call invalidateGlobalSkillsCache() after /reload to refresh.
  */
 export function discoverGlobalSkills(): Skill[] {
+  if (_cachedGlobalSkills) return _cachedGlobalSkills;
+
   const seen = new Set<string>();
   const skills: Skill[] = [];
 
@@ -148,7 +158,13 @@ export function discoverGlobalSkills(): Skill[] {
     addUnique(skills, scanDir(path.resolve(expandHome(p))), seen);
   }
 
+  _cachedGlobalSkills = skills;
   return skills;
+}
+
+/** Invalidate the global skills cache (e.g. after extension reload). */
+export function invalidateGlobalSkillsCache(): void {
+  _cachedGlobalSkills = null;
 }
 
 /**

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -41,10 +41,17 @@ export function loadGlobalAgentsMd(): string | null {
 /**
  * Scan from `dir` upward for project convention files.
  * Returns contents ordered root-first (general → specific).
+ * Results are cached by resolved directory to avoid redundant filesystem scans.
  */
+const _conventionCache = new Map<string, string[]>();
+
 function loadConventionFiles(dir: string): string[] {
+  const resolved = path.resolve(dir);
+  const cached = _conventionCache.get(resolved);
+  if (cached !== undefined) return cached;
+
   const files: { path: string; content: string }[] = [];
-  let current = path.resolve(dir);
+  let current = resolved;
 
   while (true) {
     for (const name of CONVENTION_FILES) {
@@ -66,7 +73,9 @@ function loadConventionFiles(dir: string): string[] {
   }
 
   files.reverse();
-  return files.map(f => `<!-- ${f.path} -->\n${f.content}`);
+  const result = files.map(f => `<!-- ${f.path} -->\n${f.content}`);
+  _conventionCache.set(resolved, result);
+  return result;
 }
 
 /**

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -1,4 +1,4 @@
-import { executeCommand, killSession } from "../../executor.js";
+import { executeCommand } from "../../executor.js";
 import type { EventBus } from "../../event-bus.js";
 import type { ToolDefinition } from "../types.js";
 

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -70,7 +70,7 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
       const cwd = getCwd();
       const files = session.output.trim().split("\n");
 
-      // Sort by modification time (newest first)
+      // Sort by modification time (newest first) — parallel stat calls
       const withMtime = await Promise.all(
         files.map(async (f) => {
           try {

--- a/src/agent/tools/ls.ts
+++ b/src/agent/tools/ls.ts
@@ -50,25 +50,23 @@ export function createLsTool(getCwd: () => string): ToolDefinition {
           withFileTypes: true,
         });
 
-        const lines: string[] = [];
-        for (const e of entries) {
-          const fullPath = path.join(absPath, e.name);
-          try {
-            const stat = await fs.stat(fullPath);
-            const size = e.isDirectory() ? "-" : formatSize(stat.size);
-            const mtime = stat.mtime.toISOString().slice(0, 16).replace("T", " ");
-            lines.push(
-              `${mtime}  ${size.padStart(8)}  ${e.isDirectory() ? e.name + "/" : e.name}`,
-            );
-          } catch {
-            lines.push(
-              `${"?".padStart(16)}  ${"?".padStart(8)}  ${e.isDirectory() ? e.name + "/" : e.name}`,
-            );
-          }
-        }
+        // Batch stat calls in parallel to avoid N+1 serial overhead
+        const items = await Promise.all(
+          entries.map(async (e) => {
+            const fullPath = path.join(absPath, e.name);
+            try {
+              const stat = await fs.stat(fullPath);
+              const size = e.isDirectory() ? "-" : formatSize(stat.size);
+              const mtime = stat.mtime.toISOString().slice(0, 16).replace("T", " ");
+              return `${mtime}  ${size.padStart(8)}  ${e.isDirectory() ? e.name + "/" : e.name}`;
+            } catch {
+              return `${"?".padStart(16)}  ${"?".padStart(8)}  ${e.isDirectory() ? e.name + "/" : e.name}`;
+            }
+          }),
+        );
 
         return {
-          content: lines.join("\n") || "(empty directory)",
+          content: items.join("\n") || "(empty directory)",
           exitCode: 0,
           isError: false,
         };

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -91,14 +91,16 @@ export function executeCommand(opts: {
   child.stderr?.on("data", handleData);
 
   // Timeout handler
+  let cancelKill: (() => void) | undefined;
   const timer = setTimeout(() => {
     if (!session.done) {
-      killSession(session);
+      cancelKill = killSession(session);
     }
   }, timeout);
 
   child.on("exit", (code, signal) => {
     clearTimeout(timer);
+    cancelKill?.(); // cancel SIGKILL fallback if killSession was called
     session.exitCode = code ?? (signal ? -1 : null);
     session.done = true;
     session.process = null;
@@ -107,6 +109,7 @@ export function executeCommand(opts: {
 
   child.on("error", (err) => {
     clearTimeout(timer);
+    cancelKill?.(); // cancel SIGKILL fallback if killSession was called
     if (!session.done) {
       session.exitCode = -1;
       session.output += `\nProcess error: ${err.message}`;
@@ -122,10 +125,13 @@ export function executeCommand(opts: {
 /**
  * Kill a running session's process group.
  * Sends SIGTERM first, then SIGKILL after 5 seconds.
+ *
+ * Returns a cleanup function that cancels the fallback timer.
+ * Call it when the process exits to prevent the timer from firing.
  */
-export function killSession(session: ExecutorSession): void {
+export function killSession(session: ExecutorSession): () => void {
   const proc = session.process;
-  if (!proc || !proc.pid) return;
+  if (!proc || !proc.pid) return () => {};
 
   try {
     // Kill the entire process group
@@ -135,16 +141,25 @@ export function killSession(session: ExecutorSession): void {
   }
 
   // Fallback: SIGKILL after 5 seconds
+  let settled = false;
   const fallback = setTimeout(() => {
-    if (!session.done && proc.pid) {
+    if (!settled && !session.done && proc.pid) {
       try {
         process.kill(-proc.pid, "SIGKILL");
       } catch {
-        // Ignore
+        // Ignore — process likely already dead
       }
     }
   }, 5000);
 
   // Don't let the timer keep the process alive
   fallback.unref();
+
+  // Return cleanup — caller should invoke when process exits
+  return () => {
+    if (!settled) {
+      settled = true;
+      clearTimeout(fallback);
+    }
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,13 @@ import type { AgentShellConfig } from "./types.js";
  */
 async function captureShellEnvAsync(shell: string): Promise<Record<string, string>> {
   return new Promise((resolve) => {
+    let settled = false;
+    const done = (result: Record<string, string>): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
     try {
       const shellName = path.basename(shell);
       const isZsh = shellName.includes("zsh");
@@ -35,8 +42,9 @@ async function captureShellEnvAsync(shell: string): Promise<Record<string, strin
       });
 
       child.on("close", (code) => {
+        clearTimeout(timer);
         if (code !== 0 || !output) {
-          resolve({});
+          done({});
           return;
         }
         const env: Record<string, string> = {};
@@ -44,19 +52,20 @@ async function captureShellEnvAsync(shell: string): Promise<Record<string, strin
           const eq = entry.indexOf("=");
           if (eq > 0) env[entry.slice(0, eq)] = entry.slice(eq + 1);
         }
-        resolve(env);
+        done(env);
       });
 
       child.on("error", () => {
-        resolve({});
+        clearTimeout(timer);
+        done({});
       });
 
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         child.kill("SIGTERM");
-        resolve({});
+        done({});
       }, 5000);
     } catch {
-      resolve({});
+      done({});
     }
   });
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,7 +102,7 @@ const DEFAULTS: Required<Settings> = {
   extensions: [],
   historySize: 500,
   providers: {},
-  defaultProvider: undefined as any,
+  defaultProvider: undefined as unknown as string,
   defaultBackend: "ash",
   toolMode: "api" as "api" | "deferred" | "inline",
   contextWindowSize: 20,

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -138,16 +138,20 @@ export class InputHandler {
         p.accent + after + p.reset +
         "\x1b8"                             // DECRC — restore cursor position
       );
-      const N = promptVisLen + dCursor;
-      this.cursorRowsBelow = N > 0 ? Math.ceil(N / termW) - 1 : 0;
-      this.cursorTermCol = N === 0 ? 1 : (N % termW === 0 ? termW : (N % termW) + 1);
+      // cursorRowsBelow tracks total rows the prompt occupies so we can
+      // reliably clear the entire area on next redraw.  Must account for
+      // the *full* content visible width (cursor + after), not just up to cursor.
+      const totalVisLen = promptVisLen + visibleLen(display);
+      this.cursorRowsBelow = totalVisLen > 0 ? Math.ceil(totalVisLen / termW) - 1 : 0;
+      const cursorVisCol = promptVisLen + visibleLen(before);
+      this.cursorTermCol = cursorVisCol === 0 ? 1 : (cursorVisCol % termW === 0 ? termW : (cursorVisCol % termW) + 1);
     } else {
       // Multi-line: render each line with continuation indent.
       // Same save/restore strategy — cursor position is never computed.
       const lines = display.split("\n");
       const indent = " ".repeat(promptVisLen);
 
-      // Locate cursor: which logical line and offset within it
+      // Locate cursor: which logical line and offset within it (character offset)
       let charsRemaining = dCursor;
       let cursorLine = 0;
       for (let li = 0; li < lines.length; li++) {
@@ -166,20 +170,20 @@ export class InputHandler {
       for (let li = 0; li < lines.length; li++) {
         const prefix = li === 0 ? promptPrefix : indent;
         const lineText = lines[li]!;
-        const lineVisLen = promptVisLen + lineText.length;
+        const lineVisLen = promptVisLen + visibleLen(lineText);
         const lineTermRows = lineVisLen > 0 ? Math.ceil(lineVisLen / termW) : 1;
 
         if (li === cursorLine) {
-          // Split this line at the cursor
+          // Split this line at the cursor (character offset)
           const before = lineText.slice(0, charsRemaining);
           const after = lineText.slice(charsRemaining);
           output += prefix + p.accent + before + p.reset;
           output += "\x1b7";                // DECSC — save cursor position
           output += p.accent + after + p.reset;
 
-          const beforeColAbs = promptVisLen + charsRemaining;
-          cursorRowFromTop = rowsSoFar + (beforeColAbs > 0 ? Math.ceil(beforeColAbs / termW) - 1 : 0);
-          this.cursorTermCol = beforeColAbs === 0 ? 1 : (beforeColAbs % termW === 0 ? termW : (beforeColAbs % termW) + 1);
+          const beforeVisCol = promptVisLen + visibleLen(before);
+          cursorRowFromTop = rowsSoFar + (beforeVisCol > 0 ? Math.ceil(beforeVisCol / termW) - 1 : 0);
+          this.cursorTermCol = beforeVisCol === 0 ? 1 : (beforeVisCol % termW === 0 ? termW : (beforeVisCol % termW) + 1);
         } else {
           output += prefix + p.accent + lineText + p.reset;
         }
@@ -189,7 +193,9 @@ export class InputHandler {
       }
 
       process.stdout.write(output + "\x1b8"); // DECRC — restore cursor position
-      this.cursorRowsBelow = cursorRowFromTop;
+      // Use total rows (rowsSoFar) so next redraw clears the entire area,
+      // not just up to the cursor line.
+      this.cursorRowsBelow = rowsSoFar - 1 > 0 ? rowsSoFar - 1 : 0;
     }
   }
 
@@ -304,6 +310,9 @@ export class InputHandler {
     // Disable kitty keyboard protocol and bracket paste mode
     process.stdout.write("\x1b[<u\x1b[?2004l");
     this.clearPromptArea();
+    // Reset tracking state after clearing — back to raw shell mode
+    this.cursorRowsBelow = 0;
+    this.cursorTermCol = 1;
     this.printPrompt();
   }
 
@@ -513,6 +522,8 @@ export class InputHandler {
           const currentMode = this.activeMode!;
           this.activeMode = null;
           this.editor.clear();
+          this.cursorRowsBelow = 0;
+          this.cursorTermCol = 1;
           this.dismissAutocomplete();
           if (query && query.startsWith("/")) {
             const spaceIdx = query.indexOf(" ");

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -343,12 +343,19 @@ export class Shell implements InputContext {
     });
 
     this.handlers.define("shell:on-processing-done", () => {
-      this.paused = false;
       this.agentActive = false;
       if (!this.inputHandler.handleProcessingDone()) {
+        this.paused = false;
         if (this.freshPrompt()) {
           this.echoSkip = true;
         }
+      } else {
+        // Re-entered a mode via handleProcessingDone — keep stdout paused
+        // briefly so any stale PTY data (e.g. shell prompt from a tool exec)
+        // doesn't overwrite the mode prompt. Set echoSkip to discard the
+        // first line of PTY output once we unpause.
+        this.echoSkip = true;
+        this.paused = false;
       }
     });
 
@@ -389,6 +396,10 @@ export class Shell implements InputContext {
         const handler = (e: { command: string; output: string; cwd: string; exitCode: number | null }) => {
           clearTimeout(timeout);
           this.bus.off("shell:command-done", handler);
+          // Re-pause stdout immediately so the prompt text that follows
+          // the prompt marker isn't displayed to the terminal. Without this,
+          // the shell prompt leaks through during agent processing.
+          this.paused = true;
           resolve({ output: e.output, cwd: e.cwd, exitCode: e.exitCode });
         };
         this.bus.on("shell:command-done", handler);

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -15,7 +15,7 @@ export const RESET = "\x1b[0m";
  * Check if a Unicode code point is a wide character (CJK, fullwidth, emoji, etc.)
  * Returns 2 for wide chars, 1 for normal chars.
  */
-function charWidth(codePoint: number): number {
+export function charWidth(codePoint: number): number {
   // CJK Unified Ideographs
   if (codePoint >= 0x4e00 && codePoint <= 0x9fff) return 2;
   // CJK Unified Ideographs Extension A

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -7,7 +7,7 @@
  */
 import { highlight } from "cli-highlight";
 import type { DiffResult, DiffHunk, DiffLine } from "./diff.js";
-import { visibleLen } from "./ansi.js";
+import { visibleLen, charWidth } from "./ansi.js";
 import { palette as p } from "./palette.js";
 import { wrapLine } from "./markdown.js";
 
@@ -622,7 +622,8 @@ function truncateText(text: string, maxWidth: number): string {
   if (visibleLen(text) <= maxWidth) return text;
   if (maxWidth <= 1) return "…";
 
-  // Walk through the string, tracking visible characters
+  // Walk through the string, tracking visible characters.
+  // Accounts for CJK double-width characters (width=2).
   let visible = 0;
   let i = 0;
   while (i < text.length && visible < maxWidth - 1) {
@@ -634,8 +635,11 @@ function truncateText(text: string, maxWidth: number): string {
         continue;
       }
     }
-    visible++;
-    i++;
+    const cp = text.codePointAt(i) ?? 0;
+    const cw = charWidth(cp);
+    if (visible + cw > maxWidth - 1) break; // not enough room for this char + "…"
+    visible += cw;
+    i += cp > 0xffff ? 2 : 1; // advance past surrogate pairs
   }
 
   return text.slice(0, i) + p.reset + "…";

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -12,6 +12,8 @@
  *   - `setText()`     — replace buffer content (clears paste attachments)
  */
 
+import { charWidth } from "./ansi.js";
+
 // ── Kitty protocol keycode → readable name ──────────────────────
 
 const KITTY_KEY_NAMES: Record<number, string> = {
@@ -85,7 +87,7 @@ export class LineEditor {
     return result;
   }
 
-  /** Cursor position mapped to display-text coordinates. */
+  /** Cursor position mapped to display-text character offset. */
   get displayCursor(): number {
     let pos = 0;
     for (let i = 0; i < this._buf.length && i < this.cursor; i++) {
@@ -99,6 +101,22 @@ export class LineEditor {
       }
     }
     return pos;
+  }
+
+  /** Cursor position as visible terminal-column width (accounts for CJK etc.). */
+  get displayCursorWidth(): number {
+    let width = 0;
+    for (let i = 0; i < this._buf.length && i < this.cursor; i++) {
+      const ch = this._buf[i]!;
+      const paste = this.pastes.get(ch.charCodeAt(0) - PUA_BASE);
+      if (paste) {
+        const n = paste.split("\n").length;
+        width += `[paste +${n} lines]`.length; // ASCII-only, 1 col each
+      } else {
+        width += charWidth(ch.codePointAt(0) ?? 0);
+      }
+    }
+    return width;
   }
 
   /** Number of logical positions in the buffer. */


### PR DESCRIPTION
## 变更说明

将本地 14 个混合 commit（核心代码 + ember 插件记录混杂）重新整理为 7 个干净的核心 commit，并停止追踪 ember 扩展目录。

### 主要变更

1. **`.gitignore`** — 添加 `.DS_Store` 和 `examples/extensions/ember/`
2. **history-file 重构** — async/await 重写，移除回调
3. **4 项代码修复** — agent-loop、conversation-state、bash 工具、executor
4. **CJK diff 修复** — `truncateText` 正确计算双宽字符列宽
5. **3 项代码修复** — convention 缓存、nuclear block O(1) 索引、defaultProvider 类型安全
6. **中文输入换行修复** — `visibleLen` 替代 `string.length`
7. **shell prompt 泄露修复** — agent 回复后正确处理 paused 状态

### 统计

- 17 个文件，+228 / -83 行
- 仅涉及 `src/` 和 `.gitignore`
- ember 插件目录不再被 Git 追踪