### PR TITLE
Stop compaction from producing orphan tool / empty assistant messages

### DIFF
--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -223,11 +223,8 @@ export class ConversationState {
     );
   }
 
-  /**
-   * Strip role:"tool" messages whose tool_call_id doesn't match any
-   * preceding assistant tool_call. Compaction or external mutation can
-   * leave such orphans, and strict providers (DeepSeek) 400 on them.
-   */
+  /** Drop tool messages with no matching preceding tool_call — strict
+   *  providers (DeepSeek) 400, and compaction can leave such orphans. */
   private dropOrphanToolMessages(
     messages: ChatCompletionMessageParam[],
   ): ChatCompletionMessageParam[] {
@@ -706,10 +703,7 @@ export class ConversationState {
           return true;
         });
         if (kept.length === 0) {
-          // Drop the husk if the assistant had no user-facing content; an
-          // {assistant, content:null, no tool_calls} message is malformed
-          // (DeepSeek 400) and would orphan any following tool result whose
-          // call we just stripped.
+          // No content + no tool_calls is malformed (DeepSeek 400); drop the husk.
           const text = typeof msg.content === "string" ? msg.content.trim() : "";
           if (!text) continue;
           const { tool_calls: _, ...rest } = msg;

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -218,7 +218,31 @@ export class ConversationState {
   }
 
   getMessages(): ChatCompletionMessageParam[] {
-    return this.normalizeReasoningConsistency(this.stubDanglingToolCalls(this.messages));
+    return this.normalizeReasoningConsistency(
+      this.stubDanglingToolCalls(this.dropOrphanToolMessages(this.messages)),
+    );
+  }
+
+  /**
+   * Strip role:"tool" messages whose tool_call_id doesn't match any
+   * preceding assistant tool_call. Compaction or external mutation can
+   * leave such orphans, and strict providers (DeepSeek) 400 on them.
+   */
+  private dropOrphanToolMessages(
+    messages: ChatCompletionMessageParam[],
+  ): ChatCompletionMessageParam[] {
+    const knownIds = new Set<string>();
+    const result: ChatCompletionMessageParam[] = [];
+    for (const msg of messages) {
+      if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
+        for (const tc of msg.tool_calls) knownIds.add(tc.id);
+      }
+      if (msg.role === "tool" && !knownIds.has((msg as { tool_call_id: string }).tool_call_id)) {
+        continue;
+      }
+      result.push(msg);
+    }
+    return result;
   }
 
   /**
@@ -669,19 +693,25 @@ export class ConversationState {
   private slimTurn(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
     const MAX_RESULT_LEN = 1500;
     const result: ChatCompletionMessageParam[] = [];
-    const readOnlyToolIds = new Set<string>();
+    const droppedToolIds = new Set<string>();
 
     for (const msg of messages) {
       if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
         const kept = msg.tool_calls.filter((tc) => {
           if (!("function" in tc)) return true;
           if (READ_ONLY_TOOLS.has(tc.function.name)) {
-            readOnlyToolIds.add(tc.id);
+            droppedToolIds.add(tc.id);
             return false;
           }
           return true;
         });
         if (kept.length === 0) {
+          // Drop the husk if the assistant had no user-facing content; an
+          // {assistant, content:null, no tool_calls} message is malformed
+          // (DeepSeek 400) and would orphan any following tool result whose
+          // call we just stripped.
+          const text = typeof msg.content === "string" ? msg.content.trim() : "";
+          if (!text) continue;
           const { tool_calls: _, ...rest } = msg;
           result.push(rest);
         } else {
@@ -690,7 +720,7 @@ export class ConversationState {
         continue;
       }
       if (msg.role === "tool") {
-        if (readOnlyToolIds.has(msg.tool_call_id)) continue;
+        if (droppedToolIds.has(msg.tool_call_id)) continue;
         const content = typeof msg.content === "string" ? msg.content : "";
         if (content.length > MAX_RESULT_LEN) {
           result.push({ ...msg, content: content.slice(0, MAX_RESULT_LEN) + "\n... [truncated by compact]" });


### PR DESCRIPTION
## Summary

PR #110 repaired empty assistant turns at the `addAssistantMessage` boundary, but compaction creates the same malformed shapes through a different path. After auto-compaction (or `/compact`) on a conversation with read-only tool calls, DeepSeek native rejects the next request with either:

- `400 Invalid assistant message: content or tool_calls must be set`, or
- `400 Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

depending on the surrounding messages.

## Root cause

`slimTurn` (in `conversation-state.ts`) strips read-only `tool_calls` from slimmed turns and drops their corresponding tool results. When the original assistant message had `content: null` (very common — reasoning models emit `<think>…</think>` plus a `read_file` call with no user-facing text), stripping leaves `{role: "assistant", content: null}` with **neither** `content` **nor** `tool_calls`. That message is malformed.

In single-call turns DeepSeek surfaces this as the original "content or tool_calls must be set" error. In multi-iteration turns like `[user, assistant1(read_file, content=null), tool_read, assistant2(write_file), tool_write]` the slimmed result becomes `[user, assistant1_empty_husk, assistant2(write), tool_write]` — and DeepSeek's pairwise validator flags `tool_write` as orphaned because the message immediately before it (`assistant1_empty_husk`) has no `tool_calls`.

## Changes

- **`slimTurn`**: when all `tool_calls` are stripped and the assistant has no usable text content, drop the assistant entirely instead of pushing an empty husk. Track the dropped tool_call ids so the corresponding tool messages also get dropped (they'd be orphans now). Renamed `readOnlyToolIds` → `droppedToolIds` to reflect the broader semantic.
- **`dropOrphanToolMessages`**: new defensive sweep applied in `getMessages()`. Strips any `role:"tool"` message whose `tool_call_id` doesn't match a preceding `assistant.tool_calls`. Sibling to the existing `stubDanglingToolCalls` — together they enforce the invariant that every API-bound message array is structurally valid, regardless of what mutated `this.messages` (compaction, custom strategies, extensions calling `replaceMessages`).

## Test plan

Verified with an inline harness (8 cases, all pass):

- [x] Empty assistant + read-only call → assistant + tool both dropped (no husk, no orphan)
- [x] Assistant with text + read-only call → assistant kept (text preserved, `tool_calls` removed), tool dropped
- [x] Mixed read-only + write call → assistant kept with only the write call, only the write tool result kept
- [x] Multi-iteration `[user, asst1(read, content=null), tool_read, asst2(write), tool_write]` → collapses to `[user, asst2(write), tool_write]`
- [x] `dropOrphanToolMessages`: standalone orphan tool stripped at `getMessages()`
- [x] `dropOrphanToolMessages`: legitimate tool pair preserved
- [ ] Manual: reproduce the user's `/compact` → next-turn 400 on deepseek-v4-pro and confirm it's fixed