### PR TITLE
Reset shell state when remote session ends

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -274,6 +274,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
               active = false;
               for (const fn of cleanups.reverse()) fn();
               cleanups.length = 0;
+              bus.emit("shell:remote-session-end", {});
             },
           };
         },

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -207,6 +207,11 @@ export interface ShellEvents {
   "shell:stdout-show": Record<string, never>;
   "shell:stdout-hide": Record<string, never>;
 
+  // RemoteSession.close() emits this so the shell can clear paused/echoSkip
+  // state that on-processing-done would have cleared, but couldn't because
+  // RemoteSession's advisors suppressed it.
+  "shell:remote-session-end": Record<string, never>;
+
   // Terminal interception (sync pipe: extensions can intercept before execution)
   "agent:terminal-intercept": {
     command: string;

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -248,6 +248,15 @@ export class Shell implements InputContext {
     // Ref-counted stdout show — tools temporarily force output visible during agent processing
     this.bus.on("shell:stdout-show", () => { this.stdoutShow.increment(); });
     this.bus.on("shell:stdout-hide", () => { this.stdoutShow.decrement(); });
+
+    // RemoteSession (overlay) advisors suppress on-processing-done; clear
+    // the state it would have cleared. No freshPrompt — shell is already
+    // at its prompt, a \n nudge would just be noise.
+    this.bus.on("shell:remote-session-end", () => {
+      this.paused = false;
+      this.echoSkip = false;
+      this.agentActive = false;
+    });
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──


### PR DESCRIPTION
## Summary
- Fixes host-display freeze after an overlay-driven agent session that involved tool permission prompts (e.g. agent launches lldb via terminal_keys, requests permission for a few tool calls, dismisses).
- Root cause: \`createRemoteSession\` advises \`shell:on-processing-start/done\` to no-ops while the overlay session is active. The default handler that resets \`paused=false\` never runs. Meanwhile the permission flow pumps \`paused=true\` during the session and has nothing to balance it. After dismiss, \`paused\` stays stuck and silently drops every PTY chunk on its way to the host terminal — the mirror keeps updating, but the host stays frozen.
- Fix: \`RemoteSession.close()\` emits a new \`shell:remote-session-end\` event; the shell listener resets \`paused\`, \`echoSkip\`, and \`agentActive\`. No \`freshPrompt\` — the user is already at the shell prompt, a \`\n\` nudge would just be noise.

Diagnostic logging that localized this bug is preserved on \`debug/overlay-shell-state-diagnostics\` for future troubleshooting.

## Test plan
- [x] Build clean (\`npm run build\`).
- [x] Manually verified: open overlay over shell prompt, ask agent to launch and quit lldb (which exercises permission prompts via terminal_keys), dismiss — host display continues updating, agent mode (\`>\`) trigger fires correctly.
- [ ] Regression check: simple overlay session with no permission requests dismissed cleanly — should be unchanged.
- [ ] Regression check: overlay session that's still processing when user dismisses (passthrough → setDone → dismiss) — should still close session correctly.