### PR TITLE
Batch per-line diff streaming into a single onChunk emit

### DIFF
--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -140,16 +140,18 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
 
         await fs.writeFile(absPath, finalContent);
 
-        // Compute and stream diff for display (windowed — only diffs the edit region)
+        // Compute and stream diff for display. Batch into one onChunk —
+        // per-line emits trigger N TUI renders for large hunks.
         const diff = computeEditDiff(normalized, normalizedOld, normalizedNew, replaceAll);
         if (onChunk && diff.hunks.length > 0) {
+          const parts: string[] = [];
           for (const hunk of diff.hunks) {
             for (const line of hunk.lines) {
-              if (line.type === "added") onChunk(`+${line.text}\n`);
-              else if (line.type === "removed") onChunk(`-${line.text}\n`);
-              else onChunk(` ${line.text}\n`);
+              const prefix = line.type === "added" ? "+" : line.type === "removed" ? "-" : " ";
+              parts.push(`${prefix}${line.text}\n`);
             }
           }
+          onChunk(parts.join(""));
         }
 
         const stats = diff.isNewFile

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -57,16 +57,18 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
         await fs.mkdir(path.dirname(absPath), { recursive: true });
         await fs.writeFile(absPath, content);
 
-        // Compute and stream diff for display
+        // Compute and stream diff for display. Batch into one onChunk —
+        // per-line emits trigger N TUI renders for large files.
         const diff = computeDiff(oldContent, content);
         if (onChunk && diff.hunks.length > 0) {
+          const parts: string[] = [];
           for (const hunk of diff.hunks) {
             for (const line of hunk.lines) {
-              if (line.type === "added") onChunk(`+${line.text}\n`);
-              else if (line.type === "removed") onChunk(`-${line.text}\n`);
-              else onChunk(` ${line.text}\n`);
+              const prefix = line.type === "added" ? "+" : line.type === "removed" ? "-" : " ";
+              parts.push(`${prefix}${line.text}\n`);
             }
           }
+          onChunk(parts.join(""));
         }
 
         const stats = diff.isNewFile


### PR DESCRIPTION
## Summary

- `edit_file` and `write_file` were emitting one `onChunk` per diff line. Each emit drives a TUI re-render, so large hunks produced N renders and visible flicker.
- Build the diff string once and emit it as a single chunk.

## Test plan

- [ ] Run a large `edit_file` replacement and confirm the diff renders in one paint, no flicker
- [ ] Run a large `write_file` (new file or full rewrite) and confirm the same
- [ ] Diff content (`+`/`-`/` ` prefixes, line ordering) is unchanged from before