### PR TITLE
stdin string-sequence passthrough + persisted-model robustness

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -191,13 +191,22 @@ export class AgentLoop implements AgentBackend {
     onCtor("config:add-modes", ({ modes: extra }) => {
       const providers = new Set(extra.map((m) => m.provider).filter(Boolean));
       const prev = this.modes[this.currentModeIndex];
+      // Keep the active mode even if the re-registration drops it (persisted
+      // model missing from a refreshed catalog) — otherwise currentModeIndex
+      // slips to modes[0] and the next stream() call uses a different model
+      // mid-turn.
+      const activePreserved =
+        prev &&
+        prev.provider &&
+        providers.has(prev.provider) &&
+        !extra.some((m) => m.model === prev.model && m.provider === prev.provider);
       this.modes = [
-        ...this.modes.filter((m) => !m.provider || !providers.has(m.provider)),
+        ...this.modes.filter((m) => {
+          if (activePreserved && m === prev) return true;
+          return !m.provider || !providers.has(m.provider);
+        }),
         ...extra,
       ];
-      // Preserve active model across provider re-registration — the index
-      // would otherwise slip when an async catalog fetch replaces the
-      // curated stub list with the full model set.
       if (prev) {
         const newIdx = this.modes.findIndex(
           (m) => m.model === prev.model && m.provider === prev.provider,

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -213,6 +213,11 @@ export class AgentLoop implements AgentBackend {
         );
         if (newIdx !== -1) this.currentModeIndex = newIdx;
       }
+      if (activePreserved && prev) {
+        this.bus.emit("ui:info", {
+          message: `${prev.provider}:${prev.model} is not in the refreshed catalog — keeping it active until you /model to another.`,
+        });
+      }
       this.bus.emit("config:changed", {});
     });
     // Fires before wire() too — agent-backend emits this from

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -190,10 +190,20 @@ export class AgentLoop implements AgentBackend {
     // here in the ctor so late-registered modes aren't dropped.
     onCtor("config:add-modes", ({ modes: extra }) => {
       const providers = new Set(extra.map((m) => m.provider).filter(Boolean));
+      const prev = this.modes[this.currentModeIndex];
       this.modes = [
         ...this.modes.filter((m) => !m.provider || !providers.has(m.provider)),
         ...extra,
       ];
+      // Preserve active model across provider re-registration — the index
+      // would otherwise slip when an async catalog fetch replaces the
+      // curated stub list with the full model set.
+      if (prev) {
+        const newIdx = this.modes.findIndex(
+          (m) => m.model === prev.model && m.provider === prev.provider,
+        );
+        if (newIdx !== -1) this.currentModeIndex = newIdx;
+      }
       this.bus.emit("config:changed", {});
     });
     // Fires before wire() too — agent-backend emits this from

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -110,9 +110,26 @@ export default function agentBackend(ctx: ExtensionContext): void {
 
     modes = buildModes();
     if (modes.length === 0) modes = [{ model: effectiveModel }];
-    initialModeIndex = Math.max(0, modes.findIndex(
+    let foundIdx = modes.findIndex(
       (m) => m.model === effectiveModel && (!activeProvider || m.provider === activeProvider.id),
-    ));
+    );
+    // Persisted default may not be in the provider's curated list yet (e.g.
+    // openrouter's async catalog fetch hasn't returned). Prepend a stub so
+    // the initial config:set-modes activeIndex points at the real model —
+    // otherwise AgentLoop reconfigures llmClient back to modes[0].
+    if (foundIdx === -1 && activeProvider) {
+      modes = [
+        {
+          model: effectiveModel,
+          provider: activeProvider.id,
+          providerConfig: { apiKey: effectiveApiKey, baseURL: effectiveBaseURL },
+          supportsReasoningEffort: activeProvider.supportsReasoningEffort,
+        },
+        ...modes,
+      ];
+      foundIdx = 0;
+    }
+    initialModeIndex = Math.max(0, foundIdx);
 
     llmClient.reconfigure({ apiKey: effectiveApiKey, baseURL: effectiveBaseURL, model: effectiveModel });
     bus.emit("config:set-modes", { modes, activeIndex: initialModeIndex });

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -276,10 +276,13 @@ export class InputHandler {
             // SS3: ESC O <char>
             seq += next; i++;
             if (i + 1 < data.length) { i++; seq += data[i]!; }
-          } else if (next === "]") {
-            // OSC: ESC ] ... (BEL | ESC \). Forward as a unit so the payload
-            // bytes don't land in lineBuffer — otherwise OSC 10/11 color-query
-            // responses leak onto the bash command line after tmux exits.
+          } else if (next === "]" || next === "P" || next === "_" || next === "^") {
+            // String sequences terminated by BEL or ST (ESC \):
+            //   OSC (ESC ]) — OSC 10/11 color-query responses
+            //   DCS (ESC P) — tmux XTVERSION query response (iTerm2 etc.)
+            //   APC (ESC _), PM (ESC ^) — rarer, same termination
+            // Forward as a unit so the payload doesn't leak into lineBuffer
+            // and onto the bash command line after a foreground app exits.
             let j = i + 2;
             let termEnd = -1;
             while (j < data.length) {

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -276,6 +276,26 @@ export class InputHandler {
             // SS3: ESC O <char>
             seq += next; i++;
             if (i + 1 < data.length) { i++; seq += data[i]!; }
+          } else if (next === "]") {
+            // OSC: ESC ] ... (BEL | ESC \). Forward as a unit so the payload
+            // bytes don't land in lineBuffer — otherwise OSC 10/11 color-query
+            // responses leak onto the bash command line after tmux exits.
+            let j = i + 2;
+            let termEnd = -1;
+            while (j < data.length) {
+              const c = data[j]!;
+              if (c === "\x07") { termEnd = j; break; }
+              if (c === "\x1b" && j + 1 < data.length && data[j + 1] === "\\") {
+                termEnd = j + 1; break;
+              }
+              j++;
+            }
+            if (termEnd !== -1) {
+              seq = data.slice(i, termEnd + 1);
+              i = termEnd;
+            } else {
+              seq += next; i++;
+            }
           } else {
             // ESC + single char (alt-key, etc.)
             seq += next; i++;


### PR DESCRIPTION
## Summary

Five fixes in the same area (startup + stdin escape handling), grouped into one PR because they were found while chasing the same symptom ("tmux left garbage on my prompt / my banner shows the wrong model / my model silently switched mid-turn").

### 1. Stdin string-sequence passthrough (`b04c564`, `faa7ba1`)
The stdin escape handler recognized CSI (`ESC [`) and SS3 (`ESC O`) but not the four ECMA-48 string-sequence openers — OSC (`ESC ]`), DCS (`ESC P`), APC (`ESC _`), PM (`ESC ^`). Terminal query responses (e.g. tmux's OSC 10/11 color query, DCS XTVERSION) fell into the printable-char branch and got appended byte-by-byte to \`lineBuffer\` and the PTY. While tmux was foreground it consumed those bytes; anything arriving after tmux exited landed on the bash command line as \`10;rgb:...: command not found\` or \`>|iTerm2 3.6.9\`.

Fix: when we see one of the four openers, scan for BEL or \`ESC \\\` and forward the whole sequence as a unit. Falls back to the previous byte-by-byte behavior when the terminator isn't in the current chunk.

### 2. Startup banner in sync with persisted default (`04b0646`)
When a user's persisted \`defaultModel\` wasn't in the provider's curated startup list (openrouter ships a small default set; full catalog loads async), the initial \`config:set-modes\` sent \`modes=[curated], activeIndex=0\`, which made AgentLoop reconfigure \`llmClient\` back to the curated model — overwriting the persisted-model reconfigure just above. The one-shot \`agent:info\` banner rendered the wrong model.

Fix: prepend a stub mode for the persisted model when it isn't in the curated list so \`activeIndex\` points at it. Also preserve the active mode by \`(model, provider)\` identity across re-registration so the index doesn't slip when the full catalog replaces the stub.

### 3. Preserve active mode across provider re-registration (`4f507aa`)
The previous \`config:add-modes\` handler filtered out all modes from the re-registering provider and re-added from \`extra\`. If the currently-active mode wasn't in \`extra\` (persisted model no longer in the fetched catalog — renamed, deprecated, region-restricted, or a free-tier model rotated out of \`/models\`), the filter dropped it while \`currentModeIndex\` stayed at 0. \`modes[0]\` was now whatever the catalog listed first, so the next \`stream()\` silently used that model mid-turn. Triggered by openrouter's async catalog refresh on cold start, and by \`/reload\` or superash's \`reload_extensions\` at any time.

Fix: explicitly preserve the active mode when it's dropped, so the agent continues using the user's chosen model until they \`/model\` away.

### 4. Warn when a saved model is missing from the refreshed catalog (`92133a2`)
Silent continuation is better than silently switching, but a user whose saved model gets delisted deserves to know — the next API call may fail with a harder-to-interpret error from the provider. Emit a one-line \`ui:info\` when this branch fires.

## Test plan
- [ ] Launch \`agent-sh\` in bash, run \`tmux\`, detach/exit — no \`10;rgb:...: command not found\` or \`>|iTerm2 ...\` on the prompt
- [ ] Same under zsh
- [ ] Arrow keys, alt-key bindings, vim still work (no stdin regression)
- [ ] With a persisted openrouter \`defaultModel\` not in the curated list: startup banner shows that model
- [ ] Run \`/reload\` mid-session with an active model that's in the catalog: model stays, no warning
- [ ] Set \`defaultModel\` to a model not in openrouter's \`/models\`: warning appears, next request still uses that model