### PR TITLE
provider:register merges with settings.json (no more silent clobber)

### DIFF
--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -23,19 +23,47 @@ function persistedModelFor(providerName: string | undefined): string | undefined
   return getSettings().providers?.[providerName]?.defaultModel;
 }
 
+type ModelCap = { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean };
+
 function defaultReasoningBuilder(level: string): Record<string, unknown> {
   return level === "off" ? {} : { reasoning_effort: level };
+}
+
+function mergeCaps(
+  settingsCaps: Map<string, ModelCap> | undefined,
+  payloadCaps: Map<string, ModelCap>,
+  modelIds: string[],
+): Map<string, ModelCap> | undefined {
+  const out = new Map<string, ModelCap>();
+  for (const id of modelIds) {
+    const s = settingsCaps?.get(id);
+    const p = payloadCaps.get(id);
+    if (!s && !p) continue;
+    out.set(id, {
+      reasoning: s?.reasoning ?? p?.reasoning,
+      contextWindow: s?.contextWindow ?? p?.contextWindow,
+      maxTokens: s?.maxTokens ?? p?.maxTokens,
+      echoReasoning: s?.echoReasoning ?? p?.echoReasoning,
+    });
+  }
+  return out.size > 0 ? out : undefined;
 }
 
 export default function agentBackend(ctx: ExtensionContext): void {
   const { bus } = ctx;
   const config: AgentShellConfig = ctx.call("config:get-shell-config") ?? {};
 
-  // Seed from settings.json; runtime provider:register events add more.
+  // settings.json wins per-field over runtime provider:register payloads.
+  // settingsProviders is the immutable source-of-truth for the merge —
+  // multiple sequential registers each merge against the same snapshot.
   const providerRegistry = new Map<string, ResolvedProvider>();
+  const settingsProviders = new Map<string, ResolvedProvider>();
   for (const name of getProviderNames()) {
     const p = resolveProvider(name);
-    if (p) providerRegistry.set(name, p);
+    if (p) {
+      providerRegistry.set(name, p);
+      settingsProviders.set(name, p);
+    }
   }
 
   const providerHooks = new Map<string, { reasoningParams?: (level: string, model?: string) => Record<string, unknown> }>();
@@ -178,36 +206,46 @@ export default function agentBackend(ctx: ExtensionContext): void {
 
   bus.on("provider:register", (p) => {
     const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
-    const modelIds: string[] = [];
-    const caps = new Map<string, { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean }>();
+    const payloadModelIds: string[] = [];
+    const payloadCaps = new Map<string, { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean }>();
     for (const m of rawModels) {
       if (typeof m === "string") {
-        modelIds.push(m);
+        payloadModelIds.push(m);
       } else {
-        modelIds.push(m.id);
-        caps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, maxTokens: m.maxTokens, echoReasoning: m.echoReasoning });
+        payloadModelIds.push(m.id);
+        payloadCaps.set(m.id, { reasoning: m.reasoning, contextWindow: m.contextWindow, maxTokens: m.maxTokens, echoReasoning: m.echoReasoning });
       }
     }
-    providerRegistry.set(p.id, {
+
+    const settings = settingsProviders.get(p.id);
+    const userLocksModels = !!settings?.modelsExplicit && settings.models.length > 0;
+    const modelIds = userLocksModels ? settings!.models : payloadModelIds;
+    const mergedCaps = mergeCaps(settings?.modelCapabilities, payloadCaps, modelIds);
+
+    const merged: ResolvedProvider = {
       id: p.id,
-      apiKey: p.apiKey,
-      baseURL: p.baseURL,
-      defaultModel: p.defaultModel,
+      apiKey: settings?.apiKey ?? p.apiKey,
+      baseURL: settings?.baseURL ?? p.baseURL,
+      defaultModel: settings?.defaultModel ?? p.defaultModel,
       models: modelIds,
-      supportsReasoningEffort: p.supportsReasoningEffort,
-      modelCapabilities: caps.size > 0 ? caps : undefined,
-    });
+      modelsExplicit: settings?.modelsExplicit ?? false,
+      contextWindow: settings?.contextWindow,
+      supportsReasoningEffort: settings?.supportsReasoningEffort ?? p.supportsReasoningEffort,
+      modelCapabilities: mergedCaps,
+      reasoningShape: settings?.reasoningShape,
+    };
+    providerRegistry.set(p.id, merged);
 
     const addModes: AgentMode[] = modelIds.map((m) => {
-      const mc = caps.get(m);
+      const mc = mergedCaps?.get(m);
       return {
         model: m,
         provider: p.id,
-        providerConfig: { apiKey: p.apiKey ?? "", baseURL: p.baseURL },
+        providerConfig: { apiKey: merged.apiKey ?? "", baseURL: merged.baseURL },
         contextWindow: mc?.contextWindow,
         maxTokens: mc?.maxTokens,
         reasoning: mc?.reasoning,
-        supportsReasoningEffort: p.supportsReasoningEffort,
+        supportsReasoningEffort: merged.supportsReasoningEffort,
         echoReasoning: mc?.echoReasoning,
         buildReasoningParams: bindReasoning(p.id, m),
       };

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -34,9 +34,10 @@ function mergeCaps(
   payloadCaps: Map<string, ModelCap>,
   modelIds: string[],
 ): Map<string, ModelCap> | undefined {
+  if (!settingsCaps) return payloadCaps.size > 0 ? payloadCaps : undefined;
   const out = new Map<string, ModelCap>();
   for (const id of modelIds) {
-    const s = settingsCaps?.get(id);
+    const s = settingsCaps.get(id);
     const p = payloadCaps.get(id);
     if (!s && !p) continue;
     out.set(id, {
@@ -53,9 +54,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
   const { bus } = ctx;
   const config: AgentShellConfig = ctx.call("config:get-shell-config") ?? {};
 
-  // settings.json wins per-field over runtime provider:register payloads.
-  // settingsProviders is the immutable source-of-truth for the merge —
-  // multiple sequential registers each merge against the same snapshot.
+  // Immutable settings snapshot; provider:register payloads merge against it.
   const providerRegistry = new Map<string, ResolvedProvider>();
   const settingsProviders = new Map<string, ResolvedProvider>();
   for (const name of getProviderNames()) {
@@ -207,7 +206,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
   bus.on("provider:register", (p) => {
     const rawModels = p.models ?? (p.defaultModel ? [p.defaultModel] : []);
     const payloadModelIds: string[] = [];
-    const payloadCaps = new Map<string, { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean }>();
+    const payloadCaps = new Map<string, ModelCap>();
     for (const m of rawModels) {
       if (typeof m === "string") {
         payloadModelIds.push(m);
@@ -218,8 +217,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
     }
 
     const settings = settingsProviders.get(p.id);
-    const userLocksModels = !!settings?.modelsExplicit && settings.models.length > 0;
-    const modelIds = userLocksModels ? settings!.models : payloadModelIds;
+    const modelIds = settings?.modelsExplicit && settings.models.length > 0 ? settings.models : payloadModelIds;
     const mergedCaps = mergeCaps(settings?.modelCapabilities, payloadCaps, modelIds);
 
     const merged: ResolvedProvider = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -271,6 +271,10 @@ export interface ResolvedProvider {
   baseURL?: string;
   defaultModel?: string;
   models: string[];
+  /** True when the user explicitly listed `models` in settings (locks the
+   *  catalog to that list); false when `models` was synthesized from
+   *  defaultModel or empty (extension-provided catalog is welcome). */
+  modelsExplicit: boolean;
   contextWindow?: number;
   /** Provider supports the reasoning_effort parameter. Default: true. */
   supportsReasoningEffort?: boolean;
@@ -311,6 +315,7 @@ export function resolveProvider(name: string): ResolvedProvider | null {
     baseURL: provider.baseURL,
     defaultModel,
     models: modelIds.length ? modelIds : (defaultModel ? [defaultModel] : []),
+    modelsExplicit: Array.isArray(provider.models),
     contextWindow: provider.contextWindow,
     modelCapabilities: caps.size > 0 ? caps : undefined,
     reasoningShape: provider.reasoningShape,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -271,9 +271,7 @@ export interface ResolvedProvider {
   baseURL?: string;
   defaultModel?: string;
   models: string[];
-  /** True when the user explicitly listed `models` in settings (locks the
-   *  catalog to that list); false when `models` was synthesized from
-   *  defaultModel or empty (extension-provided catalog is welcome). */
+  /** User explicitly listed `models` (locks the catalog to that list). */
   modelsExplicit: boolean;
   contextWindow?: number;
   /** Provider supports the reasoning_effort parameter. Default: true. */


### PR DESCRIPTION
## Summary

`provider:register` from built-in extensions used to **replace** the matching `settings.json` entry in `providerRegistry` wholesale. That made `settings.json` silently lose to env-var auto-activation:

- `OPENROUTER_API_KEY` set + `settings.openrouter.baseURL` (proxy) → proxy URL overwritten
- `DEEPSEEK_API_KEY` set + curated `settings.deepseek.models` with `echoReasoning: true` → flags stripped
- `settings.openai` listing extra catalog models → reduced to the 6 hardcoded `CLOUD_MODELS`

Now: settings.json is the authoritative source. The merge is per-field, settings always wins.

## Merge semantics

| Field | Behavior |
|---|---|
| `apiKey`, `baseURL`, `defaultModel` | settings wins; payload fills if undefined |
| `contextWindow` (provider-level) | settings only (payload doesn't carry it) |
| `supportsReasoningEffort` | settings wins; payload fills |
| `reasoningShape` | settings only |
| `models` | locked to settings list **only** if user wrote `models: [non-empty]` explicitly. Bare `defaultModel: "x"` no longer collapses the catalog. |
| Per-model caps (`reasoning`, `contextWindow`, `maxTokens`, `echoReasoning`) | merged field-by-field per model id; settings wins |

The `models` rule needed a new `modelsExplicit: boolean` flag on `ResolvedProvider` to distinguish "user listed models" from "models was synthesized from defaultModel by `resolveProvider`."

## Implementation notes

- `settingsProviders` is a frozen snapshot taken at startup. Subsequent `provider:register` events merge against this snapshot, not against the current `providerRegistry` state. This makes sequential registers idempotent (openrouter's sync curated catalog → async full catalog both merge against the same settings).
- `mergeCaps()` helper: per-model field-level merge, returns `undefined` if no caps remain.
- The late-registration reconcile block is unchanged — still triggers `config:switch-model` when an async catalog completes the user's persisted default.

## Backwards compatibility

- Users with **no settings entry** for a built-in provider: behavior unchanged. Extension's payload becomes the entry, full catalog available.
- Users with **`models` explicitly listed** in settings: locked list now actually enforced (was previously clobbered, then patched by the special-case in `agent-backend.ts:111-113` for `defaultModel` only).
- Users with **only `defaultModel`** in settings: still get the extension's full catalog with their chosen default, same as before.
- Users with **API key only** in settings: still get the extension's full catalog, same as before.

## Test plan

- [x] `npm run build` passes
- [ ] Smoke: `OPENROUTER_API_KEY` set, no openrouter in settings → curated then full catalog still loads
- [ ] Smoke: `OPENROUTER_API_KEY` set + `settings.openrouter.baseURL = "..."` → custom baseURL preserved post-register
- [ ] Smoke: `DEEPSEEK_API_KEY` set + `settings.deepseek.models` with `echoReasoning: true` → flags survive register
- [ ] Smoke: `settings.openrouter.defaultModel = "google/gemini-..."` → full catalog loads, gemini active
- [ ] Smoke: `settings.openrouter.models = ["a", "b"]` → only those two appear in `/model` autocomplete