### PR TITLE
Overlay: don't curtain PTY, reset leaky modes on dismiss

### DIFF
--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -95,9 +95,7 @@ export default function activate(ctx: ExtensionContext): void {
       "  - Ctrl+D: \\x04\n" +
       "  - Ctrl+Z: \\x1a\n" +
       "  - Arrow keys: \\x1b[A (up), \\x1b[B (down), \\x1b[C (right), \\x1b[D (left)\n" +
-      "  - Backspace: \\x7f\n\n" +
-      "Example: to quit vim without saving, send keys=\"\\x1b:q!\\r\" (Escape, :q!, Enter).\n" +
-      "Always call terminal_read after sending keys to verify the result.",
+      "  - Backspace: \\x7f",
     input_schema: {
       type: "object",
       properties: {
@@ -125,7 +123,7 @@ export default function activate(ctx: ExtensionContext): void {
     }),
 
     formatCall: (args) => {
-      const keys = args.keys as string;
+      const keys = (args.keys as string | undefined) ?? "";
       return keys
         .replace(/\\x1b|\x1b/g, "ESC")
         .replace(/\\r|\r/g, "⏎")

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -257,7 +257,6 @@ export class FloatingPanel {
   private prevFrame: string[] = [];
   private suppressNextRedraw = false;
   private autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
-  private usedAltScreen = false;  // whether we entered our own alt screen
   private wrapCache = new Map<string, string[]>();  // line → wrapped lines (invalidated on width change)
   private wrapCacheWidth = 0;
   private passthroughTimer: ReturnType<typeof setInterval> | null = null;
@@ -451,6 +450,15 @@ export class FloatingPanel {
   // ── Bus event wiring ───────────────────────────────────────
 
   private wireEvents(): void {
+    // Re-overlay the panel after each PTY chunk. The shell emits
+    // `shell:pty-data` synchronously *before* writing to stdout, so a
+    // microtask defers our render until after the program's bytes have
+    // landed — we paint on top of them, not under.
+    this.bus.on("shell:pty-data", () => {
+      if (!this._visible) return;
+      queueMicrotask(() => { if (this._visible) this.render(); });
+    });
+
     this.bus.onPipe("input:intercept", (payload) => this.handleIntercept(payload));
     this.bus.onPipe("shell:redraw-prompt", (payload) => {
       if (this._visible || this._passthrough) {
@@ -593,18 +601,13 @@ export class FloatingPanel {
     this.footer = "";
   }
 
-  /** Common screen enter logic shared by open() and show(). */
+  /** Common screen enter logic shared by open() and show().
+   *  No curtain — bytes flow through to the real terminal so its mode
+   *  state stays in sync with what the program is doing. We re-overlay
+   *  the panel after each PTY chunk via wireEvents. */
   private enterScreen(): void {
     this._visible = true;
-    this.bus.emit("shell:stdout-hold", {});
-
-    this.usedAltScreen = !(this.buffer?.altScreen);
-    if (this.usedAltScreen) {
-      this.surface.write("\x1b[?1049h");
-    }
-
     this.resizeUnsub = this.surface.onResize(() => { this.prevFrame = []; this.render(); });
-
     this.render();
   }
 
@@ -923,22 +926,27 @@ export class FloatingPanel {
 
   // ── Screen helpers ────────────────────────────────────────
 
-  /** Repaint from the mirror — the terminal's own alt-screen save/restore
-   *  freezes a pre-overlay snapshot and diverges from the program's cursor
-   *  model (e.g. gdb-REPL, scripted PTYs). */
+  /** Clear the panel from the screen by repainting the mirror over it.
+   *  Bytes flowed through during the overlay, so the real terminal's
+   *  underlying state already matches the mirror — this just removes
+   *  the box. The trailing reset zeroes out keyboard modes that some
+   *  terminals don't round-trip cleanly through DECSTR; programs still
+   *  alive reassert their modes on next paint. */
   private teardownScreen(): void {
     this.resizeUnsub?.();
     this.resizeUnsub = null;
     this.suppressNextRedraw = true;
 
     this.buffer?.flush();
-    if (this.usedAltScreen) this.surface.write("\x1b[?1049l");
-    this.bus.emit("shell:stdout-release", {});
-
-    const serialized = this.buffer?.serialize();
-    if (serialized) {
-      this.surface.write(`${SYNC_START}\x1b[2J\x1b[H${serialized}${SYNC_END}`);
-    }
+    const serialized = this.buffer?.serialize() ?? "";
+    const reset =
+      "\x1b[>4;0m" +   // modifyOtherKeys off
+      "\x1b[<u" +      // kitty keyboard pop
+      "\x1b[?1004l" +  // focus reporting off
+      "\x1b[?2004l" +  // bracketed paste off
+      "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" +  // mouse off
+      "\x1b[?25h";     // cursor visible
+    this.surface.write(`${SYNC_START}\x1b[2J\x1b[H${serialized}${reset}${SYNC_END}`);
   }
 
   // ── Passthrough rendering ─────────────────────────────────


### PR DESCRIPTION
## Summary

Two related changes to make the overlay leave the terminal in a usable state when the user dismisses it after a TUI program has exited.

- **`examples/extensions/terminal-buffer.ts`** — drops the *"Always call terminal_read after sending keys"* line from the `terminal_keys` description (the tool already returns the post-keystroke screen state in its result), drops the worked vim-quit example, and defends `formatCall` against `args.keys === undefined` so a malformed agent call doesn't crash the display path.
- **`src/utils/floating-panel.ts`** — stops curtaining stdout while the overlay is up. PTY bytes flow through to the real terminal so its mode state stays in sync with the program's intent; we re-overlay the panel after every PTY chunk via a microtask-deferred render. On dismiss, repaint from the mirror to clear the box and then explicitly reset keyboard modes some terminals don't round-trip cleanly (focus reporting, bracketed paste, mouse, modifyOtherKeys, kitty keyboard, cursor visibility). Drops `usedAltScreen` and the alt-screen entry/exit dance.

## Why the design

The previous architecture (curtain everything → restore on dismiss) made the panel responsible for being a complete and correct serializer of all terminal state. Each new escape shape — focus reporting (`?nh/l`), modifyOtherKeys (`>4;Nm`), kitty keyboard (`>u`/`<u`), …  — required its own parser and accumulator, with the cost of missing one being a real-terminal mode stuck on after the program exited (broken Ctrl+C, focus-reporting notices). Letting bytes flow through replaces the per-shape patching with continuous in-sync state; the explicit reset on dismiss is belt-and-suspenders for the modes whose round-trip is terminal-dependent.

## Trade-off

The panel may flicker briefly during high-frequency program output (htop, watch, tail -f) since each PTY chunk triggers a re-overlay. The program's cursor model can also be briefly disturbed during active overlay use, but the mirror serialize on dismiss repositions correctly.

## Test plan

- [ ] Send keys via terminal_keys (e.g. `\\r` at a shell prompt) — tool result already contains post-keystroke screen, agent doesn't follow up with terminal_read.
- [ ] Open vim, summon overlay, ask agent to quit vim, dismiss. Ctrl+C works at the shell prompt; no "focus reporting" notice from the terminal emulator; typing works normally.
- [ ] Open htop, summon overlay — panel renders on top of htop's live updates.
- [ ] Open overlay over plain shell, dismiss — typing and Ctrl+C still work.