### PR TITLE
agent-backend: fall through when chosen provider has no apiKey

### DIFF
--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -106,10 +106,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
       ?? (providerRegistry.size > 0 ? providerRegistry.keys().next().value : undefined);
     let activeProvider = providerName ? providerRegistry.get(providerName) ?? null : null;
 
-    // If the chosen provider has no usable apiKey (e.g. settings names
-    // ollama-cloud but OLLAMA_API_KEY isn't set in this process's env),
-    // fall through to the first registered provider that does. Without
-    // this, a stale defaultProvider strands every other working provider.
+    // Fall through to a provider with an apiKey if the chosen one lacks one.
     if (!config.apiKey && !activeProvider?.apiKey) {
       for (const [id, p] of providerRegistry) {
         if (p.apiKey) { providerName = id; activeProvider = p; break; }

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -102,9 +102,19 @@ export default function agentBackend(ctx: ExtensionContext): void {
     const settings = getSettings();
     // If the user didn't pick a default, fall back to the first registered
     // provider (built-in load order biases to openrouter → openai).
-    const providerName = config.provider ?? settings.defaultProvider
+    let providerName = config.provider ?? settings.defaultProvider
       ?? (providerRegistry.size > 0 ? providerRegistry.keys().next().value : undefined);
-    const activeProvider = providerName ? providerRegistry.get(providerName) ?? null : null;
+    let activeProvider = providerName ? providerRegistry.get(providerName) ?? null : null;
+
+    // If the chosen provider has no usable apiKey (e.g. settings names
+    // ollama-cloud but OLLAMA_API_KEY isn't set in this process's env),
+    // fall through to the first registered provider that does. Without
+    // this, a stale defaultProvider strands every other working provider.
+    if (!config.apiKey && !activeProvider?.apiKey) {
+      for (const [id, p] of providerRegistry) {
+        if (p.apiKey) { providerName = id; activeProvider = p; break; }
+      }
+    }
 
     // User's persisted defaultModel wins over the provider's declared
     // default. Dynamic providers (openrouter) re-register with their


### PR DESCRIPTION
## Summary
A stale or env-dependent `defaultProvider` (e.g. `ollama-cloud`, where the extension only resolves an apiKey when `OLLAMA_API_KEY` is in env) used to early-return the entire resolve path at \`agent-backend.ts:120\`. Other registered providers with working keys (zai with literal apiKey, openrouter with env key) were silently stranded — \`config:set-modes\` never fired and the model picker came up empty.

This is the bug behind \"agent-shell can't pick up models\" when emacs's process env doesn't have the env var that the configured \`defaultProvider\` depends on. Diagnosed earlier in this thread but not actually fixed at the framework level until now.

Now: if \`config.apiKey\` is unset and the chosen \`activeProvider\` has no \`apiKey\`, scan \`providerRegistry\` for the first provider that does and use that. Mirrors the existing fallback when \`defaultProvider\` is unset entirely.

## Test plan
- [ ] With \`defaultProvider: \"ollama-cloud\"\` in settings and only \`OPENROUTER_API_KEY\` in env, run the bridge — verify session/new returns the openrouter+zai catalog.
- [ ] With \`defaultProvider: \"ollama-cloud\"\` AND \`OLLAMA_API_KEY\` set, verify ollama-cloud is still chosen as active (no regression to the working path).
- [ ] With no \`defaultProvider\`, verify behavior unchanged.