### PR TITLE
Make pi-bridge a first-class backend (model, thinking, commands, banner, shell context)

### DIFF
--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -124,12 +124,14 @@ export default function activate(ctx: ExtensionContext): void {
         }
       });
 
-      // Report model info
       const model = session.model;
       bus.emit("agent:info", {
         name: "pi",
         version: "0.66",
         model: model ? `${model.provider}/${model.id}` : undefined,
+        notReadyHint: model
+          ? undefined
+          : "Pi has no model configured. Set ANTHROPIC_API_KEY (or another provider key) and restart, or run pi's `/login` flow.",
       });
 
       booting = false;

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -29,7 +29,7 @@ import type { ExtensionContext } from "agent-sh/types";
 
 // ── Extension entry point ─────────────────────────────────────────
 export default function activate(ctx: ExtensionContext): void {
-  const { bus } = ctx;
+  const { bus, call } = ctx;
   const cwd = process.cwd();
 
   // ── Boot pi session (async — register backend synchronously first) ──
@@ -162,8 +162,12 @@ export default function activate(ctx: ExtensionContext): void {
       bus.emit("agent:query", { query });
       bus.emit("agent:processing-start", {});
 
+      // Inline producers raw — outputs already self-tag (<shell_events>...).
+      const ctxText = String(call("query-context:build") ?? "").trim();
+      const final = ctxText ? `${ctxText}\n\n${query}` : query;
+
       try {
-        await session.prompt(query);
+        await session.prompt(final);
       } catch (err) {
         bus.emit("agent:error", {
           message: err instanceof Error ? err.message : String(err),

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -131,7 +131,7 @@ export default function activate(ctx: ExtensionContext): void {
         model: model ? `${model.provider}/${model.id}` : undefined,
         notReadyHint: model
           ? undefined
-          : "Pi has no model configured. Set ANTHROPIC_API_KEY (or another provider key) and restart, or run pi's `/login` flow.",
+          : "Pi has no model configured. Run `pi` directly to set up auth, then restart agent-sh.",
       });
 
       booting = false;

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -129,9 +129,6 @@ export default function activate(ctx: ExtensionContext): void {
         name: "pi",
         version: "0.66",
         model: model ? `${model.provider}/${model.id}` : undefined,
-        notReadyHint: model
-          ? undefined
-          : "Pi has no model configured. Run `pi` directly to set up auth, then restart agent-sh.",
       });
 
       booting = false;

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -35,12 +35,16 @@ export default function activate(ctx: ExtensionContext): void {
   // ── Boot pi session (async — register backend synchronously first) ──
   let session: any = null;
   let runtime: any = null;
+  let modelRegistry: any = null;
   let booting = true;
+
+  const PI_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
 
   const boot = async () => {
     try {
       // Pi loads its own config: ~/.pi/agent/settings.json, models, extensions
       const services = await createAgentSessionServices({ cwd });
+      modelRegistry = services.modelRegistry;
       const sessionManager = SessionManager.inMemory(cwd);
 
       // createRuntime factory — returns { session, services, ... } as expected
@@ -138,7 +142,10 @@ export default function activate(ctx: ExtensionContext): void {
   };
 
   // ── Bus listeners (wired on start, unwired on kill) ────────────
-  const listeners: Array<{ event: string; fn: Function }> = [];
+  type ListenerEntry =
+    | { kind: "on"; event: string; fn: Function }
+    | { kind: "pipe"; event: string; fn: Function };
+  const listeners: ListenerEntry[] = [];
 
   const wireListeners = () => {
     const onSubmit = async ({ query }: any) => {
@@ -169,18 +176,98 @@ export default function activate(ctx: ExtensionContext): void {
       session = runtime?.session;
     };
 
+    const onListModels = () => {
+      if (!session || !modelRegistry) return { models: [], active: null };
+      const all = modelRegistry.getAvailable() as Array<{ id: string; provider: string }>;
+      const cur = session.model;
+      return {
+        models: all.map((m) => ({ model: m.id, provider: m.provider })),
+        active: cur ? { model: cur.id, provider: cur.provider } : null,
+      };
+    };
+
+    // Slash command emits `model@provider` for disambiguation; pi looks up by (provider, id).
+    const onSwitchModel = async ({ model: target }: { model: string }) => {
+      if (!session || !modelRegistry) return;
+      const atIdx = target.lastIndexOf("@");
+      const modelId = atIdx > 0 ? target.slice(0, atIdx) : target;
+      const providerHint = atIdx > 0 ? target.slice(atIdx + 1) : undefined;
+
+      const candidates = (modelRegistry.getAvailable() as Array<{ id: string; provider: string }>)
+        .filter((m) => m.id === modelId && (!providerHint || m.provider === providerHint));
+
+      if (candidates.length === 0) {
+        bus.emit("ui:error", { message: `Unknown model: ${target}` });
+        return;
+      }
+      if (candidates.length > 1) {
+        const opts = candidates.map((m) => `${m.id}@${m.provider}`).join(", ");
+        bus.emit("ui:error", { message: `Ambiguous model "${modelId}". Use one of: ${opts}` });
+        return;
+      }
+      const picked = candidates[0]!;
+      const full = modelRegistry.find(picked.provider, picked.id);
+      if (!full) {
+        bus.emit("ui:error", { message: `Model not found: ${target}` });
+        return;
+      }
+      try {
+        await session.setModel(full);
+        bus.emit("agent:info", {
+          name: "pi",
+          version: "0.66",
+          model: `${picked.provider}/${picked.id}`,
+        });
+        bus.emit("ui:info", { message: `Model: ${picked.provider}: ${picked.id}` });
+        bus.emit("config:changed", {});
+      } catch (err) {
+        bus.emit("ui:error", {
+          message: `Failed to switch model: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    };
+
+    const onGetThinking = () => {
+      const level = session?.thinkingLevel ?? "off";
+      return { level, levels: [...PI_THINKING_LEVELS], supported: true };
+    };
+
+    const onSetThinking = ({ level }: { level: string }) => {
+      if (!session) return;
+      if (!PI_THINKING_LEVELS.includes(level as any)) {
+        bus.emit("ui:error", {
+          message: `Unknown thinking level: ${level}. Use: ${PI_THINKING_LEVELS.join(", ")}`,
+        });
+        return;
+      }
+      session.setThinkingLevel(level);
+      bus.emit("ui:info", { message: `Thinking: ${level}` });
+      bus.emit("config:changed", {});
+    };
+
     bus.on("agent:submit", onSubmit);
     bus.on("agent:cancel-request", onCancel);
     bus.on("agent:reset-session", onReset);
+    bus.on("config:switch-model", onSwitchModel as any);
+    bus.on("config:set-thinking", onSetThinking as any);
+    bus.onPipe("config:get-models", onListModels as any);
+    bus.onPipe("config:get-thinking", onGetThinking as any);
     listeners.push(
-      { event: "agent:submit", fn: onSubmit },
-      { event: "agent:cancel-request", fn: onCancel },
-      { event: "agent:reset-session", fn: onReset },
+      { kind: "on", event: "agent:submit", fn: onSubmit },
+      { kind: "on", event: "agent:cancel-request", fn: onCancel },
+      { kind: "on", event: "agent:reset-session", fn: onReset },
+      { kind: "on", event: "config:switch-model", fn: onSwitchModel },
+      { kind: "on", event: "config:set-thinking", fn: onSetThinking },
+      { kind: "pipe", event: "config:get-models", fn: onListModels },
+      { kind: "pipe", event: "config:get-thinking", fn: onGetThinking },
     );
   };
 
   const unwireListeners = () => {
-    for (const { event, fn } of listeners) bus.off(event as any, fn as any);
+    for (const { kind, event, fn } of listeners) {
+      if (kind === "pipe") bus.offPipe(event as any, fn as any);
+      else bus.off(event as any, fn as any);
+    }
     listeners.length = 0;
   };
 
@@ -196,6 +283,7 @@ export default function activate(ctx: ExtensionContext): void {
       runtime?.dispose();
       session = null;
       runtime = null;
+      modelRegistry = null;
       booting = true;
     },
   });

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -280,8 +280,43 @@ export default function activate(ctx: ExtensionContext): void {
     start: async () => {
       await boot();
       wireListeners();
+      bus.emit("command:register", {
+        name: "/compact",
+        description: "Compact pi's session context",
+        handler: async () => {
+          if (!session) return;
+          try {
+            await session.compact();
+            bus.emit("ui:info", { message: "(compacted)" });
+          } catch (err) {
+            bus.emit("ui:info", {
+              message: `(${err instanceof Error ? err.message : String(err)})`,
+            });
+          }
+        },
+      });
+      bus.emit("command:register", {
+        name: "/context",
+        description: "Show pi's context budget usage",
+        handler: () => {
+          if (!session) return;
+          const usage = session.getContextUsage() as { tokens: number; contextWindow: number } | undefined;
+          if (!usage) {
+            bus.emit("ui:info", { message: "Context: not available yet" });
+            return;
+          }
+          const pct = usage.contextWindow > 0
+            ? Math.round((usage.tokens / usage.contextWindow) * 100)
+            : 0;
+          bus.emit("ui:info", {
+            message: `Active context: ~${usage.tokens.toLocaleString()} tokens / ${usage.contextWindow.toLocaleString()} budget (${pct}%)`,
+          });
+        },
+      });
     },
     kill: () => {
+      bus.emit("command:unregister", { name: "/compact" });
+      bus.emit("command:unregister", { name: "/context" });
       unwireListeners();
       runtime?.dispose();
       session = null;

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -99,6 +99,7 @@ export class AgentLoop implements AgentBackend {
   private modes: AgentMode[];
   private currentModeIndex = 0;
   private boundListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
+  private boundPipeListeners: Array<{ event: string; fn: (...args: any[]) => any; async: boolean }> = [];
   private ctorListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
   private ctorPipeListeners: Array<{ event: string; fn: (...args: any[]) => any }> = [];
   private lastProjectSkillNames = new Set<string>();
@@ -269,6 +270,20 @@ export class AgentLoop implements AgentBackend {
       this.bus.on(event, fn);
       this.boundListeners.push({ event, fn });
     };
+    const onPipe = <K extends keyof ShellEvents>(
+      event: K,
+      fn: (payload: ShellEvents[K]) => ShellEvents[K] | void,
+    ) => {
+      this.bus.onPipe(event, fn as any);
+      this.boundPipeListeners.push({ event, fn, async: false });
+    };
+    const onPipeAsync = <K extends keyof ShellEvents>(
+      event: K,
+      fn: (payload: ShellEvents[K]) => Promise<ShellEvents[K] | void>,
+    ) => {
+      this.bus.onPipeAsync(event, fn as any);
+      this.boundPipeListeners.push({ event, fn, async: true });
+    };
 
     on("agent:submit", ({ query }) => {
       this.handleQuery(query).catch(() => {});
@@ -316,7 +331,7 @@ export class AgentLoop implements AgentBackend {
       }
       this.bus.emit("config:changed", {});
     });
-    this.bus.onPipe("config:get-models", (payload) => {
+    onPipe("config:get-models", () => {
       const models = this.modes.map((m) => ({ model: m.model, provider: m.provider ?? "" }));
       const cur = this.modes[this.currentModeIndex];
       const active = cur ? { model: cur.model, provider: cur.provider ?? "" } : null;
@@ -340,7 +355,7 @@ export class AgentLoop implements AgentBackend {
       this.bus.emit("ui:info", { message: `Thinking: ${level}` });
       this.bus.emit("config:changed", {});
     });
-    this.bus.onPipe("config:get-thinking", () => {
+    onPipe("config:get-thinking", () => {
       const mode = this.currentMode;
       const supported = mode.reasoning !== false && mode.supportsReasoningEffort !== false;
       return { level: this.thinkingLevel, levels: AgentLoop.THINKING_LEVELS, supported };
@@ -361,7 +376,7 @@ export class AgentLoop implements AgentBackend {
         this.bus.emit("ui:info", { message: "(nothing to compact)" });
       }
     });
-    this.bus.onPipe("context:get-stats", () => ({
+    onPipe("context:get-stats", () => ({
       activeTokens: this.conversation.estimateTokens(),
       totalTokens: this.conversation.estimatePromptTokens(),
       nuclearEntries: this.conversation.getNuclearEntryCount(),
@@ -369,14 +384,14 @@ export class AgentLoop implements AgentBackend {
       budgetTokens: this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     }));
 
-    this.bus.onPipe("context:snapshot", (payload) => {
+    onPipe("context:snapshot", (payload) => {
       payload.messages = this.conversation.getMessages();
       payload.contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       payload.activeTokens = this.conversation.estimateTokens();
       return payload;
     });
 
-    this.bus.onPipeAsync("context:compact", async (payload) => {
+    onPipeAsync("context:compact", async (payload) => {
       const stats = await this.compactWithHooks(0, undefined, false, payload.strategy);
       if (stats) payload.stats = { before: stats.before, after: stats.after, evictedCount: stats.evictedCount };
       return payload;
@@ -430,6 +445,11 @@ export class AgentLoop implements AgentBackend {
       this.bus.off(event as any, fn);
     }
     this.boundListeners = [];
+    for (const { event, fn, async } of this.boundPipeListeners) {
+      if (async) this.bus.offPipeAsync(event as any, fn);
+      else this.bus.offPipe(event as any, fn);
+    }
+    this.boundPipeListeners = [];
   }
 
   /** Register a tool (used by extensions via ctx.registerTool). */

--- a/src/core.ts
+++ b/src/core.ts
@@ -49,7 +49,7 @@ export interface AgentShellCore {
   /** Unique id for this agent process; used for shell-marker tagging and lineage tracking. */
   instanceId: string;
   /** Activate the agent backend (call after extensions load). */
-  activateBackend(): void;
+  activateBackend(): Promise<void>;
   /** Convenience: emit agent:submit and await the response. */
   query(text: string): Promise<string>;
   /** Convenience: emit agent:cancel-request. */
@@ -150,16 +150,12 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
     handlers,
     instanceId,
 
-    activateBackend() {
-      // Silent — backend info is shown in the startup banner.
-      // Runtime switches (config:switch-backend) still emit ui:info.
+    async activateBackend() {
       if (backends.size === 0) return;
       const preferred = settings.defaultBackend;
-      if (preferred && backends.has(preferred)) {
-        activateByName(preferred, true);
-      } else {
-        activateByName(backends.keys().next().value!, true);
-      }
+      const name = preferred && backends.has(preferred) ? preferred : backends.keys().next().value!;
+      // silent=true: startup banner shows the backend; ui:info would race against it
+      await activateByName(name, true);
     },
 
     async query(text) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -91,26 +91,20 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
   const backends = new Map<string, Backend>();
   let activeBackendName: string | null = null;
 
-  const activateByName = async (name: string, silent = false) => {
+  const activateByName = async (name: string): Promise<boolean> => {
     const backend = backends.get(name);
     if (!backend) {
       bus.emit("ui:error", { message: `Unknown backend: ${name}` });
-      return;
+      return false;
     }
 
-    // Deactivate current backend
     if (activeBackendName) {
       backends.get(activeBackendName)?.kill();
     }
 
-    // Activate new backend
     await backend.start?.();
     activeBackendName = name;
-
-    if (!silent) {
-      bus.emit("ui:info", { message: `Backend: ${name}` });
-    }
-    bus.emit("config:changed", {});
+    return true;
   };
 
   bus.on("agent:register-backend", (backend) => {
@@ -118,11 +112,12 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
   });
 
   bus.on("config:switch-backend", ({ name }) => {
-    activateByName(name).then(() => {
-      if (activeBackendName === name) {
-        settingsMod.updateSettings({ defaultBackend: name });
-        bus.emit("ui:info", { message: `Saved '${name}' as default backend.` });
-      }
+    activateByName(name).then((ok) => {
+      if (!ok) return;
+      settingsMod.updateSettings({ defaultBackend: name });
+      // Single ui:info; config:changed (which triggers prompt redraw) follows it.
+      bus.emit("ui:info", { message: `Backend: ${name} (saved as default)` });
+      bus.emit("config:changed", {});
     });
   });
 
@@ -154,8 +149,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
       if (backends.size === 0) return;
       const preferred = settings.defaultBackend;
       const name = preferred && backends.has(preferred) ? preferred : backends.keys().next().value!;
-      // silent=true: startup banner shows the backend; ui:info would race against it
-      await activateByName(name, true);
+      await activateByName(name);
     },
 
     async query(text) {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -232,7 +232,7 @@ export interface ShellEvents {
   };
 
   // Agent info (backend → frontend: connection established, info available)
-  "agent:info": { name: string; version: string; model?: string; provider?: string; contextWindow?: number; notReadyHint?: string };
+  "agent:info": { name: string; version: string; model?: string; provider?: string; contextWindow?: number };
 
   // Session reset (slash command → backend: clear conversation state)
   "agent:reset-session": Record<string, never>;
@@ -306,7 +306,7 @@ export interface ShellEvents {
   // Fires after all extensions (built-in + user) have activated.
   // agent-backend waits on this to resolve settings.defaultProvider
   // against the full provider registry, including dynamic providers.
-  "core:extensions-loaded": Record<string, never>;
+  "core:extensions-loaded": { names: string[] };
 
   // Register a provider at runtime (extensions → core)
   "provider:register": {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -232,7 +232,7 @@ export interface ShellEvents {
   };
 
   // Agent info (backend → frontend: connection established, info available)
-  "agent:info": { name: string; version: string; model?: string; provider?: string; contextWindow?: number };
+  "agent:info": { name: string; version: string; model?: string; provider?: string; contextWindow?: number; notReadyHint?: string };
 
   // Session reset (slash command → backend: clear conversation state)
   "agent:reset-session": Record<string, never>;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -526,6 +526,17 @@ export class EventBus {
     return result;
   }
 
+  /** Remove an async transform listener from a pipeline event. */
+  offPipeAsync<K extends keyof ShellEvents>(
+    event: K,
+    fn: AsyncPipeListener<ShellEvents[K]>,
+  ): void {
+    const listeners = this.asyncPipeListeners.get(event);
+    if (!listeners) return;
+    const idx = listeners.indexOf(fn);
+    if (idx !== -1) listeners.splice(idx, 1);
+  }
+
   /** Register an async transform listener for a pipeline event. */
   onPipeAsync<K extends keyof ShellEvents>(
     event: K,

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -16,6 +16,7 @@ import { AgentLoop } from "../agent/agent-loop.js";
 import { LlmClient } from "../utils/llm-client.js";
 import { resolveProvider, getProviderNames, getSettings, type ResolvedProvider } from "../settings.js";
 import { PACKAGE_VERSION } from "../utils/package-version.js";
+import { discoverSkills } from "../agent/skills.js";
 
 /** Read the user's persisted defaultModel for a provider, if any. */
 function persistedModelFor(providerName: string | undefined): string | undefined {
@@ -135,7 +136,10 @@ export default function agentBackend(ctx: ExtensionContext): void {
     history: config.history,
   });
 
-  bus.on("core:extensions-loaded", () => {
+  let loadedExtensionNames: string[] = [];
+
+  bus.on("core:extensions-loaded", ({ names }) => {
+    loadedExtensionNames = names;
     const settings = getSettings();
     // If the user didn't pick a default, fall back to the first registered
     // provider (built-in load order biases to openrouter → openai).
@@ -303,5 +307,18 @@ export default function agentBackend(ctx: ExtensionContext): void {
     bus.emit("agent:info", { name: "ash", version: PACKAGE_VERSION, model: switchModel, provider: name, contextWindow: p.contextWindow });
     bus.emit("ui:info", { message: `Switched to ${name} (${switchModel})` });
     bus.emit("config:changed", {});
+  });
+
+  bus.onPipe("banner:collect", (e) => {
+    const settings = getSettings();
+    if (settings.defaultBackend && settings.defaultBackend !== "ash") return e;
+    if (loadedExtensionNames.length > 0) {
+      e.sections.push({ label: "Extensions", items: [...loadedExtensionNames] });
+    }
+    const skills = discoverSkills(ctx.call("cwd") ?? process.cwd());
+    if (skills.length > 0) {
+      e.sections.push({ label: "Skills", items: skills.map((s) => s.name) });
+    }
+    return e;
   });
 }

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -191,11 +191,35 @@ export default function agentBackend(ctx: ExtensionContext): void {
       name: "ash",
       kill: () => {
         ashActive = false;
+        bus.emit("command:unregister", { name: "/compact" });
+        bus.emit("command:unregister", { name: "/context" });
         agentLoop.kill();
       },
       start: async () => {
         agentLoop.wire();
         ashActive = true;
+        bus.emit("command:register", {
+          name: "/compact",
+          description: "Compact conversation via the active compaction strategy",
+          handler: () => bus.emit("agent:compact-request", {}),
+        });
+        bus.emit("command:register", {
+          name: "/context",
+          description: "Show context budget usage",
+          handler: () => {
+            const stats = bus.emitPipe("context:get-stats", {
+              activeTokens: 0,
+              totalTokens: 0,
+              budgetTokens: 0,
+            });
+            const pct = stats.budgetTokens > 0
+              ? Math.round((stats.activeTokens / stats.budgetTokens) * 100)
+              : 0;
+            bus.emit("ui:info", {
+              message: `Active context: ~${stats.activeTokens.toLocaleString()} tokens / ${stats.budgetTokens.toLocaleString()} budget (${pct}%)`,
+            });
+          },
+        });
         bus.emit("agent:info", {
           name: "ash",
           version: PACKAGE_VERSION,

--- a/src/extensions/agent-backend.ts
+++ b/src/extensions/agent-backend.ts
@@ -114,6 +114,8 @@ export default function agentBackend(ctx: ExtensionContext): void {
   let modes: AgentMode[] = [];
   let initialModeIndex = 0;
   let resolved = false;
+  // Gates late-registration reconcile so its config:switch-model emit doesn't misroute under a non-ash backend.
+  let ashActive = false;
 
   bus.onPipe("config:get-initial-modes", () => ({ modes, initialModeIndex }));
 
@@ -183,9 +185,13 @@ export default function agentBackend(ctx: ExtensionContext): void {
 
     bus.emit("agent:register-backend", {
       name: "ash",
-      kill: () => agentLoop.kill(),
+      kill: () => {
+        ashActive = false;
+        agentLoop.kill();
+      },
       start: async () => {
         agentLoop.wire();
+        ashActive = true;
         bus.emit("agent:info", {
           name: "ash",
           version: PACKAGE_VERSION,
@@ -253,7 +259,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
     // Late-registration reconcile: if this completes the user's persisted
     // default (openrouter's async fetch delivers the full catalog after
     // we've already fallen back to mode 0), quietly switch to it.
-    if (!resolved) return;
+    if (!resolved || !ashActive) return;
     const pendingProvider = getSettings().defaultProvider;
     if (pendingProvider !== p.id) return;
     const pendingModel = persistedModelFor(pendingProvider);

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -91,32 +91,6 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   register({
-    name: "/compact",
-    description: "Compact conversation via the active compaction strategy",
-    handler: () => {
-      bus.emit("agent:compact-request", {});
-    },
-  });
-
-  register({
-    name: "/context",
-    description: "Show context budget usage",
-    handler: () => {
-      const stats = bus.emitPipe("context:get-stats", {
-        activeTokens: 0,
-        totalTokens: 0,
-        budgetTokens: 0,
-      });
-      const pct = stats.budgetTokens > 0
-        ? Math.round((stats.activeTokens / stats.budgetTokens) * 100)
-        : 0;
-      bus.emit("ui:info", {
-        message: `Active context: ~${stats.activeTokens.toLocaleString()} tokens / ${stats.budgetTokens.toLocaleString()} budget (${pct}%)`,
-      });
-    },
-  });
-
-  register({
     name: "/reload",
     description: "Reload user extensions from ~/.agent-sh/extensions/",
     handler: async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { palette as p } from "./utils/palette.js";
 import { loadBuiltinExtensions } from "./extensions/index.js";
 import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
-import { discoverSkills } from "./agent/skills.js";
 import { runInit } from "./init.js";
 import { PACKAGE_VERSION } from "./utils/package-version.js";
 import type { AgentShellConfig } from "./types.js";
@@ -205,7 +204,7 @@ async function main(): Promise<void> {
   const { bus } = core;
 
   // Track agent info from bus events (populated by extension backends)
-  let agentInfo: { name: string; version: string; model?: string; provider?: string; notReadyHint?: string } | null = null;
+  let agentInfo: { name: string; version: string; model?: string; provider?: string } | null = null;
   bus.on("agent:info", (info) => { agentInfo = info; });
 
   // ── Interactive frontend ──────────────────────────────────────
@@ -292,12 +291,8 @@ async function main(): Promise<void> {
     console.error('[agent-sh] Extensions loaded');
   }
 
-  // Tell deferred-init listeners (agent-backend) that the provider
-  // registry is now complete.
-  core.bus.emit("core:extensions-loaded", {});
-
-  // ── Discover skills ───────────────────────────────────────────
-  const skills = discoverSkills(process.cwd());
+  // Names ride along so backend extensions can build banner sections.
+  core.bus.emit("core:extensions-loaded", { names: loadedExtensions });
 
   // ── Activate agent backend ────────────────────────────────────
   // Extensions had their chance to register via agent:register-backend.
@@ -312,7 +307,8 @@ async function main(): Promise<void> {
       "  Alternatively, install a bridge extension (claude-code-bridge, pi-bridge).\n");
     process.exit(1);
   }
-  await core.activateBackend();
+  // No await: banner must out-race the shell's PS1 arriving via PTY.
+  core.activateBackend();
 
   // ── Startup banner ───────────────────────────────────────────
   const settings = getSettings();
@@ -322,33 +318,12 @@ async function main(): Promise<void> {
 
     const productName = `${p.accent}${p.bold}agent-sh${p.reset}`;
 
-    const info = agentInfo as { name: string; version: string; model?: string; provider?: string; notReadyHint?: string } | null;
-    const backendReady = !!info?.model;
-    const backendName = info?.name ?? "ash";
-    const model = info?.model;
-    const provider = info?.provider;
-    const notReadyHint = info?.notReadyHint;
-    const modelValue = model
-      ? provider ? `${model} [${provider}]` : model
-      : null;
+    const backendName = settings.defaultBackend && backendNames.includes(settings.defaultBackend)
+      ? settings.defaultBackend
+      : backendNames[0]!;
 
     let sections = "";
-    sections += `\n\n  ${p.muted}Backend:${p.reset} ${p.dim}${backendName}${backendReady ? "" : " (not configured)"}${p.reset}`;
-    if (modelValue) {
-      sections += `\n  ${p.muted}Model:${p.reset} ${p.dim}${modelValue}${p.reset}`;
-    }
-    if (loadedExtensions.length > 0) {
-      sections += `\n\n  ${p.muted}Extensions:${p.reset}`;
-      for (const name of loadedExtensions) {
-        sections += `\n    ${p.dim}${name}${p.reset}`;
-      }
-    }
-    if (skills.length > 0) {
-      sections += `\n\n  ${p.muted}Skills:${p.reset}`;
-      for (const s of skills) {
-        sections += `\n    ${p.dim}${s.name}${p.reset}`;
-      }
-    }
+    sections += `\n\n  ${p.muted}Backend:${p.reset} ${p.dim}${backendName}${p.reset}`;
 
     const extSections = bus.emitPipe("banner:collect", { sections: [] }).sections;
     for (const sec of extSections) {
@@ -358,9 +333,7 @@ async function main(): Promise<void> {
       }
     }
 
-    const hint = backendReady
-      ? `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}>/help${p.muted} for commands${p.reset}`
-      : `${p.muted}${notReadyHint ?? `Backend "${backendName}" is not configured.`}${p.reset}`;
+    const hint = `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}>/help${p.muted} for commands${p.reset}`;
     const borderLine = `${p.muted}${"─".repeat(bannerW)}${p.reset}`;
 
     process.stdout.write(

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,7 @@ async function main(): Promise<void> {
       "  Alternatively, install a bridge extension (claude-code-bridge, pi-bridge).\n");
     process.exit(1);
   }
-  core.activateBackend();
+  await core.activateBackend();
 
   // ── Startup banner ───────────────────────────────────────────
   const settings = getSettings();

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
   const { bus } = core;
 
   // Track agent info from bus events (populated by extension backends)
-  let agentInfo: { name: string; version: string; model?: string; provider?: string } | null = null;
+  let agentInfo: { name: string; version: string; model?: string; provider?: string; notReadyHint?: string } | null = null;
   bus.on("agent:info", (info) => { agentInfo = info; });
 
   // ── Interactive frontend ──────────────────────────────────────
@@ -322,11 +322,12 @@ async function main(): Promise<void> {
 
     const productName = `${p.accent}${p.bold}agent-sh${p.reset}`;
 
-    const info = agentInfo as { name: string; version: string; model?: string; provider?: string } | null;
+    const info = agentInfo as { name: string; version: string; model?: string; provider?: string; notReadyHint?: string } | null;
     const backendReady = !!info?.model;
     const backendName = info?.name ?? "ash";
     const model = info?.model;
     const provider = info?.provider;
+    const notReadyHint = info?.notReadyHint;
     const modelValue = model
       ? provider ? `${model} [${provider}]` : model
       : null;
@@ -359,7 +360,7 @@ async function main(): Promise<void> {
 
     const hint = backendReady
       ? `${p.muted}Type ${p.warning}>${p.muted} to ask AI · ${p.warning}>/help${p.muted} for commands${p.reset}`
-      : `${p.muted}Set ${p.warning}OPENROUTER_API_KEY${p.muted} or ${p.warning}OPENAI_API_KEY${p.muted} and restart to enable AI${p.reset}`;
+      : `${p.muted}${notReadyHint ?? `Backend "${backendName}" is not configured.`}${p.reset}`;
     const borderLine = `${p.muted}${"─".repeat(bannerW)}${p.reset}`;
 
     process.stdout.write(


### PR DESCRIPTION
## Summary

Brings pi-bridge up to functional parity with ash and pushes ash-specific assumptions out of the harness. Pi-bridge users now get working `/model`, `/thinking`, `/compact`, `/context`, a correct startup banner that doesn't list ash-only extensions, and shell context (`<shell_events>`) feeding into pi.

The recurring theme: anything that's "ash's view of the world" — provider registry, conversation compaction, context tokens, loaded extensions, discovered skills — moves down past the backend boundary. The harness owns chrome (border, banner frame, backend switcher, extension loader); each backend owns the rest.

## What changed

**Backend-owned model and thinking state** — `config:get-models` / `config:switch-model` / `config:get-thinking` / `config:set-thinking` keep their public event names; handler ownership moves into each backend's start/kill lifecycle. Pi-bridge backs them with pi's `ModelRegistry` and `AgentSession.setModel` / `setThinkingLevel`. Fixes a latent pipe-listener leak in ash's `agent-loop.ts:wire/unwire` (became real once a second backend could shadow ash's pipes). Adds `offPipeAsync` to `event-bus.ts` for symmetry. Gates ash's late-registration `config:switch-model` emit on a new `ashActive` flag so it doesn't misroute under a non-ash backend.

**Backend-owned slash commands** — `/compact` and `/context` move out of `slash-commands.ts` and become per-backend registrations. Ash registers them in its `start` callback (emits `agent:compact-request`, calls `context:get-stats` pipe) and unregisters in `kill`. Pi-bridge registers its own variants backed by `session.compact()` and `session.getContextUsage()`. Switching backends swaps the available commands.

**Backend-owned banner content** — banner harness in `index.ts` now renders only chrome (border, product name, backend name, `banner:collect` contributions, hint). The `Extensions:` and `Skills:` sections move into ash's `banner:collect` contributor, gated on `settings.defaultBackend === \"ash\"`. Pi banner is just `Backend: pi` — pi manages its own extensions and skills internally and would be free to contribute its own sections later. `core:extensions-loaded` payload now carries `{ names: string[] }` so backend extensions can build banner sections without needing a separate handler.

**Banner timing fix** — `core.activateBackend()` returns `Promise<void>` and runs unawaited. Awaiting blocked startup on pi's full boot, which let the user shell's `PS1` arrive via PTY before the banner was written, leaving the prompt invisible. Without the await, the banner wins the race the way it used to under ash's sync activation.

**Shell context reaches pi** — pi-bridge calls `query-context:build` and inlines the result before `session.prompt()`, so registered per-query producers (e.g. `<shell_events>` from `shell-context.ts`) actually reach pi. No `<query_context>` wrapper — producer outputs already self-tag.

## Behaviour notes

- **Public bus contract unchanged.** Every event renamed-then-reverted. External consumers (slash commands, ash-acp-bridge, ash-mcp-bridge, user extensions) keep working.
- **Pi `setModel` is session-only** (does not persist). Ash's persists to `settings.json`. Acceptable difference — pi has its own `~/.pi/agent/settings.json`.
- **Thinking levels differ between backends.** Pi: `off/minimal/low/medium/high/xhigh`. Ash: ash's existing set. `/thinking` already renders whatever `levels` array the active backend reports.
- **No XML envelope from pi-bridge.** Pi's system prompt isn't ours to extend; producer outputs are inlined raw and rely on their own tags being self-explanatory to the LLM.
- **Pi exposes 21 builtin slash commands** but most are interactive-TUI-only. Only `/compact` and `/context` are wired up here; `/login`, `/logout`, `/export`, `/new`, `/session` are SDK-mappable and can be follow-ups.

## Test plan

- [x] Under ash: `/model`, `/thinking`, `/compact`, `/context` all work as before
- [x] Under pi: `/model` lists pi's available models; `/model <id>` and `/model <id>@<provider>` switch
- [x] Under pi: `/thinking` reports pi's levels and current state; `/thinking <level>` updates it
- [x] Under pi: `/compact` runs pi's `session.compact()`; `/context` shows pi's actual token usage
- [x] `/backend ash` then `/backend pi` then `/help` — confirm only the right backend's commands show up
- [x] Banner shows `Backend: ash` with Extensions + Skills sections under ash; `Backend: pi` with no extra sections under pi
- [x] Startup is fast (no blocking on pi boot); shell prompt appears below the banner
- [x] Pi without auth: banner shows `Backend: pi`; pi-bridge's onSubmit guard handles early queries with a "still starting up" message
- [x] Shell context (`<shell_events>` from recent commands) reaches pi when invoking a query