### PR TITLE
feat: make max_tokens configurable per-model via settings

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1729,6 +1729,7 @@ export class AgentLoop implements AgentBackend {
       messages,
       tools: apiTools,
       model: this.currentModel,
+      max_tokens: this.currentMode.maxTokens ?? 65536,
       ...this.reasoningParams(),
     };
     this.bus.emit("llm:request", requestParams);

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -60,6 +60,7 @@ export interface ShellEvents {
     messages: unknown[];
     tools?: unknown;
     model?: string;
+    max_tokens?: number;
     reasoning_effort?: string;
   };
   "llm:chunk": { chunk: unknown };
@@ -314,7 +315,7 @@ export interface ShellEvents {
     /** Optional — providers for custom endpoints may not know the catalog
      *  at registration time. Falls back to models[0] when absent. */
     defaultModel?: string;
-    models?: (string | { id: string; reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean })[];
+    models?: (string | { id: string; reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean })[];
     /** Provider supports the reasoning_effort parameter. Default: true. */
     supportsReasoningEffort?: boolean;
   };

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -53,6 +53,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
           provider: id,
           providerConfig: { apiKey: p.apiKey, baseURL: p.baseURL },
           contextWindow: mc?.contextWindow ?? p.contextWindow,
+          maxTokens: mc?.maxTokens ?? (mc?.contextWindow ? Math.min(Math.floor(mc.contextWindow * 0.4), 65536) : undefined),
           reasoning: mc?.reasoning,
           supportsReasoningEffort: p.supportsReasoningEffort,
           echoReasoning: mc?.echoReasoning,
@@ -170,13 +171,13 @@ export default function agentBackend(ctx: ExtensionContext): void {
   bus.on("provider:register", (p) => {
     const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
     const modelIds: string[] = [];
-    const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>();
+    const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean }>();
     for (const m of rawModels) {
       if (typeof m === "string") {
         modelIds.push(m);
       } else {
         modelIds.push(m.id);
-        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, echoReasoning: m.echoReasoning });
+        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, maxTokens: m.maxTokens, echoReasoning: m.echoReasoning });
       }
     }
     providerRegistry.set(p.id, {
@@ -197,6 +198,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
         provider: p.id,
         providerConfig: { apiKey: p.apiKey ?? "", baseURL: p.baseURL },
         contextWindow: mc?.contextWindow,
+        maxTokens: mc?.maxTokens,
         reasoning: mc?.reasoning,
         supportsReasoningEffort: p.supportsReasoningEffort,
         echoReasoning: mc?.echoReasoning,
@@ -241,6 +243,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
         provider: name,
         providerConfig: { apiKey: p.apiKey!, baseURL: p.baseURL },
         contextWindow: mc?.contextWindow ?? p.contextWindow,
+        maxTokens: mc?.maxTokens ?? (mc?.contextWindow ? Math.min(Math.floor(mc.contextWindow * 0.4), 65536) : undefined),
         reasoning: mc?.reasoning,
         supportsReasoningEffort: p.supportsReasoningEffort,
         echoReasoning: mc?.echoReasoning,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,8 @@ export interface ModelCapabilityConfig {
   reasoning?: boolean;
   /** Context window size in tokens for this specific model. */
   contextWindow?: number;
+  /** Max output tokens for this model. */
+  maxTokens?: number;
   /** Echo reasoning_content back on assistant turns. Required by DeepSeek. */
   echoReasoning?: boolean;
 }
@@ -273,7 +275,7 @@ export interface ResolvedProvider {
   /** Provider supports the reasoning_effort parameter. Default: true. */
   supportsReasoningEffort?: boolean;
   /** Per-model capabilities, keyed by model id. */
-  modelCapabilities?: Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>;
+  modelCapabilities?: Map<string, { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean }>;
   /** Borrow another registered provider's reasoning request shape by id. */
   reasoningShape?: string;
 }
@@ -289,14 +291,14 @@ export function resolveProvider(name: string): ResolvedProvider | null {
 
   const rawModels = provider.models ?? (provider.defaultModel ? [provider.defaultModel] : []);
   const modelIds: string[] = [];
-  const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; echoReasoning?: boolean }>();
+  const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean }>();
   for (const m of rawModels) {
     if (typeof m === "string") {
       modelIds.push(m);
     } else {
       modelIds.push(m.id);
-      if (m.reasoning !== undefined || m.contextWindow !== undefined || m.echoReasoning !== undefined) {
-        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, echoReasoning: m.echoReasoning });
+      if (m.reasoning !== undefined || m.contextWindow !== undefined || m.maxTokens !== undefined || m.echoReasoning !== undefined) {
+        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, maxTokens: m.maxTokens, echoReasoning: m.echoReasoning });
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface AgentMode {
   providerConfig?: { apiKey: string; baseURL?: string };
   /** Context window size in tokens (for usage display). */
   contextWindow?: number;
+  /** Max output tokens for this mode. */
+  maxTokens?: number;
   /** Model supports reasoning/thinking tokens. */
   reasoning?: boolean;
   /** Provider supports the reasoning_effort parameter. */

--- a/src/utils/llm-client.ts
+++ b/src/utils/llm-client.ts
@@ -68,7 +68,7 @@ export class LlmClient {
       model: opts.model ?? this.model,
       messages: opts.messages,
       tools: opts.tools?.length ? opts.tools : undefined,
-      max_tokens: opts.max_tokens ?? 8192,
+      max_tokens: opts.max_tokens ?? 65536,
       stream: true as const,
       stream_options: { include_usage: true },
       ...(opts.reasoning_effort


### PR DESCRIPTION
## Problem

`max_tokens` was hardcoded to 8192 in `llm-client.ts`, and `agent-loop.ts` `streamResponse()` did not pass `max_tokens` to the LLM call. Complex tasks requiring long output + multiple tool calls were frequently truncated.

## Solution

Add a `maxTokens` field to `ModelCapabilityConfig` and propagate it through the entire pipeline:

1. **settings.ts** — add `maxTokens` to `ModelCapabilityConfig`, `resolveProvider()` caps, and `ResolvedProvider`
2. **agent-backend.ts** — read `mc?.maxTokens` when building mode config (with fallback: `min(contextWindow × 0.4, 65536)`)
3. **agent-loop.ts** — pass `currentMode.maxTokens ?? 65536` as `max_tokens` in `streamResponse()` request params
4. **llm-client.ts** — bump safety-net default from 8192 → 65536
5. **event-bus.ts** — update `provider:register` and `llm:request` event types for completeness

Users can now configure per-model `maxTokens` in `~/.agent-sh/settings.json`:

```json
{
  "providers": {
    "openrouter": {
      "models": [
        { "id": "deepseek/deepseek-v4-flash", "maxTokens": 300000 }
      ]
    }
  }
}
```

## Testing

- TypeScript `tsc --noEmit` passes with zero errors
- All existing patterns preserved — new field flows through same pipeline as `contextWindow` / `echoReasoning`
- Fallback chain: config value → derived from contextWindow → 65536