### PR TITLE
add ctx.onDispose for extension teardown

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -232,6 +232,8 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         list: () => handlers.list(),
         get terminalBuffer() { return getTerminalBuffer(); },
         compositor,
+        // Default no-op — scoped contexts override to track for /reload teardown.
+        onDispose: () => {},
         createRemoteSession: (opts: RemoteSessionOptions): RemoteSession => {
           const { surface } = opts;
           const cleanups: (() => void)[] = [];

--- a/src/core.ts
+++ b/src/core.ts
@@ -232,7 +232,6 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         list: () => handlers.list(),
         get terminalBuffer() { return getTerminalBuffer(); },
         compositor,
-        // Default no-op — scoped contexts override to track for /reload teardown.
         onDispose: () => {},
         createRemoteSession: (opts: RemoteSessionOptions): RemoteSession => {
           const { surface } = opts;

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -111,6 +111,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     registerTool: scopedRegisterTool,
     unregisterTool: ctx.unregisterTool,
     registerCommand: scopedRegisterCommand,
+    onDispose: (fn: () => void) => { cleanups.push(fn); },
   };
 
   const dispose = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,12 @@ export interface ExtensionContext {
    */
   compositor: Compositor;
 
+  // ── Lifecycle ──────────────────────────────────────────────────
+  /** Register a teardown callback fired when the extension is disposed
+   *  (e.g. /reload). Use for resources the scoped context can't track:
+   *  process listeners, timers, file watchers, sockets. */
+  onDispose: (fn: () => void) => void;
+
   // ── Remote sessions ────────────────────────────────────────────
   /**
    * Create a remote session that routes agent output to a surface and

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,9 +173,8 @@ export interface ExtensionContext {
   compositor: Compositor;
 
   // ── Lifecycle ──────────────────────────────────────────────────
-  /** Register a teardown callback fired when the extension is disposed
-   *  (e.g. /reload). Use for resources the scoped context can't track:
-   *  process listeners, timers, file watchers, sockets. */
+  /** Teardown callback fired on /reload. For resources the scoped context
+   *  can't track: process listeners, timers, watchers, sockets. */
   onDispose: (fn: () => void) => void;
 
   // ── Remote sessions ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `ctx.onDispose(fn)` so extensions can register teardown callbacks for resources the scoped context can't track (process listeners, timers, file watchers, sockets).
- Scoped wrapper appends them to the same cleanup list as `bus.on` / `advise`, so they fire on `/reload`. Default is a no-op on unscoped contexts.

## Motivation
Repeated `/reload` triggered:
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 exit listeners added to [process].
```
because extensions like superash's peer-mesh and browser register `process.on("exit"/"SIGTERM"/"SIGINT")` directly. Each reload re-runs `activate()`, listeners stack up, Node's default cap of 10 trips on the third reload.

## Test plan
- [ ] `/reload` repeatedly with a superash-style extension that uses `ctx.onDispose` to detach process listeners — no MaxListenersExceededWarning.
- [ ] Existing extensions that don't call `onDispose` still load and reload as before (default no-op).
- [ ] Type-check passes (`npx tsc --noEmit`).