### PR TITLE
defer LLM config to core:extensions-loaded

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -147,10 +147,11 @@ export class AgentLoop implements AgentBackend {
     this.historyFile = new HistoryFile({ instanceId: this.instanceId });
     this.conversation = new ConversationState(this.handlers, this.instanceId);
 
-    // Default modes: just the configured model
-    this.modes = config.modes ?? [
-      { model: config.llmClient.model },
-    ];
+    // Fall back to a single-mode placeholder if the caller passed an
+    // empty array (agent-backend does this pre-resolution).
+    this.modes = config.modes?.length
+      ? config.modes
+      : [{ model: config.llmClient.model }];
     this.currentModeIndex = config.initialModeIndex ?? 0;
 
     // Unified token budget — adapts to current model's context window
@@ -202,6 +203,22 @@ export class AgentLoop implements AgentBackend {
       ];
       this.bus.emit("config:changed", {});
     });
+    // Fires before wire() too — agent-backend emits this from
+    // `core:extensions-loaded` to replace the placeholder mode list.
+    onCtor("config:set-modes", ({ modes: newModes, activeIndex }) => {
+      this.modes = newModes;
+      const inRange = activeIndex != null && activeIndex >= 0 && activeIndex < newModes.length;
+      this.currentModeIndex = inRange ? activeIndex! : 0;
+      const m = newModes[this.currentModeIndex];
+      if (!m) return;
+      if (m.providerConfig) {
+        this.llmClient.reconfigure({ ...m.providerConfig, model: m.model });
+      } else {
+        this.llmClient.model = m.model;
+      }
+      this.tokenBudget.update(m.contextWindow, this.toolRegistry.all().length);
+      this.bus.emit("config:changed", {});
+    });
     const getToolsPipe = () => ({ tools: this.getTools() });
     this.bus.onPipe("agent:get-tools", getToolsPipe);
     this.ctorPipeListeners.push({ event: "agent:get-tools", fn: getToolsPipe });
@@ -242,6 +259,9 @@ export class AgentLoop implements AgentBackend {
       this.bus.emit("agent:info", { name: "ash", version: "0.4", model: m.model, provider: m.provider, contextWindow: m.contextWindow });
 
       // Persist as the new default — selection survives restart.
+      // Safe even for dynamic providers: agent-backend defers mode
+      // resolution to `core:extensions-loaded`, so the extension gets
+      // to re-register before the persisted default is looked up.
       if (m.provider) {
         updateSettings({
           defaultProvider: m.provider,
@@ -280,18 +300,6 @@ export class AgentLoop implements AgentBackend {
       const mode = this.currentMode;
       const supported = mode.reasoning !== false && mode.supportsReasoningEffort !== false;
       return { level: this.thinkingLevel, levels: AgentLoop.THINKING_LEVELS, supported };
-    });
-    on("config:set-modes", ({ modes: newModes }) => {
-      this.modes = newModes;
-      this.currentModeIndex = 0;
-      const m = this.modes[0];
-      if (m.providerConfig) {
-        this.llmClient.reconfigure({ ...m.providerConfig, model: m.model });
-      } else {
-        this.llmClient.model = m.model;
-      }
-      this.tokenBudget.update(m.contextWindow, this.toolRegistry.all().length);
-      this.bus.emit("config:changed", {});
     });
     on("agent:reset-session", () => {
       this.cancel();

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -268,10 +268,16 @@ export interface ShellEvents {
 
   // Query initial modes (sync pipe: agent backend extension → core)
   "config:get-initial-modes": { modes: AgentMode[]; initialModeIndex: number };
-  // Set modes (core → agent loop: after provider switch)
-  "config:set-modes": { modes: AgentMode[] };
+  // Set modes (core → agent loop: after provider switch).
+  // Optional activeIndex honors the persisted default without resetting to 0.
+  "config:set-modes": { modes: AgentMode[]; activeIndex?: number };
   // Append modes (core → agent loop: after provider register)
   "config:add-modes": { modes: AgentMode[] };
+
+  // Fires after all extensions (built-in + user) have activated.
+  // agent-backend waits on this to resolve settings.defaultProvider
+  // against the full provider registry, including dynamic providers.
+  "core:extensions-loaded": Record<string, never>;
 
   // Register a provider at runtime (extensions → core)
   "provider:register": {

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -216,18 +216,20 @@ async function loadSpecifiers(
         const base = path.basename(specifier).replace(/\.(ts|js|mjs|mts|tsx)$/, "");
         const name = base === "index" ? path.basename(path.dirname(specifier)) : base;
 
-        // User extensions get a scoped context so /reload can tear them down
-        // All extensions get scoped contexts with the extension name captured
+        // Scoped context so /reload can tear user extensions down.
+        // Awaiting activate() lets extensions with async setup (e.g.
+        // openrouter fetching its model catalog) finish before we move
+        // on; a 10s outer timeout in index.ts guards against hangs.
         if (userSet.has(specifier)) {
           // Dispose previous load if reloading
           extensionDisposers.get(name)?.();
 
           const { scoped, dispose } = createScopedContext(ctx, name);
-          activate(scoped);
+          await activate(scoped);
           extensionDisposers.set(name, dispose);
         } else {
           const { scoped, dispose } = createScopedContext(ctx, name);
-          activate(scoped);
+          await activate(scoped);
           // Non-user extensions aren't reloadable, but track for cleanup on shutdown
           extensionDisposers.set(name, dispose);
         }

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -1,13 +1,14 @@
 /**
  * Built-in agent backend extension.
  *
- * Owns the full LLM lifecycle:
- *   1. Resolves providers from settings + CLI config
- *   2. Creates and manages the LlmClient
- *   3. Builds mode list for model cycling
- *   4. Creates AgentLoop and registers it as the "ash" backend
- *   5. Handles runtime provider switching and provider registration
- *   6. Exposes llm:get-client handler for other extensions (e.g. command-suggest)
+ * Constructs the AgentLoop synchronously with a placeholder LlmClient,
+ * so core handlers (history:append, system-prompt:build, conversation:*)
+ * are defined before user extensions activate. Mode resolution is
+ * deferred to `core:extensions-loaded`, giving runtime-registered
+ * providers (e.g. openrouter) a chance to register before we look up
+ * settings.defaultProvider. Without this deferral, a persisted
+ * `defaultProvider: "openrouter"` loses to a cold-start race and the
+ * backend bails silently.
  */
 import type { ExtensionContext } from "../types.js";
 import type { AgentMode, AgentShellConfig } from "../types.js";
@@ -15,27 +16,23 @@ import { AgentLoop } from "../agent/agent-loop.js";
 import { LlmClient } from "../utils/llm-client.js";
 import { resolveProvider, getProviderNames, getSettings, type ResolvedProvider } from "../settings.js";
 
+/** Read the user's persisted defaultModel for a provider, if any. */
+function persistedModelFor(providerName: string | undefined): string | undefined {
+  if (!providerName) return undefined;
+  return getSettings().providers?.[providerName]?.defaultModel;
+}
+
 export default function agentBackend(ctx: ExtensionContext): void {
   const { bus } = ctx;
-
-  // ── Resolve providers ──────────────────────────────────────
   const config: AgentShellConfig = ctx.call("config:get-shell-config") ?? {};
-  const settings = getSettings();
 
-  let activeProvider: ResolvedProvider | null = null;
+  // Seed from settings.json; runtime provider:register events add more.
   const providerRegistry = new Map<string, ResolvedProvider>();
-
   for (const name of getProviderNames()) {
     const p = resolveProvider(name);
     if (p) providerRegistry.set(name, p);
   }
 
-  const providerName = config.provider ?? settings.defaultProvider;
-  if (providerName) {
-    activeProvider = providerRegistry.get(providerName) ?? null;
-  }
-
-  // ── Build modes ────────────────────────────────────────────
   const buildModes = (): AgentMode[] => {
     const allModes: AgentMode[] = [];
     for (const [id, p] of providerRegistry) {
@@ -55,43 +52,23 @@ export default function agentBackend(ctx: ExtensionContext): void {
     return allModes;
   };
 
-  const effectiveApiKey = config.apiKey ?? activeProvider?.apiKey;
-  const effectiveBaseURL = config.baseURL ?? activeProvider?.baseURL;
-  const effectiveModel = config.model ?? activeProvider?.defaultModel;
-
-  let modes = buildModes();
-  if (modes.length === 0 && effectiveApiKey && effectiveModel) {
-    modes = [{ model: effectiveModel }];
-  }
-
-  const initialModeIndex = Math.max(0, modes.findIndex(
-    (m) => m.model === effectiveModel && (!activeProvider || m.provider === activeProvider.id),
-  ));
-
-  // ── Create LLM client ─────────────────────────────────────
-  if (!effectiveApiKey) return; // No LLM provider configured — skip
-
-  if (!effectiveModel) {
-    bus.emit("ui:error", { message: "No model specified. Use --model or configure a provider with defaultModel in ~/.agent-sh/settings.json" });
-    return;
-  }
-
-  const llmClient = new LlmClient({
-    apiKey: effectiveApiKey,
-    baseURL: effectiveBaseURL,
-    model: effectiveModel,
-  });
-
-  // Expose LLM client for other extensions (e.g. command-suggest)
+  // Placeholder client — reconfigured at core:extensions-loaded. Any
+  // stream() call before then fails from the OpenAI SDK; start() won't
+  // wire the loop until we've resolved, so users never hit that path.
+  const llmClient = new LlmClient({ apiKey: "not-configured", model: "not-configured" });
   ctx.define("llm:get-client", () => llmClient);
 
-  // ── Initial modes (queryable via pipe) ─────────────────────
-  bus.onPipe("config:get-initial-modes", () => ({
-    modes,
-    initialModeIndex,
-  }));
+  let modes: AgentMode[] = [];
+  let initialModeIndex = 0;
+  let resolved = false;
 
-  // ── Create agent loop ──────────────────────────────────────
+  bus.onPipe("config:get-initial-modes", () => ({ modes, initialModeIndex }));
+
+  // AgentLoop must be constructed *before* user extensions activate,
+  // because its ctor defines handlers (history:append, etc.) that
+  // extensions like superash call synchronously during their own
+  // activate. Advise-before-define works for advisers, but plain calls
+  // would hit a no-op stub.
   const agentLoop = new AgentLoop({
     bus,
     contextManager: ctx.contextManager,
@@ -103,11 +80,14 @@ export default function agentBackend(ctx: ExtensionContext): void {
     instanceId: ctx.instanceId,
   });
 
-  // Register as backend
   bus.emit("agent:register-backend", {
     name: "ash",
     kill: () => agentLoop.kill(),
     start: async () => {
+      if (!resolved) {
+        bus.emit("ui:error", { message: "Agent backend not started — no LLM provider available. See earlier messages." });
+        return;
+      }
       agentLoop.wire();
       bus.emit("agent:info", {
         name: "ash",
@@ -119,7 +99,40 @@ export default function agentBackend(ctx: ExtensionContext): void {
     },
   });
 
-  // ── Runtime provider registration ──────────────────────────
+  bus.on("core:extensions-loaded", () => {
+    const settings = getSettings();
+    const providerName = config.provider ?? settings.defaultProvider;
+    const activeProvider = providerName ? providerRegistry.get(providerName) ?? null : null;
+
+    // User's persisted defaultModel wins over the provider's declared
+    // default. Dynamic providers (openrouter) re-register with their
+    // hardcoded DEFAULT_MODELS[0] each startup, which would otherwise
+    // clobber the user's /model selection.
+    const effectiveApiKey = config.apiKey ?? activeProvider?.apiKey;
+    const effectiveBaseURL = config.baseURL ?? activeProvider?.baseURL;
+    const effectiveModel = config.model ?? persistedModelFor(providerName) ?? activeProvider?.defaultModel;
+
+    if (!effectiveApiKey) {
+      bus.emit("ui:error", { message: "No LLM provider configured. Set --api-key, configure a provider in ~/.agent-sh/settings.json, or load a provider extension (e.g. openrouter) that sets OPENROUTER_API_KEY." });
+      return;
+    }
+    if (!effectiveModel) {
+      bus.emit("ui:error", { message: "No model specified. Use --model or configure a provider with defaultModel in ~/.agent-sh/settings.json" });
+      return;
+    }
+
+    modes = buildModes();
+    if (modes.length === 0) modes = [{ model: effectiveModel }];
+    initialModeIndex = Math.max(0, modes.findIndex(
+      (m) => m.model === effectiveModel && (!activeProvider || m.provider === activeProvider.id),
+    ));
+
+    llmClient.reconfigure({ apiKey: effectiveApiKey, baseURL: effectiveBaseURL, model: effectiveModel });
+    bus.emit("config:set-modes", { modes, activeIndex: initialModeIndex });
+    resolved = true;
+    // start() emits agent:info after wiring.
+  });
+
   bus.on("provider:register", (p) => {
     const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
     const modelIds: string[] = [];
@@ -154,18 +167,26 @@ export default function agentBackend(ctx: ExtensionContext): void {
       };
     });
     bus.emit("config:add-modes", { modes: addModes });
+
+    // Late-registration reconcile: if this completes the user's persisted
+    // default (openrouter's async fetch delivers the full catalog after
+    // we've already fallen back to mode 0), quietly switch to it.
+    if (!resolved) return;
+    const pendingProvider = getSettings().defaultProvider;
+    if (pendingProvider !== p.id) return;
+    const pendingModel = persistedModelFor(pendingProvider);
+    if (pendingModel && modelIds.includes(pendingModel) && llmClient.model !== pendingModel) {
+      bus.emit("config:switch-model", { model: pendingModel });
+    }
   });
 
-  // ── Runtime provider switching ─────────────────────────────
   bus.on("config:switch-provider", ({ provider: name }) => {
     const p = providerRegistry.get(name);
     if (!p) {
       bus.emit("ui:error", { message: `Unknown provider: ${name}` });
       return;
     }
-
-    const newApiKey = p.apiKey;
-    if (!newApiKey) {
+    if (!p.apiKey) {
       bus.emit("ui:error", { message: `Provider "${name}" has no API key configured` });
       return;
     }
@@ -174,18 +195,14 @@ export default function agentBackend(ctx: ExtensionContext): void {
       bus.emit("ui:error", { message: `Provider "${name}" has no models configured` });
       return;
     }
-    llmClient.reconfigure({
-      apiKey: newApiKey,
-      baseURL: p.baseURL,
-      model: switchModel,
-    });
+    llmClient.reconfigure({ apiKey: p.apiKey, baseURL: p.baseURL, model: switchModel });
 
     const newModes: AgentMode[] = p.models.map((m) => {
       const mc = p.modelCapabilities?.get(m);
       return {
         model: m,
         provider: name,
-        providerConfig: { apiKey: newApiKey, baseURL: p.baseURL },
+        providerConfig: { apiKey: p.apiKey!, baseURL: p.baseURL },
         contextWindow: mc?.contextWindow ?? p.contextWindow,
         reasoning: mc?.reasoning,
         supportsReasoningEffort: p.supportsReasoningEffort,
@@ -193,7 +210,6 @@ export default function agentBackend(ctx: ExtensionContext): void {
     });
     bus.emit("config:set-modes", { modes: newModes });
 
-    activeProvider = p;
     bus.emit("agent:info", { name: "ash", version: "0.4", model: switchModel, provider: name, contextWindow: p.contextWindow });
     bus.emit("ui:info", { message: `Switched to ${name} (${switchModel})` });
     bus.emit("config:changed", {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,10 @@ async function main(): Promise<void> {
     console.error('[agent-sh] Extensions loaded');
   }
 
+  // Tell deferred-init listeners (agent-backend) that the provider
+  // registry is now complete.
+  core.bus.emit("core:extensions-loaded", {});
+
   // ── Discover skills ───────────────────────────────────────────
   const skills = discoverSkills(process.cwd());
 


### PR DESCRIPTION
## Summary
- Fixes persistence of dynamic (runtime-registered) providers as the default selection. Previously, `/model`-persisting a selection from the openrouter extension silently broke the next startup (agent-backend resolved settings.defaultProvider before openrouter had a chance to register, provider came back with no apiKey, backend bailed).
- agent-backend now constructs AgentLoop synchronously with a placeholder LlmClient, then defers mode resolution to a new `core:extensions-loaded` event emitted after `loadExtensions()` returns. Handlers extensions depend on (e.g. `history:append` in superash's nuclear module) stay defined before user extensions activate.

## Fixes
- Refactor `agent-backend` into a two-phase activation: sync AgentLoop construction, deferred LlmClient reconfigure.
- `config:set-modes` accepts optional `activeIndex` so startup honors the persisted defaultModel without resetting to mode 0.
- `config:set-modes` handler moves to `onCtor` (fires before `wire()`) so the resolve path can replace the placeholder modes cleanly.
- Extension loader now awaits `activate()` return. Extensions with async setup (openrouter fetching its catalog) can return a promise; the 10s load timeout still guards against hangs.
- `provider:register` handler reconciles late registrations — if an extension registers after resolution and the newly-available models include the persisted default, silently switch to it. Handles openrouter's `fetchModels()` case where the full 300-model catalog arrives async.
- User's persisted `settings.providers[name].defaultModel` wins over the provider's own declared default, so openrouter re-registering with `DEFAULT_MODELS[0]` no longer clobbers the user's selection each startup.
- `AgentLoop` constructor tolerates empty `modes` array.

## Test plan
- [ ] `npm run build` passes
- [ ] Fresh launch with `settings.defaultProvider = "openrouter"` + a persisted openrouter defaultModel loads the persisted model at startup (banner shows it, first query uses it).
- [ ] `/model`-selecting an openrouter model persists and survives restart.
- [ ] Launch with no API key anywhere produces a clear `ui:error` instead of silent failure.
- [ ] Superash session-start marker still writes (verify `~/.agent-sh/history` grows on each session).