### PR TITLE
let extensions opt tools into read-only body-drop

### DIFF
--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -65,6 +65,10 @@ export function registerReadOnlyTool(name: string): void {
   extraReadOnlyTools.add(name);
 }
 
+export function unregisterReadOnlyTool(name: string): void {
+  extraReadOnlyTools.delete(name);
+}
+
 /** State-changing tools whose summaries are kept in nuclear memory. */
 export const WRITE_TOOLS = new Set([
   "write_file", "edit_file", "write", "edit", "patch",

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -58,6 +58,13 @@ export const READ_ONLY_TOOLS = new Set([
   "read_file", "grep", "glob", "ls", "search",
 ]);
 
+/** Extensions opt their tools in via ToolRegistry.register when readOnly is set. */
+const extraReadOnlyTools = new Set<string>();
+
+export function registerReadOnlyTool(name: string): void {
+  extraReadOnlyTools.add(name);
+}
+
 /** State-changing tools whose summaries are kept in nuclear memory. */
 export const WRITE_TOOLS = new Set([
   "write_file", "edit_file", "write", "edit", "patch",
@@ -270,7 +277,8 @@ export function deserializeEntry(line: string): NuclearEntry | null {
 
 /** Check if a nuclear entry represents a read-only action (should be dropped). */
 export function isReadOnly(entry: NuclearEntry): boolean {
-  return entry.kind === "tool" && entry.tool != null && READ_ONLY_TOOLS.has(entry.tool);
+  if (entry.kind !== "tool" || entry.tool == null) return false;
+  return READ_ONLY_TOOLS.has(entry.tool) || extraReadOnlyTools.has(entry.tool);
 }
 
 // ── Internal helpers ──────────────────────────────────────────────

--- a/src/agent/tool-registry.ts
+++ b/src/agent/tool-registry.ts
@@ -1,6 +1,6 @@
 import type { ToolDefinition } from "./types.js";
 import type { ChatCompletionTool } from "../utils/llm-client.js";
-import { registerReadOnlyTool } from "./nuclear-form.js";
+import { registerReadOnlyTool, unregisterReadOnlyTool } from "./nuclear-form.js";
 
 /**
  * Registry for agent tools. Holds tool definitions and converts them
@@ -12,10 +12,12 @@ export class ToolRegistry {
   register(tool: ToolDefinition): void {
     this.tools.set(tool.name, tool);
     if (tool.readOnly) registerReadOnlyTool(tool.name);
+    else unregisterReadOnlyTool(tool.name);
   }
 
   unregister(name: string): void {
     this.tools.delete(name);
+    unregisterReadOnlyTool(name);
   }
 
   get(name: string): ToolDefinition | undefined {

--- a/src/agent/tool-registry.ts
+++ b/src/agent/tool-registry.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "./types.js";
 import type { ChatCompletionTool } from "../utils/llm-client.js";
+import { registerReadOnlyTool } from "./nuclear-form.js";
 
 /**
  * Registry for agent tools. Holds tool definitions and converts them
@@ -10,6 +11,7 @@ export class ToolRegistry {
 
   register(tool: ToolDefinition): void {
     this.tools.set(tool.name, tool);
+    if (tool.readOnly) registerReadOnlyTool(tool.name);
   }
 
   unregister(name: string): void {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -86,6 +86,10 @@ export interface ToolDefinition {
   /** Whether this tool may modify files — triggers file watcher (default: false). */
   modifiesFiles?: boolean;
 
+  /** Results are re-fetchable; nuclear compaction drops the tool_result
+   *  body on eviction (like the builtin read_file/grep/ls). Default: false. */
+  readOnly?: boolean;
+
   /** Whether to gate execution via permission:request (default: false). */
   requiresPermission?: boolean;
 


### PR DESCRIPTION
## Summary
Builtin \`READ_ONLY_TOOLS\` is a hardcoded Set of tool names (read_file, grep, glob, ls, search) that nuclear compaction drops the body of on eviction. Extensions had no way to opt their own re-fetchable tools into the same treatment — repeated calls lingered in the history file at full size.

## Change
- New \`readOnly?: boolean\` flag on \`ToolDefinition\`
- \`ToolRegistry.register\` forwards it to \`nuclear-form\` via \`registerReadOnlyTool\`
- \`nuclear-form\` keeps a separate \`extraReadOnlyTools\` Set, merged with the builtin Set at \`isReadOnly\` check time
- Builtin Set stays immutable; safe to call repeatedly across extension reloads

## Test plan
- [ ] Builtin read_file/grep/etc. still body-drop on eviction (unchanged behavior)
- [ ] Register an extension tool with \`readOnly: true\` — its eviction drops the body
- [ ] Register without the flag — body persists (current behavior)
- [ ] Reload the extension — registerReadOnlyTool called again is a no-op (Set dedupes)