### PR TITLE
support configurable history file path

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -143,7 +143,8 @@ export class AgentLoop implements AgentBackend {
     // Shell-history-shaped log. Default writes go through the advisable
     // `history:append` handler registered below; extensions swap the
     // backend without touching this wiring.
-    this.historyFile = new HistoryFile({ instanceId: this.instanceId });
+    const filePath = process.env.AGENT_SH_HISTORY_FILE || getSettings().historyFilePath;
+    this.historyFile = new HistoryFile({ instanceId: this.instanceId, filePath });
     this.conversation = new ConversationState(this.handlers, this.instanceId);
 
     // Fall back to a single-mode placeholder if the caller passed an

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -19,16 +19,20 @@ import {
 } from "./nuclear-form.js";
 
 const HISTORY_PATH = path.join(CONFIG_DIR, "history");
-const LOCK_PATH = HISTORY_PATH + ".lock";
 const LOCK_STALE_MS = 10_000; // consider lock stale after 10s
 
 export class HistoryFile {
   readonly instanceId: string;
   private filePath: string;
+  private lockPath: string;
 
   constructor(opts?: { filePath?: string; instanceId?: string }) {
     this.filePath = opts?.filePath ?? HISTORY_PATH;
+    this.lockPath = this.filePath + ".lock";
     this.instanceId = opts?.instanceId ?? crypto.randomBytes(2).toString("hex");
+    // Custom paths may target a dir that doesn't exist yet; create sync so
+    // the first append() can't race with the mkdir.
+    try { fss.mkdirSync(path.dirname(this.filePath), { recursive: true }); } catch { /* ignore */ }
   }
 
   /**
@@ -230,15 +234,15 @@ export class HistoryFile {
     try {
       // Check for stale lock
       try {
-        const stat = await fs.stat(LOCK_PATH);
+        const stat = await fs.stat(this.lockPath);
         if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
-          await fs.unlink(LOCK_PATH).catch(() => {});
+          await fs.unlink(this.lockPath).catch(() => {});
         }
       } catch {
         // Lock doesn't exist — good
       }
       // O_EXCL ensures atomicity
-      const fd = await fs.open(LOCK_PATH, fss.constants.O_CREAT | fss.constants.O_EXCL | fss.constants.O_WRONLY);
+      const fd = await fs.open(this.lockPath, fss.constants.O_CREAT | fss.constants.O_EXCL | fss.constants.O_WRONLY);
       await fd.close();
       return true;
     } catch {
@@ -247,6 +251,6 @@ export class HistoryFile {
   }
 
   private async releaseLock(): Promise<void> {
-    await fs.unlink(LOCK_PATH).catch(() => {});
+    await fs.unlink(this.lockPath).catch(() => {});
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,6 +62,13 @@ export interface Settings {
   historyMaxBytes?: number;
   /** Number of prior history entries to load on startup (default: 50). */
   historyStartupEntries?: number;
+  /**
+   * Override the history file path. Defaults to `~/.agent-sh/history`.
+   * The `AGENT_SH_HISTORY_FILE` env var takes precedence over this setting.
+   * Use a per-project path to keep sessions isolated (e.g. embedding apps
+   * that boot agent-sh as a library against a specific working tree).
+   */
+  historyFilePath?: string;
   /** Auto-compact threshold as fraction of conversation budget (0-1, default 0.5). */
   autoCompactThreshold?: number;
 
@@ -125,6 +132,7 @@ const DEFAULTS: Required<Settings> = {
   shellTailLines: 10,
   historyMaxBytes: 104857600, // 100MB — history is only accessed via search/expand, never loaded wholesale
   historyStartupEntries: 100,
+  historyFilePath: undefined as unknown as string,
   autoCompactThreshold: 0.5,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,


### PR DESCRIPTION
## Summary
- Add `historyFilePath` setting and `AGENT_SH_HISTORY_FILE` env var to override where conversation history is written. Env wins over setting; default remains `~/.agent-sh/history`.
- Fix a latent lock collision: `LOCK_PATH` was a module-level constant pinned to the default path, so a `HistoryFile` constructed with a custom `filePath` would contend on (and unlink) the default lock. Lock path is now derived from the actual file path.
- `mkdir -p` the parent dir so custom paths that target a not-yet-existing directory work on the first `append()`.

Motivation: per-project / embedding use cases where agent-sh boots as a library against a specific working tree and needs an isolated history.

## Test plan
- [ ] Default boot still writes to `~/.agent-sh/history` (no env, no setting).
- [ ] `AGENT_SH_HISTORY_FILE=/tmp/foo/history ash` writes to `/tmp/foo/history` and creates `/tmp/foo/` if missing.
- [ ] `historyFilePath` in `settings.json` works; env var overrides it.
- [ ] Two concurrent instances with different file paths don't cross-unlink each other's `.lock` files.