### PR TITLE
per-provider reasoning shape + ergonomic provider config

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -312,7 +312,7 @@ export class AgentLoop implements AgentBackend {
         return;
       }
       const mode = this.currentMode;
-      if (level !== "off" && mode.reasoning === false) {
+      if (level !== "off" && !mode.reasoning) {
         this.bus.emit("ui:error", { message: `Model ${mode.model} does not support thinking.` });
         return;
       }
@@ -326,7 +326,7 @@ export class AgentLoop implements AgentBackend {
     });
     this.bus.onPipe("config:get-thinking", () => {
       const mode = this.currentMode;
-      const supported = mode.reasoning !== false && mode.supportsReasoningEffort !== false;
+      const supported = !!mode.reasoning && mode.supportsReasoningEffort !== false;
       return { level: this.thinkingLevel, levels: AgentLoop.THINKING_LEVELS, supported };
     });
     on("agent:reset-session", () => {
@@ -546,7 +546,7 @@ export class AgentLoop implements AgentBackend {
 
   private reasoningParams(): Record<string, unknown> {
     const mode = this.currentMode;
-    if (mode.reasoning === false) return {};
+    if (!mode.reasoning) return {};
     if (mode.supportsReasoningEffort === false) return {};
     if (mode.buildReasoningParams) return mode.buildReasoningParams(this.thinkingLevel);
     if (this.thinkingLevel === "off") return {};

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -312,7 +312,7 @@ export class AgentLoop implements AgentBackend {
         return;
       }
       const mode = this.currentMode;
-      if (level !== "off" && !mode.reasoning) {
+      if (level !== "off" && mode.reasoning === false) {
         this.bus.emit("ui:error", { message: `Model ${mode.model} does not support thinking.` });
         return;
       }
@@ -326,7 +326,7 @@ export class AgentLoop implements AgentBackend {
     });
     this.bus.onPipe("config:get-thinking", () => {
       const mode = this.currentMode;
-      const supported = !!mode.reasoning && mode.supportsReasoningEffort !== false;
+      const supported = mode.reasoning !== false && mode.supportsReasoningEffort !== false;
       return { level: this.thinkingLevel, levels: AgentLoop.THINKING_LEVELS, supported };
     });
     on("agent:reset-session", () => {
@@ -546,7 +546,7 @@ export class AgentLoop implements AgentBackend {
 
   private reasoningParams(): Record<string, unknown> {
     const mode = this.currentMode;
-    if (!mode.reasoning) return {};
+    if (mode.reasoning === false) return {};
     if (mode.supportsReasoningEffort === false) return {};
     if (mode.buildReasoningParams) return mode.buildReasoningParams(this.thinkingLevel);
     if (this.thinkingLevel === "off") return {};

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -232,6 +232,16 @@ export class AgentLoop implements AgentBackend {
           message: `${prev.provider}:${prev.model} is not in the refreshed catalog — keeping it active until you /model to another.`,
         });
       }
+      const active = this.modes[this.currentModeIndex];
+      if (active && active.contextWindow !== prev?.contextWindow) {
+        this.bus.emit("agent:info", {
+          name: "ash",
+          version: PACKAGE_VERSION,
+          model: active.model,
+          provider: active.provider,
+          contextWindow: active.contextWindow,
+        });
+      }
       this.bus.emit("config:changed", {});
     });
     // Fires before wire() too — agent-backend emits this from

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -544,13 +544,13 @@ export class AgentLoop implements AgentBackend {
     this.abortController?.abort();
   }
 
-  /** Check if reasoning_effort should be sent for the current model/provider. */
-  private shouldSendReasoningEffort(): boolean {
-    if (this.thinkingLevel === "off") return false;
+  private reasoningParams(): Record<string, unknown> {
     const mode = this.currentMode;
-    if (mode.reasoning === false) return false;
-    if (mode.supportsReasoningEffort === false) return false;
-    return true;
+    if (mode.reasoning === false) return {};
+    if (mode.supportsReasoningEffort === false) return {};
+    if (mode.buildReasoningParams) return mode.buildReasoningParams(this.thinkingLevel);
+    if (this.thinkingLevel === "off") return {};
+    return { reasoning_effort: this.thinkingLevel };
   }
 
 
@@ -1732,7 +1732,7 @@ export class AgentLoop implements AgentBackend {
       messages,
       tools: apiTools,
       model: this.currentModel,
-      reasoning_effort: this.shouldSendReasoningEffort() ? this.thinkingLevel : undefined,
+      ...this.reasoningParams(),
     };
     this.bus.emit("llm:request", requestParams);
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -205,6 +205,9 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         contextManager,
         instanceId,
         llm: createLlmFacade(handlers),
+        providers: {
+          configure: (id, opts) => bus.emit("provider:configure", { id, ...opts }),
+        },
         quit: opts.quit,
         setPalette,
         createBlockTransform: (o) => streamTransform.createBlockTransform(bus, o),

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -317,7 +317,11 @@ export interface ShellEvents {
     models?: (string | { id: string; reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean })[];
     /** Provider supports the reasoning_effort parameter. Default: true. */
     supportsReasoningEffort?: boolean;
-    buildReasoningParams?: (level: string) => Record<string, unknown>;
+  };
+
+  "provider:configure": {
+    id: string;
+    reasoningParams?: (level: string) => Record<string, unknown>;
   };
 
   // Tool/instruction registration (extension → active agent backend)

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -317,6 +317,7 @@ export interface ShellEvents {
     models?: (string | { id: string; reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean })[];
     /** Provider supports the reasoning_effort parameter. Default: true. */
     supportsReasoningEffort?: boolean;
+    buildReasoningParams?: (level: string) => Record<string, unknown>;
   };
 
   // Tool/instruction registration (extension → active agent backend)

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -156,6 +156,14 @@ export default function agentBackend(ctx: ExtensionContext): void {
     });
   });
 
+  const providerHooks = new Map<string, { reasoningParams?: (level: string) => Record<string, unknown> }>();
+
+  bus.on("provider:configure", ({ id, reasoningParams }) => {
+    const prev = providerHooks.get(id) ?? {};
+    if (reasoningParams !== undefined) prev.reasoningParams = reasoningParams;
+    providerHooks.set(id, prev);
+  });
+
   bus.on("provider:register", (p) => {
     const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
     const modelIds: string[] = [];
@@ -178,7 +186,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
       modelCapabilities: caps.size > 0 ? caps : undefined,
     });
 
-    const buildReasoningParams = p.buildReasoningParams ?? defaultReasoningBuilder;
+    const buildReasoningParams = providerHooks.get(p.id)?.reasoningParams ?? defaultReasoningBuilder;
     const addModes: AgentMode[] = modelIds.map((m) => {
       const mc = caps.get(m);
       return {

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -23,13 +23,8 @@ function persistedModelFor(providerName: string | undefined): string | undefined
   return getSettings().providers?.[providerName]?.defaultModel;
 }
 
-function reasoningBuilderFor(providerId: string): (level: string) => Record<string, unknown> {
-  if (providerId === "openrouter") {
-    return (level) => level === "off"
-      ? { reasoning: { enabled: false } }
-      : { reasoning: { effort: level } };
-  }
-  return (level) => level === "off" ? {} : { reasoning_effort: level };
+function defaultReasoningBuilder(level: string): Record<string, unknown> {
+  return level === "off" ? {} : { reasoning_effort: level };
 }
 
 export default function agentBackend(ctx: ExtensionContext): void {
@@ -183,7 +178,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
       modelCapabilities: caps.size > 0 ? caps : undefined,
     });
 
-    const buildReasoningParams = reasoningBuilderFor(p.id);
+    const buildReasoningParams = p.buildReasoningParams ?? defaultReasoningBuilder;
     const addModes: AgentMode[] = modelIds.map((m) => {
       const mc = caps.get(m);
       return {

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -38,10 +38,14 @@ export default function agentBackend(ctx: ExtensionContext): void {
     if (p) providerRegistry.set(name, p);
   }
 
+  const providerHooks = new Map<string, { reasoningParams?: (level: string) => Record<string, unknown> }>();
+
   const buildModes = (): AgentMode[] => {
     const allModes: AgentMode[] = [];
     for (const [id, p] of providerRegistry) {
       if (!p.apiKey) continue;
+      const shapeId = p.reasoningShape ?? id;
+      const buildReasoningParams = providerHooks.get(shapeId)?.reasoningParams ?? defaultReasoningBuilder;
       for (const model of p.models) {
         const mc = p.modelCapabilities?.get(model);
         allModes.push({
@@ -52,6 +56,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
           reasoning: mc?.reasoning,
           supportsReasoningEffort: p.supportsReasoningEffort,
           echoReasoning: mc?.echoReasoning,
+          buildReasoningParams,
         });
       }
     }
@@ -155,8 +160,6 @@ export default function agentBackend(ctx: ExtensionContext): void {
       },
     });
   });
-
-  const providerHooks = new Map<string, { reasoningParams?: (level: string) => Record<string, unknown> }>();
 
   bus.on("provider:configure", ({ id, reasoningParams }) => {
     const prev = providerHooks.get(id) ?? {};

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -23,6 +23,15 @@ function persistedModelFor(providerName: string | undefined): string | undefined
   return getSettings().providers?.[providerName]?.defaultModel;
 }
 
+function reasoningBuilderFor(providerId: string): (level: string) => Record<string, unknown> {
+  if (providerId === "openrouter") {
+    return (level) => level === "off"
+      ? { reasoning: { enabled: false } }
+      : { reasoning: { effort: level } };
+  }
+  return (level) => level === "off" ? {} : { reasoning_effort: level };
+}
+
 export default function agentBackend(ctx: ExtensionContext): void {
   const { bus } = ctx;
   const config: AgentShellConfig = ctx.call("config:get-shell-config") ?? {};
@@ -174,6 +183,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
       modelCapabilities: caps.size > 0 ? caps : undefined,
     });
 
+    const buildReasoningParams = reasoningBuilderFor(p.id);
     const addModes: AgentMode[] = modelIds.map((m) => {
       const mc = caps.get(m);
       return {
@@ -184,6 +194,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
         reasoning: mc?.reasoning,
         supportsReasoningEffort: p.supportsReasoningEffort,
         echoReasoning: mc?.echoReasoning,
+        buildReasoningParams,
       };
     });
     bus.emit("config:add-modes", { modes: addModes });

--- a/src/extensions/openai.ts
+++ b/src/extensions/openai.ts
@@ -6,12 +6,12 @@
 import type { ExtensionContext } from "../types.js";
 
 const DEFAULT_MODELS = [
-  "gpt-5",
-  "gpt-4.1",
-  "gpt-4o",
-  "gpt-4o-mini",
-  "o3",
-  "o3-mini",
+  { id: "gpt-5", reasoning: true },
+  { id: "gpt-4.1", reasoning: false },
+  { id: "gpt-4o", reasoning: false },
+  { id: "gpt-4o-mini", reasoning: false },
+  { id: "o3", reasoning: true },
+  { id: "o3-mini", reasoning: true },
 ];
 
 export default function activate(ctx: ExtensionContext): void {
@@ -25,7 +25,7 @@ export default function activate(ctx: ExtensionContext): void {
     ctx.bus.emit("provider:register", {
       id,
       apiKey,
-      defaultModel: DEFAULT_MODELS[0],
+      defaultModel: DEFAULT_MODELS[0].id,
       models: DEFAULT_MODELS,
     });
     return;

--- a/src/extensions/openai.ts
+++ b/src/extensions/openai.ts
@@ -1,11 +1,13 @@
 /**
- * Built-in OpenAI-compatible provider — auto-activates when OPENAI_API_KEY
- * is set. OPENAI_BASE_URL redirects to local servers (Ollama, LM Studio,
- * vLLM, llama.cpp) which then get their catalog via /models.
+ * Built-in OpenAI-compatible provider. Two activation paths:
+ *   - OPENAI_API_KEY only       → cloud OpenAI, ships a curated catalog.
+ *   - OPENAI_BASE_URL (any key) → local/3rd-party server (Ollama, LM Studio,
+ *                                  vLLM, llama.cpp); the catalog is fetched
+ *                                  from the server's /models endpoint.
  */
 import type { ExtensionContext } from "../types.js";
 
-const DEFAULT_MODELS = [
+const OPENAI_CLOUD_MODELS = [
   { id: "gpt-5", reasoning: true },
   { id: "gpt-4.1", reasoning: false },
   { id: "gpt-4o", reasoning: false },
@@ -15,29 +17,30 @@ const DEFAULT_MODELS = [
 ];
 
 export default function activate(ctx: ExtensionContext): void {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) return;
-
+  const apiKey = process.env.OPENAI_API_KEY ?? "";
   const baseURL = process.env.OPENAI_BASE_URL;
-  const id = baseURL ? "openai-compatible" : "openai";
 
   if (!baseURL) {
+    if (!apiKey) return;
     ctx.bus.emit("provider:register", {
-      id,
+      id: "openai",
       apiKey,
-      defaultModel: DEFAULT_MODELS[0].id,
-      models: DEFAULT_MODELS,
+      defaultModel: OPENAI_CLOUD_MODELS[0].id,
+      models: OPENAI_CLOUD_MODELS,
     });
     return;
   }
 
-  // Register empty immediately so the provider resolves; refill from /models.
-  ctx.bus.emit("provider:register", { id, apiKey, baseURL, models: [] });
+  const id = "openai-compatible";
+  // Local servers (Ollama, llama.cpp) often need no key; the SDK still
+  // requires a non-empty string for construction.
+  const sdkKey = apiKey || "no-key";
+  ctx.bus.emit("provider:register", { id, apiKey: sdkKey, baseURL, models: [] });
   fetchModels(baseURL, apiKey).then((models) => {
     if (models.length === 0) return;
     ctx.bus.emit("provider:register", {
       id,
-      apiKey,
+      apiKey: sdkKey,
       baseURL,
       defaultModel: models[0],
       models,
@@ -46,9 +49,9 @@ export default function activate(ctx: ExtensionContext): void {
 }
 
 async function fetchModels(baseURL: string, apiKey: string): Promise<string[]> {
-  const res = await fetch(`${baseURL.replace(/\/$/, "")}/models`, {
-    headers: { Authorization: `Bearer ${apiKey}` },
-  });
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  const res = await fetch(`${baseURL.replace(/\/$/, "")}/models`, { headers });
   if (!res.ok) return [];
   const data = await res.json() as { data?: { id: string }[] };
   return (data.data ?? []).map((m) => m.id);

--- a/src/extensions/openrouter.ts
+++ b/src/extensions/openrouter.ts
@@ -16,6 +16,12 @@ const DEFAULT_MODELS = ["deepseek/deepseek-v4-flash"];
 //   providers.openrouter.models[*].echoReasoning = true | false
 const BUILTIN_ECHO_REASONING_PATTERNS: RegExp[] = [/deepseek/i];
 
+function buildReasoningParams(level: string): Record<string, unknown> {
+  return level === "off"
+    ? { reasoning: { enabled: false } }
+    : { reasoning: { effort: level } };
+}
+
 interface OpenRouterModel {
   id: string;
   supported_parameters?: string[];
@@ -32,6 +38,7 @@ export default function activate(ctx: ExtensionContext): void {
     baseURL: BASE_URL,
     defaultModel: DEFAULT_MODELS[0],
     models: DEFAULT_MODELS,
+    buildReasoningParams,
   });
 
   fetchModels(apiKey).then((models) => {
@@ -44,6 +51,7 @@ export default function activate(ctx: ExtensionContext): void {
       baseURL: BASE_URL,
       defaultModel: DEFAULT_MODELS[0],
       supportsReasoningEffort: true,
+      buildReasoningParams,
       models: models.map((m) => ({
         id: m.id,
         reasoning: m.supported_parameters?.includes("reasoning") ?? false,

--- a/src/extensions/openrouter.ts
+++ b/src/extensions/openrouter.ts
@@ -32,13 +32,14 @@ export default function activate(ctx: ExtensionContext): void {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) return;
 
+  ctx.providers.configure("openrouter", { reasoningParams: buildReasoningParams });
+
   ctx.bus.emit("provider:register", {
     id: "openrouter",
     apiKey,
     baseURL: BASE_URL,
     defaultModel: DEFAULT_MODELS[0],
     models: DEFAULT_MODELS,
-    buildReasoningParams,
   });
 
   fetchModels(apiKey).then((models) => {
@@ -51,7 +52,6 @@ export default function activate(ctx: ExtensionContext): void {
       baseURL: BASE_URL,
       defaultModel: DEFAULT_MODELS[0],
       supportsReasoningEffort: true,
-      buildReasoningParams,
       models: models.map((m) => ({
         id: m.id,
         reasoning: m.supported_parameters?.includes("reasoning") ?? false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,9 @@ export interface ProviderConfig {
   /** Case-insensitive regex sources matched against model id; matches default
    *  to echoReasoning=true. Per-model echoReasoning still wins. */
   echoReasoningPatterns?: string[];
+  /** Borrow another registered provider's reasoning request shape by id
+   *  (e.g. "openrouter"). Defaults to OpenAI-compat. */
+  reasoningShape?: string;
 }
 
 export interface Settings {
@@ -268,6 +271,8 @@ export interface ResolvedProvider {
   supportsReasoningEffort?: boolean;
   /** Per-model capabilities, keyed by model id. */
   modelCapabilities?: Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>;
+  /** Borrow another registered provider's reasoning request shape by id. */
+  reasoningShape?: string;
 }
 
 /**
@@ -303,6 +308,7 @@ export function resolveProvider(name: string): ResolvedProvider | null {
     models: modelIds.length ? modelIds : (defaultModel ? [defaultModel] : []),
     contextWindow: provider.contextWindow,
     modelCapabilities: caps.size > 0 ? caps : undefined,
+    reasoningShape: provider.reasoningShape,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,11 @@ export interface ExtensionContext {
   /** Remove a registered skill by name. */
   removeSkill: (name: string) => void;
 
+  // ── Provider configuration ────────────────────────────────
+  providers: {
+    configure: (id: string, opts: { reasoningParams?: (level: string) => Record<string, unknown> }) => void;
+  };
+
   // ── LLM access (backend-agnostic) ─────────────────────────
   llm: LlmInterface;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface AgentMode {
   /** Echo reasoning_content back on assistant turns. Required by DeepSeek;
    *  default off (leaky shims may forward it to the model as OOD input). */
   echoReasoning?: boolean;
+  buildReasoningParams?: (level: string) => Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Provider-specific reasoning request shape.** New \`AgentMode.buildReasoningParams(level)\` hook is spread into the LLM request. Each provider decides how to encode \`/thinking\` levels — including whether \`off\` means \"omit the field\" or \"send an explicit disable flag.\" Default builder preserves prior OpenAI-compat behavior.
- **OpenRouter encodes off correctly.** Sends \`reasoning: { enabled: false }\` for \`/thinking off\` and \`reasoning: { effort: level }\` otherwise. Fixes hybrid models (DeepSeek v4) that kept thinking when the agent only *omitted* \`reasoning_effort\`.
- **\`ctx.providers.configure(id, opts)\`.** New extension-context namespace decouples per-provider behavior hooks from the data-shaped \`provider:register\` event. Forward-extensible — new hook types become new keys in the same options bag. Order-independent: configure-before-register and register-before-configure both work.
- **Reasoning capability is opt-in.** \`mode.reasoning\` is now treated as falsy when undefined; only models explicitly tagged \`reasoning: true\` get reasoning fields in their requests. OpenAI's static catalog now flags only \`gpt-5\`/\`o3\`/\`o3-mini\`; non-reasoning models (\`gpt-4o\`, \`gpt-4.1\`) no longer 400 on \`/thinking high\`.
- **OpenAI-compatible: activate from \`OPENAI_BASE_URL\` alone.** Local servers (Ollama, llama.cpp) typically need no API key — relaxed the activation gate. Renamed \`DEFAULT_MODELS\` → \`OPENAI_CLOUD_MODELS\` and scoped it inside the cloud branch to make the cloud-only assumption explicit.

## Test plan
- [ ] \`/thinking off\` on \`deepseek/deepseek-v4-flash\` (OpenRouter) — verify no reasoning streamed.
- [ ] \`/thinking high\` on the same — verify reasoning still flows.
- [ ] \`/thinking high\` on \`gpt-4o\` — verify request omits reasoning fields (no 400).
- [ ] \`/thinking high\` on \`gpt-5\` / \`o3\` — verify \`reasoning_effort: high\` is sent.
- [ ] OpenAI-compatible with \`OPENAI_BASE_URL=http://localhost:11434/v1\` and no \`OPENAI_API_KEY\` — provider activates and \`/models\` populates the catalog.