### PR TITLE
rework dynamic context: trailing-message wrap, two-handler design

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -29,7 +29,7 @@ The key insight: **the agent is a loop, not a single call**. The LLM calls tools
 
 Every query draws on two distinct streams of context:
 
-- **Shell context** — the user's terminal activity (commands + outputs). This is what lets ash understand "fix this" after you ran a failing command. New shell activity since the last turn is injected as a `<shell-events>` delta prepended to your query.
+- **Shell context** — the user's terminal activity (commands + outputs). This is what lets ash understand "fix this" after you ran a failing command. New shell activity since the last turn is wrapped as `<shell_events>` inside the per-query `<query_context>` envelope and prepended to your user message.
 - **Conversation state** — the OpenAI chat messages array (`user`/`assistant`/`tool` messages). This is the LLM's memory of what it already said and did within this session.
 
 The two streams don't overlap: agent tool outputs live only in the conversation, and shell context tracks only user-initiated activity. When either stream grows large, ash has escape hatches rather than silent truncation:
@@ -52,7 +52,12 @@ The system prompt is assembled once per `cwd` and cached (invalidated when the w
 7. **Available tools** — name + description of every registered tool
 8. **Extension-appended content** — extensions can advise `system-prompt:build` to append additional context (instance IDs, memory files, etc.)
 
-**Shell context**, **environment metadata** (date, cwd, token usage), and any other per-iteration signals live in the *dynamic context* — a user-role message injected fresh before every LLM call via the `dynamic-context:build` handler. Each section is wrapped in a named XML tag (`<shell>`, `<environment>`, etc.) so extensions can add their own tagged sections without colliding.
+Per-turn signals live in two symmetric handlers, both empty by default:
+
+- **`query-context:build`** — fires once at user-query start. Output is wrapped in `<query_context>` and frozen into the user message, so it persists in conversation history. Shell events are the canonical example (`<shell_events>` sub-tag); other "what happened between turns" signals (notifications, calendar/inbox deltas) go here too.
+- **`dynamic-context:build`** — fires on every LLM call (each tool-loop iteration). Output is wrapped in `<dynamic_context>` and ephemerally prepended to the trailing message at request time, so the cacheable prefix stays byte-stable. Use for "current state" signals: in-flight subagents, threshold warnings, active mode markers.
+
+Extensions populate either via `ctx.registerContextProducer(name, fn, { mode: "per-query" | "per-request" })`. When no producer contributes, no envelope tag is emitted at all — vanilla sessions send exactly `[system, ...history]`.
 
 ## Project Conventions
 

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -39,17 +39,19 @@ Owned by `ConversationState`. This is the OpenAI-shaped messages array (`user` /
 - Assistant messages (the LLM's replies)
 - Tool calls and tool results
 
-The two streams merge at one point: when the user submits a new query, new shell events are prepended to that user message as a `<shell-events>` delta. They then live inside the conversation array as regular bytes, but they are never stored separately in both places.
+The two streams merge at one point: when the user submits a new query, new shell events are wrapped inside `<shell_events>` (itself nested in the per-query `<query_context>` envelope) and prepended to that user message. They then live inside the conversation array as regular bytes, but they are never stored separately in both places.
 
 ## How shell activity reaches the LLM
 
-Each exchange (a shell command + output, or an agent-query marker) gets a sequential `id` as it's captured. The agent keeps a `lastShellSeq` cursor — the highest id it has already sent to the model. On each new user query:
+Each exchange (a shell command + output, or an agent-query marker) gets a sequential `id` as it's captured. The agent keeps a `lastShellSeq` cursor — the highest id it has already sent to the model.
+
+Shell events are emitted as a per-query producer (advising `query-context:build` in `agent-loop.ts`):
 
 1. `getEventsSince(lastShellSeq)` returns every exchange with a higher id.
-2. The delta is formatted as `<shell-events>...</shell-events>` and prepended to the user's query inside a single user message.
+2. The body is wrapped as `<shell_events>...</shell_events>`, joined alongside any other per-query producer output, and the whole bundle is wrapped in `<query_context>...</query_context>` and prepended to the user's query inside a single user message.
 3. `lastShellSeq` advances to the new high-water mark.
 
-The delta is sent **once per user query**, not per tool-use step inside the agent loop. Inside the loop (where the LLM calls tools, sees results, calls more tools), no new shell events are injected — injecting mid-loop would break the `tool_call → tool_result` chain some providers require.
+The delta is sent **once per user query**, not per tool-use step inside the agent loop. Inside the loop (where the LLM calls tools, sees results, calls more tools), no new shell events are injected — injecting mid-loop would break the `tool_call → tool_result` chain some providers require, and per-tool-call shell visibility isn't the right semantic anyway.
 
 Prior-turn shell events remain visible in later turns because they're embedded in earlier user messages in the conversation history. They are not *re-sent* as fresh bytes — the provider's prefix cache amortizes them to O(1) per turn.
 
@@ -122,7 +124,7 @@ People often conflate shell output truncation and conversation compaction. They'
 
 | | Shell output truncation | Conversation compaction |
 |---|---|---|
-| **Stream** | Shell context (`<shell-events>` deltas) | Conversation messages array |
+| **Stream** | Shell context (`<shell_events>` deltas) | Conversation messages array |
 | **When** | Once, at the moment each exchange is captured | On threshold crossing, `/compact`, or overflow retry |
 | **State change** | Permanent: `ex.output` becomes head+tail+path | Permanent: evicted turns collapse to one-liners |
 | **Full-text location** | Tempfile on disk | In-memory archive + `~/.agent-sh/history` |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -68,6 +68,7 @@ TypeScript and JavaScript are both supported (`.ts`, `.tsx`, `.mts`, `.js`, `.mj
 | `removeInstruction` | `(name) => void` | Remove a named instruction block |
 | `registerSkill` | `(name, description, filePath) => void` | Register a skill — on-demand reference material the agent can invoke |
 | `removeSkill` | `(name) => void` | Remove a registered skill |
+| `registerContextProducer` | `(name, () => string \| null, opts?: { mode? }) => () => void` | Contribute a per-turn signal. `mode: "per-request"` (default) — fires every LLM call, ephemerally wrapped on the trailing message in `<dynamic_context>`. `mode: "per-query"` — fires once per user query, frozen into the user message in `<query_context>`. Return `null` to skip. Returns a dispose fn. |
 | `define` | `(name, fn) => void` | Register a named handler |
 | `advise` | `(name, wrapper) => () => void` | Wrap a named handler (receives `next` + args). Returns an `unadvise()` function. |
 | `call` | `(name, ...args) => any` | Call a named handler |
@@ -396,7 +397,8 @@ These are registered by the `agent-backend` built-in extension (AgentLoop) and l
 | Handler | Signature | Description |
 |---|---|---|
 | `system-prompt:build` | `() → string` | Assemble the cached system prompt. Advise to append identity blocks, memory files, learned lessons, etc. Rebuilt on cwd change, not every query. |
-| `dynamic-context:build` | `() → string` | Build the per-iteration user-role injection. Rebuilt before every LLM call. Default: `<shell>` + `<environment>` XML-tagged sections. Advisors add more tagged sections. |
+| `dynamic-context:build` | `() → string` | Per-request signal block. Fires on every LLM call (including each tool-loop iteration). Output is wrapped in `<dynamic_context>` and ephemerally prepended to the trailing message at request time. Default: `""`. Advisors append; extensions usually go through `ctx.registerContextProducer(name, fn)` instead of advising directly. |
+| `query-context:build` | `() → string` | Per-query signal block. Fires once at user-query start in `handleQuery`. Output is wrapped in `<query_context>` and frozen into the user message. Built-in: an advisor that emits `<shell_events>` from the shell-event cursor. Default: `""`. Reach via `ctx.registerContextProducer(name, fn, { mode: "per-query" })`. |
 | `conversation:prepare` | `(messages[]) → messages[]` | Transform the full message array before it's sent to the LLM. Default: pass through. |
 | `conversation:compact` | `({target, keepRecent, force}) → { before, after, evictedCount } \| null` | Compaction strategy (returns null when nothing is compacted). Default: pins the first turn + the last `keepRecent` turns and evicts the middle by priority × recency. Advise for richer strategies (topic pinning, LLM summarization). |
 | `conversation:get-messages` | `() → messages[]` | Read the current in-memory messages array. Used by compaction advisors to compute a replacement. |
@@ -659,7 +661,6 @@ A remote session bundles all the wiring needed to route agent output away from s
 const session = ctx.createRemoteSession({
   surface: mySurface,          // where output goes (RenderSurface)
   suppressQueryBox: true,      // hide query box (session has own input)
-  interactive: true,           // set interactive-session context
 });
 
 session.submit("what's on screen?");  // submit a query
@@ -674,7 +675,8 @@ session.close();                       // restore everything
 | `suppressBorders` | `boolean` | `true` | Suppress response top/bottom borders |
 | `suppressQueryBox` | `boolean` | `false` | Suppress the user query box (use when the session has its own input) |
 | `suppressUsage` | `boolean` | `true` | Suppress token usage stats line |
-| `interactive` | `boolean` | `false` | Add `interactive-session: true` to dynamic context. Signals to the agent that it is operating inside an interactive surface (e.g. an overlay or side pane) rather than the main shell. Extensions that provide PTY-inspection tools (like the `terminal-buffer` example) watch this flag. |
+
+If your extension wants to signal "this session is interactive — read the screen, prefer terminal_keys" to the LLM, register a context producer while the session is open. See `examples/extensions/overlay-agent.ts` for the pattern.
 
 ### What createRemoteSession handles
 
@@ -683,7 +685,6 @@ Internally, a remote session:
 1. **Redirects render streams** — `"agent"`, `"query"`, `"status"` all route to the provided surface
 2. **Keeps the shell interactive** — advises `shell:on-processing-start` and `shell:on-processing-done` to skip pause/unpause
 3. **Suppresses chrome** — advises `tui:response-border`, `tui:render-user-query`, `tui:render-usage` based on options
-4. **Sets dynamic context** — advises `dynamic-context:build` to inject `interactive-session: true` when `interactive` is set
 
 Calling `session.close()` removes all advisors and restores all compositor routing in one call.
 
@@ -698,7 +699,6 @@ const session = ctx.createRemoteSession({ surface });
 const session = ctx.createRemoteSession({
   surface,
   suppressQueryBox: true,
-  interactive: true,
 });
 conn.on("data", (d) => session.submit(d.toString().trim()));
 ```
@@ -709,7 +709,6 @@ conn.on("data", (d) => session.submit(d.toString().trim()));
 const session = ctx.createRemoteSession({
   surface: panelSurface,
   suppressQueryBox: true,
-  interactive: true,
 });
 session.submit(query);
 // ... later, on dismiss ...

--- a/docs/tui-composition.md
+++ b/docs/tui-composition.md
@@ -245,7 +245,6 @@ For most extensions that route output to a different surface, use `createRemoteS
 const session = ctx.createRemoteSession({
   surface: panelSurface,
   suppressQueryBox: true,   // session has own input
-  interactive: true,         // enable terminal_read/terminal_keys context
 });
 
 session.submit("what's on screen?");

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -237,7 +237,7 @@ Set `startupBanner: false` in settings to disable.
 The agent automatically receives structured context about your shell session with each query:
 
 - **Current working directory** — tracked via OSC 7 escape sequences
-- **Recent commands and output** — new shell activity since the last turn is injected as a `<shell-events>` delta prepended to your query
+- **Recent commands and output** — new shell activity since the last turn is wrapped as `<shell_events>` inside `<query_context>` and prepended to your query
 - **Long outputs are spilled to tempfiles** — outputs over `shellTruncateThreshold` lines are written to `<tmpdir>/agent-sh-<pid>/<id>.out` at capture; the agent sees head+tail plus the path and recovers the full text via the built-in `read_file` tool
 
 This means you can run a failing command, then type `> fix this` and the agent knows exactly what happened — including a pointer to the full output if it got truncated. See [Context Management](context-management.md) for the full design.

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -59,6 +59,13 @@ export default function activate(ctx: ExtensionContext): void {
   const panelSurface = createPanelSurface(panel);
   let session: RemoteSession | null = null;
 
+  // Tell the LLM it's running inside an overlay session. The matching
+  // system-prompt block (registered via registerInstruction below) describes
+  // how to behave in this mode.
+  ctx.registerContextProducer("interactive-session", () =>
+    session?.active ? "interactive-session: true" : null,
+  );
+
   registerInstruction("Interactive Overlay Sessions", [
     "When the dynamic context includes `interactive-session: true`, the user has summoned you",
     "via a hotkey overlay from inside their live terminal. They may be in the middle of using",
@@ -77,7 +84,6 @@ export default function activate(ctx: ExtensionContext): void {
       session = createRemoteSession({
         surface: panelSurface,
         suppressQueryBox: true,
-        interactive: true,
       });
     }
     panel.setActive();
@@ -90,7 +96,6 @@ export default function activate(ctx: ExtensionContext): void {
       session = createRemoteSession({
         surface: panelSurface,
         suppressQueryBox: true,
-        interactive: true,
       });
     }
   });

--- a/examples/extensions/tmux-pane.ts
+++ b/examples/extensions/tmux-pane.ts
@@ -149,6 +149,11 @@ export default function activate(ctx: ExtensionContext): void {
 
   let state: PaneState | null = null;
 
+  // Tell the LLM it's running inside an interactive pane session.
+  ctx.registerContextProducer("interactive-session", () =>
+    state?.mode === "rsplit" ? "interactive-session: true" : null,
+  );
+
   registerInstruction("Tmux Interactive Session", [
     "When the dynamic context includes `interactive-session: true`, the user is chatting",
     "with you in a side pane next to their terminal. They may have a program running in",
@@ -229,7 +234,6 @@ export default function activate(ctx: ExtensionContext): void {
       const session = createRemoteSession({
         surface,
         suppressQueryBox: true,
-        interactive: true,
       });
 
       state = { mode: "rsplit", paneId, ttyFd, session, server, client, sockPath, scriptPath };

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -27,11 +27,12 @@ import { ToolRegistry } from "./tool-registry.js";
 import { ConversationState, type CompactResult } from "./conversation-state.js";
 import { HistoryFile, type HistoryAdapter } from "./history-file.js";
 import { nucleate, formatNuclearLine, isReadOnly, type NuclearEntry } from "./nuclear-form.js";
-import { STATIC_SYSTEM_PROMPT, buildDynamicContext, buildStaticByCwd, formatSkillsBlock, loadGlobalAgentsMd } from "./system-prompt.js";
+import { STATIC_SYSTEM_PROMPT, buildStaticByCwd, formatSkillsBlock, loadGlobalAgentsMd } from "./system-prompt.js";
 import type { Compositor } from "../utils/compositor.js";
 import { createToolUI } from "../utils/tool-interactive.js";
 import { RESPONSE_RESERVE, DEFAULT_CONTEXT_WINDOW } from "./token-budget.js";
 import { PACKAGE_VERSION } from "../utils/package-version.js";
+import { wrapTrailingWithDynamicContext } from "../utils/message-utils.js";
 import { getSettings, updateSettings } from "../settings.js";
 import { createToolProtocol, type ToolProtocol, type PendingToolCall as ProtocolPendingToolCall, type ToolResult as ProtocolToolResult } from "./tool-protocol.js";
 
@@ -143,8 +144,8 @@ export class AgentLoop implements AgentBackend {
   private toolProtocol: ToolProtocol;
   private instanceId: string;
   // Cursor into ContextManager's exchange stream. Events with id > this
-  // have not yet been shown to the LLM. We inject the delta as a user
-  // message before each stream so the prefix stays cacheable.
+  // have not yet been shown to the LLM. The query-context:build advisor
+  // emits the delta into each new user message, then advances the cursor.
   private lastShellSeq = 0;
 
   constructor(config: AgentLoopConfig) {
@@ -919,14 +920,30 @@ export class AgentLoop implements AgentBackend {
 
     h.define("agent:get-self", () => this);
 
-    // Extensions compose additional context (git info, project rules, etc.)
-    h.define("dynamic-context:build", () => {
-      const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
-      const promptTokens = this.conversation.estimatePromptTokens();
-      return buildDynamicContext(
-        this.contextManager,
-        { promptTokens, contextWindow },
-      );
+    // Two symmetric context handlers, both empty by default. Extensions
+    // (and the kernel) advise them to contribute — directly, or via
+    // ctx.registerContextProducer which dispatches by mode.
+    //
+    //   dynamic-context:build  — per-request, fires on every LLM call,
+    //                            output ephemerally wrapped in
+    //                            <dynamic_context> onto trailing message.
+    //   query-context:build    — per-query, fires once in handleQuery,
+    //                            output frozen into the user message
+    //                            inside <query_context>.
+    h.define("dynamic-context:build", () => "");
+    h.define("query-context:build", () => "");
+
+    // Shell events are a per-query signal: what the user did in their
+    // shell between agent turns. Migrated from an inline prepend in
+    // handleQuery to an advisor here so it composes uniformly with any
+    // other per-query producer (notifications, inbox deltas, etc.).
+    h.advise("query-context:build", (next) => {
+      const base = next() as string;
+      const delta = this.contextManager.getEventsSince(this.lastShellSeq);
+      if (!delta) return base;
+      this.lastShellSeq = delta.lastSeq;
+      const part = `<shell_events>\n${delta.text}\n</shell_events>`;
+      return base ? `${base}\n\n${part}` : part;
     });
 
     // Full control over what the LLM sees: takes messages[], returns messages[].
@@ -1198,13 +1215,14 @@ export class AgentLoop implements AgentBackend {
     let responseText = "";
 
     try {
-      // Prepend any shell events that preceded this query into the same
-      // user message, so the conversation reads chronologically and we
-      // don't emit two consecutive user-role messages (some providers
-      // reject that).
-      const preDelta = this.contextManager.getEventsSince(this.lastShellSeq);
-      const userContent = preDelta ? `${preDelta.text}\n\n${query}` : query;
-      if (preDelta) this.lastShellSeq = preDelta.lastSeq;
+      // Per-query producers (shell events + any extension-registered
+      // per-query signals) produce content that gets frozen into this
+      // user message inside <query_context>, distinguishing it from the
+      // per-request <dynamic_context> wrapped on the trailing message.
+      const queryContext = ((this.handlers.call("query-context:build") as string) ?? "").trim();
+      const userContent = queryContext
+        ? `<query_context>\n${queryContext}\n</query_context>\n\n${query}`
+        : query;
 
       this.conversation.addUserMessage(userContent);
       this.bus.emit("conversation:message-appended", { role: "user", content: query });
@@ -1719,27 +1737,19 @@ export class AgentLoop implements AgentBackend {
     const reasoningDetailsByIndex = new Map<number, Record<string, unknown>>();
     const pendingToolCalls: PendingToolCall[] = [];
 
-    const rawMessages = [
-      { role: "system" as const, content: systemPrompt },
-      { role: "user" as const, content: `<context>\n${dynamicContext}\n</context>` },
-      { role: "assistant" as const, content: "Understood." },
-      ...this.conversation.getMessages(),
-    ];
-
-    // Let extensions transform the message array (compact, summarize, filter, etc.)
-    const messages = this.handlers.call("conversation:prepare", rawMessages);
-
     // Tool protocol controls what goes in the API tools param vs dynamic context
     const apiTools = this.toolProtocol.getApiTools(this.toolRegistry.all());
     const toolPrompt = this.toolProtocol.getToolPrompt(this.toolRegistry.all());
 
-    // Append tool catalog to dynamic context (closer to user query = better followed)
-    if (toolPrompt) {
-      const ctxMsg = messages[1]; // dynamic context user message
-      if (ctxMsg && typeof ctxMsg.content === "string") {
-        ctxMsg.content += "\n" + toolPrompt;
-      }
-    }
+    // Dynamic context rides on the trailing message — see
+    // wrapTrailingWithDynamicContext for the cache-stability rationale.
+    const rawMessages = [
+      { role: "system" as const, content: systemPrompt },
+      ...wrapTrailingWithDynamicContext(this.conversation.getMessages(), dynamicContext, toolPrompt),
+    ];
+
+    // Let extensions transform the message array (compact, summarize, filter, etc.)
+    const messages = this.handlers.call("conversation:prepare", rawMessages);
 
     // Stream filter strips tool tags from display (inline mode only)
     const streamFilter = this.toolProtocol.createStreamFilter(

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -13,6 +13,7 @@ import type { EventBus } from "../event-bus.js";
 import type { LlmClient } from "../utils/llm-client.js";
 import type { ToolDefinition } from "./types.js";
 import { ConversationState } from "./conversation-state.js";
+import { wrapTrailingWithDynamicContext } from "../utils/message-utils.js";
 
 interface PendingToolCall {
   id: string;
@@ -207,16 +208,11 @@ async function streamOnce(
   const pendingToolCalls: PendingToolCall[] = [];
   let usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | null = null;
 
-  const messages: Array<{ role: "system" | "user" | "assistant"; content: string }> = [
-    { role: "system", content: systemPrompt },
-  ];
-  if (dynamicContext) {
-    messages.push({ role: "user", content: `<context>\n${dynamicContext}\n</context>` });
-    messages.push({ role: "assistant", content: "Understood." });
-  }
-
   const stream = await llmClient.stream({
-    messages: [...messages, ...conversation.getMessages()],
+    messages: [
+      { role: "system", content: systemPrompt },
+      ...wrapTrailingWithDynamicContext(conversation.getMessages(), dynamicContext ?? ""),
+    ],
     tools: apiTools.length > 0 ? apiTools : undefined,
     model,
     signal,

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -123,24 +123,16 @@ Extensions may register additional tools — follow their instructions.
 - Keep bash commands focused; avoid long-running blocking commands
 - Always check command exit codes for errors
 
+# Context Envelopes
+- \`<query_context>\` (e.g. \`<shell_events>\`): the user's situation when they sent this turn — ground "fix this" / "what just happened" requests with it.
+- \`<dynamic_context>\`: current system state — in-flight work, mode markers, warnings.
+Either may be absent on any turn.
+
 # Preference Learning
 
 Treat the user's past commands as standing preferences. Before acting, check shell history
 and conversation context for recurring patterns — apply them proactively and do not wait to
 be reminded.`;
-
-/**
- * Build the dynamic context — injected as a user message before each query.
- * Contains everything that changes: shell context, conventions, cwd.
- *
- * Runs through the "dynamic-context:build" handler so extensions can advise.
- */
-export interface TokenStatus {
-  /** Estimated prompt tokens (API-grounded when available, else chars/4). */
-  promptTokens: number;
-  /** Model's context window in tokens. */
-  contextWindow: number;
-}
 
 /**
  * CWD-scoped static context: project conventions (CLAUDE.md / AGENT.md)
@@ -162,32 +154,4 @@ export function buildStaticByCwd(cwd: string): string {
   }
 
   return sections.join("\n\n");
-}
-
-/**
- * Per-iteration dynamic context: date, working directory, token usage.
- * Rebuilt every LLM call. Extension advisors add more sections (budget,
- * subagents, metacognitive signals, etc.) on top.
- *
- * Skills, AGENTS.md, and project conventions live in the system prompt
- * (see `system-prompt:build` in agent-loop) so they enter the provider's
- * prefix cache instead of being rebuilt and re-sent every turn.
- *
- * Shell context is likewise not injected here — it flows into the
- * conversation as incremental <shell-events> messages (see
- * AgentLoop.injectShellDelta) for the same reason.
- */
-export function buildDynamicContext(
-  contextManager: ContextManager,
-  tokenStatus: TokenStatus,
-): string {
-  const envLines = [
-    `Current date: ${new Date().toISOString().split("T")[0]}`,
-    `Working directory: ${contextManager.getCwd()}`,
-  ];
-  const usedK = (tokenStatus.promptTokens / 1000).toFixed(1);
-  const maxK = (tokenStatus.contextWindow / 1000).toFixed(0);
-  const pct = Math.min(100, Math.round((tokenStatus.promptTokens / tokenStatus.contextWindow) * 100));
-  envLines.push(`Token usage: ${usedK}k/${maxK}k (${pct}%)`);
-  return `<environment>\n${envLines.join("\n")}\n</environment>`;
 }

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -125,15 +125,14 @@ export class ContextManager {
   }
 
   /**
-   * Return shell events with id > afterId, formatted as an incremental
-   * delta suitable for injection into conversation history. Skips
+   * Return shell events with id > afterId as raw delta body. Skips
    * agent-source commands (already visible in tool results). Returns
-   * null when nothing new exists.
+   * null when nothing new exists. Caller is responsible for wrapping
+   * (typically inside <shell_events> within the per-query envelope).
    *
-   * The motivation: resending the full <shell_context> every turn wastes
-   * tokens — N turns × full history = O(N²) cost for O(N) information.
-   * Instead we inject only new events as regular conversation messages,
-   * so the provider's prefix cache amortizes them to O(N).
+   * Resending the full history every turn would be O(N²); injecting
+   * only the delta into a new user message that then freezes into
+   * conversation history amortizes to O(N) under prefix caching.
    */
   getEventsSince(afterId: number): { text: string; lastSeq: number } | null {
     const fresh = this.exchanges.filter((e) => e.id > afterId && !(e.type === "shell_command" && e.source === "agent"));
@@ -144,9 +143,8 @@ export class ContextManager {
     // Outputs already carry head+tail+spillPath stubs from capture time.
     const parts = fresh.map((ex) => this.formatExchangeTruncated(ex)).filter((s) => s.length > 0);
     if (parts.length === 0) return null;
-    const body = parts.join("\n");
     return {
-      text: `<shell-events>\n${body}</shell-events>`,
+      text: parts.join("\n"),
       lastSeq,
     };
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -230,6 +230,19 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         removeInstruction: (name) => bus.emit("agent:remove-instruction", { name }),
         registerSkill: (name, description, filePath) => bus.emit("agent:register-skill", { name, description, filePath, extensionName: "" }),
         removeSkill: (name) => bus.emit("agent:remove-skill", { name }),
+        registerContextProducer: (_name, producer, opts) => {
+          const handlerName = opts?.mode === "per-query"
+            ? "query-context:build"
+            : "dynamic-context:build";
+          return handlers.advise(handlerName, (next) => {
+            const base = next() as string;
+            const part = producer();
+            if (!part) return base;
+            const trimmed = part.trim();
+            if (!trimmed) return base;
+            return base ? `${base}\n\n${trimmed}` : trimmed;
+          });
+        },
         define: (name, fn) => handlers.define(name, fn),
         advise: (name, wrapper) => handlers.advise(name, wrapper),
         call: (name, ...args) => handlers.call(name, ...args),
@@ -261,13 +274,6 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           if (opts.suppressUsage !== false) {
             cleanups.push(handlers.advise("tui:render-usage", (next, ...a) => active ? "" : next(...a)));
           }
-          if (opts.interactive) {
-            cleanups.push(handlers.advise("dynamic-context:build", (next) => {
-              const base = next() as string;
-              return active ? base + "\ninteractive-session: true\n" : base;
-            }));
-          }
-
           return {
             submit(query: string) { bus.emit("agent:submit", { query }); },
             get surface() { return surface; },

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -86,6 +86,13 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     cleanups.push(() => bus.emit("agent:remove-skill", { name }));
   };
 
+  // Track dynamic-context producer registrations
+  const scopedRegisterContextProducer: typeof ctx.registerContextProducer = (name, producer) => {
+    const dispose = ctx.registerContextProducer(name, producer);
+    cleanups.push(dispose);
+    return dispose;
+  };
+
   // Track tool registrations — extension name captured in scope
   const scopedRegisterTool: typeof ctx.registerTool = (tool) => {
     bus.emit("agent:register-tool", { tool, extensionName });
@@ -108,6 +115,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     removeInstruction: ctx.removeInstruction,
     registerSkill: scopedRegisterSkill,
     removeSkill: ctx.removeSkill,
+    registerContextProducer: scopedRegisterContextProducer,
     registerTool: scopedRegisterTool,
     unregisterTool: ctx.unregisterTool,
     registerCommand: scopedRegisterCommand,

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,6 @@ export interface RemoteSessionOptions {
   suppressQueryBox?: boolean;
   /** Suppress usage stats line (default: true). */
   suppressUsage?: boolean;
-  /** Set interactive-session dynamic context (default: false). */
-  interactive?: boolean;
 }
 
 export interface RemoteSession {
@@ -150,6 +148,35 @@ export interface ExtensionContext {
   /** Remove a registered skill by name. */
   removeSkill: (name: string) => void;
 
+  // ── Dynamic context registration ──────────────────────────
+  /**
+   * Register a context producer — a function that contributes a string
+   * (or `null` to skip) into one of two lifecycles:
+   *
+   * - `mode: "per-request"` (default) — fires on **every LLM request**,
+   *   including each tool-loop iteration. Output is ephemerally wrapped
+   *   in `<dynamic_context>` onto the trailing message at request time;
+   *   never persisted. Use for "current state" signals (in-flight work,
+   *   active mode, threshold warnings).
+   *
+   * - `mode: "per-query"` — fires **once at user-query start** in
+   *   handleQuery. Output is wrapped in `<query_context>` and frozen into
+   *   the user message; persists in conversation history. Use for
+   *   "what happened between turns" signals (shell events, accumulated
+   *   notifications, calendar/inbox deltas).
+   *
+   * In both modes producers run in registration order, non-null outputs
+   * joined with blank lines. When nothing contributes, no envelope tag
+   * is emitted.
+   *
+   * Returns a dispose fn that unregisters the producer.
+   */
+  registerContextProducer: (
+    name: string,
+    producer: () => string | null,
+    opts?: { mode?: "per-request" | "per-query" },
+  ) => () => void;
+
   // ── Provider configuration ────────────────────────────────
   providers: {
     configure: (id: string, opts: { reasoningParams?: (level: string) => Record<string, unknown> }) => void;
@@ -193,7 +220,7 @@ export interface ExtensionContext {
    * optionally accepts queries. Handles all compositor routing, shell
    * lifecycle advisors, and chrome suppression.
    *
-   *   const session = ctx.createRemoteSession({ surface, interactive: true });
+   *   const session = ctx.createRemoteSession({ surface });
    *   session.submit("what's on screen?");
    *   session.close();  // restores everything
    */

--- a/src/utils/message-utils.ts
+++ b/src/utils/message-utils.ts
@@ -58,6 +58,35 @@ export function stubToolResults(
 }
 
 /**
+ * Prepend a `<dynamic_context>` block onto the trailing message.
+ *
+ * Wrapping the *trailing* message (rather than inserting at the head) keeps
+ * the [system] + [prior history] prefix byte-stable across turns, so the
+ * provider's prefix cache holds. Caller passes a copy; conversation state
+ * is never mutated.
+ *
+ * No-op when both `dynamicContext` and `toolPrompt` are empty — i.e. no
+ * extension registered any per-turn signal — so a vanilla session sends
+ * exactly `[system, ...history]` with no synthetic envelope.
+ */
+export function wrapTrailingWithDynamicContext(
+  history: any[],
+  dynamicContext: string,
+  toolPrompt?: string,
+): any[] {
+  const ctx = dynamicContext.trim();
+  const tp = (toolPrompt ?? "").trim();
+  if (!ctx && !tp) return history;
+  if (history.length === 0) return history;
+  const last = history[history.length - 1];
+  if (typeof last.content !== "string") return history;
+
+  const blockBody = ctx && tp ? `${ctx}\n${tp}` : ctx || tp;
+  const wrappedContent = `<dynamic_context>\n${blockBody}\n</dynamic_context>\n\n${last.content}`;
+  return [...history.slice(0, -1), { ...last, content: wrappedContent }];
+}
+
+/**
  * Deduplicate tool results: keep only the latest result for a given
  * tool name + argument filter, replace all older results with a stub.
  *


### PR DESCRIPTION
## Summary

End-to-end cleanup of the dynamic context system: cache-friendly placement, no kernel-side defaults, two symmetric handlers for the two real lifecycles, and a unified extension API.

### 1. Fix prefix-cache invalidation (the original bug)

Dynamic context was injected at \`messages[1]\` — ahead of the whole conversation. Token usage embedded in the block changed every iteration, so the prefix hash flipped each turn and the provider's prefix cache invalidated for the entire history on every loop step.

Now wrapped onto the **trailing** message (\`user\` at query start, \`tool\` mid-loop) inside a \`<dynamic_context>…</dynamic_context>\` block. Cacheable prefix becomes \`[system] + [all prior messages]\` and stays byte-identical turn over turn. Drops the \`Understood.\` priming pair and folds the tool-prompt catalog into the same block. Same fix in \`subagent.ts\`.

### 2. Kernel injects nothing by default

\`buildDynamicContext\` is **deleted**. No more auto-injected date / cwd / token usage:

- date is recoverable from \`date\`,
- cwd from \`pwd\`,
- token usage is operational telemetry the LLM doesn't act on per-turn.

Both \`dynamic-context:build\` and \`query-context:build\` default to \`""\`. \`wrapTrailingWithDynamicContext\` is a no-op on empty input — a vanilla session sends exactly \`[system, ...history]\` with no synthetic envelope.

### 3. Two symmetric handlers for two real lifecycles

| Handler | Fires on | Persistence | Envelope |
|---|---|---|---|
| \`dynamic-context:build\` | every LLM call (incl. tool-loop iterations) | ephemeral, wraps trailing message | \`<dynamic_context>\` |
| \`query-context:build\`   | once at user-query start (\`handleQuery\`) | frozen into user message | \`<query_context>\` |

Both are define-able / advise-stackable on the same handler-registry surface. The kernel registers an advisor on \`query-context:build\` for shell events (migrated from the inline prepend in \`handleQuery\`); now any per-query signal an extension wants to add (notifications, inbox deltas, calendar events) composes with it uniformly.

\`getEventsSince\` is now a pure data fetch — caller wraps in \`<shell_events>\`, matching the snake-case convention of the new envelopes.

### 4. \`registerContextProducer\` extension API

```typescript
registerContextProducer(
  name: string,
  producer: () => string | null,
  opts?: { mode?: "per-request" | "per-query" }   // default: "per-request"
): () => void;
```

Thin dispatcher over \`handlers.advise(...)\`. \`mode\` selects which of the two handlers the advisor lands on. When the producer returns \`null\` (or empty/whitespace) it skips that turn; non-null outputs from multiple producers join with blank lines. Producer disposers are tracked by \`extension-loader\`'s scoped context so \`/reload\` cleans up.

### 5. Move \`interactive-session: true\` out of core

The marker was hardcoded in \`src/core.ts\` via an \`interactive: true\` flag on \`RemoteSessionOptions\`. It's specific to two example extensions (\`overlay-agent\`, \`tmux-pane\`) that need to tell the LLM "you've been summoned via an overlay — read the screen, prefer terminal_keys."

Removed from core. Both extensions migrated to \`ctx.registerContextProducer("interactive-session", () => …)\`. \`RemoteSessionOptions.interactive\` is gone.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Verify in a long session that \`prompt_tokens\` stops growing super-linearly (cache hits visible in provider usage metrics)
- [ ] Confirm \`<dynamic_context>\` does not appear at all in vanilla sessions (no extension registered)
- [ ] Confirm \`<shell_events>\` appears inside \`<query_context>\` on the user message at query start, not mid-tool-loop
- [ ] Confirm overlay-agent + tmux-pane still emit \`interactive-session: true\` while their session is active
- [ ] Confirm \`/reload\` of a user extension calling \`registerContextProducer\` cleanly unregisters it