### PR TITLE
fix(tui): account for 2-char left margin in cappedW()

### DIFF
--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -135,8 +135,11 @@ export default function activate(ctx: ExtensionContext): void {
   /** Shorthand — get the current agent surface. */
   function out(): RenderSurface { return compositor.surface("agent"); }
 
-  /** Capped width for borders, tool lines, and content — keeps everything aligned. */
-  function cappedW(): number { return Math.min(MAX_CONTENT_WIDTH + 2, out().columns); }
+  /** Capped width for borders, tool lines, and content — keeps everything aligned.
+   *  MarkdownRenderer.writeLine prepends a 2-char indent ("  ") to every line,
+   *  so available width for actual content is columns - 2.  Subtract an additional
+   *  1 to prevent terminal auto-wrap when a line lands exactly at the right edge. */
+  function cappedW(): number { return Math.min(MAX_CONTENT_WIDTH + 2, out().columns) - 2 - 1; }
 
   // Gate: other extensions (e.g. overlay) can advise this to suppress
   // TUI rendering of agent output while they own the display.


### PR DESCRIPTION
## Summary

\`MarkdownRenderer.writeLine\` prepends a 2-space left margin to every line it emits, including border lines. But \`cappedW()\` was returning the raw terminal width, so on a 91-column terminal it returned 91 — producing a rendered line of \`2 (margin) + 91 (content) = 93\` visible columns, overflowing by exactly 2 characters onto a second line.

## Fix

Subtract the 2-char left margin (and 1 more for cursor room) from the width returned by \`cappedW()\`, so the rendered line fits within the terminal width.

## Test plan

- [ ] Resize terminal to an exact width (e.g. 91 cols) and render a bordered box — confirm the bottom border stays on one line instead of wrapping
- [ ] Verify nothing visibly shrinks on standard-width terminals (80, 120)