### PR TITLE
fix: correct CJK and emoji character width calculation for box rendering

### DIFF
--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -13,9 +13,41 @@ export const RESET = "\x1b[0m";
 
 /**
  * Check if a Unicode code point is a wide character (CJK, fullwidth, emoji, etc.)
- * Returns 2 for wide chars, 1 for normal chars.
+ * Returns 2 for wide chars, 1 for normal chars, 0 for combining chars.
+ *
+ * Based on East Asian Width and Unicode categories.
  */
 export function charWidth(codePoint: number): number {
+  // Combining characters (zero width)
+  if (codePoint >= 0x0300 && codePoint <= 0x036f) return 0; // Combining Diacritical Marks
+  if (codePoint >= 0x1ab0 && codePoint <= 0x1aff) return 0; // Combining Diacritical Marks Extended
+  if (codePoint >= 0x1dc0 && codePoint <= 0x1dff) return 0; // Combining Diacritical Marks Supplement
+  if (codePoint >= 0x20d0 && codePoint <= 0x20ff) return 0; // Combining Diacritical Marks for Symbols
+  if (codePoint >= 0xfe20 && codePoint <= 0xfe2f) return 0; // Combining Half Marks
+  if (codePoint >= 0xfe00 && codePoint <= 0xfe0f) return 0; // Variation Selectors
+  if (codePoint >= 0xe0100 && codePoint <= 0xe01ef) return 0; // Variation Selectors Supplement
+
+  // Emoji and symbols that render as wide (2 columns)
+  // Emoji presentation sequences and keycap
+  if (codePoint === 0x20e3) return 2; // Combining Enclosing Keycap
+
+  // Emoji blocks
+  if (codePoint >= 0x1f600 && codePoint <= 0x1f64f) return 2; // Emoticons
+  if (codePoint >= 0x1f300 && codePoint <= 0x1f5ff) return 2; // Misc Symbols and Pictographs
+  if (codePoint >= 0x1f680 && codePoint <= 0x1f6ff) return 2; // Transport and Map
+  if (codePoint >= 0x1f700 && codePoint <= 0x1f77f) return 2; // Alchemical Symbols
+  if (codePoint >= 0x1f780 && codePoint <= 0x1f7ff) return 2; // Geometric Shapes Extended
+  if (codePoint >= 0x1f800 && codePoint <= 0x1f8ff) return 2; // Supplemental Arrows-C
+  if (codePoint >= 0x1f900 && codePoint <= 0x1f9ff) return 2; // Supplemental Symbols and Pictographs
+  if (codePoint >= 0x1fa00 && codePoint <= 0x1faff) return 2; // Chess Symbols, Symbols and Pictographs Extended-A
+  // NOTE: 0x2300-0x23ff (Misc Technical), 0x2600-0x26ff (Misc Symbols),
+  // and 0x2700-0x27bf (Dingbats) are intentionally NOT width 2 — these ranges
+  // contain mostly "Ambiguous" width characters that render as 1 column in
+  // non-CJK terminal locales (e.g. ❯, ⌘, ★, ♦).
+
+  // Regional indicator symbols (flag emoji components)
+  if (codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff) return 2;
+
   // CJK Unified Ideographs
   if (codePoint >= 0x4e00 && codePoint <= 0x9fff) return 2;
   // CJK Unified Ideographs Extension A
@@ -26,7 +58,6 @@ export function charWidth(codePoint: number): number {
   if (codePoint >= 0x20000 && codePoint <= 0x2ebef) return 2;
   // Fullwidth ASCII variants
   if (codePoint >= 0xff01 && codePoint <= 0xff5e) return 2;
-  // Halfwidth Katakana (actually narrow, skip)
   // Fullwidth bracket forms
   if (codePoint >= 0xff5f && codePoint <= 0xff60) return 2;
   // Fullwidth symbol variants
@@ -69,18 +100,27 @@ export function visibleLen(str: string): number {
  */
 export function truncateToWidth(str: string, maxWidth: number): string {
   const clean = str.replace(/\x1b\[[^m]*m/g, "");
+  if (maxWidth < 2) return clean.slice(0, maxWidth > 0 ? 1 : 0);
+  // First check if the entire string fits
+  let fullWidth = 0;
+  for (const char of clean) {
+    fullWidth += charWidth(char.codePointAt(0) ?? 0);
+  }
+  if (fullWidth <= maxWidth) return clean;
+  // String doesn't fit — truncate with "…"
+  // Reserve 1 column for "…", so target content width is maxWidth - 1
+  const target = maxWidth - 1;
   let width = 0;
   let i = 0;
   for (const char of clean) {
     const cw = charWidth(char.codePointAt(0) ?? 0);
-    if (width + cw > maxWidth - 1) {
-      // Need room for the "…" (1 column wide)
-      return clean.slice(0, i) + "…";
-    }
+    if (width + cw > target) break;
     width += cw;
     i += char.length;
   }
-  return clean;
+  // If we consumed nothing (first char is wider than target), take at least 1 char
+  if (i === 0) i = (clean.codePointAt(0) ?? 0) > 0xffff ? 2 : 1;
+  return clean.slice(0, i) + "…";
 }
 
 /**

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -100,7 +100,7 @@ export function visibleLen(str: string): number {
  */
 export function truncateToWidth(str: string, maxWidth: number): string {
   const clean = str.replace(/\x1b\[[^m]*m/g, "");
-  if (maxWidth < 2) return clean.slice(0, maxWidth > 0 ? 1 : 0);
+  if (maxWidth <= 0) return "";
   // First check if the entire string fits
   let fullWidth = 0;
   for (const char of clean) {
@@ -108,6 +108,8 @@ export function truncateToWidth(str: string, maxWidth: number): string {
   }
   if (fullWidth <= maxWidth) return clean;
   // String doesn't fit — truncate with "…"
+  // At maxWidth=1 the ellipsis alone fills the budget.
+  if (maxWidth === 1) return "…";
   // Reserve 1 column for "…", so target content width is maxWidth - 1
   const target = maxWidth - 1;
   let width = 0;
@@ -118,8 +120,9 @@ export function truncateToWidth(str: string, maxWidth: number): string {
     width += cw;
     i += char.length;
   }
-  // If we consumed nothing (first char is wider than target), take at least 1 char
-  if (i === 0) i = (clean.codePointAt(0) ?? 0) > 0xffff ? 2 : 1;
+  // If nothing fit (first char is wider than target), just show the ellipsis
+  // rather than emit a character that would overflow the budget.
+  if (i === 0) return "…";
   return clean.slice(0, i) + "…";
 }
 

--- a/src/utils/box-frame.ts
+++ b/src/utils/box-frame.ts
@@ -5,7 +5,7 @@
  * never writes to stdout. Supports multiple border styles and
  * optional title/footer sections with dividers.
  */
-import { visibleLen } from "./ansi.js";
+import { visibleLen, truncateToWidth } from "./ansi.js";
 import { palette as p } from "./palette.js";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -107,6 +107,12 @@ export function renderBoxFrame(content: string[], opts: BoxFrameOptions): string
 // ── Helpers ──────────────────────────────────────────────────────
 
 function boxLine(text: string, innerW: number, v: string, bc: string): string {
-  const pad = Math.max(0, innerW - visibleLen(text));
+  const textWidth = visibleLen(text);
+  if (textWidth > innerW) {
+    // Content is too wide — truncate to fit exactly
+    const truncated = truncateToWidth(text, innerW);
+    return `${bc}${v}${p.reset} ${truncated} ${bc}${v}${p.reset}`;
+  }
+  const pad = innerW - textWidth;
   return `${bc}${v}${p.reset} ${text}${" ".repeat(pad)} ${bc}${v}${p.reset}`;
 }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { visibleLen, truncateToWidth, padEndToWidth } from "./ansi.js";
+import { visibleLen, truncateToWidth, padEndToWidth, charWidth } from "./ansi.js";
 import { palette as p } from "./palette.js";
 
 export const MAX_CONTENT_WIDTH = 90;
@@ -36,22 +36,36 @@ export function wrapLine(text: string, maxWidth: number): string[] {
     for (const word of words) {
       if (word.length === 0) continue;
 
-      if (currentWidth + word.length <= maxWidth) {
+      const wordWidth = visibleLen(word);
+      if (currentWidth + wordWidth <= maxWidth) {
         currentLine += word;
-        currentWidth += word.length;
+        currentWidth += wordWidth;
       } else if (currentWidth === 0) {
-        // Single word longer than maxWidth — hard break
+        // Single word longer than maxWidth — hard break by visible width
         let remaining = word;
         while (remaining.length > 0) {
-          const chunk = remaining.slice(0, maxWidth - currentWidth || maxWidth);
-          remaining = remaining.slice(chunk.length);
+          // Find the largest prefix that fits
+          let fitLen = 0;
+          let fitWidth = 0;
+          for (const ch of remaining) {
+            const cw = charWidth(ch.codePointAt(0) ?? 0);
+            if (fitWidth + cw > maxWidth) break;
+            fitWidth += cw;
+            fitLen += ch.length;
+          }
+          if (fitLen === 0) {
+            // Even one char doesn't fit — force take one char to avoid infinite loop
+            fitLen = remaining[0]?.length ?? 1;
+          }
+          const chunk = remaining.slice(0, fitLen);
+          remaining = remaining.slice(fitLen);
           currentLine += chunk;
           if (remaining.length > 0) {
             result.push(currentLine + p.reset);
             currentLine = activeStyles;
             currentWidth = 0;
           } else {
-            currentWidth += chunk.length;
+            currentWidth += fitWidth;
           }
         }
       } else {
@@ -62,7 +76,7 @@ export function wrapLine(text: string, maxWidth: number): string[] {
         // Skip leading spaces on new line
         const trimmed = word.replace(/^ +/, "");
         currentLine += trimmed;
-        currentWidth = trimmed.length;
+        currentWidth = visibleLen(trimmed);
       }
     }
   }


### PR DESCRIPTION
## Summary

Re-opens #67 with only the CJK-width fix — the original PR also carried an unrelated commit (`ember #015`) touching a local `ember` extension that doesn't exist in this repo, plus `.gitignore` lines for those personal extensions. This branch cherry-picks the legitimate fix commit verbatim, preserving @firslov as the author.

## What the fix does

CJK text, emoji, and other wide Unicode characters caused box-frame borders to break — content would overflow past the right edge of the frame, misaligning the closing border. The root cause was that several places in the rendering pipeline used character count (`string.length`) instead of **visible display width** (columns), and `charWidth()` had limited Unicode coverage.

- **`src/utils/ansi.ts`**
  - `charWidth()`: expanded with combining characters (width 0), emoji blocks, regional indicators, and variation selectors
  - `truncateToWidth()`: pre-check whole-string fit, reserve 1 column for ellipsis, guard against first-char-wider-than-target
- **`src/utils/box-frame.ts`**: `boxLine()` now truncates overflow instead of breaking frame alignment
- **`src/utils/markdown.ts`**: `wrapLine()` uses `visibleLen()` / `charWidth()` instead of `.length` so CJK words wrap by display columns

## Credit

Commit authored by @firslov — full credit for the investigation and fix. This PR exists only to carry the change forward cleanly.

## Test plan

- [ ] Render a box frame with mixed CJK / ASCII / emoji content; verify the right border stays aligned
- [ ] Truncate wide-char strings at various widths and confirm no border overflow
- [ ] `npm run build` passes