### PR TITLE
Reset stuck terminal modes on overlay dismiss

### DIFF
--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -923,16 +923,42 @@ export class FloatingPanel {
 
   // ── Screen helpers ────────────────────────────────────────
 
-  /** Repaint from the mirror — the terminal's own alt-screen save/restore
-   *  freezes a pre-overlay snapshot and diverges from the program's cursor
-   *  model (e.g. gdb-REPL, scripted PTYs). */
   private teardownScreen(): void {
     this.resizeUnsub?.();
     this.resizeUnsub = null;
     this.suppressNextRedraw = true;
 
     this.buffer?.flush();
-    if (this.usedAltScreen) this.surface.write("\x1b[?1049l");
+
+    const programInAlt = !!this.buffer?.altScreen;
+
+    if (!this.usedAltScreen && programInAlt) {
+      // Program still in its own alt-screen — SIGWINCH so it redraws
+      // and re-asserts its modes; replaying from the mirror would
+      // freeze modes serialize() doesn't track (modifyOtherKeys, kitty
+      // kbd) and leave ctrl-c arriving as \x1b[27;5;99~.
+      this.bus.emit("shell:stdout-release", {});
+      const cols = this.surface.columns;
+      const rows = this.surface.rows;
+      this.bus.emit("shell:pty-resize", { cols, rows: rows - 1 });
+      setTimeout(() => {
+        this.bus.emit("shell:pty-resize", { cols, rows });
+      }, 50);
+      return;
+    }
+
+    this.surface.write("\x1b[?1049l");
+
+    if (!this.usedAltScreen) {
+      // Program exited mid-overlay; its reset bytes were eaten by
+      // stdout-hold. Reset modes serialize() doesn't track or the
+      // host stays in vim's modifyOtherKeys mode.
+      this.surface.write(
+        "\x1b[>4;0m\x1b[<u\x1b[?2004l\x1b[?1004l" +
+        "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+      );
+    }
+
     this.bus.emit("shell:stdout-release", {});
 
     const serialized = this.buffer?.serialize();


### PR DESCRIPTION
## Summary
- Bug: after summoning the overlay over vim and having the agent quit vim mid-overlay (e.g. via `terminal_keys`), ctrl-c / ctrl-d stop working at the shell prompt and the overlay leaves residual frame on screen. iTerm2 also pops a "focus reporting was left on" banner.
- Cause: vim's mode-reset bytes (`\x1b[>4;0m`, `\x1b[?1004l`, alt-screen exit, etc.) hit the PTY while `stdoutHold` was active, so they only reached the mirror — not the host terminal. `SerializeAddon.serialize()` doesn't represent modifyOtherKeys / kitty kbd / focus reporting / mouse / bracketed paste, so the dismiss replay can't compensate. The host stays in vim's modifyOtherKeys mode and ctrl-c arrives as `\x1b[27;5;99~`, which the shell ignores.
- Fix: split `teardownScreen()` on `mirror.altScreen` at dismiss. If the program is still in alt-screen, just SIGWINCH and let it own its modes. If it exited during the overlay, exit alt-screen on the host, emit explicit resets for the modes `serialize()` doesn't track, then repaint from the mirror. The non-TUI / gdb path is unchanged.

## Test plan
- [x] Build passes (`npm run build`).
- [x] Manually verified: open overlay over vim, ask agent to quit vim, dismiss — overlay residue cleared and ctrl-c / ctrl-d work at the shell prompt.
- [ ] Regression check: dismiss overlay over a still-running TUI (vim left untouched) — vim should redraw cleanly via SIGWINCH and ctrl-c inside vim still works.
- [ ] Regression check: dismiss overlay opened from a plain shell prompt and from a non-TUI REPL (gdb, python -i) — screen state still restored from mirror.