### PR TITLE
make every tool call cancellable

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -21,7 +21,7 @@ import * as fs from "node:fs/promises";
 import * as fsSync from "node:fs";
 import * as path from "node:path";
 import { computeDiff, computeEditDiff, computeInputDiff } from "../utils/diff.js";
-import type { AgentBackend, ToolDefinition } from "./types.js";
+import type { AgentBackend, ToolDefinition, ToolExecutionContext } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState, type CompactResult } from "./conversation-state.js";
 import { HistoryFile } from "./history-file.js";
@@ -55,6 +55,19 @@ type PendingToolCall = ProtocolPendingToolCall;
  * the LLM via the API `tools` param (or via load_tool in deferred-
  * lookup mode) — this only trims the always-visible catalog.
  */
+/** Reject on abort; orphaned `p` keeps running but its result is dropped. */
+function raceAbort<T>(p: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error("cancelled"));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error("cancelled"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    p.then(
+      (v) => { signal.removeEventListener("abort", onAbort); resolve(v); },
+      (e) => { signal.removeEventListener("abort", onAbort); reject(e); },
+    );
+  });
+}
+
 function summarizeDescription(desc: string): string {
   const firstLine = desc.split("\n", 1)[0]!;
   const sentenceEnd = firstLine.search(/[.!?](\s|$)/);
@@ -951,10 +964,14 @@ export class AgentLoop implements AgentBackend {
       this.bus.emit("conversation:message-appended", { role: "system", content: text });
     });
 
+    // Fires on user-abort; extensions advise per tool name for cleanup.
+    h.define("tool:cancel", (_ctx: {
+      name: string;
+      args: Record<string, unknown>;
+      reason: "user-aborted";
+    }) => {});
+
     // Wraps each tool call: permission → execute → emit events.
-    // Extensions advise to add safe-mode, logging, metrics, custom policies.
-    // The ctx.onChunk callback is exposed so advisors can wrap it to
-    // intercept/transform streamed tool output (e.g. secret redaction).
     h.define("tool:execute", async (ctx: {
       name: string; id: string;
       args: Record<string, unknown>;
@@ -962,8 +979,9 @@ export class AgentLoop implements AgentBackend {
       onChunk?: (chunk: string) => void;
       batchIndex?: number;
       batchTotal?: number;
+      signal: AbortSignal;
     }) => {
-      const { name, id, args, tool } = ctx;
+      const { name, id, args, tool, signal } = ctx;
 
       // Validate required input fields before display/permission/execute.
       // Some models emit wrong arg names (e.g. `file_path` instead of `path`),
@@ -1063,15 +1081,17 @@ export class AgentLoop implements AgentBackend {
       const onChunk = (tool.showOutput !== false && !diffShown)
         ? ctx.onChunk
         : undefined;
-      const toolCtx = this.compositor
-        ? { ui: createToolUI(this.bus, this.compositor.surface("agent")) }
-        : undefined;
-      // Surface thrown errors as tool results so the agent can self-correct
-      // instead of the throw killing the whole turn.
+      const toolCtx: ToolExecutionContext = { signal };
+      if (this.compositor) {
+        toolCtx.ui = createToolUI(this.bus, this.compositor.surface("agent"));
+      }
       let result: Awaited<ReturnType<typeof tool.execute>>;
       try {
-        result = await tool.execute(args, onChunk, toolCtx);
+        result = await raceAbort(tool.execute(args, onChunk, toolCtx), signal);
       } catch (err) {
+        if (signal.aborted) {
+          try { this.handlers.call("tool:cancel", { name, args, reason: "user-aborted" }); } catch {}
+        }
         const message = err instanceof Error ? err.message : String(err);
         result = { content: message, exitCode: 1, isError: true };
       }
@@ -1332,7 +1352,8 @@ export class AgentLoop implements AgentBackend {
         const result = await this.handlers.call(
           "tool:execute",
           { name: tc.name, id: tc.id, args, tool, onChunk: defaultOnChunk,
-            batchIndex, batchTotal: batchTotal > 1 ? batchTotal : undefined },
+            batchIndex, batchTotal: batchTotal > 1 ? batchTotal : undefined,
+            signal },
         );
 
         // Truncate large outputs to avoid blowing context

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -1,4 +1,4 @@
-import { executeCommand } from "../../executor.js";
+import { executeCommand, killSession } from "../../executor.js";
 import type { EventBus } from "../../event-bus.js";
 import type { ToolDefinition } from "../types.js";
 
@@ -45,7 +45,7 @@ export function createBashTool(opts: {
       locations: [],
     }),
 
-    async execute(args, onChunk) {
+    async execute(args, onChunk, ctx) {
       const command = args.command as string;
       const timeout = ((args.timeout as number) ?? 60) * 1000;
 
@@ -72,7 +72,13 @@ export function createBashTool(opts: {
         onOutput: onChunk,
       });
 
-      await done;
+      const onAbort = () => killSession(session);
+      ctx?.signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        await done;
+      } finally {
+        ctx?.signal?.removeEventListener("abort", onAbort);
+      }
 
       const content = session.truncated
         ? `[output truncated, showing last portion]\n${session.output}`

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -64,7 +64,9 @@ export interface ToolUI {
 
 /** Context passed to tool execute() as optional third parameter. */
 export interface ToolExecutionContext {
-  ui: ToolUI;
+  ui?: ToolUI;
+  /** Aborted on Ctrl-C — tools with subprocess work should listen and clean up. */
+  signal?: AbortSignal;
 }
 
 export interface ToolDefinition {


### PR DESCRIPTION
## Summary
Ctrl-C during a long-running tool call (notably \`bash\`) was being swallowed: the abort flag was only checked at the next LLM stream, so the agent stayed blocked until the tool finished on its own. Three composable layers fix this:

1. **Kernel races every \`tool.execute\` against the abort signal** in the \`tool:execute\` handler. Ctrl-C unblocks the agent loop for every tool, no per-tool work needed. Uncooperative tools leak their pending work; the agent moves on.
2. **\`ToolExecutionContext\` now carries an optional \`AbortSignal\`.** Tools that own subprocess work (bash) listen and kill it themselves so the OS process actually dies, not just the wait.
3. **New \`tool:cancel\` handler.** Default no-op; extensions advise per tool name for out-of-band cleanup (locks, temp files, telemetry). Failures swallowed.

\`bash\` is wired up: it calls \`killSession\` on abort, sending SIGTERM/SIGKILL to the process group instead of orphaning the child.

## Test plan
- [ ] Long-running \`bash\` (\`sleep 60\`) → Ctrl-C cancels within ms; child process dies.
- [ ] Bare \`Promise\`-only tool that ignores \`signal\` → Ctrl-C still unblocks the agent loop.
- [ ] An extension advising \`tool:cancel\` for tool name X → cleanup fires when X is aborted, not when other tools are aborted.
- [ ] Ctrl-C with no tool running → existing LLM-stream abort path still works.