### PR TITLE
subagent budget + wire observability + tui orphan-complete fix

### DIFF
--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -44,10 +44,14 @@ export interface SubagentOptions {
    */
   dynamicContext?: string;
   /**
-   * Per-subagent token budget. When total (prompt+completion) tokens
-   * exceed this, the subagent terminates gracefully on the next
-   * iteration. The parent's daily budget still counts these tokens
-   * via onUsage; this is an additional per-call cap.
+   * Per-subagent completion-token budget. When the cumulative
+   * completion_tokens across iterations exceeds this, the subagent
+   * terminates gracefully on the next iteration. We deliberately don't
+   * count prompt tokens: the full history is resent each iteration, so
+   * prompt-inclusive counting double-charges context and makes a budget
+   * of N exhaust after O(log N) tool calls. Completion tokens measure
+   * the work the subagent actually produces. The parent's daily budget
+   * still sees real prompt+completion via onUsage.
    */
   budgetTokens?: number;
   /**
@@ -107,7 +111,7 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
       await streamOnce(llmClient, systemPrompt, conversation, apiTools, model, signal, dynamicContext);
 
     if (usage) {
-      tokensConsumed += usage.total_tokens || 0;
+      tokensConsumed += usage.completion_tokens || 0;
       onUsage?.(usage);
     }
 
@@ -172,7 +176,7 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
   }
 
   if (budgetExhausted) {
-    const note = `\n\n[Subagent terminated: token budget (${budgetTokens}) exhausted after ${tokensConsumed} tokens. Returning partial progress.]`;
+    const note = `\n\n[Subagent terminated: completion-token budget (${budgetTokens}) exhausted after ${tokensConsumed} completion tokens. Returning partial progress.]`;
     return fullResponseText + note;
   }
 


### PR DESCRIPTION
Bundled set of orthogonal fixes and hooks, all landing on the same branch.

## 1. Subagent budget by completion tokens (\`80f659b\`)

\`runSubagent\` counted \`total_tokens\` (prompt+completion), but the full history is resent every iteration — so prompt tokens get multiply-charged and a 30k "total" budget exhausts after ~3 tool calls while the subagent has produced only ~3k of actual output. Switch to cumulative \`completion_tokens\`, which measures what the subagent actually generates. The parent's daily budget still sees real prompt+completion via \`onUsage\`.

## 2. Expose llm:request + llm:chunk events and advisable tool-call extraction (\`7c72d49\`)

Two hooks that let extensions handle wire-level protocol issues without touching core:

- \`llm:request\` / \`llm:chunk\` — fired by agent-loop around the LlmClient streaming call. Observer-only; a wire-log extension can subscribe and dump each turn's request body + streamed chunks for diagnosing protocol bugs.
- \`tool-protocol:extract-calls\` — advisable handler that defaults to the active ToolProtocol's \`extractToolCalls\`. Extensions advise it to inject fallback parsers (e.g. recover DeepSeek's text-format \`name{json}\` calls when a provider drops structured tool_calls) without subclassing the protocol.

## 3. Example extensions (\`2f3829e\`)

- \`examples/extensions/wire-log.ts\` — captures request body + chunks to \`~/.agent-sh/wire/\` for replay via curl. Turned a "is this provider or agent-sh?" debugging session from hand-waving into a deterministic replay in minutes.
- \`examples/extensions/deepseek-text-tools.ts\` — opt-in (\`DEEPSEEK_TEXT_FALLBACK=1\`) advisor that parses text-format \`name{...}\` calls and synthesizes structured \`PendingToolCall\`s. Balanced-brace scanner respects string literals; skips fenced code blocks to avoid grabbing discussed-not-invoked examples.

## 4. TUI: orphaned grouped-tool completions get a (cont.) header (\`cbcc4ba\`)

When a batch mixes kinds (e.g. \`search(p1), search(p2), read, grep, glob\`), parallel read-only execution means tool-started events can finalize the search group before any member has completed. The remaining pending completes then render as \`  ⎿ labeled\` lines — indented under whatever rendered between them and their group header, visually adopted as that tool's children. Track an orphaned flag per pending entry, re-emit a muted \`⌕ search (cont.)\` header before their ⎿ lines land so they regain a legitimate parent. Use \`displayDetail\` as the label (matching inline \`├\` children) instead of the tool name.

## Test plan

- [ ] Multi-tool subagent task no longer exhausts the default 30k budget on 3 calls
- [ ] With \`wire-log\` enabled, a normal turn produces \`*.request.json\` + \`*.chunks.jsonl\` pair in \`~/.agent-sh/wire/\`
- [ ] On a provider that collapses (DeepSeek V3.x+, large context), with \`DEEPSEEK_TEXT_FALLBACK=1\`, text-format calls get recovered and dispatched; ui:info announces "recovered N tool call(s)"
- [ ] Batch like \`[search(p1), read, grep]\` renders two groups, not grep/read adopted by each other