### PR TITLE
feat: appendUserMessage for safe mid-turn user injection

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -276,6 +276,10 @@ export class AgentLoop implements AgentBackend {
     on("agent:cancel-request", (e) => {
       this.abortController?.abort(e.silent ? "silent" : undefined);
     });
+    on("agent:append-user-message", ({ text }) => {
+      this.conversation.appendUserMessage(text);
+      this.bus.emit("conversation:message-appended", { role: "user", content: text });
+    });
     on("config:switch-model", ({ model: target }) => {
       const atIdx = target.lastIndexOf("@");
       const modelId = atIdx > 0 ? target.slice(0, atIdx) : target;

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -103,10 +103,10 @@ export class ConversationState {
   private lastApiTokenCount: number | null = null;
   private lastApiMessageCount: number = 0;
 
-  // Notes queued when addSystemNote fires mid-tool-pair; flushed once
-  // the trailing tool_result lands. Splicing into the gap breaks
-  // reasoning_content pairing and is rejected by strict providers.
-  private pendingNotes: string[] = [];
+  // Buffered when addSystemNote/appendUserMessage fires mid-tool-pair;
+  // flushed once the trailing tool_result lands. Splicing into the gap
+  // breaks reasoning_content pairing and is rejected by strict providers.
+  private pendingMessages: Array<{ kind: "system" | "user"; text: string }> = [];
 
   constructor(handlers?: HandlerFunctions, instanceId: string = "0000") {
     this.handlers = handlers ?? null;
@@ -170,24 +170,32 @@ export class ConversationState {
     this.messages.push({ role: "tool", tool_call_id: toolCallId, content });
     if (isError) this.toolErrors.add(toolCallId);
     this.invalidateMessagesCache();
-    this.flushPendingNotes();
+    this.flushPendingMessages();
   }
 
   /** Add tool results as a user message (for inline tool protocol). */
   addToolResultInline(content: string): void {
     this.messages.push({ role: "user", content });
     this.invalidateMessagesCache();
-    this.flushPendingNotes();
+    this.flushPendingMessages();
   }
 
   /** Safe from any context: queues if mid-tool-pair, appends otherwise. */
   addSystemNote(text: string): void {
     if (this.hasOpenToolCalls()) {
-      this.pendingNotes.push(text);
+      this.pendingMessages.push({ kind: "system", text });
       return;
     }
     this.messages.push({ role: "user", content: text });
     this.invalidateMessagesCache();
+  }
+
+  appendUserMessage(text: string): void {
+    if (this.hasOpenToolCalls()) {
+      this.pendingMessages.push({ kind: "user", text });
+      return;
+    }
+    this.addUserMessage(text);
   }
 
   private hasOpenToolCalls(): boolean {
@@ -207,13 +215,18 @@ export class ConversationState {
     return false;
   }
 
-  private flushPendingNotes(): void {
-    if (this.pendingNotes.length === 0) return;
+  private flushPendingMessages(): void {
+    if (this.pendingMessages.length === 0) return;
     if (this.hasOpenToolCalls()) return;
-    for (const text of this.pendingNotes) {
-      this.messages.push({ role: "user", content: text });
+    const pending = this.pendingMessages;
+    this.pendingMessages = [];
+    for (const m of pending) {
+      if (m.kind === "user") {
+        this.addUserMessage(m.text);
+      } else {
+        this.messages.push({ role: "user", content: m.text });
+      }
     }
-    this.pendingNotes = [];
     this.invalidateMessagesCache();
   }
 
@@ -310,7 +323,7 @@ export class ConversationState {
     this.invalidateMessagesCache();
     this.lastApiTokenCount = null;
     this.lastApiMessageCount = 0;
-    this.flushPendingNotes();
+    this.flushPendingMessages();
   }
 
   private pruneToolErrors(): void {
@@ -630,7 +643,7 @@ export class ConversationState {
     this.nuclearEntries = [];
     this.nuclearBySeq.clear();
     this.recallArchive.clear();
-    this.pendingNotes = [];
+    this.pendingMessages = [];
     this.invalidateMessagesCache();
     this.lastApiTokenCount = null;
     this.lastApiMessageCount = 0;

--- a/src/core.ts
+++ b/src/core.ts
@@ -54,6 +54,8 @@ export interface AgentShellCore {
   query(text: string): Promise<string>;
   /** Convenience: emit agent:cancel-request. */
   cancel(): void;
+  /** Convenience: emit agent:append-user-message. */
+  appendUserMessage(text: string): void;
   /** Build an ExtensionContext for loading extensions against this core. */
   extensionContext(opts: { quit: () => void }): ExtensionContext;
   /** Tear down the agent and clean up. */
@@ -196,6 +198,10 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
 
     cancel() {
       bus.emit("agent:cancel-request", {});
+    },
+
+    appendUserMessage(text) {
+      bus.emit("agent:append-user-message", { text });
     },
 
     extensionContext(opts) {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -41,6 +41,7 @@ export interface ShellEvents {
   // Agent input (frontend → core: user submitted a query or wants to cancel)
   "agent:submit": { query: string };
   "agent:cancel-request": { silent?: boolean };
+  "agent:append-user-message": { text: string };
 
   // Input mode registration (extensions → InputHandler)
   "input-mode:register": import("./types.js").InputModeConfig;


### PR DESCRIPTION
## Summary

Adds a public way for bridges to inject a user message into an in-flight turn without violating the wire protocol.

- New bus event `agent:append-user-message` and matching `core.appendUserMessage(text)` convenience method.
- `ConversationState.appendUserMessage(text)` reuses the existing mid-tool-pair buffering pattern (previously only used for `addSystemNote`), generalized to a tagged `pendingMessages` queue with `kind: "system" | "user"`. User-kind entries flow through `addUserMessage` on flush so eager nucleation runs and the entry lands in conversation history.
- Kernel encodes only **protocol correctness** (must buffer if a `tool_use` / `tool_result` pair is open; flush on the next `tool_result`). Policy — *when* to call, *whether* to merge bursts — lives in the caller.

## Test plan

- [ ] Build typechecks: `npx tsc -p . --noEmit`
- [ ] Existing `addSystemNote` mid-tool-pair behavior still works (smoke test via subagent / peer-message paths)
- [ ] Calling `core.appendUserMessage(text)` mid-turn appends a real user message at the next safe boundary, with eager nucleation
- [ ] Calling outside an open tool pair appends immediately