### PR TITLE
honor AGENT_SH_HOME for config dir override

### DIFF
--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -13,7 +13,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { getSettings } from "../settings.js";
+import { CONFIG_DIR, getSettings } from "../settings.js";
 
 export interface Skill {
   name: string;
@@ -144,7 +144,7 @@ export function discoverGlobalSkills(): Skill[] {
   const seen = new Set<string>();
   const skills: Skill[] = [];
 
-  addUnique(skills, scanDir(path.join(os.homedir(), ".agent-sh", "skills")), seen);
+  addUnique(skills, scanDir(path.join(CONFIG_DIR, "skills")), seen);
 
   const settings = getSettings();
   for (const p of settings.skillPaths ?? []) {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -16,9 +16,8 @@ export function formatSkillsBlock(skills: Skill[]): string {
     + skills.map(s => `- **${s.name}**: ${s.description}\n  Path: ${s.filePath}`).join("\n\n");
 }
 
-// Resolve to the user's home-based config dir — user's standing instructions to the agent
-import * as os from "node:os";
-const GLOBAL_AGENTS_MD = path.join(os.homedir(), ".agent-sh", "AGENTS.md");
+import { CONFIG_DIR } from "../settings.js";
+const GLOBAL_AGENTS_MD = path.join(CONFIG_DIR, "AGENTS.md");
 
 // ── File caches ─────────────────────────────────────────────────────
 // Convention files (CLAUDE.md/AGENT.md) are walked synchronously from

--- a/src/core.ts
+++ b/src/core.ts
@@ -28,10 +28,8 @@ import { TerminalBuffer } from "./utils/terminal-buffer.js";
 import crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as os from "node:os";
 import { DefaultCompositor, StdoutSurface } from "./utils/compositor.js";
-
-const STORAGE_ROOT = path.join(os.homedir(), ".agent-sh");
+import { CONFIG_DIR } from "./settings.js";
 
 // Re-export types that library consumers need
 export { EventBus } from "./event-bus.js";
@@ -213,7 +211,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           streamTransform.createFencedBlockTransform(bus, o),
         getExtensionSettings: settingsMod.getExtensionSettings,
         getStoragePath: (namespace: string) => {
-          const dir = path.join(STORAGE_ROOT, namespace);
+          const dir = path.join(CONFIG_DIR, namespace);
           fs.mkdirSync(dir, { recursive: true });
           return dir;
         },

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,8 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as os from "node:os";
-
-const CONFIG_DIR = path.join(os.homedir(), ".agent-sh");
+import { CONFIG_DIR } from "./settings.js";
 const EXTENSIONS_DIR = path.join(CONFIG_DIR, "extensions");
 const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
 const EXAMPLE_PATH = path.join(CONFIG_DIR, "settings.example.json");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 
-export const CONFIG_DIR = path.join(os.homedir(), ".agent-sh");
+/** Root config directory. Override via AGENT_SH_HOME for isolated instances
+ *  (testing, multi-agent setups). Path is resolved at module load. */
+export const CONFIG_DIR = process.env.AGENT_SH_HOME
+  ? path.resolve(process.env.AGENT_SH_HOME)
+  : path.join(os.homedir(), ".agent-sh");
 const SETTINGS_PATH = path.join(CONFIG_DIR, "settings.json");
 
 /** Per-model capability overrides. */


### PR DESCRIPTION
## Summary

\`CONFIG_DIR\` now honors the \`AGENT_SH_HOME\` env var, falling back to \`~/.agent-sh\`. This lets you run multiple isolated agent-sh instances on the same machine — different settings, extensions, history, peer-mesh state — without renaming directories or symlinking.

\`\`\`bash
AGENT_SH_HOME=~/.agent-sh-critic agent-sh   # second instance
agent-sh                                    # default ~/.agent-sh
\`\`\`

Also dedupes two redundant declarations: \`init.ts\` and \`core.ts\` each had their own copy of \`path.join(os.homedir(), ".agent-sh")\` for related but slightly different purposes (init scaffolding, per-extension storage roots). Both now import \`CONFIG_DIR\` from \`settings.ts\` so the env var override flows through them.

## Why

Currently if you want to run a worker agent + critic agent locally for testing peer-to-peer scenarios, both processes share \`~/.agent-sh/\` — same settings.json, same extensions dir, same history. You can work around it by renaming directories or running one instance in a container, but that's friction for a small need.

This is the smallest possible change that unblocks "two agent-sh processes, side by side, isolated."

## Test plan

- [ ] \`AGENT_SH_HOME=/tmp/foo agent-sh init\` scaffolds at \`/tmp/foo/\`.
- [ ] Two terminals, one with override, one without — both run, write history to their own dirs, load extensions from their own \`extensions/\` dir.
- [ ] No env var set: behavior unchanged from main.
- [ ] \`npx tsc --noEmit\` passes.