### PR TITLE
recover from tool throws and tighten auth-error classifier

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -608,8 +608,9 @@ export class AgentLoop implements AgentBackend {
       return `Could not connect to ${target} (${raw}). Check that the API endpoint is reachable.`;
     }
 
-    // Auth errors
-    if (status === 401 || raw.toLowerCase().includes("auth")) {
+    // Explicit signals only — bare "auth" hit "author" in echoed API params.
+    if (status === 401 || status === 403 ||
+        /\b(unauthorized|authentication|api[-_ ]?key|invalid[-_ ]?token)\b/i.test(raw)) {
       return `Authentication failed for ${provider ?? "provider"} (model: ${model}). Check your API key.`;
     }
 
@@ -1034,7 +1035,15 @@ export class AgentLoop implements AgentBackend {
       const toolCtx = this.compositor
         ? { ui: createToolUI(this.bus, this.compositor.surface("agent")) }
         : undefined;
-      const result = await tool.execute(args, onChunk, toolCtx);
+      // Surface thrown errors as tool results so the agent can self-correct
+      // instead of the throw killing the whole turn.
+      let result: Awaited<ReturnType<typeof tool.execute>>;
+      try {
+        result = await tool.execute(args, onChunk, toolCtx);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        result = { content: message, exitCode: 1, isError: true };
+      }
 
       // Invalidate read cache when a file is modified
       if (tool.modifiesFiles && typeof args.path === "string" && !result.isError) {


### PR DESCRIPTION
## Summary
Two related bugs surfaced from a real failure where an ADS tool call returned a 400 and the user saw *\"Authentication failed for openrouter\"* — wrong error, and the agent never got a chance to correct its query.

- **Tool throws no longer kill the turn.** \`tool.execute()\` is now wrapped in try/catch inside the \`tool:execute\` handler; thrown errors become \`{isError: true, content: message}\` results. The agent sees the error on the tool-output lane and can retry with a corrected invocation.
- **Auth-error classifier narrowed.** \`formatError\` matched the bare substring \`\"auth\"\` and hit \`\"author\"\` in an echoed ADS Solr \`fl\` param list, mislabeling a 400 as an authentication failure. Now checks \`status 401/403\` or the explicit words \`unauthorized\`, \`authentication\`, \`api[-_]?key\`, \`invalid[-_]?token\`.

## Test plan
- [ ] Provoke a tool throw (e.g. an ADS query that returns 400). Confirm the turn continues, the error appears as a tool result, and the agent can retry.
- [ ] Confirm a real 401 from the LLM provider still shows the \"Authentication failed\" message.
- [ ] Confirm a tool output containing the word \"author\" (e.g. ADS responses, git log) doesn't trip the auth classifier.