### PR TITLE
Refactor shell stdout gating to scope-based locks

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -251,9 +251,12 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           cleanups.push(compositor.redirect("query", surface));
           cleanups.push(compositor.redirect("status", surface));
 
-          // Keep shell interactive
+          // Keep shell interactive: suppress the host shell's mute lifecycle
+          // and the post-turn freshPrompt nudge. on-processing-done's state
+          // cleanup is intentionally NOT advised — releasing scopes must
+          // always run, even when the redraw is suppressed.
           cleanups.push(handlers.advise("shell:on-processing-start", (next) => active ? undefined : next()));
-          cleanups.push(handlers.advise("shell:on-processing-done", (next) => active ? undefined : next()));
+          cleanups.push(handlers.advise("shell:on-processing-redraw", (next) => active ? undefined : next()));
 
           // Suppress chrome
           if (opts.suppressBorders !== false) {
@@ -274,7 +277,6 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
               active = false;
               for (const fn of cleanups.reverse()) fn();
               cleanups.length = 0;
-              bus.emit("shell:remote-session-end", {});
             },
           };
         },

--- a/src/core.ts
+++ b/src/core.ts
@@ -251,10 +251,9 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           cleanups.push(compositor.redirect("query", surface));
           cleanups.push(compositor.redirect("status", surface));
 
-          // Keep shell interactive: suppress the host shell's mute lifecycle
-          // and the post-turn freshPrompt nudge. on-processing-done's state
-          // cleanup is intentionally NOT advised — releasing scopes must
-          // always run, even when the redraw is suppressed.
+          // Suppress the host shell's mute lifecycle and post-turn
+          // redraw nudge. on-processing-done is intentionally not advised
+          // — its scope cleanup must always run.
           cleanups.push(handlers.advise("shell:on-processing-start", (next) => active ? undefined : next()));
           cleanups.push(handlers.advise("shell:on-processing-redraw", (next) => active ? undefined : next()));
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -207,11 +207,6 @@ export interface ShellEvents {
   "shell:stdout-show": Record<string, never>;
   "shell:stdout-hide": Record<string, never>;
 
-  // RemoteSession.close() emits this so the shell can clear paused/echoSkip
-  // state that on-processing-done would have cleared, but couldn't because
-  // RemoteSession's advisors suppressed it.
-  "shell:remote-session-end": Record<string, never>;
-
   // Terminal interception (sync pipe: extensions can intercept before execution)
   "agent:terminal-intercept": {
     command: string;

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -215,12 +215,9 @@ export interface ShellEvents {
     output: string;
   };
 
-  // Prompt redraw (sync pipe: core sends \n to PTY as default fallback;
-  // extensions can set `handled: true` and write their own prompt to stdout).
-  // kind="fresh" = freshPrompt — sends a \n to PTY, triggers full precmd
-  // cycle, leaves a blank line. Suppressible after overlay teardown.
-  // kind="redraw" = redrawPrompt — in-place \e[9999~ redraw, no \n, no
-  // visual noise; should not be suppressed by post-teardown state.
+  // Prompt redraw (sync pipe: extensions set handled=true to suppress).
+  // kind="fresh" — \n to PTY, full precmd cycle, leaves a blank line.
+  // kind="redraw" — in-place \e[9999~, no visual noise.
   "shell:redraw-prompt": {
     cwd: string;
     kind: "fresh" | "redraw";

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -216,9 +216,14 @@ export interface ShellEvents {
   };
 
   // Prompt redraw (sync pipe: core sends \n to PTY as default fallback;
-  // extensions can set `handled: true` and write their own prompt to stdout)
+  // extensions can set `handled: true` and write their own prompt to stdout).
+  // kind="fresh" = freshPrompt — sends a \n to PTY, triggers full precmd
+  // cycle, leaves a blank line. Suppressible after overlay teardown.
+  // kind="redraw" = redrawPrompt — in-place \e[9999~ redraw, no \n, no
+  // visual noise; should not be suppressed by post-teardown state.
   "shell:redraw-prompt": {
     cwd: string;
+    kind: "fresh" | "redraw";
     handled: boolean;
   };
 

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -6,12 +6,25 @@ import type { EventBus } from "../event-bus.js";
 import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
 import { getSettings } from "../settings.js";
-import { RefCounter } from "../utils/ref-counter.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface ShellHandlers {
   define: (name: string, fn: (...args: any[]) => any) => void;
   call: (name: string, ...args: any[]) => any;
+}
+
+/**
+ * A scope that holds a "mute the host stdout" or "force visible" claim.
+ * The shell's gate logic is: stdout is muted iff at least one MuteScope
+ * is held AND no UnmuteScope is held. release() is idempotent.
+ *
+ * Acquire one with shell.acquireMute() / shell.acquireUnmute(). Always
+ * pair acquire with release in a try/finally — the API is shaped to make
+ * leaks visible (you hold a token and must release it).
+ */
+export interface ShellScope {
+  readonly reason: string;
+  release(): void;
 }
 
 export class Shell implements InputContext {
@@ -20,10 +33,9 @@ export class Shell implements InputContext {
   private handlers: ShellHandlers;
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
-  private paused = false;
-  private stdoutHold = new RefCounter();
-  private stdoutShow = new RefCounter();
-  private echoSkip = false;
+  private muteScopes = new Set<ShellScope>();
+  private unmuteScopes = new Set<ShellScope>();
+  private pendingEchoSkips = 0;
   private agentActive = false;
   private isZsh = false;
   private tmpDir?: string;
@@ -241,22 +253,72 @@ export class Shell implements InputContext {
       this.ptyProcess.resize(cols, rows);
     });
 
-    // Ref-counted stdout hold — overlay extensions suppress PTY output
-    this.bus.on("shell:stdout-hold", () => { this.stdoutHold.increment(); });
-    this.bus.on("shell:stdout-release", () => { this.stdoutHold.decrement(); });
-
-    // Ref-counted stdout show — tools temporarily force output visible during agent processing
-    this.bus.on("shell:stdout-show", () => { this.stdoutShow.increment(); });
-    this.bus.on("shell:stdout-hide", () => { this.stdoutShow.decrement(); });
-
-    // RemoteSession (overlay) advisors suppress on-processing-done; clear
-    // the state it would have cleared. No freshPrompt — shell is already
-    // at its prompt, a \n nudge would just be noise.
-    this.bus.on("shell:remote-session-end", () => {
-      this.paused = false;
-      this.echoSkip = false;
-      this.agentActive = false;
+    // Compat shims: existing extensions emit the old ref-counted bus events.
+    // Each pair of hold/release (or show/hide) is bridged to a single scope.
+    let holdRefcount = 0;
+    let holdScope: ShellScope | null = null;
+    this.bus.on("shell:stdout-hold", () => {
+      if (holdRefcount === 0) holdScope = this.acquireMute("bus:stdout-hold");
+      holdRefcount++;
     });
+    this.bus.on("shell:stdout-release", () => {
+      if (holdRefcount === 0) return;
+      holdRefcount--;
+      if (holdRefcount === 0) { holdScope?.release(); holdScope = null; }
+    });
+
+    let showRefcount = 0;
+    let showScope: ShellScope | null = null;
+    this.bus.on("shell:stdout-show", () => {
+      if (showRefcount === 0) showScope = this.acquireUnmute("bus:stdout-show");
+      showRefcount++;
+    });
+    this.bus.on("shell:stdout-hide", () => {
+      if (showRefcount === 0) return;
+      showRefcount--;
+      if (showRefcount === 0) { showScope?.release(); showScope = null; }
+    });
+  }
+
+  // ── Scope-based gating ─────────────────────────────────────
+
+  /**
+   * Mute host stdout for as long as the returned scope is held.
+   * Reason is for diagnostics; release is idempotent.
+   */
+  acquireMute(reason: string): ShellScope {
+    const scope: ShellScope = {
+      reason,
+      release: () => { this.muteScopes.delete(scope); },
+    };
+    this.muteScopes.add(scope);
+    return scope;
+  }
+
+  /**
+   * Force host stdout visible while held, even if mute scopes are active.
+   * Use for permission UIs, tool outputs, or anything that briefly needs
+   * the user to see PTY output during a paused agent turn.
+   */
+  acquireUnmute(reason: string): ShellScope {
+    const scope: ShellScope = {
+      reason,
+      release: () => { this.unmuteScopes.delete(scope); },
+    };
+    this.unmuteScopes.add(scope);
+    return scope;
+  }
+
+  /**
+   * Tell setupOutput to swallow the first \n of upcoming PTY chunks.
+   * One increment swallows one \n. Used by exec-request to skip command
+   * echo and by freshPrompt to skip the \n it sent. Auto-decrements when
+   * a \n is consumed by a chunk that would otherwise have been written.
+   */
+  skipNextLine(): void { this.pendingEchoSkips++; }
+
+  private isHostMuted(): boolean {
+    return this.muteScopes.size > 0 && this.unmuteScopes.size === 0;
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──
@@ -282,10 +344,7 @@ export class Shell implements InputContext {
    * zsh (ZLE widget) and bash (readline redraw-current-line) bind to repaint.
    */
   redrawPrompt(): void {
-    // Stale echoSkip/paused from handleProcessingDone re-entering a mode
-    // would swallow the redraw and freeze the terminal visually.
-    this.echoSkip = false;
-    this.paused = false;
+    // No more flag-cleanup needed — scopes own their own lifecycle now.
     const result = this.bus.emitPipe("shell:redraw-prompt", {
       cwd: this.outputParser.getCwd(),
       handled: false,
@@ -326,14 +385,15 @@ export class Shell implements InputContext {
       this.bus.emit("shell:pty-data", { raw: data });
       this.outputParser.processData(data);
 
-      if (this.stdoutHold.active) return;
-      if (this.paused && !this.stdoutShow.active) return;
+      if (this.isHostMuted()) return;
 
-      // During user_shell exec, skip the command echo (first line)
-      if (this.echoSkip) {
+      // Swallow up to pendingEchoSkips leading \n-terminated lines (one per
+      // skip). These are command echos / redraw nudges we explicitly sent
+      // and don't want to render twice.
+      if (this.pendingEchoSkips > 0) {
         const nlIdx = data.indexOf("\n");
         if (nlIdx === -1) return;
-        this.echoSkip = false;
+        this.pendingEchoSkips--;
         const rest = data.slice(nlIdx + 1);
         if (rest) process.stdout.write(rest);
         return;
@@ -351,31 +411,34 @@ export class Shell implements InputContext {
   }
 
   /**
-   * React to agent lifecycle events — Shell manages its own state
-   * rather than being driven by AcpClient. This means AcpClient has
-   * zero frontend knowledge; any frontend can subscribe to the same events.
+   * React to agent lifecycle events. Shell ownership of mute state is
+   * expressed through scopes — every "I'm muting" claim is paired with
+   * a release in the same closure, so leaks are visible at compile time.
+   *
+   * Handler split: shell:on-processing-done always runs state cleanup,
+   * then calls shell:on-processing-redraw which is the only advisable
+   * piece. Overlay sessions (RemoteSession) suppress the redraw, never
+   * the cleanup — so paused-equivalent state can't get stuck.
    */
   private setupAgentLifecycle(): void {
-    // Default agent lifecycle: pause the shell while the agent works,
-    // then redraw the prompt when done. Extensions advise these handlers
-    // to change behavior (e.g. tmux split keeps the shell interactive).
+    let agentTurnScope: ShellScope | null = null;
+
     this.handlers.define("shell:on-processing-start", () => {
       this.agentActive = true;
-      this.paused = true;
+      agentTurnScope = this.acquireMute("agent-turn");
+    });
+
+    this.handlers.define("shell:on-processing-redraw", () => {
+      if (!this.inputHandler.handleProcessingDone()) {
+        if (this.freshPrompt()) this.skipNextLine();
+      }
     });
 
     this.handlers.define("shell:on-processing-done", () => {
       this.agentActive = false;
-      // If handleProcessingDone re-entered a mode, leave stdout paused so
-      // stale PTY output doesn't overwrite the mode prompt (exitMode →
-      // redrawPrompt will unpause). Setting echoSkip here would swallow
-      // that PTY output since no \n was sent.
-      if (!this.inputHandler.handleProcessingDone()) {
-        this.paused = false;
-        if (this.freshPrompt()) {
-          this.echoSkip = true;
-        }
-      }
+      agentTurnScope?.release();
+      agentTurnScope = null;
+      this.handlers.call("shell:on-processing-redraw");
     });
 
     this.bus.on("agent:processing-start", () => {
@@ -386,56 +449,55 @@ export class Shell implements InputContext {
       this.handlers.call("shell:on-processing-done");
     });
 
-    // Permission prompts need stdout unpaused so the interactive UI renders,
-    // then re-paused after the decision.
+    // Permission UI is briefly visible during the prompt; an unmute scope
+    // overrides whatever mute is currently held, then releases cleanly.
+    // Doesn't touch agent-turn state, so suppressed handlers can't leak.
+    let permissionVisible: ShellScope | null = null;
     this.bus.on("permission:request", () => {
-      this.paused = false;
+      permissionVisible?.release();
+      permissionVisible = this.acquireUnmute("permission-ui");
     });
     this.bus.onPipeAsync("permission:request", async (payload) => {
-      this.paused = true;
+      permissionVisible?.release();
+      permissionVisible = null;
       return payload;
     });
 
-    // Shell exec: write a command to the live PTY and capture its output.
-    // stdout is paused during agent processing, so PTY output flows through
-    // OutputParser (for OSC detection) but never reaches the terminal.
     this.bus.onPipeAsync("shell:exec-request", async (payload) => {
-      this.echoSkip = true;
-      this.paused = false;
+      const visible = this.acquireUnmute("exec-request");
+      this.skipNextLine();
       process.stdout.write("\n");
       this.bus.emit("shell:agent-exec-start", {});
 
-      const output = await new Promise<{ output: string; cwd: string; exitCode: number | null }>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          this.bus.off("shell:command-done", handler);
-          this.ptyProcess.write("\x03");
-          reject(new Error("Shell exec timed out after 30s"));
-        }, 30_000);
+      try {
+        const output = await new Promise<{ output: string; cwd: string; exitCode: number | null }>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            this.bus.off("shell:command-done", handler);
+            this.ptyProcess.write("\x03");
+            reject(new Error("Shell exec timed out after 30s"));
+          }, 30_000);
 
-        const handler = (e: { command: string; output: string; cwd: string; exitCode: number | null }) => {
-          clearTimeout(timeout);
-          this.bus.off("shell:command-done", handler);
-          // Re-pause stdout so the prompt text following the marker doesn't
-          // leak to the terminal while the agent is still processing.
-          this.paused = true;
-          resolve({ output: e.output, cwd: e.cwd, exitCode: e.exitCode });
-        };
-        this.bus.on("shell:command-done", handler);
+          const handler = (e: { command: string; output: string; cwd: string; exitCode: number | null }) => {
+            clearTimeout(timeout);
+            this.bus.off("shell:command-done", handler);
+            resolve({ output: e.output, cwd: e.cwd, exitCode: e.exitCode });
+          };
+          this.bus.on("shell:command-done", handler);
 
-        this.outputParser.onCommandEntered(payload.command, this.outputParser.getCwd());
-        // Collapse literal newlines to spaces so the PTY receives a single-line
-        // command. Multi-line commands (e.g. git commit -m "...\n...") would
-        // cause the shell to execute prematurely, producing garbled output from
-        // syntax highlighting plugins (zsh syntax highlighting, etc).
-        const oneLine = payload.command.replace(/\n/g, " ");
-        this.ptyProcess.write(oneLine + "\r");
-      });
+          this.outputParser.onCommandEntered(payload.command, this.outputParser.getCwd());
+          // Collapse literal newlines to spaces so the PTY receives a single-line
+          // command. Multi-line commands (e.g. git commit -m "...\n...") would
+          // cause the shell to execute prematurely, producing garbled output from
+          // syntax highlighting plugins (zsh syntax highlighting, etc).
+          const oneLine = payload.command.replace(/\n/g, " ");
+          this.ptyProcess.write(oneLine + "\r");
+        });
 
-      this.paused = true;
-      this.echoSkip = false;
-      this.bus.emit("shell:agent-exec-done", {});
-
-      return { ...payload, output: output.output, cwd: output.cwd, exitCode: output.exitCode, done: true };
+        return { ...payload, output: output.output, cwd: output.cwd, exitCode: output.exitCode, done: true };
+      } finally {
+        visible.release();
+        this.bus.emit("shell:agent-exec-done", {});
+      }
     });
   }
 

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -33,7 +33,13 @@ export class Shell implements InputContext {
   private handlers: ShellHandlers;
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
-  private muteScopes = new Set<ShellScope>();
+  // Two mute tiers:
+  //   - hardMuteScopes: unconditional. The overlay holds this while drawing
+  //     its compositing layer — no other code path can override it.
+  //   - softMuteScopes: agent-turn / exec-style mutes. An unmuteScope
+  //     (permission UI, terminal_keys' stdout-show) can override these.
+  private hardMuteScopes = new Set<ShellScope>();
+  private softMuteScopes = new Set<ShellScope>();
   private unmuteScopes = new Set<ShellScope>();
   private pendingEchoSkips = 0;
   private agentActive = false;
@@ -255,10 +261,14 @@ export class Shell implements InputContext {
 
     // Compat shims: existing extensions emit the old ref-counted bus events.
     // Each pair of hold/release (or show/hide) is bridged to a single scope.
+    // shell:stdout-hold maps to a HARD mute — the old stdoutHold gate was
+    // unconditional (couldn't be overridden by stdoutShow), so the overlay
+    // compositing layer stays opaque even when terminal_keys is forcing
+    // stdout visible during agent processing.
     let holdRefcount = 0;
     let holdScope: ShellScope | null = null;
     this.bus.on("shell:stdout-hold", () => {
-      if (holdRefcount === 0) holdScope = this.acquireMute("bus:stdout-hold");
+      if (holdRefcount === 0) holdScope = this.acquireHardMute("bus:stdout-hold");
       holdRefcount++;
     });
     this.bus.on("shell:stdout-release", () => {
@@ -283,22 +293,36 @@ export class Shell implements InputContext {
   // ── Scope-based gating ─────────────────────────────────────
 
   /**
-   * Mute host stdout for as long as the returned scope is held.
-   * Reason is for diagnostics; release is idempotent.
+   * Hard mute: the overlay's "I own the screen" claim. No unmuteScope
+   * can override this. Use for compositing layers that must not be
+   * painted over by raw PTY output.
    */
-  acquireMute(reason: string): ShellScope {
+  acquireHardMute(reason: string): ShellScope {
     const scope: ShellScope = {
       reason,
-      release: () => { this.muteScopes.delete(scope); },
+      release: () => { this.hardMuteScopes.delete(scope); },
     };
-    this.muteScopes.add(scope);
+    this.hardMuteScopes.add(scope);
     return scope;
   }
 
   /**
-   * Force host stdout visible while held, even if mute scopes are active.
-   * Use for permission UIs, tool outputs, or anything that briefly needs
-   * the user to see PTY output during a paused agent turn.
+   * Soft mute: the agent-turn / exec-request "shell paused while I work"
+   * claim. An unmuteScope (permission UI, terminal_keys stdout-show)
+   * overrides this for as long as the unmute is held.
+   */
+  acquireMute(reason: string): ShellScope {
+    const scope: ShellScope = {
+      reason,
+      release: () => { this.softMuteScopes.delete(scope); },
+    };
+    this.softMuteScopes.add(scope);
+    return scope;
+  }
+
+  /**
+   * Force host stdout visible while held, overriding soft mutes only.
+   * Hard mutes (overlay) still win.
    */
   acquireUnmute(reason: string): ShellScope {
     const scope: ShellScope = {
@@ -318,7 +342,8 @@ export class Shell implements InputContext {
   skipNextLine(): void { this.pendingEchoSkips++; }
 
   private isHostMuted(): boolean {
-    return this.muteScopes.size > 0 && this.unmuteScopes.size === 0;
+    if (this.hardMuteScopes.size > 0) return true;
+    return this.softMuteScopes.size > 0 && this.unmuteScopes.size === 0;
   }
 
   // ── InputContext implementation (delegates to OutputParser) ──
@@ -342,9 +367,15 @@ export class Shell implements InputContext {
   /**
    * Ask the shell to redraw its own prompt in place via \e[9999~, which both
    * zsh (ZLE widget) and bash (readline redraw-current-line) bind to repaint.
+   *
+   * Defensive: clear pendingEchoSkips. The redraw response is a fresh
+   * prompt write (no \n), so a stuck skip counter would silently swallow
+   * it and leave the prompt invisible until something with \n flushed
+   * the skip — which is exactly the symptom of "prompt missing after
+   * exiting a mode, until ctrl-c forces a real redraw".
    */
   redrawPrompt(): void {
-    // No more flag-cleanup needed — scopes own their own lifecycle now.
+    this.pendingEchoSkips = 0;
     const result = this.bus.emitPipe("shell:redraw-prompt", {
       cwd: this.outputParser.getCwd(),
       handled: false,

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -14,13 +14,9 @@ export interface ShellHandlers {
 }
 
 /**
- * A scope that holds a "mute the host stdout" or "force visible" claim.
- * The shell's gate logic is: stdout is muted iff at least one MuteScope
- * is held AND no UnmuteScope is held. release() is idempotent.
- *
- * Acquire one with shell.acquireMute() / shell.acquireUnmute(). Always
- * pair acquire with release in a try/finally — the API is shaped to make
- * leaks visible (you hold a token and must release it).
+ * A claim on the shell's stdout-mute state. Acquire from shell.acquire*,
+ * pair with release() in a try/finally. Token-shape forces symmetry —
+ * the only way to influence the gate is to hold and release a scope.
  */
 export interface ShellScope {
   readonly reason: string;
@@ -33,11 +29,9 @@ export class Shell implements InputContext {
   private handlers: ShellHandlers;
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
-  // Two mute tiers:
-  //   - hardMuteScopes: unconditional. The overlay holds this while drawing
-  //     its compositing layer — no other code path can override it.
-  //   - softMuteScopes: agent-turn / exec-style mutes. An unmuteScope
-  //     (permission UI, terminal_keys' stdout-show) can override these.
+  // hardMute is unconditional (overlay compositing); softMute is overridable
+  // by unmute (terminal_keys, permission UI). Gate: hard wins; otherwise
+  // muted iff softMute held without an unmute.
   private hardMuteScopes = new Set<ShellScope>();
   private softMuteScopes = new Set<ShellScope>();
   private unmuteScopes = new Set<ShellScope>();
@@ -259,12 +253,8 @@ export class Shell implements InputContext {
       this.ptyProcess.resize(cols, rows);
     });
 
-    // Compat shims: existing extensions emit the old ref-counted bus events.
-    // Each pair of hold/release (or show/hide) is bridged to a single scope.
-    // shell:stdout-hold maps to a HARD mute — the old stdoutHold gate was
-    // unconditional (couldn't be overridden by stdoutShow), so the overlay
-    // compositing layer stays opaque even when terminal_keys is forcing
-    // stdout visible during agent processing.
+    // Compat shims for the bus-event API. shell:stdout-hold maps to hard
+    // mute so terminal_keys' stdout-show can't paint through the overlay.
     let holdRefcount = 0;
     let holdScope: ShellScope | null = null;
     this.bus.on("shell:stdout-hold", () => {
@@ -292,11 +282,7 @@ export class Shell implements InputContext {
 
   // ── Scope-based gating ─────────────────────────────────────
 
-  /**
-   * Hard mute: the overlay's "I own the screen" claim. No unmuteScope
-   * can override this. Use for compositing layers that must not be
-   * painted over by raw PTY output.
-   */
+  /** Compositing-layer claim — overrides any unmute. */
   acquireHardMute(reason: string): ShellScope {
     const scope: ShellScope = {
       reason,
@@ -306,11 +292,7 @@ export class Shell implements InputContext {
     return scope;
   }
 
-  /**
-   * Soft mute: the agent-turn / exec-request "shell paused while I work"
-   * claim. An unmuteScope (permission UI, terminal_keys stdout-show)
-   * overrides this for as long as the unmute is held.
-   */
+  /** Agent-turn / exec-style mute — overridable by unmute. */
   acquireMute(reason: string): ShellScope {
     const scope: ShellScope = {
       reason,
@@ -320,10 +302,7 @@ export class Shell implements InputContext {
     return scope;
   }
 
-  /**
-   * Force host stdout visible while held, overriding soft mutes only.
-   * Hard mutes (overlay) still win.
-   */
+  /** Force visible while held; overrides soft mutes only. */
   acquireUnmute(reason: string): ShellScope {
     const scope: ShellScope = {
       reason,
@@ -333,12 +312,7 @@ export class Shell implements InputContext {
     return scope;
   }
 
-  /**
-   * Tell setupOutput to swallow the first \n of upcoming PTY chunks.
-   * One increment swallows one \n. Used by exec-request to skip command
-   * echo and by freshPrompt to skip the \n it sent. Auto-decrements when
-   * a \n is consumed by a chunk that would otherwise have been written.
-   */
+  /** Swallow the next \n-terminated chunk from PTY (one per call). */
   skipNextLine(): void { this.pendingEchoSkips++; }
 
   private isHostMuted(): boolean {
@@ -367,15 +341,8 @@ export class Shell implements InputContext {
   /**
    * Ask the shell to redraw its own prompt in place via \e[9999~, which both
    * zsh (ZLE widget) and bash (readline redraw-current-line) bind to repaint.
-   *
-   * Defensive: clear pendingEchoSkips. The redraw response is a fresh
-   * prompt write (no \n), so a stuck skip counter would silently swallow
-   * it and leave the prompt invisible until something with \n flushed
-   * the skip — which is exactly the symptom of "prompt missing after
-   * exiting a mode, until ctrl-c forces a real redraw".
    */
   redrawPrompt(): void {
-    this.pendingEchoSkips = 0;
     const result = this.bus.emitPipe("shell:redraw-prompt", {
       cwd: this.outputParser.getCwd(),
       kind: "redraw",
@@ -420,9 +387,6 @@ export class Shell implements InputContext {
 
       if (this.isHostMuted()) return;
 
-      // Swallow up to pendingEchoSkips leading \n-terminated lines (one per
-      // skip). These are command echos / redraw nudges we explicitly sent
-      // and don't want to render twice.
       if (this.pendingEchoSkips > 0) {
         const nlIdx = data.indexOf("\n");
         if (nlIdx === -1) return;
@@ -444,14 +408,10 @@ export class Shell implements InputContext {
   }
 
   /**
-   * React to agent lifecycle events. Shell ownership of mute state is
-   * expressed through scopes — every "I'm muting" claim is paired with
-   * a release in the same closure, so leaks are visible at compile time.
-   *
-   * Handler split: shell:on-processing-done always runs state cleanup,
-   * then calls shell:on-processing-redraw which is the only advisable
-   * piece. Overlay sessions (RemoteSession) suppress the redraw, never
-   * the cleanup — so paused-equivalent state can't get stuck.
+   * shell:on-processing-done splits into unconditional state cleanup
+   * (release agent-turn scope) and an advisable redraw (freshPrompt).
+   * RemoteSession suppresses the redraw, never the cleanup, so soft-mute
+   * can't leak past the end of a turn even when overlays are involved.
    */
   private setupAgentLifecycle(): void {
     let agentTurnScope: ShellScope | null = null;

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -378,6 +378,7 @@ export class Shell implements InputContext {
     this.pendingEchoSkips = 0;
     const result = this.bus.emitPipe("shell:redraw-prompt", {
       cwd: this.outputParser.getCwd(),
+      kind: "redraw",
       handled: false,
     });
     if (!result.handled) {
@@ -396,6 +397,7 @@ export class Shell implements InputContext {
   freshPrompt(): boolean {
     const result = this.bus.emitPipe("shell:redraw-prompt", {
       cwd: this.outputParser.getCwd(),
+      kind: "fresh",
       handled: false,
     });
     if (!result.handled) {

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -456,9 +456,10 @@ export class FloatingPanel {
       if (this._visible || this._passthrough) {
         return { ...payload, handled: true };
       }
-      // After dismiss, suppress one redraw — restoreScreen already
-      // restored the terminal content, so freshPrompt's \n is unwanted.
-      if (this.suppressNextRedraw) {
+      // After dismiss, suppress only the noisy fresh-prompt \n — an
+      // in-place redraw (e.g. from agent-mode exit) is harmless and must
+      // not consume the suppression slot.
+      if (this.suppressNextRedraw && payload.kind === "fresh") {
         this.suppressNextRedraw = false;
         return { ...payload, handled: true };
       }

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -456,9 +456,8 @@ export class FloatingPanel {
       if (this._visible || this._passthrough) {
         return { ...payload, handled: true };
       }
-      // After dismiss, suppress only the noisy fresh-prompt \n — an
-      // in-place redraw (e.g. from agent-mode exit) is harmless and must
-      // not consume the suppression slot.
+      // Suppress only freshPrompt's \n — an in-place redraw must not
+      // consume the slot, or unrelated mode-exit redraws go missing.
       if (this.suppressNextRedraw && payload.kind === "fresh") {
         this.suppressNextRedraw = false;
         return { ...payload, handled: true };


### PR DESCRIPTION
## Summary

Replaces the boolean-flag soup that gated host stdout (`paused`, `echoSkip`, `agentActive`, `stdoutHold` / `stdoutShow` refcounters) with scope-based locks. The same class of bug that caused the recent host-display freeze (PR #125) becomes structurally impossible: there's no setter to misuse, every "I'm muting" claim is a token paired with a `release()`, leaks are visible at the call site.

## Architecture

Three scope sets:

- **`hardMuteScopes`** — unconditional. The overlay holds this while compositing; no `unmute` can override.
- **`softMuteScopes`** — agent-turn / exec-style. Overridable by an `unmute` scope.
- **`unmuteScopes`** — force visible (permission UI, `terminal_keys`' `stdout-show`). Overrides soft mutes only.

Gate: `if (hardMute) muted; else muted iff (softMute && no unmute)`.

API:
```ts
interface ShellScope { reason: string; release(): void }

shell.acquireHardMute(reason): ShellScope    // overlay compositing
shell.acquireMute(reason): ShellScope         // agent-turn, exec
shell.acquireUnmute(reason): ShellScope       // permission UI, tool show
shell.skipNextLine(): void                    // queue echoSkip
```

## Lifecycle handler split

`shell:on-processing-done` now does two things:

1. **State cleanup** (release the agent-turn scope) — always runs, never advisable.
2. **Redraw** (`freshPrompt`) — the only advisable piece, exposed as `shell:on-processing-redraw`.

`RemoteSession.close()` advises `on-processing-redraw` instead of the whole `done` handler. Scope cleanup is unsuppressable, so the leak class from PR #125 cannot recur.

## Backwards compatibility

`shell:stdout-hold` / `stdout-release` / `stdout-show` / `stdout-hide` bus events stay as compat shims that bridge to scopes internally. No extension code needs to change. `floating-panel.ts`, `terminal-buffer.ts`, etc. continue to work as-is.

## Two related fixes found during testing

Both pre-existing bugs that the refactor surfaced; main has them too. Folded into this PR.

1. **Mute tier collapse** (would have been a regression if shipped without the fix): the initial sketch collapsed all mutes into one set, which let `terminal_keys`' `stdout-show` paint PTY output through the overlay's compositing layer. Restored two-tier model.

2. **Suppression slot consumed by wrong redraw**: `suppressNextRedraw` (set unconditionally in `teardownScreen` to swallow `freshPrompt`'s noisy `\n`) is a one-shot flag with no scope — if no `freshPrompt` is queued, the next unrelated `redrawPrompt` (e.g. agent-mode exit) consumes it and the prompt silently fails to render. Added `kind` field to the `shell:redraw-prompt` pipe; only `kind: "fresh"` is suppressible.

## Test plan

Manually verified on this branch:

- [x] Plain shell (typing, ctrl-c, ctrl-d at prompt)
- [x] Host shell agent — text only, with Bash tool, with permission, mid-turn cancel
- [x] `user_shell` happy path
- [x] Overlay — text only, dismiss
- [x] Overlay with permissions, dismiss (the original PR #125 repro — host stays responsive)
- [x] Overlay — lldb via `terminal_keys`, dismiss
- [x] Overlay → host shell agent (verifies advisor cleanup didn't leak across)
- [x] Sequential overlay sessions
- [x] Issue 1: `terminal_keys` no longer paints through overlay dim layer
- [x] Issue 2: agent-mode exit redraws the shell prompt (no ctrl-c needed)

Diagnostic logging (gated on `AGENT_SH_DEBUG_HOLD=<path>`) preserved on `debug/refactor-diagnostics` for future troubleshooting.