### PR TITLE
gate reasoning_content echo behind per-mode opt-in

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1795,11 +1795,14 @@ export class AgentLoop implements AgentBackend {
       try { JSON.parse(s); } catch { tc.argumentsJson = "{}"; }
     }
 
+    // Echo reasoning only for modes that opt in (e.g. DeepSeek-R1).
     const extras: Record<string, unknown> = {};
-    if (reasoning && reasoningField) extras[reasoningField] = reasoning;
-    if (reasoningDetailsByIndex.size > 0) {
-      extras.reasoning_details = [...reasoningDetailsByIndex.entries()]
-        .sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+    if (this.currentMode.echoReasoning) {
+      if (reasoning && reasoningField) extras[reasoningField] = reasoning;
+      if (reasoningDetailsByIndex.size > 0) {
+        extras.reasoning_details = [...reasoningDetailsByIndex.entries()]
+          .sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+      }
     }
     return {
       text,

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -298,7 +298,7 @@ export interface ShellEvents {
     /** Optional — providers for custom endpoints may not know the catalog
      *  at registration time. Falls back to models[0] when absent. */
     defaultModel?: string;
-    models?: (string | { id: string; reasoning?: boolean; contextWindow?: number })[];
+    models?: (string | { id: string; reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean })[];
     /** Provider supports the reasoning_effort parameter. Default: true. */
     supportsReasoningEffort?: boolean;
   };

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -47,6 +47,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
           contextWindow: mc?.contextWindow ?? p.contextWindow,
           reasoning: mc?.reasoning,
           supportsReasoningEffort: p.supportsReasoningEffort,
+          echoReasoning: mc?.echoReasoning,
         });
       }
     }
@@ -154,13 +155,13 @@ export default function agentBackend(ctx: ExtensionContext): void {
   bus.on("provider:register", (p) => {
     const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
     const modelIds: string[] = [];
-    const caps = new Map<string, { reasoning?: boolean; contextWindow?: number }>();
+    const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>();
     for (const m of rawModels) {
       if (typeof m === "string") {
         modelIds.push(m);
       } else {
         modelIds.push(m.id);
-        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow });
+        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, echoReasoning: m.echoReasoning });
       }
     }
     providerRegistry.set(p.id, {
@@ -182,6 +183,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
         contextWindow: mc?.contextWindow,
         reasoning: mc?.reasoning,
         supportsReasoningEffort: p.supportsReasoningEffort,
+        echoReasoning: mc?.echoReasoning,
       };
     });
     bus.emit("config:add-modes", { modes: addModes });
@@ -224,6 +226,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
         contextWindow: mc?.contextWindow ?? p.contextWindow,
         reasoning: mc?.reasoning,
         supportsReasoningEffort: p.supportsReasoningEffort,
+        echoReasoning: mc?.echoReasoning,
       };
     });
     bus.emit("config:set-modes", { modes: newModes });

--- a/src/extensions/openrouter.ts
+++ b/src/extensions/openrouter.ts
@@ -4,10 +4,17 @@
  * fetches the full catalog to populate /model autocomplete.
  */
 import type { ExtensionContext } from "../types.js";
+import { getSettings } from "../settings.js";
 
 const BASE_URL = "https://openrouter.ai/api/v1";
 
 const DEFAULT_MODELS = ["anthropic/claude-sonnet-4.6"];
+
+// Built-in defaults for models requiring reasoning_content echoed back
+// (server 400s without it). Extend or override in settings.json:
+//   providers.openrouter.echoReasoningPatterns = ["deepseek", "..."]
+//   providers.openrouter.models[*].echoReasoning = true | false
+const BUILTIN_ECHO_REASONING_PATTERNS: RegExp[] = [/deepseek/i];
 
 interface OpenRouterModel {
   id: string;
@@ -29,6 +36,8 @@ export default function activate(ctx: ExtensionContext): void {
 
   fetchModels(apiKey).then((models) => {
     if (models.length === 0) return;
+    const userOverrides = readUserOverrides();
+    const patterns = readEchoPatterns();
     ctx.bus.emit("provider:register", {
       id: "openrouter",
       apiKey,
@@ -39,9 +48,32 @@ export default function activate(ctx: ExtensionContext): void {
         id: m.id,
         reasoning: m.supported_parameters?.includes("reasoning") ?? false,
         contextWindow: m.context_length,
+        echoReasoning: userOverrides.get(m.id) ?? patterns.some((re) => re.test(m.id)),
       })),
     });
   }).catch(() => { /* keep curated defaults */ });
+}
+
+function readEchoPatterns(): RegExp[] {
+  const userPatterns = getSettings().providers?.openrouter?.echoReasoningPatterns ?? [];
+  const compiled: RegExp[] = [];
+  for (const src of userPatterns) {
+    try { compiled.push(new RegExp(src, "i")); }
+    catch { /* skip invalid pattern */ }
+  }
+  return [...BUILTIN_ECHO_REASONING_PATTERNS, ...compiled];
+}
+
+function readUserOverrides(): Map<string, boolean> {
+  const out = new Map<string, boolean>();
+  const models = getSettings().providers?.openrouter?.models;
+  if (!Array.isArray(models)) return out;
+  for (const m of models) {
+    if (typeof m === "object" && m && m.echoReasoning !== undefined) {
+      out.set(m.id, m.echoReasoning);
+    }
+  }
+  return out;
 }
 
 async function fetchModels(apiKey: string): Promise<OpenRouterModel[]> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,8 @@ export interface ModelCapabilityConfig {
   reasoning?: boolean;
   /** Context window size in tokens for this specific model. */
   contextWindow?: number;
+  /** Echo reasoning_content back on assistant turns. Required by DeepSeek. */
+  echoReasoning?: boolean;
 }
 
 /** Provider profile — a named LLM configuration. */
@@ -33,6 +35,9 @@ export interface ProviderConfig {
   models?: (string | ModelCapabilityConfig)[];
   /** Context window size in tokens (e.g. 128000). Used for usage display. */
   contextWindow?: number;
+  /** Case-insensitive regex sources matched against model id; matches default
+   *  to echoReasoning=true. Per-model echoReasoning still wins. */
+  echoReasoningPatterns?: string[];
 }
 
 export interface Settings {
@@ -258,7 +263,7 @@ export interface ResolvedProvider {
   /** Provider supports the reasoning_effort parameter. Default: true. */
   supportsReasoningEffort?: boolean;
   /** Per-model capabilities, keyed by model id. */
-  modelCapabilities?: Map<string, { reasoning?: boolean; contextWindow?: number }>;
+  modelCapabilities?: Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>;
 }
 
 /**
@@ -272,14 +277,14 @@ export function resolveProvider(name: string): ResolvedProvider | null {
 
   const rawModels = provider.models ?? (provider.defaultModel ? [provider.defaultModel] : []);
   const modelIds: string[] = [];
-  const caps = new Map<string, { reasoning?: boolean; contextWindow?: number }>();
+  const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>();
   for (const m of rawModels) {
     if (typeof m === "string") {
       modelIds.push(m);
     } else {
       modelIds.push(m.id);
-      if (m.reasoning !== undefined || m.contextWindow !== undefined) {
-        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow });
+      if (m.reasoning !== undefined || m.contextWindow !== undefined || m.echoReasoning !== undefined) {
+        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, echoReasoning: m.echoReasoning });
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,9 @@ export interface AgentMode {
   reasoning?: boolean;
   /** Provider supports the reasoning_effort parameter. */
   supportsReasoningEffort?: boolean;
+  /** Echo reasoning_content back on assistant turns. Required by DeepSeek;
+   *  default off (leaky shims may forward it to the model as OOD input). */
+  echoReasoning?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Echoing `reasoning_content` / `reasoning_details` back on assistant turns is required by DeepSeek-family models but can leak prior chain-of-thought into other providers as OOD input via lenient OpenAI-compatible shims.
- New `AgentMode.echoReasoning` flag — default `false`. The agent loop only attaches reasoning extras to assistant messages when the active mode opts in.
- OpenRouter auto-flags DeepSeek models via `BUILTIN_ECHO_REASONING_PATTERNS = [/deepseek/i]` (covers V3, V3.2, V4, rebadges).
- Users can extend or override in `settings.json`:
  - `providers.openrouter.echoReasoningPatterns: string[]` — additional regex sources merged with built-ins.
  - `providers.openrouter.models[*].echoReasoning: boolean` — explicit per-model override (wins over patterns).

## Test plan
- [ ] DeepSeek V3.2 / V4 via OpenRouter: still works (echo path active by default).
- [ ] Non-DeepSeek reasoning model (e.g. `openai/gpt-5.5`, `anthropic/claude-opus-4.7`): assistant turns no longer carry `reasoning_content` / `reasoning_details` in the round-trip.
- [ ] User override: setting `echoReasoning: false` on a DeepSeek model in settings.json disables echo.
- [ ] Invalid regex in `echoReasoningPatterns` is silently skipped without breaking provider registration.