### PR TITLE
Ash improvements: compositor introspection, glob/grep hints, peer messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Most AI terminal tools get this backwards: the LLM drives the experience and the
 agent-sh flips this. It's your shell first — full PTY, your rc config, your aliases, everything just works. But type `>` at the start of a line, and you're talking to an agent that has full context of what you've been doing.
 
 ```
-~ $ ls -la                          # real shell command
-~ $ cd ../tests && npm test          # real cd, env, aliases — all just work
-~ $ vim file.ts                      # opens vim in the same PTY
-~ $ > explain the last error          # agent investigates using its own tools
-~ $ > deploy to staging              # agent runs it in your live shell
+~ $ ls -la                       # real shell command
+~ $ cd ../tests && npm test      # real cd, env, aliases — all just work
+~ $ vim file.ts                  # opens vim in the same PTY
+~ $ > explain the last error     # agent investigates using its own tools
+~ $ > draft a commit message     # agent reads your diff and shell history
 ```
 
 ## Quick Start
@@ -47,10 +47,6 @@ Requires Node.js 18+.
 **Extensible by design.** The entire system is built on a typed event bus. Extensions can add custom input modes, content transforms (render LaTeX as images, Mermaid as diagrams), themes, slash commands, or replace the agent backend entirely. The built-in TUI renderer is itself just an extension.
 
 **Embeddable as a library.** The core is a headless kernel — `import { createCore } from "agent-sh"` to build WebSocket servers, REST APIs, Electron apps, or test harnesses. No terminal required.
-
-## Configuration
-
-Configure via `~/.agent-sh/settings.json`. See the [Usage Guide](docs/usage.md#configuration) for the full settings reference.
 
 ## Documentation
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -184,8 +184,8 @@ Extensions can add tools that cross the shell↔agent boundary via `shell:exec-r
 | `ls` | List directory contents (with timestamps and sizes) | No | No |
 | `list_skills` | List available skills (name, description, path) | No | No |
 | `shell_recall` | Browse or search truncated shell context (extension: shell-recall) | No | No |
-| `terminal_read` | Read the current terminal screen (extension: terminal-buffer) | No | No |
-| `terminal_keys` | Send keystrokes to the user's live PTY (extension: terminal-buffer) | No | No |
+| `terminal_read` | Read the current terminal screen (example extension: `terminal-buffer`) | No | No |
+| `terminal_keys` | Send keystrokes to the user's live PTY (example extension: `terminal-buffer`) | No | No |
 
 **Common pattern**: all file-based tools resolve relative paths from the current working directory (`contextManager.getCwd()`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,6 @@ index.ts — interactive terminal frontend:
   │     file-autocomplete — @ file path completion
   │     shell-recall      — shell_recall terminal interception
   │     command-suggest   — fix suggestions on failed commands (fast-path LLM)
-  │     terminal-buffer   — terminal_read + terminal_keys tools
   │
   ├── Shared utilities:
   │     palette           — semantic color system (accent, success, warning, error, muted)
@@ -156,8 +155,7 @@ agent-sh/
 │       ├── agent-backend.ts  # LLM provider resolution + AgentLoop registration
 │       ├── tui-renderer.ts, slash-commands.ts
 │       ├── file-autocomplete.ts, shell-recall.ts
-│       ├── command-suggest.ts
-│       └── terminal-buffer.ts  # terminal_read + terminal_keys tools
+│       └── command-suggest.ts
 │
 ├── examples/                 # Example extensions and agent integrations
 │   └── extensions/

--- a/docs/tui-composition.md
+++ b/docs/tui-composition.md
@@ -256,6 +256,18 @@ See [Extensions: Remote Sessions](extensions.md#remote-sessions) for the full AP
 
 Use the compositor directly only when you need fine-grained control — e.g. redirecting a single sub-stream like `"agent:diff"` without affecting the rest.
 
+## Observing writes (`compositor:write`)
+
+When the core creates the compositor with an `EventBus` attached, every surface write emits a `compositor:write` event:
+
+```typescript
+bus.on("compositor:write", ({ stream, text }) => {
+  // `stream` is the named stream (e.g. "agent", "agent:diff"), `text` is the raw write
+});
+```
+
+This lets an extension mirror or inspect rendered output without intercepting stdout. Used by e.g. a compositor-mirror extension that buffers recent agent output and exposes a `compositor_read` tool.
+
 ## Relationship to other systems
 
 | System | Role | Compositor interaction |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,8 +101,6 @@ cp examples/extensions/overlay-agent.ts ~/.agent-sh/extensions/
 agent-sh -e ./examples/extensions/overlay-agent.ts
 ```
 
-The agent can read the terminal screen and send keystrokes via the built-in `terminal_read` and `terminal_keys` tools, enabling it to operate inside interactive programs.
-
 While the agent is working, press **Ctrl+\\** or **Esc** to hide the overlay and continue using your program — the agent keeps running in the background and control returns automatically when it finishes. If the overlay is still visible when the agent finishes, it shows a follow-up prompt for multi-turn conversation.
 
 Requires `@xterm/headless` for the dimmed background compositing:

--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -428,6 +428,10 @@ async function handleSessionNew(id: number | string, params: Record<string, unkn
       process.stderr.write(`Warning: ${err instanceof Error ? err.message : err}\n`);
     });
 
+    // Signal deferred-init listeners (agent-backend) that the provider
+    // registry is complete — they resolve their LLM config on this event.
+    core.bus.emit("core:extensions-loaded", {});
+
     core.activateBackend();
   }
 

--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -411,7 +411,6 @@ async function handleSessionNew(id: number | string, params: Record<string, unkn
     const headlessDisabled = [
       "tui-renderer",
       "file-autocomplete",
-      "terminal-buffer",
       "overlay-agent",
       ...(settings.disabledBuiltins ?? []),
     ];

--- a/examples/extensions/peer-mesh.ts
+++ b/examples/extensions/peer-mesh.ts
@@ -268,6 +268,54 @@ export default function activate(ctx: ExtensionContext): void {
   define("peer:context-search", (query: string) => contextManager.search(query));
   server.expose("peer:context-search");
 
+  // ── Inter-peer messaging ───────────────────────────────────
+
+  interface InboxEntry { from: string; text: string; at: number; }
+  const inbox: InboxEntry[] = [];
+  const INBOX_MAX = 100;
+
+  const pending: InboxEntry[] = [];
+
+  define("peer:message", (from: string, text: string) => {
+    if (typeof from !== "string" || typeof text !== "string") {
+      throw new Error("peer:message requires (from: string, text: string)");
+    }
+    const entry: InboxEntry = { from, text, at: Date.now() };
+    inbox.push(entry);
+    if (inbox.length > INBOX_MAX) inbox.splice(0, inbox.length - INBOX_MAX);
+    pending.push(entry);
+    bus.emit("peer:message-received", entry);
+    bus.emit("ui:info", { message: `[peer ${from}] ${text}` });
+    setTimeout(drainPending, 100);
+    return { ok: true };
+  });
+  server.expose("peer:message");
+
+  // Drain pending peer messages by injecting a synthetic user turn.
+  // Only one submission per processing cycle — wait for agent:processing-done
+  // before releasing the next batch.
+  let busy = false;
+
+  function drainPending(): void {
+    if (busy || pending.length === 0) return;
+    const batch = pending.splice(0, pending.length);
+    const lines = batch.map((e) => `[from peer ${e.from}] ${e.text}`);
+    const query = [
+      "You received message(s) from other peer(s) in the mesh:",
+      "",
+      ...lines,
+      "",
+      "Decide whether to reply (via `peer_send`), act on the request, or note and continue.",
+    ].join("\n");
+    busy = true;
+    bus.emit("agent:submit", { query });
+  }
+
+  bus.on("agent:processing-done", () => {
+    busy = false;
+    setTimeout(drainPending, 100);
+  });
+
   // ── Handler registry API (for other extensions) ────────────
 
   define("peer:discover", () => server.discover());
@@ -412,6 +460,71 @@ export default function activate(ctx: ExtensionContext): void {
     }),
   });
 
+  registerTool({
+    name: "peer_send",
+    description: "Send a text message to another running agent-sh peer. The peer will see it in their UI and on their next turn.",
+    input_schema: {
+      type: "object",
+      properties: {
+        peer_id: { type: "string", description: "The instance ID of the peer (from the peers tool)." },
+        text: { type: "string", description: "Message body." },
+      },
+      required: ["peer_id", "text"],
+    },
+    showOutput: false,
+    getDisplayInfo: () => ({ kind: "write" as const }),
+    formatCall: (args) => `peer ${args.peer_id}: "${String(args.text).slice(0, 40)}"`,
+
+    async execute(args) {
+      try {
+        await server.call(args.peer_id as string, "peer:message", ctx.instanceId, args.text as string);
+        return { content: `Sent to peer ${args.peer_id}.`, exitCode: 0, isError: false };
+      } catch (e) {
+        return {
+          content: `Failed to send: ${e instanceof Error ? e.message : String(e)}`,
+          exitCode: 1,
+          isError: true,
+        };
+      }
+    },
+
+    formatResult: (_args, result) => ({
+      summary: result.isError ? "failed" : "sent",
+    }),
+  });
+
+  registerTool({
+    name: "peer_inbox",
+    description: "Read recent messages received from other peers via peer_send.",
+    input_schema: {
+      type: "object",
+      properties: {
+        count: { type: "number", description: "Number of recent messages to return (default: 20)." },
+      },
+      required: [],
+    },
+    showOutput: false,
+    getDisplayInfo: () => ({ kind: "read" as const }),
+    formatCall: () => "reading inbox",
+
+    async execute(args) {
+      const n = (args.count as number) || 20;
+      const recent = inbox.slice(-n);
+      if (recent.length === 0) {
+        return { content: "(inbox empty)", exitCode: 0, isError: false };
+      }
+      const lines = recent.map((e) => {
+        const ago = Math.round((Date.now() - e.at) / 1000);
+        return `[${ago}s ago] ${e.from}: ${e.text}`;
+      });
+      return { content: lines.join("\n"), exitCode: 0, isError: false };
+    },
+
+    formatResult: (_args, result) => ({
+      summary: result.content === "(inbox empty)" ? "empty" : `${result.content.split("\n").length} msg`,
+    }),
+  });
+
   // ── Slash command ──────────────────────────────────────────
 
   registerCommand("peers", "List running agent-sh peer instances", () => {
@@ -435,6 +548,8 @@ export default function activate(ctx: ExtensionContext): void {
     "- `peer_terminal` to see what's on another terminal's screen",
     "- `peer_history` to see what commands they ran recently",
     "- `peer_search` to search their shell context by keyword",
+    "- `peer_send` to deliver a text message to another peer (appears in their UI)",
+    "- `peer_inbox` to read messages other peers have sent you",
     "When the user references 'the other terminal' or 'my other shell', use these tools.",
   ].join("\n"));
 

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -8,9 +8,13 @@
  * Together these let the agent operate inside interactive programs
  * (vim, htop, less, etc.) by reading the screen and typing keys.
  *
- * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ * Requires xterm in the extension directory:
+ *   npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ *
+ * Core already loads xterm lazily (for floating-panel compositing), so
+ * installing these deps anywhere on the NODE_PATH is enough.
  */
-import type { ExtensionContext } from "../types.js";
+import type { ExtensionContext } from "agent-sh/types";
 
 /** Interpret C-style escape sequences (e.g. \r → CR, \x1b → ESC). */
 function interpretEscapes(str: string): string {

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -1,5 +1,5 @@
 /**
- * Built-in terminal buffer extension.
+ * Terminal buffer extension.
  *
  * Registers two agent tools:
  *   - terminal_read: get the current screen contents + cursor position

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -7,9 +7,11 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
   return {
     name: "glob",
     description:
-      "Find files by name pattern. Returns paths sorted by modification time (newest first). " +
+      "Use this when you know a FILENAME or PATH SHAPE (e.g. `**/*.ts`, `src/**/*.md`, `package.json`). " +
+      "Returns matching file paths sorted by modification time (newest first). " +
+      "This does NOT search file contents — use `grep` for that. " +
       "ALWAYS use this instead of find/ls via bash. " +
-      "Use glob to locate files, then read_file or grep to inspect contents.",
+      "Typical flow: `glob` to locate files, then `read_file` or `grep` to inspect contents.",
     input_schema: {
       type: "object",
       properties: {

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -5,6 +5,8 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
   return {
     name: "grep",
     description:
+      "Use this when you know something INSIDE the file (text, identifier, regex). " +
+      "To find files by filename alone, use `glob` instead. " +
       "Search file contents using ripgrep. ALWAYS use this instead of running grep/rg via bash. " +
       "Supports three output modes: " +
       "'files_with_matches' (default, returns file paths only — use this to find which files contain a pattern), " +
@@ -137,8 +139,17 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
       await done;
 
       if (session.exitCode === 1 && !session.output.trim()) {
+        // If the pattern looks like a filename (e.g. "SKILL.md", "package.json"),
+        // the agent probably meant to find files by name, not search inside them.
+        // Surface a redirect hint instead of a silent zero.
+        const looksLikeFilename =
+          /^[A-Za-z0-9_.\-*/]+\.[A-Za-z0-9]{1,6}$/.test(pattern) &&
+          !/[\\()\[\]|^$+{}]/.test(pattern);
+        const hint = looksLikeFilename
+          ? ` Hint: "${pattern}" looks like a filename. grep searches file *contents* — to find files by name, use the \`glob\` tool instead.`
+          : "";
         return {
-          content: "No matches found.",
+          content: `No matches found.${hint}`,
           exitCode: 0,
           isError: false,
         };

--- a/src/core.ts
+++ b/src/core.ts
@@ -127,7 +127,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
   });
 
   // ── Compositor ──────────────────────────────────────────────
-  const compositor = new DefaultCompositor();
+  const compositor = new DefaultCompositor(bus);
   const stdoutSurface = new StdoutSurface();
   compositor.setDefault("agent", stdoutSurface);
   compositor.setDefault("query", stdoutSurface);

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -172,6 +172,9 @@ export interface ShellEvents {
   "ui:error": { message: string };
   "ui:suggestion": { text: string };
 
+  // Compositor surface writes (emitted by DefaultCompositor when bus provided)
+  "compositor:write": { stream: string; text: string };
+
   // Generic keypress forwarding (control chars not handled by input-handler)
   "input:keypress": { key: string };
 

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -19,7 +19,6 @@ export const BUILTIN_EXTENSIONS: Array<{
   { name: "file-autocomplete", load: () => import("./file-autocomplete.js").then(m => m.default) },
   { name: "shell-recall",     load: () => import("./shell-recall.js").then(m => m.default) },
   { name: "command-suggest",   load: () => import("./command-suggest.js").then(m => m.default) },
-  { name: "terminal-buffer",   load: () => import("./terminal-buffer.js").then(m => m.default) },
 ];
 
 /**

--- a/src/utils/compositor.ts
+++ b/src/utils/compositor.ts
@@ -27,6 +27,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { EventBus } from "../event-bus.js";
+
 /**
  * A surface accepts rendered output.  Stdout is a surface.
  * A floating panel's content area is a surface.  A test buffer is a surface.
@@ -77,6 +79,11 @@ export class StdoutSurface implements RenderSurface {
 export class DefaultCompositor implements Compositor {
   private defaults = new Map<string, RenderSurface>();
   private overrides = new Map<string, RenderSurface[]>();
+  private readonly bus?: EventBus;
+
+  constructor(bus?: EventBus) {
+    this.bus = bus;
+  }
 
   surface(stream: string): RenderSurface {
     const stack = this.overrides.get(stream);
@@ -91,12 +98,13 @@ export class DefaultCompositor implements Compositor {
   }
 
   redirect(stream: string, target: RenderSurface): () => void {
+    const wrapped = this.wrap(stream, target);
     let stack = this.overrides.get(stream);
     if (!stack) {
       stack = [];
       this.overrides.set(stream, stack);
     }
-    stack.push(target);
+    stack.push(wrapped);
 
     let restored = false;
     return () => {
@@ -104,12 +112,29 @@ export class DefaultCompositor implements Compositor {
       restored = true;
       const s = this.overrides.get(stream);
       if (!s) return;
-      const idx = s.indexOf(target);
+      const idx = s.indexOf(wrapped);
       if (idx !== -1) s.splice(idx, 1);
     };
   }
 
   setDefault(stream: string, target: RenderSurface): void {
-    this.defaults.set(stream, target);
+    this.defaults.set(stream, this.wrap(stream, target));
+  }
+
+  /** Wrap a surface so writes emit `compositor:write` before delegating. */
+  private wrap(stream: string, target: RenderSurface): RenderSurface {
+    const bus = this.bus;
+    if (!bus) return target;
+    return {
+      write: (text: string) => {
+        try { bus.emit("compositor:write", { stream, text }); } catch {}
+        target.write(text);
+      },
+      writeLine: (line: string) => {
+        try { bus.emit("compositor:write", { stream, text: line + "\n" }); } catch {}
+        target.writeLine(line);
+      },
+      get columns() { return target.columns; },
+    };
   }
 }


### PR DESCRIPTION
## Summary
- **compositor:write event** — `DefaultCompositor` optionally takes an `EventBus` and emits `compositor:write { stream, text }` on every surface write, enabling extensions to mirror/observe rendered output.
- **glob vs grep disambiguation** — tightened tool descriptions to state the filename-vs-contents distinction; grep surfaces a redirect hint when the pattern looks like a filename and finds nothing.
- **peer messaging** — `peer_send` / `peer_inbox` tools plus a `peer:message` RPC handler in the peer-mesh example. Received messages schedule a synthetic user turn via `agent:submit`, gated on `agent:processing-done`.
- **ash-acp-bridge fix** — emit `core:extensions-loaded` before `activateBackend()` so deferred LLM-config init works via ACP.
- **terminal-buffer refactor** — the `terminal_read` / `terminal_keys` tools move from built-in extensions to `examples/extensions/terminal-buffer.ts`. No xterm dependency added to core; users who want these tools install `@xterm/headless` alongside the extension.

## Test plan
- [ ] Start two agent-sh instances, verify `peer_send` delivers into the receiver's inbox and triggers a nudge turn
- [ ] Grep for a filename-shaped pattern (e.g. `SKILL.md`) and confirm the hint appears
- [ ] Activate a compositor-reader extension and confirm `compositor:write` events fire for agent output
- [ ] Launch via ACP and confirm LLM config resolves
- [ ] Copy the terminal-buffer example extension + install xterm, confirm `terminal_read` works