### PR TITLE
Add --version flag, repair empty assistant turns

### DIFF
--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -140,12 +140,22 @@ export class ConversationState {
     toolCalls?: { id: string; function: { name: string; arguments: string } }[],
     extras?: Record<string, unknown>,
   ): void {
-    // extras is opaque provider payload to echo back (reasoning_content,
-    // reasoning_details, etc.). Spread verbatim; shape is the stream
-    // parser's concern.
-    const base: Record<string, unknown> = { role: "assistant", content: content ?? (toolCalls?.length ? null : "") };
-    if (toolCalls?.length) {
-      base.tool_calls = toolCalls.map((tc) => ({
+    const hasToolCalls = !!toolCalls?.length;
+
+    // Promote reasoning into content on reasoning-only turns; strict
+    // providers (DeepSeek native) reject content="" with no tool_calls.
+    if (!content && !hasToolCalls) {
+      const r = (extras?.reasoning_content ?? extras?.reasoning) as unknown;
+      if (typeof r === "string" && r) content = r;
+    }
+    if (!content && !hasToolCalls) return;
+
+    const base: Record<string, unknown> = {
+      role: "assistant",
+      content: hasToolCalls ? (content ?? null) : content,
+    };
+    if (hasToolCalls) {
+      base.tool_calls = toolCalls!.map((tc) => ({
         id: tc.id,
         type: "function" as const,
         function: tc.function,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
 import { discoverSkills } from "./agent/skills.js";
 import { runInit } from "./init.js";
+import { PACKAGE_VERSION } from "./utils/package-version.js";
 import type { AgentShellConfig } from "./types.js";
 
 /**
@@ -105,6 +106,9 @@ function parseArgs(argv: string[]): AgentShellConfig {
     } else if ((arg === "--extensions" || arg === "-e") && argv[i + 1]) {
       const exts = argv[++i]!.split(",").map(s => s.trim());
       extensions = extensions ? [...extensions, ...exts] : exts;
+    } else if (arg === "--version" || arg === "-V") {
+      console.log(PACKAGE_VERSION);
+      process.exit(0);
     } else if (arg === "--help" || arg === "-h") {
       console.log(`agent-sh — a shell-first terminal where AI is one keystroke away
 
@@ -123,6 +127,7 @@ General Options:
   --shell <path>      Shell to use (default: $SHELL or /bin/bash)
   -e, --extensions    Extensions to load (comma-separated, repeatable)
   -h, --help          Show this help
+  -V, --version       Print version and exit
 
 Environment Variables:
   OPENAI_API_KEY     API key for LLM provider


### PR DESCRIPTION
## Summary

Two unrelated fixes surfaced from a user issue.

**`--version` CLI flag.** Users on installed builds had no way to check which version they were running (`agent-sh --version` previously failed). Reads from `package.json` via the existing `PACKAGE_VERSION` util.

**Empty assistant turns rejected by DeepSeek native.** When a stream returns no text and no `tool_calls` (e.g. a reasoning-only turn), `addAssistantMessage` was recording `{role: "assistant", content: ""}` with no `tool_calls`. OpenRouter and Ollama tolerate that shape; DeepSeek's own platform rejects on replay:

```
Error: 400 Invalid assistant message: content or tool_calls must be set
```

Fix at the kernel boundary in `conversation-state.ts`: if only reasoning was produced, promote it into `content`; if truly nothing was produced, skip recording entirely. Both rules enforce the invariant "every assistant message has content or tool_calls set." No changes needed in the four `recordAssistant` overrides — they all funnel through `addAssistantMessage`.

## Test plan

- [ ] `agent-sh --version` prints version and exits 0
- [ ] `agent-sh -V` works the same
- [ ] DeepSeek native (deepseek-v4-pro) doesn't 400 after a reasoning-only turn
- [ ] OpenRouter / Ollama / OpenAI flows unchanged