### PR TITLE
windows: bundle rg, drop bash for tool invocations, document WSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [20]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Type-check + build
+        run: npm run build
+
+      - name: Confirm bundled ripgrep is present
+        shell: bash
+        run: |
+          node -e "const {rgPath}=require('@vscode/ripgrep');require('fs').accessSync(rgPath);console.log('rg at',rgPath)"
+          node -e "const {rgPath}=require('@vscode/ripgrep');require('child_process').execFileSync(rgPath,['--version'],{stdio:'inherit'})"
+
+      - name: Smoke-test executeArgv via bundled rg
+        shell: bash
+        run: |
+          node --input-type=module -e "
+            import { executeArgv } from './dist/executor.js';
+            import { resolveRgPath } from './dist/utils/ripgrep-path.js';
+            const rg = resolveRgPath();
+            const { session, done } = executeArgv({ file: rg, args: ['--files', '--glob', '*.json', '.'], cwd: process.cwd(), timeout: 10000 });
+            await done;
+            const lines = session.output.split('\n').filter(Boolean).length;
+            if (session.exitCode !== 0 || lines === 0) {
+              console.error('rg smoke test failed: exit=' + session.exitCode + ' lines=' + lines);
+              console.error(session.output);
+              process.exit(1);
+            }
+            console.log('ok: exit=' + session.exitCode + ' lines=' + lines);
+          "

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ alias ash="agent-sh"
 
 Requires Node.js 18+. Currently supports **bash** and **zsh**; other shells (fish, nushell, etc.) are not yet wired up.
 
+**Windows:** the interactive shell layer is bash/zsh-only. Run agent-sh inside **WSL** for the full experience. Native Windows (cmd.exe / PowerShell) is not supported as the host shell, though headless / library / ACP-bridge usage may work — file an issue if you hit a gap.
+
 ## Key Features
 
 **Real terminal, zero compromise.** Full PTY with your shell config, aliases, and environment. Shell starts instantly — the agent connects asynchronously in the background.

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@vscode/ripgrep": "^1.17.1",
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/headless": "^5.5.0",
     "cli-highlight": "^2.1.11",

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -20,6 +20,7 @@ import { setMaxListeners } from "node:events";
 import * as fs from "node:fs/promises";
 import * as fsSync from "node:fs";
 import * as path from "node:path";
+import * as os from "node:os";
 import { computeDiff, computeEditDiff, computeInputDiff } from "../utils/diff.js";
 import type { AgentBackend, ToolDefinition, ToolExecutionContext } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
@@ -33,7 +34,6 @@ import { RESPONSE_RESERVE, DEFAULT_CONTEXT_WINDOW } from "./token-budget.js";
 import { PACKAGE_VERSION } from "../utils/package-version.js";
 import { getSettings, updateSettings } from "../settings.js";
 import { createToolProtocol, type ToolProtocol, type PendingToolCall as ProtocolPendingToolCall, type ToolResult as ProtocolToolResult } from "./tool-protocol.js";
-import * as os from "node:os";
 
 // Core tool factories
 import { createBashTool } from "./tools/bash.js";
@@ -1079,7 +1079,7 @@ export class AgentLoop implements AgentBackend {
               permKind = "file-write";
               // Shorten path for display
               const cwd = process.cwd();
-              const home = process.env.HOME;
+              const home = process.env.HOME ?? os.homedir();
               let displayPath = absPath;
               if (absPath.startsWith(cwd + "/")) displayPath = absPath.slice(cwd.length + 1);
               else if (home && absPath.startsWith(home + "/")) displayPath = "~/" + absPath.slice(home.length + 1);

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { executeArgv } from "../../executor.js";
+import { resolveRgPath } from "../../utils/ripgrep-path.js";
 import type { ToolDefinition } from "../types.js";
 import { expandHome } from "./expand-home.js";
 
@@ -50,7 +51,7 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
 
       // Use ripgrep for correct glob matching + .gitignore awareness
       const { session, done } = executeArgv({
-        file: "rg",
+        file: resolveRgPath(),
         args: ["--files", "--glob", pattern, searchPath],
         cwd: getCwd(),
         timeout: 10_000,
@@ -59,7 +60,7 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
 
       if (session.exitCode === -1 && session.output.startsWith("Failed to spawn")) {
         return {
-          content: "ripgrep (rg) not found on PATH. Install ripgrep to use the glob tool.",
+          content: "ripgrep not available — the bundled binary failed to load and `rg` is not on PATH. Reinstall agent-sh, or install ripgrep manually (https://github.com/BurntSushi/ripgrep#installation).",
           exitCode: 1,
           isError: true,
         };

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { executeCommand } from "../../executor.js";
+import { executeArgv } from "../../executor.js";
 import type { ToolDefinition } from "../types.js";
 import { expandHome } from "./expand-home.js";
 
@@ -49,18 +49,21 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
       const searchPath = expandHome((args.path as string) ?? ".");
 
       // Use ripgrep for correct glob matching + .gitignore awareness
-      const shellEsc = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
-      const parts = [
-        "rg", "--files",
-        "--glob", shellEsc(pattern),
-        shellEsc(searchPath),
-      ];
-      const { session, done } = executeCommand({
-        command: parts.join(" "),
+      const { session, done } = executeArgv({
+        file: "rg",
+        args: ["--files", "--glob", pattern, searchPath],
         cwd: getCwd(),
         timeout: 10_000,
       });
       await done;
+
+      if (session.exitCode === -1 && session.output.startsWith("Failed to spawn")) {
+        return {
+          content: "ripgrep (rg) not found on PATH. Install ripgrep to use the glob tool.",
+          exitCode: 1,
+          isError: true,
+        };
+      }
 
       if (!session.output.trim()) {
         return {

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -19,11 +19,11 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
       properties: {
         pattern: {
           type: "string",
-          description: "Glob pattern (e.g., 'src/**/*.ts', '*.json')",
+          description: "Glob pattern (e.g., 'src/**/*.ts', '*.json'). Do NOT put `~` or absolute prefixes here — pass the directory in `path` instead.",
         },
         path: {
           type: "string",
-          description: "Base directory to search (default: cwd)",
+          description: "Base directory to search (default: cwd). Supports `~` and `~/...` for the home directory.",
         },
       },
       required: ["pattern"],

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -1,4 +1,5 @@
 import { executeArgv } from "../../executor.js";
+import { resolveRgPath } from "../../utils/ripgrep-path.js";
 import type { ToolDefinition } from "../types.js";
 import { expandHome } from "./expand-home.js";
 
@@ -131,7 +132,7 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
       rgArgs.push("-e", pattern, searchPath);
 
       const { session, done } = executeArgv({
-        file: "rg",
+        file: resolveRgPath(),
         args: rgArgs,
         cwd: getCwd(),
         timeout: 10_000,
@@ -141,7 +142,7 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
 
       if (session.exitCode === -1 && session.output.startsWith("Failed to spawn")) {
         return {
-          content: "ripgrep (rg) not found on PATH. Install ripgrep to use the grep tool.",
+          content: "ripgrep not available — the bundled binary failed to load and `rg` is not on PATH. Reinstall agent-sh, or install ripgrep manually (https://github.com/BurntSushi/ripgrep#installation).",
           exitCode: 1,
           isError: true,
         };

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -1,4 +1,4 @@
-import { executeCommand } from "../../executor.js";
+import { executeArgv } from "../../executor.js";
 import type { ToolDefinition } from "../types.js";
 import { expandHome } from "./expand-home.js";
 
@@ -100,44 +100,52 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
       const headLimit = args.head_limit as number | undefined;
       const offset = (args.offset as number) ?? 0;
 
-      const shellEsc = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
-      const parts = ["rg", "--color=never"];
+      const rgArgs: string[] = ["--color=never"];
 
       // Mode-specific flags
       if (mode === "files_with_matches") {
-        parts.push("--files-with-matches");
+        rgArgs.push("--files-with-matches");
       } else if (mode === "count") {
-        parts.push("--count");
+        rgArgs.push("--count");
       } else {
         // content mode
-        parts.push("--line-number", "--no-heading");
+        rgArgs.push("--line-number", "--no-heading");
         if (contextBefore != null && contextBefore > 0) {
-          parts.push(`-B${contextBefore}`);
+          rgArgs.push(`-B${contextBefore}`);
         }
         if (contextAfter != null && contextAfter > 0) {
-          parts.push(`-A${contextAfter}`);
+          rgArgs.push(`-A${contextAfter}`);
         }
         // If neither -A nor -B specified, use --max-count to limit per-file
         if (contextBefore == null && contextAfter == null) {
-          parts.push("--max-count=50");
+          rgArgs.push("--max-count=50");
         }
       }
 
       if (caseInsensitive) {
-        parts.push("-i");
+        rgArgs.push("-i");
       }
       if (include) {
-        parts.push("--glob", shellEsc(include));
+        rgArgs.push("--glob", include);
       }
-      parts.push("-e", shellEsc(pattern), shellEsc(searchPath));
+      rgArgs.push("-e", pattern, searchPath);
 
-      const { session, done } = executeCommand({
-        command: parts.join(" "),
+      const { session, done } = executeArgv({
+        file: "rg",
+        args: rgArgs,
         cwd: getCwd(),
         timeout: 10_000,
         maxOutputBytes: 64 * 1024,
       });
       await done;
+
+      if (session.exitCode === -1 && session.output.startsWith("Failed to spawn")) {
+        return {
+          content: "ripgrep (rg) not found on PATH. Install ripgrep to use the grep tool.",
+          exitCode: 1,
+          isError: true,
+        };
+      }
 
       if (session.exitCode === 1 && !session.output.trim()) {
         // If the pattern looks like a filename (e.g. "SKILL.md", "package.json"),

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -122,6 +122,107 @@ export function executeCommand(opts: {
 }
 
 /**
+ * Spawn a binary directly (no shell). Use for invoking known tools like `rg`
+ * with structured args — avoids shell-quoting bugs and works on platforms
+ * without /bin/bash.
+ */
+export function executeArgv(opts: {
+  file: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+  timeout?: number;
+  maxOutputBytes?: number;
+  onOutput?: (chunk: string) => void;
+}): { session: ExecutorSession; done: Promise<void> } {
+  const timeout = opts.timeout ?? DEFAULT_TIMEOUT;
+  const maxOutput = opts.maxOutputBytes ?? DEFAULT_MAX_OUTPUT;
+
+  const session: ExecutorSession = {
+    id: "",
+    command: `${opts.file} ${opts.args.join(" ")}`,
+    output: "",
+    exitCode: null,
+    done: false,
+    truncated: false,
+    process: null,
+  };
+
+  const done = new Promise<void>((resolve) => {
+    session.resolve = resolve;
+  });
+
+  const env: Record<string, string> = {};
+  const source = opts.env ?? process.env;
+  for (const [k, v] of Object.entries(source)) {
+    if (v !== undefined) env[k] = v;
+  }
+
+  let child: ChildProcess;
+  try {
+    child = spawn(opts.file, opts.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: opts.cwd,
+      env,
+    });
+  } catch (err) {
+    session.exitCode = -1;
+    session.output = `Failed to spawn ${opts.file}: ${err instanceof Error ? err.message : String(err)}`;
+    session.done = true;
+    session.resolve?.();
+    return { session, done };
+  }
+
+  session.process = child;
+
+  const handleData = (data: Buffer) => {
+    const raw = data.toString("utf-8");
+    const clean = stripAnsi(raw);
+    session.output += clean;
+    if (session.output.length > maxOutput) {
+      session.output = session.output.slice(-maxOutput);
+      session.truncated = true;
+    }
+    opts.onOutput?.(raw);
+  };
+
+  child.stdout?.on("data", handleData);
+  child.stderr?.on("data", handleData);
+
+  const timer = setTimeout(() => {
+    if (!session.done && session.process) {
+      try { session.process.kill("SIGTERM"); } catch {}
+      setTimeout(() => {
+        if (!session.done && session.process) {
+          try { session.process.kill("SIGKILL"); } catch {}
+        }
+      }, 5000).unref();
+    }
+  }, timeout);
+
+  child.on("exit", (code, signal) => {
+    clearTimeout(timer);
+    session.exitCode = code ?? (signal ? -1 : null);
+    session.done = true;
+    session.process = null;
+    session.resolve?.();
+  });
+
+  child.on("error", (err) => {
+    clearTimeout(timer);
+    if (!session.done) {
+      session.exitCode = -1;
+      session.output += `\nProcess error: ${err.message}`;
+      session.done = true;
+      session.process = null;
+      session.resolve?.();
+    }
+  });
+
+  return { session, done };
+}
+
+/**
  * Kill a running session's process group: SIGTERM, then SIGKILL after 5s.
  * Returns a cleanup that cancels the pending SIGKILL — callers should invoke
  * it once the process has exited.

--- a/src/utils/ripgrep-path.ts
+++ b/src/utils/ripgrep-path.ts
@@ -1,0 +1,17 @@
+import * as fs from "node:fs";
+import { rgPath as bundledRgPath } from "@vscode/ripgrep";
+
+/**
+ * Resolve the ripgrep binary path. Prefers the version bundled via
+ * @vscode/ripgrep (downloaded by its postinstall hook). Falls back to plain
+ * "rg" so users with rg on PATH still work even if the postinstall failed
+ * (offline install, blocked egress, etc.).
+ */
+export function resolveRgPath(): string {
+  try {
+    if (bundledRgPath && fs.existsSync(bundledRgPath)) return bundledRgPath;
+  } catch {
+    // fall through
+  }
+  return "rg";
+}

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -5,6 +5,7 @@
  * Also provides a spinner/timer component for in-progress tools.
  */
 import * as path from "node:path";
+import * as os from "node:os";
 import { visibleLen } from "./ansi.js";
 import { palette as p } from "./palette.js";
 
@@ -298,7 +299,7 @@ function shortenPath(p: string | undefined | null, cwd: string): string {
   if (!p || typeof p !== "string") return "";
   if (p.startsWith(cwd + "/")) return p.slice(cwd.length + 1);
   if (p.startsWith(cwd)) return p.slice(cwd.length) || ".";
-  const home = process.env.HOME;
+  const home = process.env.HOME ?? os.homedir();
   if (home && p.startsWith(home + "/")) return "~/" + p.slice(home.length + 1);
   return p;
 }


### PR DESCRIPTION
## Summary
Cheap + medium tier from the Windows portability audit. Net effect: the headless / library / hub / ACP-bridge surfaces work on native Windows, and the interactive TUI binary requires WSL (documented).

### Changes
- **Drop bash from tool invocations.** New `executeArgv()` in `src/executor.ts` spawns binaries directly (no `/bin/bash -c` shim, no shell-quoting). The `grep` and `glob` tools route `rg` through it.
- **Bundle ripgrep via `@vscode/ripgrep`.** Postinstall downloads the platform-correct `rg` into `node_modules/`. New `resolveRgPath()` prefers the bundled binary, falls back to `"rg"` on PATH if the postinstall failed (offline install, blocked egress).
- **HOME fallback** to `os.homedir()` in `agent-loop.ts:1082` and `tool-display.ts:301`.
- **README**: note the interactive shell layer is bash/zsh-only; Windows users should run inside WSL.
- **Tool description**: clarified that `glob`'s `~` expansion belongs in `path`, not `pattern`.

### Out of scope (deferred)
- PowerShell-native prompt instrumentation — would replace the bash/zsh hooks in `shell/shell.ts`. The TUI binary remains WSL-only on Windows.
- `bash` tool itself — by definition bash; needs a `pwsh` sibling for native Windows.
- Compositor / `StdoutSurface` default leak in `core.ts` (separate design fix, tracked separately).

## Test plan
- [x] `npm run build` clean.
- [x] grep / glob via running agent-sh — same results as before.
- [x] Bundled rg resolved at expected path; smoke test passed.
- [ ] Fallback path: rename `node_modules/@vscode/ripgrep/bin/rg` aside, confirm tool falls back to PATH `rg`; remove from PATH too, confirm friendly error.
- [ ] HOME-unset environment: tilde-shortened paths still render correctly in tool display.
- [ ] CI matrix on `ubuntu-latest` / `macos-latest` / `windows-latest` (recommended follow-up).