### PR TITLE
Fix Windows tool execution: bash output capture and PowerShell fallback

### DIFF
--- a/src/agent/tools/pwsh.ts
+++ b/src/agent/tools/pwsh.ts
@@ -1,10 +1,35 @@
+import { spawnSync } from "node:child_process";
 import { executeArgv, killSession } from "../../executor.js";
 import type { EventBus } from "../../event-bus.js";
 import type { ToolDefinition } from "../types.js";
 
-// Targets PowerShell 7+ (`pwsh`). Legacy `powershell.exe` is intentionally
-// not auto-fallback — its tool surface diverges enough that compatibility
-// shims aren't worth the maintenance.
+let cachedPwshPath: string | null | undefined;
+
+/** Resolve a usable PowerShell binary, or null if none is on PATH.
+ *  Prefers PowerShell 7+ (`pwsh`), falls back to Windows PowerShell (`powershell`). */
+function findPwsh(): string | null {
+  if (cachedPwshPath !== undefined) return cachedPwshPath;
+
+  // Prefer PowerShell 7 (pwsh)
+  const pwsh = spawnSync("where", ["pwsh"], { encoding: "utf-8" });
+  if (pwsh.status === 0) {
+    cachedPwshPath = pwsh.stdout.split(/\r?\n/)[0]!.trim() || null;
+    if (cachedPwshPath) return cachedPwshPath;
+  }
+
+  // Fallback to Windows PowerShell (powershell.exe)
+  const ps = spawnSync("where", ["powershell"], { encoding: "utf-8" });
+  cachedPwshPath = ps.status === 0 ? ps.stdout.split(/\r?\n/)[0]!.trim() || null : null;
+  return cachedPwshPath;
+}
+
+/** Return the PowerShell executable name for display purposes. */
+function getPwshDisplayName(): string {
+  const path = findPwsh();
+  if (!path) return "PowerShell";
+  return path.toLowerCase().includes("pwsh") ? "pwsh" : "powershell";
+}
+
 export function createPwshTool(opts: {
   getCwd: () => string;
   getEnv: () => Record<string, string>;
@@ -68,8 +93,17 @@ export function createPwshTool(opts: {
         };
       }
 
+      const pwshPath = findPwsh();
+      if (!pwshPath) {
+        return {
+          content: "PowerShell not found on PATH. Neither pwsh (PowerShell 7+) nor powershell (Windows PowerShell) is available.",
+          exitCode: 1,
+          isError: true,
+        };
+      }
+
       const { session, done } = executeArgv({
-        file: "pwsh",
+        file: pwshPath,
         args: ["-NoProfile", "-NonInteractive", "-Command", command],
         cwd: opts.getCwd(),
         env: opts.getEnv(),
@@ -87,7 +121,7 @@ export function createPwshTool(opts: {
 
       if (session.spawnFailed) {
         return {
-          content: "PowerShell (pwsh) not found on PATH. Install PowerShell 7: winget install Microsoft.PowerShell.",
+          content: `${getPwshDisplayName()} not found on PATH. Install PowerShell 7: winget install Microsoft.PowerShell.`,
           exitCode: 1,
           isError: true,
         };

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -80,7 +80,8 @@ export function executeCommand(opts: {
       stdio: ["ignore", "pipe", "pipe"],
       cwd: opts.cwd,
       env,
-      detached: true,
+      detached: process.platform !== "win32",
+      windowsHide: true,
     });
   } catch (err) {
     session.exitCode = -1;
@@ -261,15 +262,19 @@ export function killSession(session: ExecutorSession): () => void {
   if (!proc || !proc.pid) return () => {};
 
   // Try process-group kill first (works for executeCommand's detached bash
-  // children); fall back to direct kill (executeArgv's non-detached spawn,
-  // and Windows where negative pids aren't supported).
-  try { process.kill(-proc.pid, "SIGTERM"); } catch {}
+  // children on Unix); fall back to direct kill (executeArgv's non-detached
+  // spawn, and Windows where negative pids aren't supported).
+  if (process.platform !== "win32") {
+    try { process.kill(-proc.pid, "SIGTERM"); } catch {}
+  }
   try { proc.kill("SIGTERM"); } catch {}
 
   let settled = false;
   const fallback = setTimeout(() => {
     if (!settled && !session.done && proc.pid) {
-      try { process.kill(-proc.pid, "SIGKILL"); } catch {}
+      if (process.platform !== "win32") {
+        try { process.kill(-proc.pid, "SIGKILL"); } catch {}
+      }
       try { proc.kill("SIGKILL"); } catch {}
     }
   }, 5000);


### PR DESCRIPTION
## Summary

Fixes two Windows-specific issues with the agent's tool execution:

1. **bash tool returns `(no output)`** — The `detached: true` spawn option on Windows causes the bash child process to detach from the parent console, making stdout/stderr pipes fail to capture output. This PR disables `detached` on Windows and adds `windowsHide: true` to suppress the console window popup.

2. **pwsh tool requires PowerShell 7+** — The tool hardcoded `pwsh` which is only available after installing PowerShell 7. Most Windows users only have the built-in `powershell.exe` (PowerShell 5.1). This PR adds auto-detection that prefers `pwsh` and falls back to `powershell`.

## Changes

- `src/executor.ts`:
  - `detached: process.platform !== "win32"` — only use detached mode on Unix
  - `windowsHide: true` — hide console window on Windows
  - Guard `process.kill(-pid)` with platform check (Windows doesn't support negative PIDs)

- `src/agent/tools/pwsh.ts`:
  - Add `findPwsh()` — probes `where pwsh` then `where powershell`
  - Add early-exit with clear error message when no PowerShell is found
  - Use resolved full path instead of bare executable name

## Testing

- [x] `bash` tool now captures output correctly on Windows with Git Bash installed
- [x] `pwsh` tool works on Windows without PowerShell 7 (falls back to built-in PowerShell)