### PR TITLE
fix TUI bundle: parallel tools, ctrl-k/u, table markdown, read_file stub

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -332,6 +332,12 @@ export class AgentLoop implements AgentBackend {
       if (beforeTokens > this.peakConversationTokens) {
         this.peakConversationTokens = beforeTokens;
       }
+      // The fileReadCache's "File unchanged since last read — refer to the
+      // earlier result" stub assumes the original read_file output is still
+      // in active context. Compaction can evict that output, turning the
+      // stub into a dangling pointer. Clearing the cache forces the next
+      // read_file to return full content instead.
+      this.fileReadCache.clear();
     });
 
     on("shell:cwd-change", ({ cwd }) => {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -332,11 +332,8 @@ export class AgentLoop implements AgentBackend {
       if (beforeTokens > this.peakConversationTokens) {
         this.peakConversationTokens = beforeTokens;
       }
-      // The fileReadCache's "File unchanged since last read — refer to the
-      // earlier result" stub assumes the original read_file output is still
-      // in active context. Compaction can evict that output, turning the
-      // stub into a dangling pointer. Clearing the cache forces the next
-      // read_file to return full content instead.
+      // The "File unchanged" stub assumes the prior read output is still
+      // in context; compaction can evict it. Clear so the next read re-emits.
       this.fileReadCache.clear();
     });
 

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -70,7 +70,12 @@ interface RenderState {
   spinnerStartTime: number;
 
   // ── Tool output ──
-  toolLineOpen: boolean;
+  /** The tool whose last line is still "open" (no trailing newline) —
+   *  its completion will append ✓ inline. Null when no line is open. */
+  openTool: { callId: string; title: string } | null;
+  /** Tools whose line was closed before their complete fired (parallel
+   *  read-only batches). Their ✓ renders as a labeled standalone line. */
+  pendingToolCompletes: Map<string, { title: string }>;
   currentToolKind: string | undefined;
   toolStartTime: number;
   toolExitCode: number | null;
@@ -105,7 +110,8 @@ function createRenderState(): RenderState {
     spinnerOpts: {},
     spinnerInterval: null,
     spinnerStartTime: 0,
-    toolLineOpen: false,
+    openTool: null,
+    pendingToolCompletes: new Map(),
     currentToolKind: undefined,
     toolStartTime: 0,
     toolExitCode: null,
@@ -387,22 +393,13 @@ export default function activate(ctx: ExtensionContext): void {
       s.toolGroupCount++;
 
       if (s.toolGroupRendered < GROUP_MAX_VISIBLE) {
-        showToolCall(e.title, "", {
-          ...e,
-          batchIndex: e.batchIndex,
-          batchTotal: e.batchTotal,
-          groupContinuation: true,
-        });
+        showToolCall(e.title, "", { ...e, groupContinuation: true });
         s.toolGroupRendered++;
       }
     } else {
       // Standalone tool — single in its batch kind, or not groupable
       finalizeToolGroup();
-      showToolCall(e.title, "", {
-        ...e,
-        batchIndex: e.batchIndex,
-        batchTotal: e.batchTotal,
-      });
+      showToolCall(e.title, "", { ...e });
     }
   });
 
@@ -417,7 +414,12 @@ export default function activate(ctx: ExtensionContext): void {
       if (e.resultDisplay?.summary) s.toolGroupSummaries.push(e.resultDisplay.summary);
       s.currentToolKind = undefined;
     } else {
-      showToolComplete(e.exitCode, e.resultDisplay);
+      // Parallel read-only batches let multiple tools be started before any
+      // completes; completions for ones that lost the inline slot render as
+      // labeled ⎿ lines so the ✓ stays attached to its tool.
+      const pending = e.toolCallId ? s.pendingToolCompletes.get(e.toolCallId) : undefined;
+      if (pending) s.pendingToolCompletes.delete(e.toolCallId!);
+      showToolComplete(e.exitCode, e.resultDisplay, pending?.title);
       s.currentToolKind = undefined;
       s.spinnerStartTime = 0;
       startThinkingSpinner();
@@ -774,6 +776,7 @@ export default function activate(ctx: ExtensionContext): void {
     title: string,
     command?: string,
     extra?: {
+      toolCallId?: string;
       kind?: string;
       icon?: string;
       locations?: { path: string; line?: number | null }[];
@@ -824,10 +827,9 @@ export default function activate(ctx: ExtensionContext): void {
         // Grouped tools: close the line immediately — checkmarks go on the ⎿ summary
         s.renderer!.writeLine(`  ${batchPrefix}${lines[lines.length - 1]}`);
         drain();
-        s.toolLineOpen = false;
       } else {
         out().write(`  ${batchPrefix}${lines[lines.length - 1]}`);
-        s.toolLineOpen = true;
+        if (extra?.toolCallId) s.openTool = { callId: extra.toolCallId, title };
       }
     }
     s.hadToolCalls = true;
@@ -835,26 +837,29 @@ export default function activate(ctx: ExtensionContext): void {
     s.commandOutputOverflow = 0;
   }
 
-  function showToolComplete(exitCode: number | null, resultDisplay?: ToolResultDisplay): void {
+  function showToolComplete(
+    exitCode: number | null,
+    resultDisplay?: ToolResultDisplay,
+    labelTitle?: string,
+  ): void {
     if (!s.renderer) return;
     stopCurrentSpinner();
     const elapsed = s.toolStartTime ? formatElapsed(Date.now() - s.toolStartTime) : "";
     const mark: string = ctx.call("tui:render-tool-complete", exitCode, elapsed, resultDisplay?.summary);
 
-    if (s.toolLineOpen && s.commandOutputLineCount === 0) {
+    if (!labelTitle && s.openTool && s.commandOutputLineCount === 0) {
       out().write(` ${mark}\n`);
-      s.toolLineOpen = false;
+      s.openTool = null;
     } else {
       closeToolLine();
       flushCommandOutput();
-      s.renderer.writeLine(`  ${mark}`);
+      s.renderer.writeLine(labelTitle
+        ? `  ${p.muted}⎿${p.reset} ${p.dim}${labelTitle}${p.reset} ${mark}`
+        : `  ${mark}`);
       drain();
     }
 
-    // Render structured body if present
-    if (resultDisplay?.body) {
-      renderResultBody(resultDisplay.body);
-    }
+    if (resultDisplay?.body) renderResultBody(resultDisplay.body);
   }
 
   function renderResultBody(body: ToolResultBody): void {
@@ -905,9 +910,12 @@ export default function activate(ctx: ExtensionContext): void {
   }
 
   function closeToolLine(): void {
-    if (s.toolLineOpen) {
+    if (s.openTool) {
       out().write("\n");
-      s.toolLineOpen = false;
+      // Tool lost its inline ✓ slot — stash identity so the complete can
+      // still render as a labeled line instead of an orphan checkmark.
+      s.pendingToolCompletes.set(s.openTool.callId, { title: s.openTool.title });
+      s.openTool = null;
     }
   }
 

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -87,6 +87,9 @@ interface RenderState {
   // ── Tool grouping (collapse sequential same-type read-only tools) ──
   toolGroupKind: string | undefined;
   toolGroupCount: number;
+  /** Number of group members whose complete has arrived — used to
+   *  suppress the aggregate line when finalize fires prematurely. */
+  toolGroupCompletedCount: number;
   toolGroupAllOk: boolean;
   /** Number of tools rendered individually in current group. */
   toolGroupRendered: number;
@@ -121,6 +124,7 @@ function createRenderState(): RenderState {
     commandOverflowLines: [],
     toolGroupKind: undefined,
     toolGroupCount: 0,
+    toolGroupCompletedCount: 0,
     toolGroupAllOk: true,
     toolGroupRendered: 0,
     toolGroupSummaries: [],
@@ -385,6 +389,7 @@ export default function activate(ctx: ExtensionContext): void {
         group.headerShown = true;
         s.toolGroupKind = kind;
         s.toolGroupCount = 0;
+        s.toolGroupCompletedCount = 0;
         s.toolGroupRendered = 0;
         s.toolGroupAllOk = true;
         s.toolGroupSummaries = [];
@@ -421,6 +426,7 @@ export default function activate(ctx: ExtensionContext): void {
       // Don't restart spinner between grouped tools — it's already running from group start.
       if (e.resultDisplay?.summary) s.toolGroupSummaries.push(e.resultDisplay.summary);
       if (e.toolCallId) s.pendingToolCompletes.delete(e.toolCallId);
+      s.toolGroupCompletedCount++;
       s.currentToolKind = undefined;
     } else {
       // Parallel read-only batches let multiple tools be started before any
@@ -930,11 +936,17 @@ export default function activate(ctx: ExtensionContext): void {
 
   /** Finalize a group of collapsed tool calls, rendering the summary. */
   function finalizeToolGroup(): void {
-    if (s.toolGroupCount <= 1) {
-      // 0–1 tools: standalone, nothing to finalize
+    // If finalize fires before any member has completed — which happens
+    // when a different-kind standalone tool starts during a parallel batch
+    // — don't emit an aggregate ✓ line with empty summaries. Late
+    // completions will render as labeled ⎿ lines individually instead.
+    const skipAggregate = s.toolGroupCount > 1 && s.toolGroupCompletedCount === 0;
+    if (s.toolGroupCount <= 1 || skipAggregate) {
       s.toolGroupKind = undefined;
       s.toolGroupCount = 0;
+      s.toolGroupCompletedCount = 0;
       s.toolGroupRendered = 0;
+      s.toolGroupAllOk = true;
       s.toolGroupSummaries = [];
       return;
     }
@@ -948,6 +960,7 @@ export default function activate(ctx: ExtensionContext): void {
     drain();
     s.toolGroupKind = undefined;
     s.toolGroupCount = 0;
+    s.toolGroupCompletedCount = 0;
     s.toolGroupAllOk = true;
     s.toolGroupRendered = 0;
     s.toolGroupSummaries = [];

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -396,6 +396,14 @@ export default function activate(ctx: ExtensionContext): void {
         showToolCall(e.title, "", { ...e, groupContinuation: true });
         s.toolGroupRendered++;
       }
+      // If a standalone tool of a different kind starts before this group's
+      // members complete, finalizeToolGroup will clear toolGroupKind — late
+      // completions then fall through to the standalone path. Record the
+      // identity here so those late completes can render as labeled ⎿ lines
+      // instead of orphan checkmarks.
+      if (e.toolCallId) {
+        s.pendingToolCompletes.set(e.toolCallId, { title: e.title });
+      }
     } else {
       // Standalone tool — single in its batch kind, or not groupable
       finalizeToolGroup();
@@ -412,6 +420,7 @@ export default function activate(ctx: ExtensionContext): void {
       // Grouped tool — track success/failure and summaries, show aggregate on ⎿ line.
       // Don't restart spinner between grouped tools — it's already running from group start.
       if (e.resultDisplay?.summary) s.toolGroupSummaries.push(e.resultDisplay.summary);
+      if (e.toolCallId) s.pendingToolCompletes.delete(e.toolCallId);
       s.currentToolKind = undefined;
     } else {
       // Parallel read-only batches let multiple tools be started before any

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -70,11 +70,9 @@ interface RenderState {
   spinnerStartTime: number;
 
   // ── Tool output ──
-  /** The tool whose last line is still "open" (no trailing newline) —
-   *  its completion will append ✓ inline. Null when no line is open. */
   openTool: { callId: string; title: string } | null;
-  /** Tools whose line was closed before their complete fired (parallel
-   *  read-only batches). Their ✓ renders as a labeled standalone line. */
+  /** Tools whose start line was closed before their complete fired.
+   *  Their ✓ renders as a labeled ⎿ line instead of an orphan. */
   pendingToolCompletes: Map<string, { title: string }>;
   currentToolKind: string | undefined;
   toolStartTime: number;
@@ -87,8 +85,7 @@ interface RenderState {
   // ── Tool grouping (collapse sequential same-type read-only tools) ──
   toolGroupKind: string | undefined;
   toolGroupCount: number;
-  /** Number of group members whose complete has arrived — used to
-   *  suppress the aggregate line when finalize fires prematurely. */
+  /** Completes-seen count — skip aggregate if finalize fires at 0. */
   toolGroupCompletedCount: number;
   toolGroupAllOk: boolean;
   /** Number of tools rendered individually in current group. */
@@ -401,11 +398,8 @@ export default function activate(ctx: ExtensionContext): void {
         showToolCall(e.title, "", { ...e, groupContinuation: true });
         s.toolGroupRendered++;
       }
-      // If a standalone tool of a different kind starts before this group's
-      // members complete, finalizeToolGroup will clear toolGroupKind — late
-      // completions then fall through to the standalone path. Record the
-      // identity here so those late completes can render as labeled ⎿ lines
-      // instead of orphan checkmarks.
+      // Record identity so late completes (after a premature finalize
+      // from a cross-kind standalone start) can render as labeled ⎿ lines.
       if (e.toolCallId) {
         s.pendingToolCompletes.set(e.toolCallId, { title: e.title });
       }
@@ -429,9 +423,7 @@ export default function activate(ctx: ExtensionContext): void {
       s.toolGroupCompletedCount++;
       s.currentToolKind = undefined;
     } else {
-      // Parallel read-only batches let multiple tools be started before any
-      // completes; completions for ones that lost the inline slot render as
-      // labeled ⎿ lines so the ✓ stays attached to its tool.
+      // Route by callId — tools that lost the inline slot get a labeled ⎿ line.
       const pending = e.toolCallId ? s.pendingToolCompletes.get(e.toolCallId) : undefined;
       if (pending) s.pendingToolCompletes.delete(e.toolCallId!);
       showToolComplete(e.exitCode, e.resultDisplay, pending?.title);
@@ -927,19 +919,15 @@ export default function activate(ctx: ExtensionContext): void {
   function closeToolLine(): void {
     if (s.openTool) {
       out().write("\n");
-      // Tool lost its inline ✓ slot — stash identity so the complete can
-      // still render as a labeled line instead of an orphan checkmark.
+      // Stash identity so the completion renders as ⎿ labeled, not orphan ✓.
       s.pendingToolCompletes.set(s.openTool.callId, { title: s.openTool.title });
       s.openTool = null;
     }
   }
 
-  /** Finalize a group of collapsed tool calls, rendering the summary. */
+  /** Render the group aggregate ⎿ line, or skip if no members have
+   *  completed yet (late completes will render individually as ⎿ labeled). */
   function finalizeToolGroup(): void {
-    // If finalize fires before any member has completed — which happens
-    // when a different-kind standalone tool starts during a parallel batch
-    // — don't emit an aggregate ✓ line with empty summaries. Late
-    // completions will render as labeled ⎿ lines individually instead.
     const skipAggregate = s.toolGroupCount > 1 && s.toolGroupCompletedCount === 0;
     if (s.toolGroupCount <= 1 || skipAggregate) {
       s.toolGroupKind = undefined;

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -254,11 +254,8 @@ export class InputHandler {
         this.lineBuffer = "";
         this.ctx.writeToPty(ch);
       } else if (ch === "\x0b" || ch === "\x15") {
-        // Ctrl-K (kill to end) / Ctrl-U (kill to start). The shell's line
-        // editor handles the actual kill; we approximate by clearing our
-        // mirror so the mode-trigger check below sees an empty buffer.
-        // Not cursor-position-accurate, but strictly better than leaving
-        // stale content that blocks `>` from entering agent mode.
+        // Ctrl-K / Ctrl-U kill the line in the shell; mirror that so the
+        // mode-trigger check sees an empty buffer. Not cursor-accurate.
         this.lineBuffer = "";
         this.ctx.writeToPty(ch);
       } else if (ch === "\x1b") {

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -253,6 +253,14 @@ export class InputHandler {
       } else if (ch === "\x04") {
         this.lineBuffer = "";
         this.ctx.writeToPty(ch);
+      } else if (ch === "\x0b" || ch === "\x15") {
+        // Ctrl-K (kill to end) / Ctrl-U (kill to start). The shell's line
+        // editor handles the actual kill; we approximate by clearing our
+        // mirror so the mode-trigger check below sees an empty buffer.
+        // Not cursor-position-accurate, but strictly better than leaving
+        // stale content that blocks `>` from entering agent mode.
+        this.lineBuffer = "";
+        this.ctx.writeToPty(ch);
       } else if (ch === "\x1b") {
         // Escape sequence — forward the entire sequence to the PTY but
         // don't let it corrupt lineBuffer.  Skip CSI (ESC [ ... final)

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -126,11 +126,8 @@ export function truncateToWidth(str: string, maxWidth: number): string {
   return clean.slice(0, i) + "…";
 }
 
-/**
- * Truncate while preserving SGR escape sequences. Use this when the input
- * already carries color/bold/italic codes (e.g. from a markdown renderer)
- * and you want them to survive the cut. `truncateToWidth` strips ANSI.
- */
+/** Truncate to visible width while preserving SGR sequences — use when
+ *  input carries color/bold codes. `truncateToWidth` strips them. */
 export function truncateAnsiToWidth(str: string, maxWidth: number): string {
   if (maxWidth <= 0) return "";
   if (visibleLen(str) <= maxWidth) return str;
@@ -140,7 +137,6 @@ export function truncateAnsiToWidth(str: string, maxWidth: number): string {
   let out = "";
   let i = 0;
   while (i < str.length) {
-    // Pass SGR escape sequences through verbatim (zero visible width)
     if (str[i] === "\x1b" && str[i + 1] === "[") {
       const end = str.indexOf("m", i);
       if (end !== -1) {
@@ -157,7 +153,6 @@ export function truncateAnsiToWidth(str: string, maxWidth: number): string {
     width += cw;
     i += chLen;
   }
-  // Reset any dangling styling before the ellipsis so it doesn't leak.
   return out + "\x1b[0m…";
 }
 

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -127,6 +127,41 @@ export function truncateToWidth(str: string, maxWidth: number): string {
 }
 
 /**
+ * Truncate while preserving SGR escape sequences. Use this when the input
+ * already carries color/bold/italic codes (e.g. from a markdown renderer)
+ * and you want them to survive the cut. `truncateToWidth` strips ANSI.
+ */
+export function truncateAnsiToWidth(str: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (visibleLen(str) <= maxWidth) return str;
+  if (maxWidth === 1) return "…";
+  const target = maxWidth - 1;
+  let width = 0;
+  let out = "";
+  let i = 0;
+  while (i < str.length) {
+    // Pass SGR escape sequences through verbatim (zero visible width)
+    if (str[i] === "\x1b" && str[i + 1] === "[") {
+      const end = str.indexOf("m", i);
+      if (end !== -1) {
+        out += str.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+    const cp = str.codePointAt(i) ?? 0;
+    const cw = charWidth(cp);
+    if (width + cw > target) break;
+    const chLen = cp > 0xffff ? 2 : 1;
+    out += str.slice(i, i + chLen);
+    width += cw;
+    i += chLen;
+  }
+  // Reset any dangling styling before the ellipsis so it doesn't leak.
+  return out + "\x1b[0m…";
+}
+
+/**
  * Pad a string with spaces to fill `targetWidth` visible columns.
  * Accounts for CJK double-width characters.
  */

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { visibleLen, truncateToWidth, padEndToWidth, charWidth } from "./ansi.js";
+import { visibleLen, truncateAnsiToWidth, padEndToWidth, charWidth } from "./ansi.js";
 import { palette as p } from "./palette.js";
 
 export const MAX_CONTENT_WIDTH = 90;
@@ -203,11 +203,12 @@ export class MarkdownRenderer {
       while (row.length < numCols) row.push("");
     }
 
-    // Calculate column widths from content
+    // Calculate column widths from rendered content — measuring the raw cell
+    // would over-count `**bold**` markers as 4 extra columns each.
     const colWidths: number[] = new Array(numCols).fill(0);
     for (const row of dataRows) {
       for (let c = 0; c < numCols; c++) {
-        colWidths[c] = Math.max(colWidths[c]!, visibleLen(row[c]!));
+        colWidths[c] = Math.max(colWidths[c]!, visibleLen(this.renderInline(row[c]!)));
       }
     }
 
@@ -235,7 +236,12 @@ export class MarkdownRenderer {
       const isHeader = hasHeader && i === 0;
       const cells = row.map((cell, c) => {
         const w = colWidths[c]!;
-        const text = visibleLen(cell) > w ? truncateToWidth(cell, w) : padEndToWidth(cell, w);
+        // Parse inline markdown (**bold**, `code`, etc.) before width-fitting
+        // so emphasis inside cells renders as styling, not literal asterisks.
+        const rendered = this.renderInline(cell);
+        const text = visibleLen(rendered) > w
+          ? truncateAnsiToWidth(rendered, w)
+          : padEndToWidth(rendered, w);
         return isHeader ? `${p.bold}${text}${p.reset}` : text;
       });
       this.writeLine(`${p.dim}│${p.reset} ${cells.join(` ${p.dim}│${p.reset} `)} ${p.dim}│${p.reset}`);

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -203,8 +203,7 @@ export class MarkdownRenderer {
       while (row.length < numCols) row.push("");
     }
 
-    // Calculate column widths from rendered content — measuring the raw cell
-    // would over-count `**bold**` markers as 4 extra columns each.
+    // Width from rendered cell — raw `**bold**` over-counts by 4 per pair.
     const colWidths: number[] = new Array(numCols).fill(0);
     for (const row of dataRows) {
       for (let c = 0; c < numCols; c++) {
@@ -236,8 +235,6 @@ export class MarkdownRenderer {
       const isHeader = hasHeader && i === 0;
       const cells = row.map((cell, c) => {
         const w = colWidths[c]!;
-        // Parse inline markdown (**bold**, `code`, etc.) before width-fitting
-        // so emphasis inside cells renders as styling, not literal asterisks.
         const rendered = this.renderInline(cell);
         const text = visibleLen(rendered) > w
           ? truncateAnsiToWidth(rendered, w)


### PR DESCRIPTION
Five fixes bundled.

## 1. Orphan ✓ from parallel read-only batches (standalone path)

When the agent emits multiple parallel standalone tools in one turn, all tool-started events fire before any complete. The single \`toolLineOpen\` bit could only track one inline ✓ slot — earlier completions dropped as bare orphan ✓ lines, the one inline ✓ misattributed to whichever tool still held the cursor. Track \`openTool: {callId, title}\`; move closed-early tools into \`pendingToolCompletes\`; render late completions as \`  ⎿ title ✓\`.

## 2. Orphan ✓ from group-then-standalone interruption

Grouped tool starts skip the \`openTool\` machinery (they render via \`writeLine\` directly), so when a standalone tool of a different kind started before the group completed, \`finalizeToolGroup\` cleared \`toolGroupKind\` and the grouped tools' late completes fell through to the standalone path with no identity — bare orphan ✓. Record grouped-tool identity in \`pendingToolCompletes\` at start time; clean up in the grouped-complete branch when the group completes normally.

## 3. Empty \`└ ✓\` aggregate rendered for interrupted groups

When a group was interrupted as above, \`finalizeToolGroup\` emitted an aggregate line claiming success with zero summaries — semantically false (the tools hadn't run yet). Track \`toolGroupCompletedCount\`; if finalize fires at count 0, skip the aggregate line and let late completions render individually as labeled ⎿ lines.

## 4. Mode trigger blocked after ctrl-k / ctrl-u

Shell's line editor kills on Ctrl-K / Ctrl-U but input-handler never cleared its own \`lineBuffer\` mirror, so \`>\` failed the \`lineBuffer === ""\` check. Clear on kill, same shape as Ctrl-C / Ctrl-D.

## 5. Table cells rendered \`**bold**\` literally

\`flushTable\` fed raw cell text to \`truncateToWidth\` / \`padEndToWidth\` without calling \`renderInline\`. \`truncateToWidth\` also strips ANSI, so naive render-then-truncate would lose styling. Added \`truncateAnsiToWidth\` that preserves SGR sequences; cells now go through \`renderInline\` before width-fitting; column widths measure rendered content.

## 6. Stale \`read_file\` stub after compaction

\`fileReadCache\` survives conversation compaction, but the "File unchanged since last read — refer to the earlier result" stub it returns assumes the earlier read is still in context. Compaction can evict that output, turning the stub into a dangling pointer. Clear \`fileReadCache\` on \`conversation:after-compact\`.

## Test plan
- [ ] Single tool: inline ✓ at end of tool line (unchanged)
- [ ] Parallel batch, all same groupable kind: \`└ ✓ summaries...\` aggregate renders
- [ ] Mixed parallel batch (grouped kind + standalone kind): no empty \`└ ✓\`; late grouped completions render as \`⎿ tool ✓ summary\`
- [ ] Type text, Ctrl-A, Ctrl-K, then \`>\`: enters agent mode
- [ ] Table with \`**bold**\` in cells: renders bold, not literal asterisks
- [ ] After /compact, next read_file on previously-read file returns full content, not stub