### PR TITLE
hard-fail when no agent backend is available

### DIFF
--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -87,25 +87,6 @@ export default function agentBackend(ctx: ExtensionContext): void {
     instanceId: ctx.instanceId,
   });
 
-  bus.emit("agent:register-backend", {
-    name: "ash",
-    kill: () => agentLoop.kill(),
-    start: async () => {
-      if (!resolved) {
-        bus.emit("ui:error", { message: "Agent backend not started — no LLM provider available. See earlier messages." });
-        return;
-      }
-      agentLoop.wire();
-      bus.emit("agent:info", {
-        name: "ash",
-        version: PACKAGE_VERSION,
-        model: llmClient.model,
-        provider: modes[initialModeIndex]?.provider,
-        contextWindow: modes[initialModeIndex]?.contextWindow,
-      });
-    },
-  });
-
   bus.on("core:extensions-loaded", () => {
     const settings = getSettings();
     // If the user didn't pick a default, fall back to the first registered
@@ -122,14 +103,10 @@ export default function agentBackend(ctx: ExtensionContext): void {
     const effectiveBaseURL = config.baseURL ?? activeProvider?.baseURL;
     const effectiveModel = config.model ?? persistedModelFor(providerName) ?? activeProvider?.defaultModel;
 
-    if (!effectiveApiKey) {
-      bus.emit("ui:error", { message: "No LLM provider configured. Export OPENROUTER_API_KEY or OPENAI_API_KEY (built-in providers auto-activate), pass --api-key, or run `agent-sh init` for a settings.json template." });
-      return;
-    }
-    if (!effectiveModel) {
-      bus.emit("ui:error", { message: "No model specified. Use --model or configure a provider with defaultModel in ~/.agent-sh/settings.json" });
-      return;
-    }
+    // No provider → don't register ash at all, so another backend (e.g.
+    // claude-code-bridge) can own activation. index.ts hard-fails only
+    // when no backend ended up registered.
+    if (!effectiveApiKey || !effectiveModel) return;
 
     modes = buildModes();
     if (modes.length === 0) modes = [{ model: effectiveModel }];
@@ -140,7 +117,21 @@ export default function agentBackend(ctx: ExtensionContext): void {
     llmClient.reconfigure({ apiKey: effectiveApiKey, baseURL: effectiveBaseURL, model: effectiveModel });
     bus.emit("config:set-modes", { modes, activeIndex: initialModeIndex });
     resolved = true;
-    // start() emits agent:info after wiring.
+
+    bus.emit("agent:register-backend", {
+      name: "ash",
+      kill: () => agentLoop.kill(),
+      start: async () => {
+        agentLoop.wire();
+        bus.emit("agent:info", {
+          name: "ash",
+          version: PACKAGE_VERSION,
+          model: llmClient.model,
+          provider: modes[initialModeIndex]?.provider,
+          contextWindow: modes[initialModeIndex]?.contextWindow,
+        });
+      },
+    });
   });
 
   bus.on("provider:register", (p) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,6 +295,16 @@ async function main(): Promise<void> {
   // ── Activate agent backend ────────────────────────────────────
   // Extensions had their chance to register via agent:register-backend.
   // If none did, the built-in AgentLoop gets wired to bus events.
+  const { names: backendNames } = core.bus.emitPipe("config:get-backends", { names: [] as string[], active: null as string | null });
+  if (backendNames.length === 0) {
+    shell.kill();
+    console.error("\nagent-sh: no agent backend available.\n\n" +
+      "  Export OPENROUTER_API_KEY or OPENAI_API_KEY for zero-config launch, or\n" +
+      "  pass --api-key on the command line, or\n" +
+      "  run `agent-sh init` for a settings.json template.\n" +
+      "  Alternatively, install a bridge extension (claude-code-bridge, pi-bridge).\n");
+    process.exit(1);
+  }
   core.activateBackend();
 
   // ── Startup banner ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
Previously, launching agent-sh without a configured LLM provider (and no bridge backend) dropped you into a shell with a mystery \"backend not configured\" banner. Confusing — users think it's broken.

Now: if no backend ends up registered, print a helpful message naming the three fixes and exit 1 before entering the interactive loop.

### Changes
- **\`src/extensions/agent-backend.ts\`** — \`agent:register-backend\` is now emitted only once an LLM provider resolves (inside the \`core:extensions-loaded\` handler), rather than unconditionally during activate(). Previously, ash registered itself even with no provider and errored at \`start()\` time, leaving a half-broken backend in the registry.
- **\`src/index.ts\`** — checks \`config:get-backends\` right before \`core.activateBackend()\`. If zero backends, tears down the shell and prints:
  \`\`\`
  agent-sh: no agent backend available.

    Export OPENROUTER_API_KEY or OPENAI_API_KEY for zero-config launch, or
    pass --api-key on the command line, or
    run \`agent-sh init\` for a settings.json template.
    Alternatively, install a bridge extension (claude-code-bridge, pi-bridge).
  \`\`\`
  Then \`exit(1)\`.

### Bridge-friendly
ash silently disables itself when there's no OpenAI-compatible provider. Someone running with only \`claude-code-bridge\` or \`pi-bridge\` isn't affected — their backend registers normally, agent-sh launches normally.

### Library impact
The CLI exit is CLI-only. Library users (\`createCore()\`) are unaffected by \`src/index.ts\`. The agent-backend change does mean \`config:get-backends\` now reports only usable backends — arguably more honest than the prior always-register-even-if-broken shape.

## Test plan
- [ ] \`unset OPENROUTER_API_KEY OPENAI_API_KEY; agent-sh\` → prints the help message and exits 1, no shell prompt lingers.
- [ ] \`OPENROUTER_API_KEY=... agent-sh\` → launches normally.
- [ ] Launch with only a bridge backend configured (no OPENAI env vars) → launches, bridge is active.
- [ ] Library embed: \`createCore()\` without a provider → \`core.activateBackend()\` is a no-op, no exit.