### PR TITLE
refactor(bridges): drop bundled PTY tools; keep bridges as pure translators

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -291,7 +291,9 @@ Built-in extensions load first (via a declarative manifest), then user extension
 
 ### Real-world bridges
 
-The echo-backend shows the protocol. The `examples/extensions/` directory has two production bridges that wire real agent SDKs into agent-sh. They follow the same pattern — the difference is just which SDK they translate.
+The echo-backend shows the protocol. The `examples/extensions/` directory has two production bridges that wire real agent SDKs into agent-sh. Both are **pure protocol translators** — they map the external SDK's event stream to agent-sh's bus events, and that's it. Neither bundles any tools of its own; each external agent uses its own built-in tools as-is.
+
+PTY-access tools (`terminal_read`, `terminal_keys`, `user_shell`) are deliberately *not* part of a bridge's job. They're opt-in capabilities that live in their own extensions, registered per backend in that backend's tool format. Keeping this separation means bridges stay narrow and composable.
 
 #### Claude Code Bridge (`claude-code-bridge/`)
 
@@ -306,9 +308,9 @@ cd ~/.agent-sh/extensions/claude-code-bridge && npm install
 **How it works:**
 
 1. **Registers as backend** via `agent:register-backend`
-2. **Exposes two MCP tools** via `tool()` + `createSdkMcpServer()`: `terminal_read` (reads the current terminal screen from `ctx.terminalBuffer`, including cursor position and alt-screen state) and `terminal_keys` (writes keystrokes to the PTY via the `shell:pty-write` event). This lets Claude Code *observe and interact with* the user's live terminal — Claude Code uses its own built-in `Bash` tool for running isolated commands, so no `user_shell` is needed here.
-3. **On each `agent:submit`**, calls the SDK's `query()` with the user's prompt, a system prompt preset, and the MCP server attached
-4. **Iterates the SDK's async iterator** — maps `stream_event` (text/thinking deltas) and `assistant` messages (tool use blocks) to agent-sh events (`agent:response-chunk`, `agent:thinking-chunk`, `agent:tool-started`)
+2. **On each `agent:submit`**, calls the SDK's `query()` with the user's prompt and a system-prompt preset. Claude Code's own tools (`Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep`) handle everything.
+3. **Iterates the SDK's async iterator** — maps `stream_event` (text/thinking deltas) and `assistant` messages (tool use blocks) to agent-sh events (`agent:response-chunk`, `agent:thinking-chunk`, `agent:tool-started`)
+4. **Snapshots files before Edit/Write** so it can compute a diff when the tool result comes back, for the TUI's inline diff rendering
 
 #### Pi Bridge (`pi-bridge/`)
 
@@ -323,26 +325,32 @@ cd ~/.agent-sh/extensions/pi-bridge && npm install
 **How it works:**
 
 1. **Registers as backend** with an async `start()` — pi needs to boot (load config from `~/.pi/`, create services, initialize tools)
-2. **Creates a `user_shell` tool** using pi's `ToolDefinition` interface (TypeBox schema). Includes `promptGuidelines` — pi's way of injecting per-tool instructions into the system prompt.
-3. **Subscribes to pi's event stream** (`session.subscribe`) — maps pi events to agent-sh events:
+2. **Subscribes to pi's event stream** (`session.subscribe`) — maps pi events to agent-sh events:
    - `message_update` → `agent:response-chunk` or `agent:thinking-chunk`
    - `tool_execution_start/update/end` → `agent:tool-started`, `agent:tool-output-chunk`, `agent:tool-completed`
    - `agent_end` → `agent:response-done` + `agent:processing-done`
-4. **Session management** — `agent:reset-session` creates a new pi session via `runtime.newSession()`
+3. **Session management** — `agent:reset-session` creates a new pi session via `runtime.newSession()`
+
+#### Adding PTY access to a bridge
+
+Neither bridge bundles PTY tools. If you want the external agent to observe or mutate the user's live terminal, write a companion extension that registers tools in the target SDK's tool format:
+
+- **`terminal_read`** — reads `ctx.terminalBuffer.readScreen()` and returns the text + cursor + alt-screen state
+- **`terminal_keys`** — emits `shell:pty-write` to send keystrokes to the PTY
+- **`user_shell`** — emits `shell:exec-request` and awaits the result, for `cd`/`export`/`source`-level state mutation
+
+For pi, this is a standalone extension that registers with pi's `customTools` (via `ctx.call` or a pi-specific hook). For Claude Code, the SDK accepts MCP servers in `query()` options — so the companion extension builds the MCP server and either forks the bridge or coordinates with it via a handler to attach the server.
 
 #### Writing your own bridge
 
-Both bridges follow the same 5-step structure:
+Both bridges follow the same 4-step structure:
 
 1. **Register as backend** — emit `agent:register-backend` with `name`, `start()`, `kill()`
-2. **Give the external agent access to the user's PTY** — in the target SDK's tool format. Which tools you expose depends on what the external agent already has:
-   - If it has no shell tool of its own: register a `user_shell` tool that runs commands via `bus.emitPipeAsync("shell:exec-request", ...)` — this is what `pi-bridge` does.
-   - If it brings its own bash/exec tool (as Claude Code does): skip `user_shell` and instead register `terminal_read` + `terminal_keys` so the agent can observe and drive the live terminal — this is what `claude-code-bridge` does.
-3. **Listen for `agent:submit`** — forward the query to the external agent
-4. **Map the agent's events** to agent-sh bus events (response chunks, tool starts/completions, thinking, errors)
-5. **Handle cancellation and reset** — wire `agent:cancel-request` and `agent:reset-session`
+2. **Listen for `agent:submit`** — forward the query to the external agent
+3. **Map the agent's events** to agent-sh bus events (response chunks, tool starts/completions, thinking, errors)
+4. **Handle cancellation and reset** — wire `agent:cancel-request` and `agent:reset-session`
 
-The difference between the two bridges is just SDK shape: Claude Code uses an async iterator you `for await` over; pi uses a subscription callback. The translation layer is the same.
+The difference between the two bridges is just SDK shape: Claude Code uses an async iterator you `for await` over; pi uses a subscription callback. The translation layer is the same. Keep PTY tools out — they belong in companion extensions.
 
 ## Named Handlers (Advice System)
 

--- a/examples/extensions/claude-code-bridge/README.md
+++ b/examples/extensions/claude-code-bridge/README.md
@@ -33,3 +33,17 @@ Or switch at runtime:
 
 - `ANTHROPIC_API_KEY` must be set in your environment
 - Claude Code manages its own model selection — no model configuration needed in agent-sh
+
+## What this bridge is
+
+A pure protocol translator between the Claude Agent SDK's event stream and agent-sh's bus events. Claude Code uses its own built-in tools exactly as the SDK ships them (`Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep`). The bridge adds no tools of its own.
+
+## What this bridge intentionally does NOT bundle
+
+Three PTY-access tools are left out on purpose:
+
+- `terminal_read` — observe the user's live terminal screen
+- `terminal_keys` — send keystrokes to the user's PTY
+- `user_shell` — run commands in the user's live shell with lasting `cd`/`export`/`source` effects
+
+These are opt-in capabilities that belong in their own extensions. If you want any of them with Claude Code, write a companion extension that uses the SDK's `tool()` + `createSdkMcpServer()` to expose them as MCP tools, and extend the bridge (or fork it) to attach that MCP server to the SDK's `query()` options.

--- a/examples/extensions/claude-code-bridge/index.ts
+++ b/examples/extensions/claude-code-bridge/index.ts
@@ -2,8 +2,14 @@
  * Claude Code bridge — runs Claude Code Agent SDK in-process as agent-sh's backend.
  *
  * Uses the official @anthropic-ai/claude-agent-sdk to spawn a Claude Code
- * session with custom MCP tools for PTY access. Claude Code
- * handles its own model selection, tool execution, and permissions.
+ * session. Claude Code handles its own model selection, tool execution, and
+ * permissions — the bridge is a pure protocol translator between the SDK's
+ * event stream and agent-sh's bus events.
+ *
+ * PTY-access tools (`terminal_read`, `terminal_keys`, `user_shell`) are
+ * intentionally NOT bundled here. If you want Claude Code to observe or
+ * drive the user's live terminal, load a companion extension that
+ * registers those tools as MCP tools the SDK can consume.
  *
  * Setup (from repo root):
  *   npm run build && npm link                    # register local agent-sh globally
@@ -15,102 +21,15 @@
  *
  * Requires: Claude Code CLI installed and authenticated (claude login).
  */
-import {
-  query,
-  tool,
-  createSdkMcpServer,
-  type Query,
-} from "@anthropic-ai/claude-agent-sdk";
-import { z } from "zod";
+import { query, type Query } from "@anthropic-ai/claude-agent-sdk";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { ExtensionContext } from "agent-sh/types";
-import type { EventBus } from "agent-sh/event-bus";
 import { computeDiff, type DiffResult } from "agent-sh/utils/diff";
-
-// ── Helpers ──────────────────────────────────────────────────────
-function interpretEscapes(str: string): string {
-  return str.replace(/\\(x[0-9a-fA-F]{2}|r|n|t|\\|0)/g, (_, seq: string) => {
-    if (seq === "r") return "\r";
-    if (seq === "n") return "\n";
-    if (seq === "t") return "\t";
-    if (seq === "\\") return "\\";
-    if (seq === "0") return "\0";
-    if (seq.startsWith("x")) return String.fromCharCode(parseInt(seq.slice(1), 16));
-    return seq;
-  });
-}
-
-function settle(ms = 100): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// ── terminal_read MCP tool ────────────────────────────────────────
-function createTerminalReadTool(ctx: ExtensionContext) {
-  return tool(
-    "terminal_read",
-    "Read the current terminal screen contents. Returns clean text (ANSI stripped) " +
-    "with cursor position and whether an alternate-screen program (vim, htop, less) is active. " +
-    "Use this to see what the user sees before sending keystrokes with terminal_keys.",
-    {},
-    async () => {
-      const tb = ctx.terminalBuffer;
-      if (!tb) return { content: [{ type: "text" as const, text: "terminal buffer not available" }] };
-      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
-      const info = [
-        altScreen ? "mode: alternate screen" : "mode: normal",
-        `cursor: row=${cursorY} col=${cursorX}`,
-      ].join(", ");
-      return { content: [{ type: "text" as const, text: `[${info}]\n\n${text}` }] };
-    },
-  );
-}
-
-// ── terminal_keys MCP tool ───────────────────────────────────────
-function createTerminalKeysTool(bus: EventBus, ctx: ExtensionContext) {
-  return tool(
-    "terminal_keys",
-    "Send keystrokes to the user's live terminal. The keys are written directly to the PTY " +
-    "as if the user typed them. Use escape sequences for special keys:\n" +
-    "  - Escape: \\x1b  - Enter: \\r  - Tab: \\t\n" +
-    "  - Ctrl+C: \\x03  - Arrow keys: \\x1b[A/B/C/D  - Backspace: \\x7f\n" +
-    "Example: to quit vim without saving, send keys=\"\\x1b:q!\\r\".\n" +
-    "Always call terminal_read after sending keys to verify the result.",
-    {
-      keys: z.string().describe("Keystrokes to send (use \\x1b for Escape, \\r for Enter, etc.)"),
-      settle_ms: z.number().optional().describe("Wait time in ms after sending keys (default: 150)"),
-    },
-    async (args) => {
-      const keys = interpretEscapes(args.keys);
-      const settleMs = args.settle_ms ?? 150;
-      bus.emit("shell:stdout-show", {});
-      process.stdout.write("\n");
-      bus.emit("shell:pty-write", { data: keys });
-      await settle(settleMs);
-
-      const tb = ctx.terminalBuffer;
-      if (!tb) return { content: [{ type: "text" as const, text: "Keys sent." }] };
-      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
-      const info = [
-        altScreen ? "mode: alternate screen" : "mode: normal",
-        `cursor: row=${cursorY} col=${cursorX}`,
-      ].join(", ");
-      return { content: [{ type: "text" as const, text: `Keys sent. Screen after:\n[${info}]\n\n${text}` }] };
-    },
-  );
-}
 
 // ── Extension entry point ─────────────────────────────────────────
 export default function activate(ctx: ExtensionContext): void {
   const { bus } = ctx;
-
-  const termReadTool = createTerminalReadTool(ctx);
-  const termKeysTool = createTerminalKeysTool(bus, ctx);
-  const shellServer = createSdkMcpServer({
-    name: "agent-sh",
-    version: "1.0.0",
-    tools: [termReadTool, termKeysTool],
-  });
 
   let activeQuery: Query | null = null;
   const listeners: Array<{ event: string; fn: Function }> = [];
@@ -119,11 +38,11 @@ export default function activate(ctx: ExtensionContext): void {
 
   /** Map Claude Code tool names to agent-sh display kinds. */
   function toolKind(name: string): string {
-    if (name === "Read" || name.includes("terminal_read")) return "read";
+    if (name === "Read") return "read";
     if (name === "Edit") return "edit";
     if (name === "Write") return "write";
     if (name === "Glob" || name === "Grep") return "search";
-    if (name === "Bash" || name.includes("terminal_keys")) return "execute";
+    if (name === "Bash") return "execute";
     return "execute";
   }
 
@@ -150,7 +69,6 @@ export default function activate(ctx: ExtensionContext): void {
     if (name === "Bash") return `$ ${str(input.command)}`;
     if (name === "Read" || name === "Edit" || name === "Write") return str(input.file_path ?? input.path);
     if (name === "Grep" || name === "Glob") return `${str(input.pattern)} ${str(input.path)}`.trim();
-    if (name.includes("terminal_keys")) return str(input.keys);
     return name;
   }
 
@@ -180,15 +98,9 @@ export default function activate(ctx: ExtensionContext): void {
               preset: "claude_code",
               append:
                 "You are running inside agent-sh, a terminal wrapper.\n" +
-                "Use your standard tools (Read, Edit, Write, Bash, Glob, Grep) for investigation.\n" +
-                "Use mcp__agent-sh__terminal_read and mcp__agent-sh__terminal_keys to observe and interact with the user's live terminal.",
+                "Use your standard tools (Read, Edit, Write, Bash, Glob, Grep) for investigation.",
             },
-            mcpServers: { "agent-sh": shellServer },
-            allowedTools: [
-              "mcp__agent-sh__terminal_read",
-              "mcp__agent-sh__terminal_keys",
-              "Read", "Edit", "Write", "Bash", "Glob", "Grep",
-            ],
+            allowedTools: ["Read", "Edit", "Write", "Bash", "Glob", "Grep"],
             permissionMode: "acceptEdits",
             includePartialMessages: true,
           },

--- a/examples/extensions/pi-bridge/README.md
+++ b/examples/extensions/pi-bridge/README.md
@@ -33,3 +33,19 @@ Or switch at runtime:
 
 - pi must be configured separately (`~/.pi/settings.json`) with API keys and model preferences
 - agent-sh does not override pi's configuration — it uses whatever pi is set up with
+
+## What this bridge is
+
+A pure protocol translator between pi's event stream and agent-sh's bus events. Pi's built-in tools (command execution, file ops, etc.) are used exactly as pi ships them. The bridge adds no tools of its own.
+
+## What this bridge intentionally does NOT bundle
+
+Three PTY-access tools are left out on purpose:
+
+- `terminal_read` — observe the user's live terminal screen
+- `terminal_keys` — send keystrokes to the user's PTY
+- `user_shell` — run commands in the user's live shell with lasting `cd`/`export`/`source` effects
+
+These are opt-in capabilities that belong in their own extensions. If you want any of them with pi, write a small companion extension that registers the tool as a pi `ToolDefinition` (TypeBox schema, wired to the relevant bus event: `shell:pty-write`, `shell:exec-request`, or `ctx.terminalBuffer.readScreen()`) and load it alongside pi-bridge.
+
+Keeping this split means the bridge stays narrow — only translating events — and the capability surface is composable per-backend.

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -5,9 +5,12 @@
  * provider settings, extensions, session management, and tool system.
  * Agent-sh provides the shell frontend and TUI rendering.
  *
- * In addition to pi's built-in tools, this bridge registers `user_shell`
- * so pi can execute commands in agent-sh's live PTY (visible to the user,
- * affects shell state like cd/export/source).
+ * The bridge is a pure protocol translator between pi's event stream and
+ * agent-sh's bus events. Pi brings its own tools for command execution,
+ * file ops, etc. PTY-access tools (`terminal_read`, `terminal_keys`,
+ * `user_shell`) are intentionally NOT bundled here — if you want pi to
+ * observe or mutate the user's live terminal, load a companion extension
+ * that registers those tools in pi's ToolDefinition format.
  *
  * Setup:
  *   npm install @mariozechner/pi-agent-core @mariozechner/pi-ai @mariozechner/pi-coding-agent
@@ -22,156 +25,12 @@ import {
   createAgentSessionRuntime,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
 import type { ExtensionContext } from "agent-sh/types";
-import type { EventBus } from "agent-sh/event-bus";
-
-// ── Helpers ──────────────────────────────────────────────────────
-function interpretEscapes(str: string): string {
-  return str.replace(/\\(x[0-9a-fA-F]{2}|r|n|t|\\|0)/g, (_, seq: string) => {
-    if (seq === "r") return "\r";
-    if (seq === "n") return "\n";
-    if (seq === "t") return "\t";
-    if (seq === "\\") return "\\";
-    if (seq === "0") return "\0";
-    if (seq.startsWith("x")) return String.fromCharCode(parseInt(seq.slice(1), 16));
-    return seq;
-  });
-}
-
-function settle(ms = 100): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// ── user_shell as a pi ToolDefinition ─────────────────────────────
-function createUserShellToolDef(bus: EventBus) {
-  // Track agent-sh's live cwd so user_shell always runs in the right place
-  let liveCwd = process.cwd();
-  bus.on("shell:cwd-change", ({ cwd }) => { liveCwd = cwd; });
-
-  const schema = Type.Object({
-    command: Type.String({ description: "Command to execute in user's shell" }),
-    return_output: Type.Optional(
-      Type.Boolean({
-        description:
-          "Whether to return the command output. Default false — output is shown directly to the user.",
-      }),
-    ),
-  });
-
-  return {
-    name: "user_shell",
-    label: "user_shell",
-    description:
-      "Run a command with lasting effects in the user's live shell (cd, export, " +
-      "install packages, start servers) or show output the user wants to see. " +
-      "Output is shown directly to the user. Set return_output=true only " +
-      "if you need to inspect the result.",
-    promptSnippet: "Execute commands in the user's live terminal (PTY).",
-    promptGuidelines: [
-      "You are running inside agent-sh, a terminal wrapper.",
-      "Use your standard tools (bash, file ops) for investigation — output goes to you, not the user.",
-      "Use user_shell to run commands in the user's live shell when they ask to see output or need lasting effects (cd, install, start servers).",
-      "Default to standard tools. Use user_shell when the user is the intended audience for the output or the command has real effects.",
-    ],
-    parameters: schema,
-
-    async execute(_toolCallId, params) {
-      const command = params.command;
-      const returnOutput = params.return_output ?? false;
-
-      const result = await bus.emitPipeAsync("shell:exec-request", {
-        command,
-        output: "",
-        cwd: liveCwd,
-        done: false,
-      });
-
-      const text = returnOutput
-        ? result.output || "(no output)"
-        : "Command executed.";
-
-      return { content: [{ type: "text", text }], details: undefined };
-    },
-  };
-}
-
-// ── terminal_read as a pi ToolDefinition ─────────────────────────
-function createTerminalReadToolDef(ctx: ExtensionContext) {
-  return {
-    name: "terminal_read",
-    label: "terminal_read",
-    description:
-      "Read the current terminal screen contents. Returns clean text (ANSI stripped) " +
-      "with cursor position and whether an alternate-screen program (vim, htop, less) is active.",
-    promptSnippet: "Read the terminal screen to see what the user sees.",
-    promptGuidelines: [
-      "Use terminal_read to see the current terminal screen before sending keystrokes.",
-      "Check altScreen to know if a full-screen program (vim, htop) is running.",
-    ],
-    parameters: Type.Object({}),
-    async execute() {
-      const tb = ctx.terminalBuffer;
-      if (!tb) return { content: [{ type: "text", text: "terminal buffer not available" }], details: undefined };
-      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
-      const info = [
-        altScreen ? "mode: alternate screen" : "mode: normal",
-        `cursor: row=${cursorY} col=${cursorX}`,
-      ].join(", ");
-      return { content: [{ type: "text", text: `[${info}]\n\n${text}` }], details: undefined };
-    },
-  };
-}
-
-// ── terminal_keys as a pi ToolDefinition ─────────────────────────
-function createTerminalKeysToolDef(bus: EventBus, ctx: ExtensionContext) {
-  return {
-    name: "terminal_keys",
-    label: "terminal_keys",
-    description:
-      "Send keystrokes to the user's live terminal as if the user typed them. " +
-      "Use escape sequences: \\x1b for Escape, \\r for Enter, \\t for Tab, " +
-      "\\x03 for Ctrl+C, \\x1b[A/B/C/D for arrow keys, \\x7f for Backspace. " +
-      "Example: \\x1b:q!\\r to quit vim. Always call terminal_read after.",
-    promptSnippet: "Send keystrokes to interactive programs in the terminal.",
-    promptGuidelines: [
-      "Use terminal_keys to type into interactive programs (vim, htop, less).",
-      "Always call terminal_read after sending keys to verify the result.",
-    ],
-    parameters: Type.Object({
-      keys: Type.String({ description: "Keystrokes to send (use \\x1b for Escape, \\r for Enter, etc.)" }),
-      settle_ms: Type.Optional(
-        Type.Number({ description: "Wait time in ms after sending keys (default: 150)" }),
-      ),
-    }),
-    async execute(_toolCallId: string, params: any) {
-      const keys = interpretEscapes(params.keys);
-      const settleMs = params.settle_ms ?? 150;
-      bus.emit("shell:stdout-show", {});
-      process.stdout.write("\n");
-      bus.emit("shell:pty-write", { data: keys });
-      await settle(settleMs);
-
-      const tb = ctx.terminalBuffer;
-      if (!tb) return { content: [{ type: "text", text: "Keys sent." }], details: undefined };
-      const { text, altScreen, cursorX, cursorY } = tb.readScreen();
-      const info = [
-        altScreen ? "mode: alternate screen" : "mode: normal",
-        `cursor: row=${cursorY} col=${cursorX}`,
-      ].join(", ");
-      return { content: [{ type: "text", text: `Keys sent. Screen after:\n[${info}]\n\n${text}` }], details: undefined };
-    },
-  };
-}
 
 // ── Extension entry point ─────────────────────────────────────────
 export default function activate(ctx: ExtensionContext): void {
   const { bus } = ctx;
   const cwd = process.cwd();
-
-  const userShellTool = createUserShellToolDef(bus);
-  const termReadTool = createTerminalReadToolDef(ctx);
-  const termKeysTool = createTerminalKeysToolDef(bus, ctx);
 
   // ── Boot pi session (async — register backend synchronously first) ──
   let session: any = null;
@@ -190,7 +49,6 @@ export default function activate(ctx: ExtensionContext): void {
         const result = await createAgentSessionFromServices({
           services,
           sessionManager: opts.sessionManager ?? sessionManager,
-          customTools: [userShellTool, termReadTool, termKeysTool],
         });
         return { ...result, services };
       };
@@ -227,9 +85,7 @@ export default function activate(ctx: ExtensionContext): void {
             bus.emit("agent:tool-started", {
               title: (event as any).toolName,
               toolCallId: (event as any).toolCallId,
-              kind: (event as any).toolName === "user_shell" || (event as any).toolName === "bash"
-                ? "execute"
-                : "read",
+              kind: (event as any).toolName === "bash" ? "execute" : "read",
             });
             break;
 
@@ -251,9 +107,7 @@ export default function activate(ctx: ExtensionContext): void {
             bus.emit("agent:tool-completed", {
               toolCallId: (event as any).toolCallId,
               exitCode: (event as any).isError ? 1 : 0,
-              kind: (event as any).toolName === "user_shell" || (event as any).toolName === "bash"
-                ? "execute"
-                : "read",
+              kind: (event as any).toolName === "bash" ? "execute" : "read",
             });
             break;
 


### PR DESCRIPTION
## Summary

Both bridges (`pi-bridge`, `claude-code-bridge`) were re-implementing PTY tools that belong in standalone extensions:

- **pi-bridge** registered `user_shell`, `terminal_read`, and `terminal_keys` in pi's `ToolDefinition` format
- **claude-code-bridge** registered `terminal_read` and `terminal_keys` as MCP tools

None of these exist in core — they live in `examples/extensions/user-shell.ts` and `examples/extensions/terminal-buffer.ts` as ash-targeted opt-ins. Duplicating them inside each bridge coupled the bridge to capabilities it shouldn't own.

**New model:** bridges are pure protocol translators between the external SDK's event stream and agent-sh's bus events. They register no tools. PTY access is a separate, opt-in capability — composed per-backend via companion extensions that register tools in the target SDK's tool format.

## Why this is better

- **Narrower bridges** — the only responsibility is event-stream translation. `+75 / −271` lines across the two bridges.
- **Composable capabilities** — users pick which PTY tools to expose to which backend, without forking the bridge.
- **Consistent with core** — core already stopped bundling these tools. Bridges now follow the same convention.

## ⚠️ Breaking change for bridge users

Loading `pi-bridge` or `claude-code-bridge` after this change no longer exposes `terminal_read` / `terminal_keys` / `user_shell` to the external agent. The external agent still has its own tools:

- pi keeps all of pi's built-in tools
- Claude Code keeps `Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep`

If you relied on PTY observation/interaction via the bridge, write a companion extension that registers the tool in the target SDK's format (see updated READMEs + `docs/extensions.md` §\"Adding PTY access to a bridge\").

## Files changed

- `examples/extensions/pi-bridge/index.ts` — strip three tool factories + unused helpers; no `customTools` passed to pi
- `examples/extensions/claude-code-bridge/index.ts` — strip two tool factories + MCP-server wiring; clean up related imports and tool-display branches
- `examples/extensions/pi-bridge/README.md`, `claude-code-bridge/README.md` — explain pure-translator model and how to add PTY access
- `docs/extensions.md` — simplify bridge sections, add \"Adding PTY access to a bridge\", drop tool-registration step from \"Writing your own bridge\" (now 4 steps, not 5)

## Test plan

- [x] \`npx tsc --noEmit\` in main repo
- [x] \`npx tsc --noEmit\` in \`examples/extensions/pi-bridge\`
- [x] \`npx tsc --noEmit\` in \`examples/extensions/claude-code-bridge\`
- [ ] Smoke: launch agent-sh with \`-e examples/extensions/pi-bridge\` and submit a query — pi still responds using its own tools
- [ ] Smoke: launch agent-sh with \`-e examples/extensions/claude-code-bridge\` and submit a query — Claude Code still responds using its built-in tools