### PR TITLE
Refresh overlay-agent: mirror-truth dismiss, screen context, UI fixes

### DIFF
--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -19,23 +19,27 @@
 import type { ExtensionContext, RemoteSession } from "agent-sh/types";
 import type { RenderSurface } from "agent-sh/utils/compositor";
 import { FloatingPanel } from "agent-sh/utils/floating-panel";
+import { formatScreenContext, type TerminalBuffer } from "agent-sh/utils/terminal-buffer";
 
 /** Adapt a FloatingPanel to the RenderSurface interface. */
 function createPanelSurface(panel: FloatingPanel): RenderSurface {
+  // Track the spinner row so a stop-clear ("\r\x1b[2K") removes it
+  // instead of leaving an orphan blank line in the panel.
+  let spinnerLine = false;
   return {
     write(text: string): void {
-      // Handle \r (carriage return) — overwrite the current line.
-      // The spinner uses "\r  <content>\x1b[K" to update in-place.
       if (text.startsWith("\r")) {
-        // Strip \r and any erase-line sequences
         const cleaned = text.replace(/^\r/, "").replace(/\x1b\[\d*K/g, "");
         if (cleaned.trim()) {
-          panel.updateLastLine(() => cleaned);
+          if (spinnerLine) panel.updateLastLine(() => cleaned);
+          else { panel.appendLine(cleaned); spinnerLine = true; }
+        } else if (spinnerLine) {
+          panel.popLastLine();
+          spinnerLine = false;
         }
         return;
       }
-
-      // Regular text — may contain newlines
+      if (spinnerLine) { panel.popLastLine(); spinnerLine = false; }
       panel.appendText(text);
     },
     writeLine(line: string): void {
@@ -44,12 +48,23 @@ function createPanelSurface(panel: FloatingPanel): RenderSurface {
     get columns(): number {
       return panel.computeGeometry().contentW;
     },
+    get rows(): number {
+      return panel.computeGeometry().contentH;
+    },
+    onResize(cb: (cols: number, rows: number) => void): () => void {
+      const handler = () => {
+        const g = panel.computeGeometry();
+        cb(g.contentW, g.contentH);
+      };
+      process.stdout.on("resize", handler);
+      return () => { process.stdout.off("resize", handler); };
+    },
   };
 }
 
 export default function activate(ctx: ExtensionContext): void {
   const { bus, registerInstruction, createRemoteSession } = ctx;
-  const terminalBuffer = ctx.call("terminal-buffer");
+  const terminalBuffer: TerminalBuffer | null = ctx.call("terminal-buffer");
 
   const panel = new FloatingPanel(bus, {
     trigger: "\x1c", // Ctrl+\
@@ -60,22 +75,21 @@ export default function activate(ctx: ExtensionContext): void {
   const panelSurface = createPanelSurface(panel);
   let session: RemoteSession | null = null;
 
-  // Tell the LLM it's running inside an overlay session. The matching
-  // system-prompt block (registered via registerInstruction below) describes
-  // how to behave in this mode.
   ctx.registerContextProducer("interactive-session", () =>
     session?.active ? "interactive-session: true" : null,
   );
 
+  // Inject the live screen for TUI / REPL programs. At a plain shell prompt
+  // `<shell_events>` already covers the visible scrollback — skip to dedupe.
+  ctx.registerContextProducer("terminal-screen", () => {
+    if (!session?.active || !terminalBuffer?.altScreen) return null;
+    return formatScreenContext(terminalBuffer.readScreen(), 80);
+  });
+
   registerInstruction("Interactive Overlay Sessions", [
-    "When the dynamic context includes `interactive-session: true`, the user has summoned you",
-    "via a hotkey overlay from inside their live terminal. They may be in the middle of using",
-    "a program (vim, ssh, a REPL, etc.) or at a shell prompt. In this mode:",
-    "- Start with terminal_read if you need to understand what's on screen.",
-    "- Prefer terminal_keys to interact with whatever is currently running.",
-    "- Use user_shell only for running new, standalone commands — not for interacting with",
-    "  what's already on screen.",
-    "- Keep responses concise — the user is in the middle of a workflow.",
+    "When dynamic context includes `interactive-session: true`, the user summoned you via a",
+    "hotkey overlay from their live terminal. They're mid-workflow (shell prompt, vim, ssh, a",
+    "REPL, etc.) — keep responses concise and prefer reading what's on screen over asking.",
   ].join("\n"));
 
   // ── Panel lifecycle ────────────────────────────────────────────
@@ -84,7 +98,6 @@ export default function activate(ctx: ExtensionContext): void {
     if (!session) {
       session = createRemoteSession({
         surface: panelSurface,
-        suppressQueryBox: true,
       });
     }
     panel.setActive();
@@ -92,18 +105,13 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   panel.handlers.advise("panel:show", (_next) => {
-    // Re-establish session if panel is shown while agent is still working
     if (panel.active && !session) {
-      session = createRemoteSession({
-        surface: panelSurface,
-        suppressQueryBox: true,
-      });
+      session = createRemoteSession({ surface: panelSurface });
     }
   });
 
-  // On dismiss: close session only if agent is not actively processing.
-  // If agent is still working (phase="active"), keep session alive so
-  // output buffers in the panel and agent can keep executing tools.
+  // Keep the session alive while the agent is still working, even after
+  // dismiss — so output keeps buffering and tools keep executing.
   panel.handlers.advise("panel:dismiss", (next) => {
     next();
     if (session && !panel.processing) {
@@ -113,10 +121,6 @@ export default function activate(ctx: ExtensionContext): void {
   });
 
   bus.on("agent:processing-done", () => {
-    if (!panel.active) return;
-    panel.setDone();
-    // If panel was hidden while processing (passthrough), setDone()
-    // triggers dismiss() which closes the session above.
-    // If panel is still visible, session stays for the follow-up prompt.
+    if (panel.active) panel.setDone();
   });
 }

--- a/examples/extensions/overlay-agent.ts
+++ b/examples/extensions/overlay-agent.ts
@@ -1,20 +1,24 @@
 /**
  * Overlay agent extension.
  *
- * Provides a hotkey (Ctrl+\) to summon the agent from anywhere — even
- * inside vim, htop, or ssh. Composites a floating response box on top
- * of the current terminal content.
+ * Press Ctrl+\ from anywhere — a shell prompt, vim, ssh, htop, a REPL — to
+ * summon the agent in a floating panel composited over the current terminal.
+ * The agent sees the live screen as `<terminal_buffer>` context (when a TUI
+ * is active) or `<shell_events>` (at a shell prompt), so screen-aware
+ * questions answer without a tool round-trip.
  *
- * Uses createRemoteSession() to route the full tui-renderer pipeline
- * (markdown, tool grouping, spinner, diffs) into the floating panel.
+ * Install (from an npm install of agent-sh):
+ *   mkdir -p ~/.agent-sh/extensions
+ *   cp "$(npm root -g)/agent-sh/examples/extensions/overlay-agent.ts" \
+ *      ~/.agent-sh/extensions/
  *
- * Install:
- *   cp examples/extensions/overlay-agent.ts ~/.agent-sh/extensions/
+ * Or load ad-hoc without copying:
+ *   agent-sh -e "$(npm root -g)/agent-sh/examples/extensions/overlay-agent.ts"
  *
- * Or load directly:
- *   agent-sh -e ./examples/extensions/overlay-agent.ts
- *
- * Requires: npm install @xterm/headless@5.5.0 @xterm/addon-serialize@0.13.0
+ * Optional companion extensions (copy the same way) — without them the
+ * overlay can read the screen but cannot interact with it:
+ *   - terminal-buffer.ts → terminal_read / terminal_keys tools
+ *   - user-shell.ts      → user_shell tool (run new shell commands)
  */
 import type { ExtensionContext, RemoteSession } from "agent-sh/types";
 import type { RenderSurface } from "agent-sh/utils/compositor";

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -257,7 +257,6 @@ export class FloatingPanel {
   private prevFrame: string[] = [];
   private suppressNextRedraw = false;
   private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
-  private ptyBuffer = "";  // PTY output accumulated while overlay is open
   private usedAltScreen = false;  // whether we entered our own alt screen
   private wrapCache = new Map<string, string[]>();  // line → wrapped lines (invalidated on width change)
   private wrapCacheWidth = 0;
@@ -452,12 +451,6 @@ export class FloatingPanel {
   // ── Bus event wiring ───────────────────────────────────────
 
   private wireEvents(): void {
-    // Buffer PTY output while overlay is visible (alt screen discards it).
-    // Don't buffer when hidden — PTY flows to terminal directly via stdout-show.
-    this.bus.on("shell:pty-data", ({ raw }) => {
-      if (this._visible) this.ptyBuffer += raw;
-    });
-
     this.bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
     this.bus.onPipe("shell:redraw-prompt", (payload) => {
       if (this._visible || this._passthrough) {
@@ -547,7 +540,6 @@ export class FloatingPanel {
       // so the background program's screen stays correct without
       // handing rendering control back to ncurses.
       this._passthrough = true;
-      this.ptyBuffer = "";
       this.startPassthrough();
     } else {
       // Agent idle or done — full teardown, hand back control.
@@ -604,7 +596,6 @@ export class FloatingPanel {
   /** Common screen enter logic shared by open() and show(). */
   private enterScreen(): void {
     this._visible = true;
-    this.ptyBuffer = "";
     this.bus.emit("shell:stdout-hold", {});
 
     this.usedAltScreen = !(this.buffer?.altScreen);
@@ -643,6 +634,15 @@ export class FloatingPanel {
   updateLastLine(fn: (line: string) => string): void {
     if (this.contentLines.length > 0) {
       this.contentLines[this.contentLines.length - 1] = fn(this.contentLines[this.contentLines.length - 1]!);
+    }
+    this.scheduleRender();
+  }
+
+  popLastLine(): void {
+    if (this.currentPartialLine) {
+      this.currentPartialLine = "";
+    } else if (this.contentLines.length > 0) {
+      this.contentLines.pop();
     }
     this.scheduleRender();
   }
@@ -923,43 +923,21 @@ export class FloatingPanel {
 
   // ── Screen helpers ────────────────────────────────────────
 
-  /** Full screen teardown: exit alt screen, release stdout, force redraw. */
+  /** Repaint from the mirror — the terminal's own alt-screen save/restore
+   *  freezes a pre-overlay snapshot and diverges from the program's cursor
+   *  model (e.g. gdb-REPL, scripted PTYs). */
   private teardownScreen(): void {
     this.resizeUnsub?.();
     this.resizeUnsub = null;
     this.suppressNextRedraw = true;
 
-    // Re-check alt screen state: the program we overlaid may have exited
-    // (e.g. agent quit vim via terminal_keys) while the panel was active.
-    const stillInAltScreen = !this.usedAltScreen && !!this.buffer?.altScreen;
-    const programExited = !this.usedAltScreen && !stillInAltScreen;
-
-    if (this.usedAltScreen) {
-      this.surface.write("\x1b[?1049l");
-    }
-
-    // Replay PTY output that arrived while the overlay was active.
-    // Without this, commands run by the agent (e.g. user_shell ls)
-    // would vanish — the alt screen exit restores the saved screen
-    // from before the overlay opened, losing any shell output produced
-    // during the session.
-    if (this.ptyBuffer) {
-      this.surface.write(this.ptyBuffer);
-    }
-    this.ptyBuffer = "";
+    this.buffer?.flush();
+    if (this.usedAltScreen) this.surface.write("\x1b[?1049l");
     this.bus.emit("shell:stdout-release", {});
 
-    if (stillInAltScreen || programExited) {
-      // Either a TUI app is still running and needs SIGWINCH to repaint,
-      // or the overlaid program exited (e.g. agent quit vim) and we
-      // discarded its stale buffer — SIGWINCH makes the shell redraw
-      // its prompt cleanly.
-      const cols = this.surface.columns;
-      const rows = this.surface.rows;
-      this.bus.emit("shell:pty-resize", { cols, rows: rows - 1 });
-      setTimeout(() => {
-        this.bus.emit("shell:pty-resize", { cols, rows });
-      }, 50);
+    const serialized = this.buffer?.serialize();
+    if (serialized) {
+      this.surface.write(`${SYNC_START}\x1b[2J\x1b[H${serialized}${SYNC_END}`);
     }
   }
 
@@ -987,7 +965,7 @@ export class FloatingPanel {
     const serialized = this.buffer.serialize();
     if (serialized && serialized !== this.prevSerialized) {
       this.prevSerialized = serialized;
-      this.surface.write(`${SYNC_START}\x1b[H${serialized}${SYNC_END}`);
+      this.surface.write(`${SYNC_START}\x1b[2J\x1b[H${serialized}${SYNC_END}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- **`src/utils/floating-panel.ts`** — replace the alt-screen save/restore + ptyBuffer replay + SIGWINCH dance with one authoritative repaint from the xterm mirror on dismiss. The terminal's own snapshot freezes pre-overlay state and silently diverges from the program's cursor model in non-TUI REPLs (gdb, lldb, scripted PTYs). Net deletion. Also clears the screen before passthrough renders so hidden-panel residue stops bleeding through. Adds a `popLastLine()` primitive for adapters that track a removable line.
- **`examples/extensions/overlay-agent.ts`** — completes the `RenderSurface` adapter (`rows`/`onResize` were added to the type since the example was last touched), tracks the spinner row so stop-clears pop it instead of leaving an orphan blank line, drops `suppressQueryBox` so the user's question echoes in the panel, and adds a per-request context producer that injects the live screen as `<terminal_buffer>` when a TUI is active. The system-prompt block stops naming foreign tools (`terminal_read` / `terminal_keys` / `user_shell` live in sibling extensions that may not be loaded).

## Test plan

- [ ] Open overlay (Ctrl+\\) over a plain shell prompt, ask "what's my cwd?" — answers in one round-trip via `<shell_events>`.
- [ ] Open overlay over a TUI (vim, lldb, gdb-tui, htop), ask about screen contents — answers in one round-trip via `<terminal_buffer>`.
- [ ] Hide overlay mid-processing, reopen — no after-image of panel content.
- [ ] Dismiss overlay over a non-TUI REPL (e.g. lldb at prompt) — terminal returns to the program's actual cursor state, not a stale snapshot.
- [ ] Spinner stops cleanly between paragraphs (no blank-line gaps).
- [ ] User query is visible in the panel after submit.