### PR TITLE
windows: skip bash tool when no bash on PATH; resolve path dynamically

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -38,6 +38,7 @@ import { createToolProtocol, type ToolProtocol, type PendingToolCall as Protocol
 // Core tool factories
 import { createBashTool } from "./tools/bash.js";
 import { createPwshTool } from "./tools/pwsh.js";
+import { findBash } from "../executor.js";
 import { createReadFileTool, type FileReadCache } from "./tools/read-file.js";
 import { createWriteFileTool } from "./tools/write-file.js";
 import { createEditFileTool } from "./tools/edit-file.js";
@@ -709,9 +710,9 @@ export class AgentLoop implements AgentBackend {
       return env;
     };
 
-    this.toolRegistry.register(
-      createBashTool({ getCwd, getEnv, bus: this.bus }),
-    );
+    if (findBash() !== null) {
+      this.toolRegistry.register(createBashTool({ getCwd, getEnv, bus: this.bus }));
+    }
     if (process.platform === "win32") {
       this.toolRegistry.register(createPwshTool({ getCwd, getEnv, bus: this.bus }));
     }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,5 +1,21 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { stripAnsi } from "./utils/ansi.js";
+
+let cachedBashPath: string | null | undefined;
+
+/** Resolve a usable bash binary, or null if none is on PATH.
+ *  Unix: `/bin/bash` (canonical, present on every Linux/macOS install).
+ *  Windows: probe via `where bash` so Git Bash users keep working. */
+export function findBash(): string | null {
+  if (cachedBashPath !== undefined) return cachedBashPath;
+  if (process.platform !== "win32") {
+    cachedBashPath = "/bin/bash";
+    return cachedBashPath;
+  }
+  const r = spawnSync("where", ["bash"], { encoding: "utf-8" });
+  cachedBashPath = r.status === 0 ? r.stdout.split(/\r?\n/)[0]!.trim() || null : null;
+  return cachedBashPath;
+}
 
 const DEFAULT_TIMEOUT = 60_000;
 const DEFAULT_MAX_OUTPUT = 256 * 1024; // 256KB
@@ -56,9 +72,11 @@ export function executeCommand(opts: {
     if (v !== undefined) env[k] = v;
   }
 
+  const bashPath = findBash();
   let child: ChildProcess;
   try {
-    child = spawn("/bin/bash", ["-c", opts.command], {
+    if (!bashPath) throw new Error("bash not found on PATH");
+    child = spawn(bashPath, ["-c", opts.command], {
       stdio: ["ignore", "pipe", "pipe"],
       cwd: opts.cwd,
       env,


### PR DESCRIPTION
## Summary
- The bash tool's executor (`src/executor.ts:61`) hardcoded `spawn(\"/bin/bash\", ...)`. On native Windows this path doesn't exist, so every `bash` tool call returned `exit -1` (spawn failed). The pwsh tool was registered alongside but the LLM kept defaulting to `bash` and burning turns trying cmd-flavored bash one-liners (`cmd /c \"...\"`, `where node 2>nul`, etc).
- New `findBash()` helper: on Windows, probes `where bash` once and caches the result (Git Bash users keep working). On Unix it returns the canonical `/bin/bash` — **no change in Unix behavior**.
- Bash tool registration is gated on `findBash() !== null`. On a clean Windows install (no bash anywhere) the LLM only sees `pwsh` and stops mixing shell dialects.

## Regression risk
- **Unix**: zero — `findBash()` returns `/bin/bash` literal without probing.
- **Windows + Git Bash**: bash tool now works (used to silently fail with exit -1). Net positive.
- **Windows native**: bash tool no longer registered. Behavioral change but the prior behavior was non-functional, so this is a fix.

## Test plan
- [ ] On macOS/Linux, run a bash tool call — confirm `/bin/bash` is still used (no regression).
- [ ] On native Windows (no bash), verify only `pwsh` appears in the tool list and the LLM uses it cleanly.
- [ ] On Windows with Git Bash installed, verify `bash` is registered and uses the Git Bash binary.