### PR TITLE
Render edit/write diffs via result-body, not fake streaming

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1151,8 +1151,6 @@ export class AgentLoop implements AgentBackend {
         this.fileReadCache.delete(absPath);
       }
 
-      // execute() may surface display directly (preferred — lets the tool
-      // pass structured data like a diff). Fall back to formatResult.
       const resultDisplay = result.display ?? tool.formatResult?.(args, result);
 
       // Emit completion events (via transform pipe so extensions can override)

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1151,8 +1151,9 @@ export class AgentLoop implements AgentBackend {
         this.fileReadCache.delete(absPath);
       }
 
-      // Compute result display: tool-provided → default (none)
-      const resultDisplay = tool.formatResult?.(args, result);
+      // execute() may surface display directly (preferred — lets the tool
+      // pass structured data like a diff). Fall back to formatResult.
+      const resultDisplay = result.display ?? tool.formatResult?.(args, result);
 
       // Emit completion events (via transform pipe so extensions can override)
       this.bus.emitTransform("agent:tool-completed", {

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ToolDefinition } from "../types.js";
-import { computeDiff, computeEditDiff } from "../../utils/diff.js";
+import { computeEditDiff } from "../../utils/diff.js";
 import { expandHome } from "./expand-home.js";
 
 /**
@@ -81,13 +81,7 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
       locations: [{ path: args.path as string }],
     }),
 
-    formatResult: (_args, result) => {
-      if (result.isError) return {};
-      const m = result.content.match(/\((\+\d+(?:\s-\d+)?)\)/);
-      return m ? { summary: m[1] } : {};
-    },
-
-    async execute(args, onChunk) {
+    async execute(args) {
       const filePath = expandHome(args.path as string);
       const oldText = args.old_text as string;
       const newText = args.new_text as string;
@@ -140,27 +134,16 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
 
         await fs.writeFile(absPath, finalContent);
 
-        // Compute and stream diff for display. Batch into one onChunk —
-        // per-line emits trigger N TUI renders for large hunks.
         const diff = computeEditDiff(normalized, normalizedOld, normalizedNew, replaceAll);
-        if (onChunk && diff.hunks.length > 0) {
-          const parts: string[] = [];
-          for (const hunk of diff.hunks) {
-            for (const line of hunk.lines) {
-              const prefix = line.type === "added" ? "+" : line.type === "removed" ? "-" : " ";
-              parts.push(`${prefix}${line.text}\n`);
-            }
-          }
-          onChunk(parts.join(""));
-        }
-
-        const stats = diff.isNewFile
-          ? `+${diff.added}`
-          : `+${diff.added} -${diff.removed}`;
+        const stats = diff.isNewFile ? `+${diff.added}` : `+${diff.added} -${diff.removed}`;
         return {
           content: `Edited ${absPath} (${stats})`,
           exitCode: 0,
           isError: false,
+          display: {
+            summary: stats,
+            body: { kind: "diff", diff, filePath: absPath },
+          },
         };
       } catch (err) {
         const msg =

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -35,13 +35,7 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
       locations: [{ path: args.path as string }],
     }),
 
-    formatResult: (_args, result) => {
-      if (result.isError) return {};
-      const m = result.content.match(/\((\+\d+(?:\s-\d+)?)\)/);
-      return m ? { summary: m[1] } : {};
-    },
-
-    async execute(args, onChunk) {
+    async execute(args) {
       const filePath = expandHome(args.path as string);
       const content = args.content as string;
       const absPath = path.resolve(getCwd(), filePath);
@@ -57,33 +51,21 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
         await fs.mkdir(path.dirname(absPath), { recursive: true });
         await fs.writeFile(absPath, content);
 
-        // Compute and stream diff for display. Batch into one onChunk —
-        // per-line emits trigger N TUI renders for large files.
         const diff = computeDiff(oldContent, content);
-        if (onChunk && diff.hunks.length > 0) {
-          const parts: string[] = [];
-          for (const hunk of diff.hunks) {
-            for (const line of hunk.lines) {
-              const prefix = line.type === "added" ? "+" : line.type === "removed" ? "-" : " ";
-              parts.push(`${prefix}${line.text}\n`);
-            }
-          }
-          onChunk(parts.join(""));
-        }
-
-        const stats = diff.isNewFile
-          ? `+${diff.added}`
-          : `+${diff.added} -${diff.removed}`;
+        const stats = diff.isNewFile ? `+${diff.added}` : `+${diff.added} -${diff.removed}`;
         return {
           content: oldContent === null
             ? `Created ${absPath} (${stats})`
             : `Wrote ${absPath} (${stats})`,
           exitCode: 0,
           isError: false,
+          display: {
+            summary: stats,
+            body: { kind: "diff", diff, filePath: absPath },
+          },
         };
       } catch (err) {
-        const msg =
-          err instanceof Error ? err.message : String(err);
+        const msg = err instanceof Error ? err.message : String(err);
         return { content: `Error: ${msg}`, exitCode: 1, isError: true };
       }
     },

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -22,6 +22,9 @@ export interface ToolResult {
   content: string;
   exitCode: number | null;
   isError: boolean;
+  /** Structured display data. When present, overrides any formatResult() output —
+   *  lets execute() surface data (e.g. a diff) it computed but doesn't fit in `content`. */
+  display?: ToolResultDisplay;
 }
 
 /** Structured result display — returned by formatResult or computed by defaults. */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -22,8 +22,7 @@ export interface ToolResult {
   content: string;
   exitCode: number | null;
   isError: boolean;
-  /** Structured display data. When present, overrides any formatResult() output —
-   *  lets execute() surface data (e.g. a diff) it computed but doesn't fit in `content`. */
+  /** When set, takes precedence over `tool.formatResult()`. */
   display?: ToolResultDisplay;
 }
 

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -736,9 +736,7 @@ export default function activate(ctx: ExtensionContext): void {
     return renderDiffBody(diff, filePath, width);
   });
 
-  /** Render a diff as framed box lines (pure — no TUI state side effects).
-   *  New files are shown as a head-of-content preview rather than a full
-   *  +-prefixed dump, since every line being "added" carries no signal. */
+  /** Render a diff as framed box lines (pure — no TUI state side effects). */
   function renderDiffBody(diff: DiffResult, filePath: string, width: number): string[] {
     if (diff.isIdentical) return [];
     const boxW = Math.min(120, width - 2);

--- a/src/extensions/tui-renderer.ts
+++ b/src/extensions/tui-renderer.ts
@@ -736,28 +736,39 @@ export default function activate(ctx: ExtensionContext): void {
     return renderDiffBody(diff, filePath, width);
   });
 
-  /** Render a diff as framed box lines (pure — no TUI state side effects). */
+  /** Render a diff as framed box lines (pure — no TUI state side effects).
+   *  New files are shown as a head-of-content preview rather than a full
+   *  +-prefixed dump, since every line being "added" carries no signal. */
   function renderDiffBody(diff: DiffResult, filePath: string, width: number): string[] {
     if (diff.isIdentical) return [];
-    const boxW = Math.min(120, width - 2);  // -2 for writeLine indent
+    const boxW = Math.min(120, width - 2);
     const contentW = boxW - 4;
 
-    const diffLines = renderDiff(diff, {
-      width: contentW,
-      filePath,
-      maxLines: getSettings().diffMaxLines,
-      trueColor: true,
-    });
-
-    const body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
-    const footer = undefined;
+    let body: string[];
+    if (diff.isNewFile) {
+      const lines = diff.hunks.flatMap(h => h.lines.map(l => l.text));
+      const preview = getSettings().newFilePreviewLines;
+      const head = lines.slice(0, preview);
+      const truncated = head.map(l => l.length > contentW ? l.slice(0, contentW - 1) + "…" : l);
+      const more = lines.length > preview
+        ? [`${p.dim}… ${lines.length - preview} more lines${p.reset}`]
+        : [];
+      body = ["", ...truncated, ...more, ""];
+    } else {
+      const diffLines = renderDiff(diff, {
+        width: contentW,
+        filePath,
+        maxLines: getSettings().diffMaxLines,
+        trueColor: true,
+      });
+      body = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
+    }
 
     return renderBoxFrame(body, {
       width: boxW,
       style: "rounded",
       borderColor: p.dim,
       title: diffTitle(filePath, diff),
-      footer,
     });
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,6 +91,9 @@ export interface Settings {
   readOutputMaxLines?: number;
   /** Max diff lines rendered in the TUI (Infinity = no limit). */
   diffMaxLines?: number;
+  /** New-file preview lines rendered in the TUI (a full +-prefixed dump
+   *  of a brand-new file is noisy; show a head + "more" marker instead). */
+  newFilePreviewLines?: number;
 
   // ── Agent integration ─────────────────────────────────────
   /** Tool protocol:
@@ -149,6 +152,7 @@ const DEFAULTS: Required<Settings> = {
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,
   diffMaxLines: Infinity,
+  newFilePreviewLines: 5,
   skillPaths: [],
   diagnose: false,
   startupBanner: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,8 +91,7 @@ export interface Settings {
   readOutputMaxLines?: number;
   /** Max diff lines rendered in the TUI (Infinity = no limit). */
   diffMaxLines?: number;
-  /** New-file preview lines rendered in the TUI (a full +-prefixed dump
-   *  of a brand-new file is noisy; show a head + "more" marker instead). */
+  /** Lines of head content shown when a brand-new file is created. */
   newFilePreviewLines?: number;
 
   // ── Agent integration ─────────────────────────────────────


### PR DESCRIPTION
## Summary

`edit_file` and `write_file` were fake-streaming a unified diff via `onChunk` after the file had already been written, then relying on the inline-output truncation (default `maxCommandOutputLines: 3`) to keep it brief. That mixed a *tool* concern with a *renderer* concern, and produced misleading output for new files (a +-prefixed dump of the entire file) and frustrated UX for overwrites (a 3-line truncation that hid the actual change).

This moves the display decision into the renderer, where it belongs.

## Changes

- `ToolResult.display?` — `execute()` can now return a `ToolResultDisplay` directly. `agent-loop` prefers `result.display` over `tool.formatResult()`. Lets tools surface structured data (e.g. a diff) without round-tripping through `result.content`.
- `write_file` / `edit_file`: drop the `onChunk` diff stream and the `formatResult` content-string regex. `execute()` returns `display: { summary, body: { kind: "diff", diff, filePath } }`.
- TUI `renderDiffBody`: special-case `diff.isNewFile` — render the head of the file as a content preview with a `… N more lines` tail. Overwrites still render a full diff (no inline truncation).
- New setting `newFilePreviewLines` (default `5`).

## Extension story

One advise point now covers everything diff-display:
```ts
ctx.advise("render:result-body", (next, body, width) => {
  if (body.kind === "diff") return myCustomDiffRenderer(body, width);
  return next(body, width);
});
```
Extensions can swap in syntax highlighting, change the preview length, hide diffs for certain paths, etc. — without forking the tools or touching the renderer's per-kind truncation logic.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Smoke test: `computeDiff` for a 12-line new file produces 12 added lines; renderer slices to first 5 + "… 7 more lines".
- [ ] Manual: ask the agent to create a new file (>5 lines) and confirm preview renders.
- [ ] Manual: ask the agent to overwrite an existing file with several changes and confirm full diff renders (no `… N more lines` truncation).
- [ ] Manual: `edit_file` flow — full diff renders the same way.