### PR TITLE
skills: walk to $HOME instead of stopping at git root

### DIFF
--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -101,21 +101,6 @@ function scanDir(dir: string): Skill[] {
   return skills;
 }
 
-/** Find the git root from a directory. */
-function findGitRoot(dir: string): string | null {
-  let current = path.resolve(dir);
-  while (true) {
-    try {
-      fs.accessSync(path.join(current, ".git"));
-      return current;
-    } catch {
-      const parent = path.dirname(current);
-      if (parent === current) return null;
-      current = parent;
-    }
-  }
-}
-
 /** Expand ~ to home directory. */
 function expandHome(p: string): string {
   if (p.startsWith("~/") || p === "~") {
@@ -161,18 +146,19 @@ export function invalidateGlobalSkillsCache(): void {
 
 /**
  * Discover project-level skills from .agents/skills/ in cwd hierarchy.
- * Scans from cwd up to git root.
+ * Walks from cwd up to $HOME (or filesystem root if cwd is outside HOME).
+ * Git boundaries are ignored — nested repos under a skills-bearing parent
+ * would otherwise hide the parent's skills.
  */
 export function discoverProjectSkills(cwd: string): Skill[] {
   const seen = new Set<string>();
   const skills: Skill[] = [];
-  const gitRoot = findGitRoot(cwd);
+  const home = path.resolve(os.homedir());
   let current = path.resolve(cwd);
 
   while (true) {
     addUnique(skills, scanDir(path.join(current, ".agents", "skills")), seen);
-
-    if (gitRoot && current === gitRoot) break;
+    if (current === home) break;
     const parent = path.dirname(current);
     if (parent === current) break;
     current = parent;


### PR DESCRIPTION
## Summary
`discoverProjectSkills` used `findGitRoot` as the upward-walk ceiling. That broke this layout:

```
/work/
├── .agents/skills/   ← skills here
└── proj/
    ├── .git/         ← nested git repo
    └── src/          ← cwd
```

`findGitRoot(cwd)` returned `/work/proj`, the loop stopped there, and `/work/.agents/skills/` was never scanned. Common with submodules, monorepos that `git init` per package, or shared skills kept above project repos.

Replace the git boundary with `$HOME` as the walk ceiling (or filesystem root if cwd is outside `$HOME`). The walk is cheap — one missing-dir check per level — and skills above `~` aren't a real use case.

`findGitRoot` is removed (no other callers).

## Test plan
- [ ] In a repo nested under a parent that holds `.agents/skills/`, run `list_skills` from inside the inner repo — confirm parent skills appear.
- [ ] Verify normal single-repo layouts still pick up project skills as before.
- [ ] Verify cwd outside `$HOME` (e.g. `/tmp/xxx/.agents/skills`) still works.