### PR TITLE
Forward shell context to claude-code-bridge; surface bridges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ The built-in agent (`ash`) is the default, but agent-sh can host a different cod
   agent-sh --backend claude-code
   ```
 
-Both bridges receive agent-sh's per-query shell context (`<shell_events>`) and follow the PTY-tracked cwd, so the hosted agent sees what you ran and where you are. Set `defaultBackend` in `~/.agent-sh/settings.json` to make a backend sticky across sessions.
+Both bridges receive agent-sh's per-query shell context (`<shell_events>`) and follow the PTY-tracked cwd, so the hosted agent sees what you ran and where you are. Switching at runtime with `/backend <name>` persists the choice across sessions automatically; the `--backend` flag above is per-session only.
+
+**Caveat:** pi and claude-code each manage their own tool surfaces, so agent-sh extensions that register tools (or skills, instructions, etc.) for the built-in `ash` agent generally won't be visible to a hosted backend. Frontend extensions (themes, content transforms, slash commands, the TUI renderer) keep working — only the agent-side capabilities differ. Use the bridges when you want that agent's toolset; stay on `ash` when you want agent-sh's extension ecosystem.
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ So I built agent-sh. Under the hood it's a normal shell on top of node-pty — y
 ~ $ > draft a commit message     # agent reads your diff and shell history
 ```
 
-I still use a proper coding harness for serious work — this doesn't replace that. But for the quick stuff in the terminal, I reach for agent-sh almost every day now. The built-in agent is lightweight and good enough for most of what I throw at it, and when it isn't, you can swap in [pi](examples/extensions/pi-bridge/) as the backend — `agent-sh install pi-bridge` followed by `agent-sh --backend pi`.
+I still use a proper coding harness for serious work — this doesn't replace that. But for the quick stuff in the terminal, I reach for agent-sh almost every day now. The built-in agent is lightweight and good enough for most of what I throw at it, and when it isn't, you can swap in a heavier coding agent as the backend (see [Bring your own agent](#bring-your-own-agent) below).
 
 ## Quick Start
 
@@ -87,6 +87,26 @@ Requires Node.js 18+. Currently supports **bash** and **zsh**; other shells (fis
 
 **Windows:** the interactive shell layer is bash/zsh-only. Run agent-sh inside **WSL** for the full experience. Native Windows (cmd.exe / PowerShell) is not supported as the host shell, though headless / library / ACP-bridge usage may work — file an issue if you hit a gap.
 
+## Bring your own agent
+
+The built-in agent (`ash`) is the default, but agent-sh can host a different coding agent as its backend — same terminal, same `>` entry point, same shell-context wiring. Two bridges ship in the box:
+
+- **[pi-bridge](examples/extensions/pi-bridge/)** — runs [pi](https://github.com/badlogic/pi-mono) (`@mariozechner/pi-coding-agent`) in-process. Pi brings its own models, tools, and `~/.pi/agent/settings.json`.
+
+  ```bash
+  agent-sh install pi-bridge
+  agent-sh --backend pi
+  ```
+
+- **[claude-code-bridge](examples/extensions/claude-code-bridge/)** — runs the official [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) in-process. Uses Claude Code's own `Read`/`Edit`/`Write`/`Bash`/`Glob`/`Grep` tools.
+
+  ```bash
+  agent-sh install claude-code-bridge
+  agent-sh --backend claude-code
+  ```
+
+Both bridges receive agent-sh's per-query shell context (`<shell_events>`) and follow the PTY-tracked cwd, so the hosted agent sees what you ran and where you are. Set `defaultBackend` in `~/.agent-sh/settings.json` to make a backend sticky across sessions.
+
 ## Key Features
 
 **Real terminal, zero compromise.** Full PTY with your shell config, aliases, and environment. Shell starts instantly — the agent connects asynchronously in the background.
@@ -95,7 +115,7 @@ Requires Node.js 18+. Currently supports **bash** and **zsh**; other shells (fis
 
 **Context that just works.** Every query includes your cwd, recent commands, and their output. Run a failing test, type `> fix this`, and agent-sh knows exactly what happened. Context management works like shell history — continuous, persistent across restarts, no sessions to manage. See [Context Management](docs/context-management.md).
 
-**Any LLM, any backend.** agent-sh works with any OpenAI-compatible API out of the box. Define multiple providers in settings and switch models at runtime with `/model <name>`. Or swap in a completely different agent — `agent-sh install pi-bridge && agent-sh --backend pi` runs [pi](examples/extensions/pi-bridge/) as a drop-in backend.
+**Any LLM, any backend.** agent-sh works with any OpenAI-compatible API out of the box. Define multiple providers in settings and switch models at runtime with `/model <name>`. Or swap in a completely different agent — bundled bridges run [pi](examples/extensions/pi-bridge/) or the [Claude Agent SDK](examples/extensions/claude-code-bridge/) as a drop-in backend (see [Bring your own agent](#bring-your-own-agent)).
 
 **Extensible by design.** The entire system is built on a typed event bus. Extensions can add custom input modes, content transforms (render LaTeX as images, Mermaid as diagrams), themes, slash commands, or replace the agent backend entirely. The built-in TUI renderer is itself just an extension.
 

--- a/examples/extensions/claude-code-bridge/README.md
+++ b/examples/extensions/claude-code-bridge/README.md
@@ -5,12 +5,16 @@ Runs Claude Code as an agent-sh backend using the official [@anthropic-ai/claude
 ## Install
 
 ```bash
-# Copy or symlink into your extensions directory
-cp -r examples/extensions/claude-code-bridge ~/.agent-sh/extensions/claude-code-bridge
+agent-sh install claude-code-bridge
+```
 
-# Install dependencies
-cd ~/.agent-sh/extensions/claude-code-bridge
-npm install
+This copies the bundled extension into `~/.agent-sh/extensions/claude-code-bridge` and runs `npm install` for you. To overwrite an existing install, pass `--force`. To uninstall, run `agent-sh uninstall claude-code-bridge`.
+
+Manual alternative (e.g. for a development checkout you want to symlink):
+
+```bash
+cp -r examples/extensions/claude-code-bridge ~/.agent-sh/extensions/claude-code-bridge
+cd ~/.agent-sh/extensions/claude-code-bridge && npm install
 ```
 
 ## Configure
@@ -34,16 +38,12 @@ Or switch at runtime:
 - `ANTHROPIC_API_KEY` must be set in your environment
 - Claude Code manages its own model selection — no model configuration needed in agent-sh
 
+## What works under claude-code
+
+agent-sh's per-query context producers (e.g. `<shell_events>` from `shell-context`) are inlined into the prompt before each query, so claude-code sees the user's recent shell activity even though the SDK doesn't subscribe to agent-sh's shell bus directly.
+
+The SDK's working directory follows agent-sh's PTY-tracked cwd, so when the user `cd`s in the terminal, claude-code's tools (Bash, Read, etc.) operate in the new directory.
+
 ## What this bridge is
 
 A pure protocol translator between the Claude Agent SDK's event stream and agent-sh's bus events. Claude Code uses its own built-in tools exactly as the SDK ships them (`Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep`). The bridge adds no tools of its own.
-
-## What this bridge intentionally does NOT bundle
-
-Three PTY-access tools are left out on purpose:
-
-- `terminal_read` — observe the user's live terminal screen
-- `terminal_keys` — send keystrokes to the user's PTY
-- `user_shell` — run commands in the user's live shell with lasting `cd`/`export`/`source` effects
-
-These are opt-in capabilities that belong in their own extensions. If you want any of them with Claude Code, write a companion extension that uses the SDK's `tool()` + `createSdkMcpServer()` to expose them as MCP tools, and extend the bridge (or fork it) to attach that MCP server to the SDK's `query()` options.

--- a/examples/extensions/claude-code-bridge/index.ts
+++ b/examples/extensions/claude-code-bridge/index.ts
@@ -1,25 +1,8 @@
 /**
  * Claude Code bridge — runs Claude Code Agent SDK in-process as agent-sh's backend.
  *
- * Uses the official @anthropic-ai/claude-agent-sdk to spawn a Claude Code
- * session. Claude Code handles its own model selection, tool execution, and
- * permissions — the bridge is a pure protocol translator between the SDK's
- * event stream and agent-sh's bus events.
- *
- * PTY-access tools (`terminal_read`, `terminal_keys`, `user_shell`) are
- * intentionally NOT bundled here. If you want Claude Code to observe or
- * drive the user's live terminal, load a companion extension that
- * registers those tools as MCP tools the SDK can consume.
- *
- * Setup (from repo root):
- *   npm run build && npm link                    # register local agent-sh globally
- *   cd examples/extensions/claude-code-bridge
- *   npm install && npm link agent-sh             # link local dev copy
- *
- * Usage:
- *   agent-sh -e examples/extensions/claude-code-bridge
- *
- * Requires: Claude Code CLI installed and authenticated (claude login).
+ * Pure protocol translator between the SDK's event stream and agent-sh's bus.
+ * Requires Claude Code CLI installed and authenticated (claude login).
  */
 import { query, type Query } from "@anthropic-ai/claude-agent-sdk";
 import { readFile } from "node:fs/promises";
@@ -29,7 +12,13 @@ import { computeDiff, type DiffResult } from "agent-sh/utils/diff";
 
 // ── Extension entry point ─────────────────────────────────────────
 export default function activate(ctx: ExtensionContext): void {
-  const { bus } = ctx;
+  const { bus, call } = ctx;
+
+  // PTY-tracked cwd from shell-context; falls back when no PTY frontend.
+  const cwd = (): string => {
+    const v = call("cwd");
+    return typeof v === "string" && v ? v : process.cwd();
+  };
 
   let activeQuery: Query | null = null;
   const listeners: Array<{ event: string; fn: Function }> = [];
@@ -88,11 +77,16 @@ export default function activate(ctx: ExtensionContext): void {
       /** Pre-edit file snapshots for diff display (Edit/Write tools). */
       const fileSnapshots = new Map<string, string | null>();
 
+      // Splice per-query context (e.g. <shell_events>) into the prompt — the
+      // SDK has no other channel for it. Mirrors pi-bridge.
+      const ctxText = String(call("query-context:build") ?? "").trim();
+      const finalPrompt = ctxText ? `${ctxText}\n\n${userQuery}` : userQuery;
+
       try {
         activeQuery = query({
-          prompt: userQuery,
+          prompt: finalPrompt,
           options: {
-            cwd: process.cwd(),
+            cwd: cwd(),
             systemPrompt: {
               type: "preset",
               preset: "claude_code",
@@ -155,7 +149,7 @@ export default function activate(ctx: ExtensionContext): void {
 
                   // Snapshot file content before Edit/Write modifies it
                   if ((meta.name === "Edit" || meta.name === "Write") && typeof (input as any).file_path === "string") {
-                    const absPath = resolve(process.cwd(), (input as any).file_path);
+                    const absPath = resolve(cwd(), (input as any).file_path);
                     readFile(absPath, "utf-8")
                       .then(content => fileSnapshots.set(meta.id, content))
                       .catch(() => fileSnapshots.set(meta.id, null)); // file doesn't exist yet
@@ -191,7 +185,7 @@ export default function activate(ctx: ExtensionContext): void {
 
                   // Snapshot file content before Edit/Write modifies it
                   if ((b.name === "Edit" || b.name === "Write") && typeof (input as any).file_path === "string") {
-                    const absPath = resolve(process.cwd(), (input as any).file_path);
+                    const absPath = resolve(cwd(), (input as any).file_path);
                     readFile(absPath, "utf-8")
                       .then(content => fileSnapshots.set(b.id, content))
                       .catch(() => fileSnapshots.set(b.id, null));
@@ -226,7 +220,7 @@ export default function activate(ctx: ExtensionContext): void {
                       fileSnapshots.delete(toolUseId);
                       const filePath = (pending.input as any)?.file_path as string | undefined;
                       if (filePath) {
-                        const absPath = resolve(process.cwd(), filePath);
+                        const absPath = resolve(cwd(), filePath);
                         try {
                           const newContent = await readFile(absPath, "utf-8");
                           const diff = computeDiff(oldContent, newContent);

--- a/examples/extensions/pi-bridge/README.md
+++ b/examples/extensions/pi-bridge/README.md
@@ -5,9 +5,16 @@ Runs [pi](https://github.com/badlogic/pi-mono) (`@mariozechner/pi-coding-agent`)
 ## Install
 
 ```bash
+agent-sh install pi-bridge
+```
+
+This copies the bundled extension into `~/.agent-sh/extensions/pi-bridge` and runs `npm install` for you. To overwrite an existing install, pass `--force`. To uninstall, run `agent-sh uninstall pi-bridge`.
+
+Manual alternative (e.g. for a development checkout you want to symlink):
+
+```bash
 cp -r examples/extensions/pi-bridge ~/.agent-sh/extensions/pi-bridge
-cd ~/.agent-sh/extensions/pi-bridge
-npm install
+cd ~/.agent-sh/extensions/pi-bridge && npm install
 ```
 
 ## Configure


### PR DESCRIPTION
## Summary

- **claude-code-bridge code fix.** The SDK had no visibility into the user's recent shell activity or the PTY-tracked cwd. Now mirrors pi-bridge: splice `query-context:build` (e.g. `<shell_events>`) into the prompt, and source cwd from `ctx.call("cwd")` (advised by `shell-context`) for both the SDK's working directory and relative-path resolution in the bridge's diff snapshots.
- **claude-code-bridge README.** Drop the stale "intentionally does NOT bundle" section that referenced `terminal_read`/`terminal_keys`/`user_shell` (those tool names aren't a thing in this codebase). Add a "What works under claude-code" section describing the new context+cwd behavior. Lead the install instructions with `agent-sh install claude-code-bridge`.
- **pi-bridge README.** Lead the install instructions with `agent-sh install pi-bridge` (the manual cp/npm-install path stays as the dev-checkout alternative).
- **Main README.** Lift both bridges out of inline prose into a dedicated **Bring your own agent** section between OS notes and Key Features, with copy-pasteable install + `--backend` snippets for each. Update the two prior pi-only mentions to link there.

## Test plan
- [ ] `agent-sh install claude-code-bridge && agent-sh --backend claude-code`, run a shell command in the PTY, then ask the agent about it — agent should see the command output via `<shell_events>`.
- [ ] `cd` to a different directory in the same session, ask claude-code to read a relative path — should resolve under the new cwd, not the directory agent-sh was launched from.
- [ ] `agent-sh install pi-bridge && agent-sh --backend pi` — unchanged behavior, just confirm install command works as documented.
- [ ] `agent-sh uninstall claude-code-bridge` / `agent-sh uninstall pi-bridge` — confirm reverse path documented in READMEs works.