### PR TITLE
Add install/uninstall/list subcommands for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ So I built agent-sh. Under the hood it's a normal shell on top of node-pty — y
 ~ $ > draft a commit message     # agent reads your diff and shell history
 ```
 
-I still use a proper coding harness for serious work — this doesn't replace that. But for the quick stuff in the terminal, I reach for agent-sh almost every day now. The built-in agent is lightweight and good enough for most of what I throw at it, and when it isn't, you can swap in [pi](examples/extensions/pi-bridge/) as the backend via a bridge extension.
+I still use a proper coding harness for serious work — this doesn't replace that. But for the quick stuff in the terminal, I reach for agent-sh almost every day now. The built-in agent is lightweight and good enough for most of what I throw at it, and when it isn't, you can swap in [pi](examples/extensions/pi-bridge/) as the backend — `agent-sh install pi-bridge` followed by `agent-sh --backend pi`.
 
 ## Quick Start
 
@@ -95,7 +95,7 @@ Requires Node.js 18+. Currently supports **bash** and **zsh**; other shells (fis
 
 **Context that just works.** Every query includes your cwd, recent commands, and their output. Run a failing test, type `> fix this`, and agent-sh knows exactly what happened. Context management works like shell history — continuous, persistent across restarts, no sessions to manage. See [Context Management](docs/context-management.md).
 
-**Any LLM, any backend.** agent-sh works with any OpenAI-compatible API out of the box. Define multiple providers in settings and switch models at runtime with `/model <name>`. Or swap in a completely different agent — [pi](examples/extensions/pi-bridge/) runs as a drop-in backend extension.
+**Any LLM, any backend.** agent-sh works with any OpenAI-compatible API out of the box. Define multiple providers in settings and switch models at runtime with `/model <name>`. Or swap in a completely different agent — `agent-sh install pi-bridge && agent-sh --backend pi` runs [pi](examples/extensions/pi-bridge/) as a drop-in backend.
 
 **Extensible by design.** The entire system is built on a typed event bus. Extensions can add custom input modes, content transforms (render LaTeX as images, Mermaid as diagrams), themes, slash commands, or replace the agent backend entirely. The built-in TUI renderer is itself just an extension.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -40,11 +40,23 @@ npm start -- -e my-ext-package -e ./local-ext.ts
 ~/.agent-sh/extensions/
 ├── my-extension.ts          # loaded directly
 ├── another.js               # JS works too
-└── complex-extension/       # directory with index file
+└── complex-extension/       # directory with index.{js,mjs,ts,tsx,mts}
     └── index.ts
 ```
 
 TypeScript and JavaScript are both supported (`.ts`, `.tsx`, `.mts`, `.js`, `.mjs`). TS is transpiled at runtime via tsx. Bare names resolve as npm packages via Node's standard module resolution. Errors in extension loading are non-fatal.
+
+The `agent-sh install` subcommand populates this directory from bundled examples or local paths:
+
+```bash
+agent-sh install pi-bridge          # copy bundled examples/extensions/pi-bridge/
+agent-sh install ./my-local-ext     # copy from a local path
+agent-sh install --force <name>     # overwrite an existing target
+agent-sh uninstall <name>           # remove
+agent-sh list                       # show all loadable extensions (extensions dir + settings.json)
+```
+
+For directory-style extensions with declared dependencies, `install` runs `npm install` in the target automatically.
 
 ## ExtensionContext API
 
@@ -279,6 +291,14 @@ By default, the built-in `"ash"` backend activates (registered by the `agent-bac
 ```
 
 On startup, `activateBackend()` checks this setting and activates the named backend if it was registered. If the named backend isn't found, it falls back to the first registered backend.
+
+For a one-off override that doesn't persist, pass `--backend <name>` on the command line:
+
+```bash
+agent-sh --backend pi    # launches pi this session, settings unchanged
+```
+
+Unlike `defaultBackend`, the CLI flag is strict: if the named backend isn't registered, agent-sh errors out with a hint pointing at `agent-sh install <bridge>` rather than silently falling back.
 
 To disable the built-in agent entirely (e.g., for bridge-only setups):
 ```json

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,12 +23,27 @@ Environment variables `OPENAI_API_KEY` and `OPENAI_BASE_URL` are supported as al
 # Use a different shell
 agent-sh --shell /bin/zsh
 
+# Launch a non-default agent backend (per-session override; doesn't touch settings)
+agent-sh --backend pi
+
 # Development mode (no build step)
 npm run dev
 
 # Debug mode
 DEBUG=1 agent-sh --api-key "$KEY" --model gpt-4o
 ```
+
+### Subcommands
+
+```bash
+agent-sh init                   # scaffold ~/.agent-sh/ (settings, examples, AGENTS.md)
+agent-sh install <name>         # install a bundled extension (e.g. agent-sh install pi-bridge)
+agent-sh install ./path/to/ext  # install from a local path
+agent-sh uninstall <name>       # remove an installed extension
+agent-sh list                   # show extensions discovered from ~/.agent-sh/extensions/ and settings.json
+```
+
+`install` accepts a bundled-extension name (see `agent-sh install` with no argument for the list), a `file:`/`./`/absolute path, or — once implemented — `npm:<pkg>` and `github:<user>/<repo>` specs.
 
 ## Updating
 
@@ -200,6 +215,7 @@ Switching mid-conversation preserves your conversation state — only the LLM en
 | `--api-key <key>` | `OPENAI_API_KEY` | API key for OpenAI-compatible API |
 | `--base-url <url>` | `OPENAI_BASE_URL` | Base URL for API endpoint |
 | `--shell <path>` | `SHELL` | Shell to use (default: `/bin/bash`) |
+| `--backend <name>` | — | Agent backend to launch (e.g. `ash`, `pi`); per-session override of `settings.defaultBackend`, does not persist. Errors out if the named backend isn't registered. |
 | `-e, --extensions` | — | Extensions to load (comma-separated, repeatable) |
 
 **Precedence** (highest to lowest): CLI flags → environment variables → provider profile in settings.json → defaults.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { loadBuiltinExtensions } from "./extensions/index.js";
 import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
 import { runInit } from "./init.js";
-import { runInstall, runUninstall, runList } from "./install.js";
+import { runInstall, runUninstall, runList, suggestBridgeFor } from "./install.js";
 import { PACKAGE_VERSION } from "./utils/package-version.js";
 import type { AgentShellConfig } from "./types.js";
 
@@ -323,15 +323,19 @@ async function main(): Promise<void> {
     console.error("\nagent-sh: no agent backend available.\n\n" +
       "  Export OPENROUTER_API_KEY or OPENAI_API_KEY for zero-config launch, or\n" +
       "  pass --api-key on the command line, or\n" +
-      "  run `agent-sh init` for a settings.json template.\n" +
-      "  Alternatively, install a bridge extension (claude-code-bridge, pi-bridge).\n");
+      "  run `agent-sh init` for a settings.json template, or\n" +
+      "  run `agent-sh install <bridge>` (e.g. pi-bridge, claude-code-bridge) to use a non-ash backend.\n");
     process.exit(1);
   }
   if (config.backend && !backendNames.includes(config.backend)) {
     shell?.kill();
+    const bridge = suggestBridgeFor(config.backend);
+    const hint = bridge
+      ? `  Try: agent-sh install ${bridge}\n`
+      : `  Run \`agent-sh install\` to see bundled bridge extensions.\n`;
     console.error(`\nagent-sh: backend "${config.backend}" is not available.\n\n` +
       `  Available backends: ${backendNames.join(", ")}\n` +
-      `  Bridge extensions (e.g. pi-bridge, claude-code-bridge) register additional backends.\n`);
+      hint);
     process.exit(1);
   }
   // No await: banner must out-race the shell's PS1 arriving via PTY.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { loadBuiltinExtensions } from "./extensions/index.js";
 import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
 import { runInit } from "./init.js";
+import { runInstall, runUninstall, runList } from "./install.js";
 import { PACKAGE_VERSION } from "./utils/package-version.js";
 import type { AgentShellConfig } from "./types.js";
 
@@ -115,7 +116,10 @@ function parseArgs(argv: string[]): AgentShellConfig {
       console.log(`agent-sh — a shell-first terminal where AI is one keystroke away
 
 Usage: agent-sh [options]
-       agent-sh init [--force]    Scaffold ~/.agent-sh/ (settings, examples, AGENTS.md)
+       agent-sh init [--force]            Scaffold ~/.agent-sh/ (settings, examples, AGENTS.md)
+       agent-sh install <spec> [--force]  Install an extension (bundled name, file:, npm:, github:)
+       agent-sh uninstall <name>          Remove an installed extension
+       agent-sh list                      List installed extensions
 
 Provider Profiles:
   --provider <name>   Use a provider from ~/.agent-sh/settings.json
@@ -164,6 +168,18 @@ async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   if (rawArgs[0] === "init") {
     runInit({ force: rawArgs.includes("--force") });
+    return;
+  }
+  if (rawArgs[0] === "install") {
+    await runInstall(rawArgs[1] ?? "", { force: rawArgs.includes("--force") });
+    return;
+  }
+  if (rawArgs[0] === "uninstall") {
+    await runUninstall(rawArgs[1] ?? "");
+    return;
+  }
+  if (rawArgs[0] === "list") {
+    runList();
     return;
   }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -181,34 +181,55 @@ export async function runUninstall(name: string): Promise<void> {
   console.log(`Uninstalled: ${name}`);
 }
 
-export function runList(): void {
-  if (!fs.existsSync(EXT_DIR)) {
-    console.log("No extensions installed.");
-    return;
-  }
-  const disabled = new Set(getSettings().disabledExtensions ?? []);
+interface ListedExtension {
+  name: string;
+  source: "extensions dir" | "settings.json";
+  detail?: string;
+}
+
+function listFromExtDir(disabled: Set<string>): ListedExtension[] {
+  if (!fs.existsSync(EXT_DIR)) return [];
   const dirents = fs.readdirSync(EXT_DIR, { withFileTypes: true });
-  const loadable = dirents.filter((d) => {
-    if (d.name.startsWith(".")) return false;
+  const out: ListedExtension[] = [];
+  for (const d of dirents) {
+    if (d.name.startsWith(".")) continue;
     const nameForDisable = d.name.replace(/\.[^.]+$/, "");
-    if (disabled.has(nameForDisable)) return false;
+    if (disabled.has(nameForDisable)) continue;
     const full = path.join(EXT_DIR, d.name);
-    // Symlinks may point at directories; resolve before checking for an index.
     let isDir = d.isDirectory();
     if (d.isSymbolicLink()) {
-      try { isDir = fs.statSync(full).isDirectory(); } catch { return false; }
+      try { isDir = fs.statSync(full).isDirectory(); } catch { continue; }
     }
-    if (isDir) return hasIndexFile(full);
-    return SCRIPT_EXTS.some((ext) => d.name.endsWith(ext));
-  });
-  if (loadable.length === 0) {
+    if (isDir) {
+      if (!hasIndexFile(full)) continue;
+    } else if (!SCRIPT_EXTS.some((ext) => d.name.endsWith(ext))) {
+      continue;
+    }
+    const detail = d.isSymbolicLink() ? `-> ${fs.readlinkSync(full)}` : undefined;
+    out.push({ name: d.name, source: "extensions dir", detail });
+  }
+  return out;
+}
+
+function listFromSettings(disabled: Set<string>): ListedExtension[] {
+  const specs = getSettings().extensions ?? [];
+  return specs
+    .filter((s) => !disabled.has(s.replace(/\.[^.]+$/, "")))
+    .map((s) => ({ name: s, source: "settings.json" as const }));
+}
+
+export function runList(): void {
+  const disabled = new Set(getSettings().disabledExtensions ?? []);
+  const items = [...listFromExtDir(disabled), ...listFromSettings(disabled)];
+  if (items.length === 0) {
     console.log("No extensions installed.");
     return;
   }
+  const nameWidth = Math.max(...items.map((i) => i.name.length));
   console.log("Installed extensions:");
-  for (const d of loadable) {
-    const full = path.join(EXT_DIR, d.name);
-    const suffix = d.isSymbolicLink() ? ` -> ${fs.readlinkSync(full)}` : "";
-    console.log(`  ${d.name}${suffix}`);
+  for (const item of items) {
+    const padded = item.name.padEnd(nameWidth);
+    const detail = item.detail ? `  ${item.detail}` : "";
+    console.log(`  ${padded}  (${item.source})${detail}`);
   }
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -7,6 +7,10 @@ import { CONFIG_DIR, getSettings } from "./settings.js";
 // Kept in sync with extension-loader.ts SCRIPT_EXTS.
 const SCRIPT_EXTS = [".js", ".mjs", ".ts", ".tsx", ".mts"];
 
+function hasIndexFile(dir: string): boolean {
+  return SCRIPT_EXTS.some((ext) => fs.existsSync(path.join(dir, `index${ext}`)));
+}
+
 const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../");
 const BUNDLED_DIR = path.join(PACKAGE_ROOT, "examples/extensions");
 const EXT_DIR = path.join(CONFIG_DIR, "extensions");
@@ -188,7 +192,13 @@ export function runList(): void {
     if (d.name.startsWith(".")) return false;
     const nameForDisable = d.name.replace(/\.[^.]+$/, "");
     if (disabled.has(nameForDisable)) return false;
-    if (d.isDirectory() || d.isSymbolicLink()) return true;
+    const full = path.join(EXT_DIR, d.name);
+    // Symlinks may point at directories; resolve before checking for an index.
+    let isDir = d.isDirectory();
+    if (d.isSymbolicLink()) {
+      try { isDir = fs.statSync(full).isDirectory(); } catch { return false; }
+    }
+    if (isDir) return hasIndexFile(full);
     return SCRIPT_EXTS.some((ext) => d.name.endsWith(ext));
   });
   if (loadable.length === 0) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,188 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { CONFIG_DIR } from "./settings.js";
+
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../");
+const BUNDLED_DIR = path.join(PACKAGE_ROOT, "examples/extensions");
+const EXT_DIR = path.join(CONFIG_DIR, "extensions");
+
+interface InstallOpts {
+  force?: boolean;
+}
+
+interface ResolvedSource {
+  sourcePath: string;
+  /** Filesystem name used under ~/.agent-sh/extensions/. Includes the file
+   *  extension for single-file resolves so the loader's SCRIPT_EXTS check matches. */
+  name: string;
+  isDirectory: boolean;
+}
+
+interface Resolver {
+  canHandle?(spec: string): boolean;
+  resolve(spec: string): Promise<ResolvedSource>;
+}
+
+function listBundled(): string[] {
+  if (!fs.existsSync(BUNDLED_DIR)) return [];
+  return fs.readdirSync(BUNDLED_DIR).map((n) => n.replace(/\.(ts|js|mjs)$/, ""));
+}
+
+const bundledResolver: Resolver = {
+  resolve: async (spec) => {
+    const candidates = [
+      { p: path.join(BUNDLED_DIR, spec), name: spec },
+      { p: path.join(BUNDLED_DIR, `${spec}.ts`), name: `${spec}.ts` },
+      { p: path.join(BUNDLED_DIR, `${spec}.js`), name: `${spec}.js` },
+    ];
+    for (const c of candidates) {
+      if (fs.existsSync(c.p)) {
+        const isDirectory = fs.statSync(c.p).isDirectory();
+        return { sourcePath: c.p, name: c.name, isDirectory };
+      }
+    }
+    const available = listBundled();
+    throw new Error(
+      `No bundled extension named "${spec}".\n\n` +
+        `Available:\n${available.map((n) => `  ${n}`).join("\n")}`,
+    );
+  },
+};
+
+const npmResolver: Resolver = {
+  canHandle: (spec) => spec.startsWith("npm:"),
+  resolve: async () => {
+    throw new Error("npm: source is not yet implemented");
+  },
+};
+
+const githubResolver: Resolver = {
+  canHandle: (spec) => spec.startsWith("github:") || spec.startsWith("https://github.com/"),
+  resolve: async () => {
+    throw new Error("github: source is not yet implemented");
+  },
+};
+
+const fileResolver: Resolver = {
+  canHandle: (spec) =>
+    spec.startsWith("file:") || spec.startsWith("/") || spec.startsWith("./") || spec.startsWith("../"),
+  resolve: async (spec) => {
+    const raw = spec.startsWith("file:") ? spec.slice("file:".length) : spec;
+    const abs = path.resolve(raw);
+    if (!fs.existsSync(abs)) throw new Error(`Path does not exist: ${abs}`);
+    const isDirectory = fs.statSync(abs).isDirectory();
+    return { sourcePath: abs, name: path.basename(abs), isDirectory };
+  },
+};
+
+const PREFIX_RESOLVERS: Resolver[] = [npmResolver, githubResolver, fileResolver];
+
+function pickResolver(spec: string): Resolver {
+  for (const r of PREFIX_RESOLVERS) if (r.canHandle?.(spec)) return r;
+  return bundledResolver;
+}
+
+function maybeNpmInstall(target: string): void {
+  const pkgJson = path.join(target, "package.json");
+  if (!fs.existsSync(pkgJson)) return;
+  const pkg = JSON.parse(fs.readFileSync(pkgJson, "utf-8"));
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}) };
+  if (Object.keys(deps).length === 0) return;
+  if (fs.existsSync(path.join(target, "node_modules"))) return;
+  console.log(`Running npm install in ${target}...`);
+  const result = spawnSync("npm", ["install", "--no-audit", "--no-fund"], {
+    cwd: target,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error(`npm install failed in ${target}; run it manually.`);
+  }
+}
+
+export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<void> {
+  if (!spec) {
+    console.error(
+      "Usage: agent-sh install <name|file:|npm:|github:> [--force]\n\n" +
+        "Bundled extensions:\n" +
+        listBundled()
+          .map((n) => `  ${n}`)
+          .join("\n"),
+    );
+    process.exit(1);
+  }
+
+  fs.mkdirSync(EXT_DIR, { recursive: true });
+
+  let resolved: ResolvedSource;
+  try {
+    resolved = await pickResolver(spec).resolve(spec);
+  } catch (err) {
+    console.error(`agent-sh: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  const target = path.join(EXT_DIR, resolved.name);
+  if (fs.lstatSync(target, { throwIfNoEntry: false })) {
+    if (!opts.force) {
+      console.error(`agent-sh: ${target} already exists (pass --force to overwrite)`);
+      process.exit(1);
+    }
+    fs.rmSync(target, { recursive: true, force: true });
+  }
+
+  if (resolved.isDirectory) {
+    fs.cpSync(resolved.sourcePath, target, { recursive: true });
+    try {
+      maybeNpmInstall(target);
+    } catch (err) {
+      console.error(`agent-sh: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+  } else {
+    fs.copyFileSync(resolved.sourcePath, target);
+  }
+
+  console.log(`Installed: ${resolved.name} -> ${target}`);
+}
+
+export async function runUninstall(name: string): Promise<void> {
+  if (!name) {
+    console.error("Usage: agent-sh uninstall <name>");
+    process.exit(1);
+  }
+  const target = path.join(EXT_DIR, name);
+  // Refuse path-traversal: target must sit directly under EXT_DIR.
+  const resolvedTarget = path.resolve(target);
+  const resolvedExtDir = path.resolve(EXT_DIR);
+  if (!resolvedTarget.startsWith(resolvedExtDir + path.sep)) {
+    console.error(`agent-sh: refusing to uninstall outside ${EXT_DIR}`);
+    process.exit(1);
+  }
+  if (!fs.lstatSync(target, { throwIfNoEntry: false })) {
+    console.error(`agent-sh: not installed: ${name}`);
+    process.exit(1);
+  }
+  fs.rmSync(target, { recursive: true, force: true });
+  console.log(`Uninstalled: ${name}`);
+}
+
+export function runList(): void {
+  if (!fs.existsSync(EXT_DIR)) {
+    console.log("No extensions installed.");
+    return;
+  }
+  const entries = fs.readdirSync(EXT_DIR).filter((n) => !n.startsWith("."));
+  if (entries.length === 0) {
+    console.log("No extensions installed.");
+    return;
+  }
+  console.log("Installed extensions:");
+  for (const name of entries) {
+    const full = path.join(EXT_DIR, name);
+    const link = fs.lstatSync(full);
+    const suffix = link.isSymbolicLink() ? ` -> ${fs.readlinkSync(full)}` : "";
+    console.log(`  ${name}${suffix}`);
+  }
+}

--- a/src/install.ts
+++ b/src/install.ts
@@ -2,7 +2,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
-import { CONFIG_DIR } from "./settings.js";
+import { CONFIG_DIR, getSettings } from "./settings.js";
+
+// Kept in sync with extension-loader.ts SCRIPT_EXTS.
+const SCRIPT_EXTS = [".js", ".mjs", ".ts", ".tsx", ".mts"];
 
 const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../");
 const BUNDLED_DIR = path.join(PACKAGE_ROOT, "examples/extensions");
@@ -179,16 +182,23 @@ export function runList(): void {
     console.log("No extensions installed.");
     return;
   }
-  const entries = fs.readdirSync(EXT_DIR).filter((n) => !n.startsWith("."));
-  if (entries.length === 0) {
+  const disabled = new Set(getSettings().disabledExtensions ?? []);
+  const dirents = fs.readdirSync(EXT_DIR, { withFileTypes: true });
+  const loadable = dirents.filter((d) => {
+    if (d.name.startsWith(".")) return false;
+    const nameForDisable = d.name.replace(/\.[^.]+$/, "");
+    if (disabled.has(nameForDisable)) return false;
+    if (d.isDirectory() || d.isSymbolicLink()) return true;
+    return SCRIPT_EXTS.some((ext) => d.name.endsWith(ext));
+  });
+  if (loadable.length === 0) {
     console.log("No extensions installed.");
     return;
   }
   console.log("Installed extensions:");
-  for (const name of entries) {
-    const full = path.join(EXT_DIR, name);
-    const link = fs.lstatSync(full);
-    const suffix = link.isSymbolicLink() ? ` -> ${fs.readlinkSync(full)}` : "";
-    console.log(`  ${name}${suffix}`);
+  for (const d of loadable) {
+    const full = path.join(EXT_DIR, d.name);
+    const suffix = d.isSymbolicLink() ? ` -> ${fs.readlinkSync(full)}` : "";
+    console.log(`  ${d.name}${suffix}`);
   }
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -25,9 +25,15 @@ interface Resolver {
   resolve(spec: string): Promise<ResolvedSource>;
 }
 
-function listBundled(): string[] {
+export function listBundled(): string[] {
   if (!fs.existsSync(BUNDLED_DIR)) return [];
   return fs.readdirSync(BUNDLED_DIR).map((n) => n.replace(/\.(ts|js|mjs)$/, ""));
+}
+
+/** Heuristic: a backend named "pi" is typically provided by an extension called "pi-bridge". */
+export function suggestBridgeFor(backend: string): string | null {
+  const candidate = `${backend}-bridge`;
+  return listBundled().includes(candidate) ? candidate : null;
 }
 
 const bundledResolver: Resolver = {


### PR DESCRIPTION
## Summary
- New \`agent-sh install <spec>\` subcommand with a pluggable resolver design so future sources slot in without churning the dispatch path.
- Companion \`uninstall <name>\` and \`list\` subcommands.
- Only the bundled resolver is wired today (\`agent-sh install pi-bridge\` copies \`examples/extensions/pi-bridge\` into \`~/.agent-sh/extensions/\` and runs \`npm install\` if its package.json declares deps). \`npm:\` and \`github:\` prefixes parse but throw "not yet implemented" — locks the surface in without committing to those backends yet. \`file:\`, \`/\`, \`./\`, \`../\` route to the file resolver.

## Spec syntax
| Spec | Resolver | Status |
|---|---|---|
| bare name (e.g. \`pi-bridge\`) | bundled | ✅ implemented |
| \`file:/abs\`, \`./rel\`, \`/abs\` | file (copy of an external path) | ✅ implemented |
| \`npm:<pkg>\` | npm | ⏳ stub — throws |
| \`github:<user>/<repo>\`, \`https://github.com/...\` | github | ⏳ stub — throws |

## Safety
- \`uninstall\` refuses targets that resolve outside \`~/.agent-sh/extensions/\` (path-traversal guard).
- \`install\` refuses to overwrite an existing target unless \`--force\` is passed; broken-symlink targets are detected via \`lstat\`.

## Test plan
- [x] \`agent-sh install\` (no spec) prints usage with bundled list
- [x] \`agent-sh install nonexistent-foo\` errors with bundled list
- [x] \`agent-sh install npm:foo\` / \`install github:user/repo\` print not-implemented
- [x] Sandbox \`HOME\` test of single-file install → list → uninstall
- [x] Path-traversal refusal in \`uninstall\`
- [ ] Directory install with auto-\`npm install\` (\`agent-sh install pi-bridge\`) — mechanically straightforward but not exercised end-to-end yet