### PR TITLE
tui: show tool detail in compact mode + label load_tool

### DIFF
--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -375,7 +375,7 @@ function getModelsPayload(): Record<string, unknown> | undefined {
   const info = core.bus.emitPipe("config:get-models", { models: [], active: null });
   if (!info.models.length) return undefined;
   return {
-    currentModelId: info.active ?? info.models[0]?.model,
+    currentModelId: info.active?.model ?? info.models[0]?.model,
     availableModels: info.models.map((m) => ({
       modelId: m.model,
       name: m.provider ? `${m.provider}/${m.model}` : m.model,

--- a/src/agent/tool-protocol.ts
+++ b/src/agent/tool-protocol.ts
@@ -628,6 +628,7 @@ export class DeferredLookupProtocol implements ToolProtocol {
     return [
       {
         name: "load_tool",
+        displayName: "Load tools",
         description:
           "Load extension tool schemas so you can call them natively on the next turn.",
         input_schema: {
@@ -642,6 +643,11 @@ export class DeferredLookupProtocol implements ToolProtocol {
           required: ["names"],
         },
         showOutput: false,
+        getDisplayInfo: () => ({ kind: "read" }),
+        formatCall: (args) => {
+          const names = Array.isArray(args.names) ? (args.names as string[]) : [];
+          return names.join(", ");
+        },
         async execute(args) {
           const names = Array.isArray(args.names) ? (args.names as string[]) : [];
           if (names.length === 0) {

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -112,9 +112,9 @@ export function renderToolCall(
 
   // Build a compact detail string to append after the title
   let detail = "";
-  if (mode === "full" && tool.displayDetail) {
+  if (tool.displayDetail) {
     detail = tool.displayDetail;
-  } else if (mode === "full") {
+  } else {
     if (tool.command) {
       detail = `$ ${tool.command}`;
     } else if (tool.locations && tool.locations.length > 0) {


### PR DESCRIPTION
## Summary
- `renderToolCall` was gating detail extraction on `mode === "full"`, so on 80-col terminals (compact mode kicks in at cols < 83) the query/path/command was silently dropped — you'd see `▶ Web Search ✓` instead of `▶ Web Search: "..."`. Detail now renders in compact mode too; existing `maxDetailW` truncation handles narrow widths.
- `load_tool` now has `displayName: "Load tools"`, `kind: "read"` (◆ icon), and a `formatCall` that lists the tools being loaded.
- ACP bridge: `config:get-models` `active` became `{ model, provider } | null` in #101 but the bridge still treated it as a string, so `currentModelId` came through as an object. Use `info.active?.model`.

## Test plan
- [ ] In a standard 80-col terminal, run a tool call (e.g., `read_file`, `grep`) — verify the detail (path / pattern / command) shows after the icon.
- [ ] Trigger `load_tool` (deferred-lookup mode) — verify it renders `◆ Load tools: <names>` instead of `▶ load_tool`.
- [ ] Launch the ACP bridge from a client (agent-shell in emacs) — verify model list loads with the correct active model.