### PR TITLE
expose context snapshot + mutate as bus pipes

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -352,6 +352,19 @@ export class AgentLoop implements AgentBackend {
       budgetTokens: this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     }));
 
+    this.bus.onPipe("context:snapshot", (payload) => {
+      payload.messages = this.conversation.getMessages();
+      payload.contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      payload.activeTokens = this.conversation.estimateTokens();
+      return payload;
+    });
+
+    this.bus.onPipeAsync("context:compact", async (payload) => {
+      const stats = await this.compactWithHooks(0, undefined, false, payload.strategy);
+      if (stats) payload.stats = { before: stats.before, after: stats.after, evictedCount: stats.evictedCount };
+      return payload;
+    });
+
     // Prior-session preamble (non-blocking). Both the read and the
     // layout go through advisable handlers.
     Promise.resolve(this.handlers.call("history:read-recent"))
@@ -557,11 +570,13 @@ export class AgentLoop implements AgentBackend {
     target: number,
     keepRecent?: number,
     force?: boolean,
+    strategy?: ShellEvents["context:compact"]["strategy"],
   ): CompactResult | null {
     const stats = this.handlers.call("conversation:compact", {
       target,
       keepRecent,
       force: !!force,
+      strategy,
     }) as CompactResult | null;
     if (stats) {
       this.bus.emit("conversation:after-compact", {
@@ -953,8 +968,33 @@ export class AgentLoop implements AgentBackend {
 
     // Compaction strategy — default delegates to the two-tier pin
     // strategy in ConversationState; advisors replace wholesale.
-    h.define("conversation:compact", (opts: { target: number; keepRecent?: number; force?: boolean }) => {
-      return this.conversation.compact(opts.target, opts.keepRecent, opts.force);
+    h.define("conversation:compact", (opts: {
+      target?: number;
+      keepRecent?: number;
+      force?: boolean;
+      strategy?:
+        | { kind: "two-tier-pin"; target: number; keepRecent?: number; force?: boolean }
+        | { kind: "rewind"; toIndex: number }
+        | { kind: "replace"; messages: unknown[] };
+    }) => {
+      const strategy = opts.strategy;
+      // Synthesize a CompactResult for manual edits so conversation:after-compact
+      // listeners (metrics, file-read cache, system-prompt cache) still run.
+      if (strategy?.kind === "rewind" || strategy?.kind === "replace") {
+        const before = this.conversation.estimatePromptTokens();
+        const beforeLen = this.conversation.getMessages().length;
+        const next = strategy.kind === "rewind"
+          ? this.conversation.getMessages().slice(0, strategy.toIndex)
+          : (strategy.messages as ReturnType<ConversationState["getMessages"]>);
+        this.conversation.replaceMessages(next);
+        const after = this.conversation.estimatePromptTokens();
+        const afterLen = this.conversation.getMessages().length;
+        return { before, after, evictedCount: Math.max(0, beforeLen - afterLen) } as CompactResult;
+      }
+      const tgt = strategy?.kind === "two-tier-pin" ? strategy.target : opts.target!;
+      const keep = strategy?.kind === "two-tier-pin" ? strategy.keepRecent : opts.keepRecent;
+      const force = strategy?.kind === "two-tier-pin" ? strategy.force : opts.force;
+      return this.conversation.compact(tgt, keep, force);
     });
 
     // Inject a system note mid-loop — used by extensions (subagents,

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -246,6 +246,22 @@ export interface ShellEvents {
     budgetTokens: number;
   };
 
+  "context:snapshot": {
+    messages: unknown[];
+    contextWindow: number;
+    activeTokens: number;
+  };
+
+  // Strategies share one seam so after-compact metrics and cache
+  // invalidation run uniformly across kernel + manual edits.
+  "context:compact": {
+    strategy?:
+      | { kind: "two-tier-pin"; target: number; keepRecent?: number; force?: boolean }
+      | { kind: "rewind"; toIndex: number }
+      | { kind: "replace"; messages: unknown[] };
+    stats?: { before: number; after: number; evictedCount: number };
+  };
+
 
   // Extension registers itself as agent backend (extension → core)
   "agent:register-backend": {


### PR DESCRIPTION
## Summary

Two purely-additive bus pipes that let external tools (e.g. `agent-sh-hub`) inspect and edit the live conversation context:

- **`context:snapshot`** — read-only. Returns `{ messages, contextWindow, activeTokens }`.
- **`context:compact`** — mutation seam with a strategy union:
  - `{ kind: "two-tier-pin", target, keepRecent?, force? }` — default; reproduces existing behavior.
  - `{ kind: "rewind", toIndex }` — truncate to a prefix.
  - `{ kind: "replace", messages }` — swap the array wholesale.

Manual strategies route through the existing `conversation:compact` handler, so `conversation:after-compact` and the downstream cache invalidations (file-read cache, system-prompt cache, metrics) fire uniformly across kernel-internal compaction and external edits.

## Why

Lays the groundwork for a context-inspection / rewind UI in `agent-sh-hub`. Manual editing is conceptually a compaction strategy, so it should share the kernel's mutation machinery instead of carving a parallel path.

## Risk

Pure addition. No call sites moved.

- `agent:compact-request`, auto-compact (threshold), and overflow recovery still flow through `compactWithHooks` unchanged.
- The `strategy` field is optional; legacy `{target, keepRecent, force}` payload still works.
- New `strategy` branches only execute when explicitly requested.

## Test plan
- [ ] `tsc` passes
- [ ] Existing slash `/compact` still compacts as before
- [ ] Auto-compact at threshold still fires (verify via long session)
- [ ] `bus.emitPipe("context:snapshot", { messages: [], contextWindow: 0, activeTokens: 0 })` returns live state
- [ ] `bus.emitPipeAsync("context:compact", { strategy: { kind: "rewind", toIndex: N } })` truncates and emits `conversation:after-compact`