### PR TITLE
/model: match active by (model, provider) tuple

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -282,7 +282,12 @@ export class AgentLoop implements AgentBackend {
       this.abortController?.abort(e.silent ? "silent" : undefined);
     });
     on("config:switch-model", ({ model: target }) => {
-      const idx = this.modes.findIndex((m) => m.model === target);
+      const atIdx = target.lastIndexOf("@");
+      const modelId = atIdx > 0 ? target.slice(0, atIdx) : target;
+      const providerHint = atIdx > 0 ? target.slice(atIdx + 1) : undefined;
+      const idx = this.modes.findIndex((m) =>
+        m.model === modelId && (!providerHint || m.provider === providerHint),
+      );
       if (idx === -1) {
         this.bus.emit("ui:error", { message: `Unknown model: ${target}` });
         return;

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -314,7 +314,8 @@ export class AgentLoop implements AgentBackend {
     });
     this.bus.onPipe("config:get-models", (payload) => {
       const models = this.modes.map((m) => ({ model: m.model, provider: m.provider ?? "" }));
-      const active = this.modes[this.currentModeIndex]?.model ?? null;
+      const cur = this.modes[this.currentModeIndex];
+      const active = cur ? { model: cur.model, provider: cur.provider ?? "" } : null;
       return { models, active };
     });
     on("config:set-thinking", ({ level }) => {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -284,7 +284,7 @@ export interface ShellEvents {
   // Switch to a specific model by name (slash command → backend)
   "config:switch-model": { model: string };
   // Query available models (sync pipe — for autocomplete)
-  "config:get-models": { models: { model: string; provider: string }[]; active: string | null };
+  "config:get-models": { models: { model: string; provider: string }[]; active: { model: string; provider: string } | null };
   // Set thinking/reasoning effort level (slash command → backend)
   "config:set-thinking": { level: string };
   // Query current thinking level (sync pipe — for autocomplete)

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -51,11 +51,10 @@ export default function activate(ctx: ExtensionContext): void {
     handler: (args) => {
       const name = args.trim();
       if (!name) {
-        const { models, active } = bus.emitPipe("config:get-models", { models: [], active: null });
-        const current = models.find((m) => m.model === active);
-        const label = current
-          ? `${current.model}${current.provider ? ` [${current.provider}]` : ""}`
-          : active ?? "none";
+        const { active } = bus.emitPipe("config:get-models", { models: [], active: null });
+        const label = active
+          ? `${active.model}${active.provider ? ` [${active.provider}]` : ""}`
+          : "none";
         bus.emit("ui:info", { message: `Model: ${label}` });
       } else {
         bus.emit("config:switch-model", { model: name });
@@ -212,7 +211,7 @@ export default function activate(ctx: ExtensionContext): void {
       .slice(0, 15)
       .map((m) => ({
         name: `/model ${m.model}`,
-        description: `${m.provider ? `[${m.provider}]` : ""}${m.model === active ? " (active)" : ""}`,
+        description: `${m.provider ? `[${m.provider}]` : ""}${active && m.model === active.model && m.provider === active.provider ? " (active)" : ""}`,
       }));
     if (items.length === 0) return payload;
     return { ...payload, items: [...payload.items, ...items] };

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -206,13 +206,19 @@ export default function activate(ctx: ExtensionContext): void {
     if (payload.command !== "/model") return payload;
     const partial = (payload.commandArgs ?? "").toLowerCase();
     const { models, active } = bus.emitPipe("config:get-models", { models: [], active: null });
+    const counts = new Map<string, number>();
+    for (const m of models) counts.set(m.model, (counts.get(m.model) ?? 0) + 1);
     const items = models
       .filter((m) => m.model.toLowerCase().includes(partial))
       .slice(0, 15)
-      .map((m) => ({
-        name: `/model ${m.model}`,
-        description: `${m.provider ? `[${m.provider}]` : ""}${active && m.model === active.model && m.provider === active.provider ? " (active)" : ""}`,
-      }));
+      .map((m) => {
+        const ambiguous = (counts.get(m.model) ?? 0) > 1 && m.provider;
+        const qualified = ambiguous ? `${m.model}@${m.provider}` : m.model;
+        return {
+          name: `/model ${qualified}`,
+          description: `${m.provider ? `[${m.provider}]` : ""}${active && m.model === active.model && m.provider === active.provider ? " (active)" : ""}`,
+        };
+      });
     if (items.length === 0) return payload;
     return { ...payload, items: [...payload.items, ...items] };
   });


### PR DESCRIPTION
## Summary
When two providers expose the same model id (e.g. \`glm-5.1\` on \`zai\` and \`ollama-cloud\`), \`/model\` autocomplete marked both \`(active)\` because it compared on the model id alone. Active is now a \`{ model, provider }\` pair end-to-end.

## Test plan
- [ ] With two providers exposing the same model id, \`/model <name>\` shows \`(active)\` only on the row matching the current provider.
- [ ] \`/model\` with no args still prints the bare label.