### PR TITLE
Add opencode-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Requires Node.js 18+. Currently supports **bash** and **zsh**; other shells (fis
 
 ## Bring your own agent
 
-The built-in agent (`ash`) is the default, but agent-sh can host a different coding agent as its backend — same terminal, same `>` entry point, same shell-context wiring. Two bridges ship in the box:
+The built-in agent (`ash`) is the default, but agent-sh can host a different coding agent as its backend — same terminal, same `>` entry point, same shell-context wiring. Three bridges ship in the box:
 
 - **[pi-bridge](examples/extensions/pi-bridge/)** — runs [pi](https://github.com/badlogic/pi-mono) (`@mariozechner/pi-coding-agent`) in-process. Pi brings its own models, tools, and `~/.pi/agent/settings.json`.
 
@@ -105,9 +105,16 @@ The built-in agent (`ash`) is the default, but agent-sh can host a different cod
   agent-sh --backend claude-code
   ```
 
-Both bridges receive agent-sh's per-query shell context (`<shell_events>`) and follow the PTY-tracked cwd, so the hosted agent sees what you ran and where you are. Switching at runtime with `/backend <name>` persists the choice across sessions automatically; the `--backend` flag above is per-session only.
+- **[opencode-bridge](examples/extensions/opencode-bridge/)** — runs [opencode](https://opencode.ai/) in-process via `@opencode-ai/sdk`. Uses opencode's tools, models, and `opencode auth login` credentials.
 
-**Caveat:** pi and claude-code each manage their own tool surfaces, so agent-sh extensions that register tools (or skills, instructions, etc.) for the built-in `ash` agent generally won't be visible to a hosted backend. Frontend extensions (themes, content transforms, slash commands, the TUI renderer) keep working — only the agent-side capabilities differ. Use the bridges when you want that agent's toolset; stay on `ash` when you want agent-sh's extension ecosystem.
+  ```bash
+  agent-sh install opencode-bridge
+  agent-sh --backend opencode
+  ```
+
+All three bridges receive agent-sh's per-query shell context (`<shell_events>`) and follow the PTY-tracked cwd, so the hosted agent sees what you ran and where you are. Switching at runtime with `/backend <name>` persists the choice across sessions automatically; the `--backend` flag above is per-session only.
+
+**Caveat:** pi, claude-code, and opencode each manage their own tool surfaces, so agent-sh extensions that register tools (or skills, instructions, etc.) for the built-in `ash` agent generally won't be visible to a hosted backend. Frontend extensions (themes, content transforms, slash commands, the TUI renderer) keep working — only the agent-side capabilities differ. Use the bridges when you want that agent's toolset; stay on `ash` when you want agent-sh's extension ecosystem.
 
 ## Key Features
 

--- a/examples/extensions/opencode-bridge/README.md
+++ b/examples/extensions/opencode-bridge/README.md
@@ -1,0 +1,59 @@
+# opencode-bridge
+
+Runs [opencode](https://opencode.ai/) as an agent-sh backend using the official [@opencode-ai/sdk](https://www.npmjs.com/package/@opencode-ai/sdk). opencode brings its own configuration, models, tools, and authentication — agent-sh just provides the terminal.
+
+## Install
+
+```bash
+agent-sh install opencode-bridge
+```
+
+This copies the bundled extension into `~/.agent-sh/extensions/opencode-bridge` and runs `npm install` for you. To overwrite an existing install, pass `--force`. To uninstall, run `agent-sh uninstall opencode-bridge`.
+
+Manual alternative (e.g. for a development checkout you want to symlink):
+
+```bash
+cp -r examples/extensions/opencode-bridge ~/.agent-sh/extensions/opencode-bridge
+cd ~/.agent-sh/extensions/opencode-bridge && npm install
+```
+
+## Configure
+
+Set as default backend in `~/.agent-sh/settings.json`:
+
+```json
+{
+  "defaultBackend": "opencode"
+}
+```
+
+Or switch at runtime:
+
+```
+> /backend opencode
+```
+
+opencode reads its own config from `~/.local/share/opencode/` (auth credentials) and `opencode.json` / `opencode.jsonc` in your project. Configure providers and authentication by running `opencode auth login` directly — agent-sh does not override opencode's configuration.
+
+## Requirements
+
+- opencode authenticated locally — run `opencode auth login` once before using this bridge.
+- Provider env vars (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) as required by opencode for the model you've selected.
+
+## What works under opencode
+
+agent-sh's per-query context producers (e.g. `<shell_events>` from `shell-context`) are inlined into opencode's prompt before each query, so opencode sees the user's recent shell activity even though the SDK doesn't subscribe to agent-sh's shell bus directly. The current cwd is part of that context, so opencode knows where the user is even when its tools are anchored elsewhere.
+
+## cwd handling
+
+opencode treats the `directory` query param as a project ID and routes its event stream per-project — switching project mid-session silences the SSE channel we already subscribed to (no tool events, no streaming text). Because of that, the bridge **pins the session to the directory agent-sh launched from** and does not propagate later in-shell `cd`s to opencode. opencode's tools (`Bash`, `Read`, `Edit`, etc.) operate from that pinned directory; the agent learns the user's real cwd from `<shell_events>` and can still reach other locations through absolute paths or `cd && cmd` in `Bash`.
+
+To re-anchor the agent to your current cwd, run `/reset` — it tears down the conversation and creates a fresh session in your present directory.
+
+## Permission prompts
+
+opencode supports a `permission.edit = "ask"` config in `opencode.json` that gates write/edit tools behind an approval. The bridge has no UI primitive for showing that prompt, so it **auto-approves each request once** — without this, write/edit tool calls hang forever waiting for a reply that never comes. This matches claude-code-bridge's `permissionMode: "acceptEdits"` behavior. If you want to actually gate edits, set `permission.edit` to `"allow"` (skip the prompt entirely) or run opencode standalone for the interactive flow.
+
+## What this bridge is
+
+A pure protocol translator between opencode's SSE event stream and agent-sh's bus events. opencode runs as an in-process HTTP server (booted by `createOpencode()`); the bridge consumes its global event stream, filters by the active session's ID, and translates `message.part.updated` events (text/reasoning deltas, `ToolPart.state` transitions) into agent-sh tool/response events. opencode's built-in tools (bash, edit, read, write, grep, glob, etc.) are used exactly as opencode ships them. The bridge adds no tools of its own.

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -1,0 +1,383 @@
+/**
+ * opencode bridge — runs opencode in-process as agent-sh's backend via
+ * @opencode-ai/sdk. The SDK boots an embedded HTTP server we talk to with
+ * a generated client; events stream over a single global SSE channel.
+ *
+ * Requires opencode authenticated locally (`opencode auth login`).
+ */
+import { createOpencode, type OpencodeClient, type Event, type Part, type ToolPart } from "@opencode-ai/sdk";
+import type { ExtensionContext } from "agent-sh/types";
+import { computeDiff, type DiffResult } from "agent-sh/utils/diff";
+
+function parseUnifiedDiff(patch: string): DiffResult | null {
+  if (!patch) return null;
+  const hunks: DiffResult["hunks"] = [];
+  let current: DiffResult["hunks"][number] | null = null;
+  let oldNo = 0;
+  let newNo = 0;
+  let added = 0;
+  let removed = 0;
+
+  for (const raw of patch.split("\n")) {
+    if (raw.startsWith("Index:") || raw.startsWith("===") || raw.startsWith("--- ") || raw.startsWith("+++ ")) continue;
+    const hunkHeader = raw.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkHeader) {
+      if (current) hunks.push(current);
+      current = { lines: [] };
+      oldNo = parseInt(hunkHeader[1]!, 10);
+      newNo = parseInt(hunkHeader[2]!, 10);
+      continue;
+    }
+    if (!current) continue;
+    if (raw.startsWith("+")) {
+      current.lines.push({ type: "added", oldNo: null, newNo, text: raw.slice(1) });
+      newNo++;
+      added++;
+    } else if (raw.startsWith("-")) {
+      current.lines.push({ type: "removed", oldNo, newNo: null, text: raw.slice(1) });
+      oldNo++;
+      removed++;
+    } else if (raw.startsWith(" ")) {
+      current.lines.push({ type: "context", oldNo, newNo, text: raw.slice(1) });
+      oldNo++;
+      newNo++;
+    }
+  }
+  if (current) hunks.push(current);
+  if (hunks.length === 0) return null;
+  return { hunks, added, removed, isIdentical: added + removed === 0, isNewFile: false };
+}
+
+export default function activate(ctx: ExtensionContext): void {
+  const { bus, call } = ctx;
+
+  const cwd = (): string => {
+    const v = call("cwd");
+    return typeof v === "string" && v ? v : process.cwd();
+  };
+
+  let runtime: { client: OpencodeClient; server: { url: string; close(): void } } | null = null;
+  let sessionId: string | null = null;
+  // opencode treats `directory` as the project ID and routes its SSE event
+  // stream per-project. If we let prompts use the user's PTY cwd freely,
+  // an in-shell `cd` switches opencode's project mid-session and our SSE
+  // (opened on the original project) goes silent — including for tool
+  // events. Pin everything to the directory captured at session.create;
+  // the agent still learns the user's real cwd via <shell_events> and
+  // can operate elsewhere through absolute paths or `cd && cmd` in Bash.
+  let sessionDirectory: string | null = null;
+  let serverAbort: AbortController | null = null;
+  let streamAbort: AbortController | null = null;
+  let booting = true;
+
+  const announcedTools = new Set<string>();
+  const completedTools = new Set<string>();
+  // message.part.delta only carries `field` ("text"), not the part's
+  // type. Cache type from message.part.updated to route deltas correctly
+  // (text → response, reasoning → thinking).
+  const partKinds = new Map<string, string>();
+  let turnText = "";
+
+  // prompt() and SSE deltas race; resolve the turn on session.idle.
+  let pendingTurnEnd: (() => void) | null = null;
+  let turnIdleSeen = false;
+
+  const listeners: Array<{ event: string; fn: Function }> = [];
+
+  function toolKind(name: string): string {
+    const n = name.toLowerCase();
+    if (n === "read") return "read";
+    if (n === "edit" || n === "patch") return "edit";
+    if (n === "write") return "write";
+    if (n === "glob" || n === "grep" || n === "list") return "search";
+    if (n === "bash" || n === "shell") return "execute";
+    return "execute";
+  }
+
+  function formatToolCall(name: string, input: Record<string, unknown>): string {
+    const str = (v: unknown) => typeof v === "string" ? v : "";
+    const n = name.toLowerCase();
+    if (n === "bash" || n === "shell") return `$ ${str(input.command)}`;
+    if (n === "read" || n === "edit" || n === "write") return str(input.filePath ?? input.file_path ?? input.path);
+    if (n === "grep" || n === "glob") return `${str(input.pattern)} ${str(input.path)}`.trim();
+    return name;
+  }
+
+  function toolLocations(input: Record<string, unknown>): { path: string; line?: number | null }[] | undefined {
+    const raw = input.filePath ?? input.file_path ?? input.path;
+    if (typeof raw !== "string") return undefined;
+    const line = (input.line_number ?? input.line ?? input.offset) as number | undefined;
+    return [{ path: raw, line: line ?? null }];
+  }
+
+  function handleToolPart(part: ToolPart): void {
+    const { callID, tool: toolName, state } = part;
+    const kind = toolKind(toolName);
+
+    if (state.status !== "pending" && !announcedTools.has(callID)) {
+      announcedTools.add(callID);
+      bus.emit("agent:tool-started", {
+        title: toolName,
+        toolCallId: callID,
+        kind,
+        locations: toolLocations(state.input ?? {}),
+        rawInput: state.input,
+        displayDetail: formatToolCall(toolName, state.input ?? {}),
+      });
+    }
+
+    if ((state.status === "completed" || state.status === "error") && !completedTools.has(callID)) {
+      completedTools.add(callID);
+      const isError = state.status === "error";
+      const rawOutput = isError ? state.error : state.output;
+
+      let resultDisplay: { summary?: string; body?: { kind: "diff"; diff: DiffResult; filePath: string } } | undefined;
+      if (!isError && state.status === "completed") {
+        const filePath = state.input?.filePath as string | undefined;
+        let diff: DiffResult | null = null;
+        if (toolName === "edit") {
+          const patch = (state.metadata as any)?.filediff?.patch as string | undefined;
+          if (patch) diff = parseUnifiedDiff(patch);
+        } else if (toolName === "write") {
+          // Overwrites of existing files render as new-file diffs —
+          // opencode doesn't surface old content.
+          const content = state.input?.content as string | undefined;
+          if (typeof content === "string") diff = computeDiff(null, content);
+        }
+        if (diff && filePath && !diff.isIdentical) {
+          const summary = diff.isNewFile
+            ? `+${diff.added}`
+            : `+${diff.added} -${diff.removed}`;
+          resultDisplay = {
+            summary,
+            body: { kind: "diff", diff, filePath },
+          };
+        }
+      }
+
+      bus.emitTransform("agent:tool-completed", {
+        toolCallId: callID,
+        exitCode: isError ? 1 : 0,
+        rawOutput,
+        kind,
+        resultDisplay,
+      });
+      bus.emit("agent:tool-output", {
+        tool: toolName,
+        output: typeof rawOutput === "string" ? rawOutput : "",
+        exitCode: isError ? 1 : 0,
+      });
+    }
+  }
+
+  function emitTextDelta(text: string): void {
+    bus.emitTransform("agent:response-chunk", {
+      blocks: [{ type: "text" as const, text }],
+    });
+    turnText += text;
+  }
+
+  function handleEvent(event: Event): void {
+    if (!sessionId) return;
+    const evType = (event as any).type as string;
+    const props = (event as any).properties ?? {};
+    const sid = props.sessionID;
+    if (typeof sid === "string" && sid !== sessionId) return;
+
+    switch (evType) {
+      // message.part.delta is undocumented in the SDK's Event union but
+      // the SSE consumer yields it. Drop chunks for unknown partIDs —
+      // misrouting bleeds reasoning into the response or vice versa.
+      case "message.part.delta": {
+        if (typeof props.delta !== "string" || !props.delta) break;
+        const kind = partKinds.get(props.partID);
+        if (kind === "reasoning") bus.emit("agent:thinking-chunk", { text: props.delta });
+        else if (kind === "text") emitTextDelta(props.delta);
+        break;
+      }
+      case "message.part.updated": {
+        const part = props.part as Part | undefined;
+        if (!part) break;
+        partKinds.set(part.id, part.type);
+        if (part.type === "tool") handleToolPart(part);
+        break;
+      }
+      case "session.idle": {
+        turnIdleSeen = true;
+        pendingTurnEnd?.();
+        break;
+      }
+      case "session.error": {
+        const err = props.error as { message?: string } | undefined;
+        bus.emit("agent:error", { message: err?.message ?? "opencode session error" });
+        break;
+      }
+      // Without a reply the gated tool hangs forever. The bridge has no
+      // interactive approval UI, so auto-approve — mirrors claude-code-
+      // bridge's permissionMode: "acceptEdits". Set permission.edit:
+      // "allow" in opencode.json to skip the round-trip entirely.
+      case "permission.asked":
+      case "permission.updated": {
+        const permissionID = props.id as string | undefined;
+        if (!permissionID || !runtime || !sessionId) break;
+        runtime.client
+          .postSessionIdPermissionsPermissionId({
+            path: { id: sessionId, permissionID },
+            query: sessionDirectory ? { directory: sessionDirectory } : undefined,
+            body: { response: "once" },
+          })
+          .catch(() => { /* approval is best-effort */ });
+        break;
+      }
+    }
+  }
+
+  async function consumeEvents(client: OpencodeClient, signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      try {
+        const result = await client.event.subscribe({ signal });
+        for await (const ev of result.stream) {
+          if (signal.aborted) return;
+          handleEvent(ev as Event);
+        }
+      } catch {
+        if (signal.aborted) return;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  }
+
+  const wireListeners = () => {
+    const onSubmit = async ({ query: userQuery }: { query: string }) => {
+      if (!runtime || !sessionId) {
+        bus.emit("agent:error", {
+          message: booting ? "opencode is still starting up..." : "opencode session not initialized",
+        });
+        bus.emit("agent:processing-done", {});
+        return;
+      }
+
+      bus.emit("agent:query", { query: userQuery });
+      bus.emit("agent:processing-start", {});
+      turnText = "";
+      turnIdleSeen = false;
+      // Set the idle waiter BEFORE prompt() so a fast session.idle can't
+      // race in before we're listening.
+      const idlePromise = new Promise<void>((resolve) => {
+        pendingTurnEnd = () => { resolve(); pendingTurnEnd = null; };
+      });
+
+      const ctxText = String(call("query-context:build") ?? "").trim();
+      const finalPrompt = ctxText ? `${ctxText}\n\n${userQuery}` : userQuery;
+
+      try {
+        const res = await runtime.client.session.prompt({
+          path: { id: sessionId },
+          query: sessionDirectory ? { directory: sessionDirectory } : undefined,
+          body: {
+            parts: [{ type: "text", text: finalPrompt }],
+          },
+        });
+        if (!turnIdleSeen) {
+          await Promise.race([
+            idlePromise,
+            new Promise<void>((r) => setTimeout(r, 60_000)),
+          ]);
+        }
+        // Fallback if SSE never delivered text (network blip, missed
+        // partKinds entry); the prompt response always carries the final.
+        if (!turnText && res.data?.parts) {
+          for (const p of res.data.parts) {
+            if (p.type === "text" && p.text) turnText += p.text;
+          }
+          if (turnText) {
+            bus.emitTransform("agent:response-chunk", {
+              blocks: [{ type: "text" as const, text: turnText }],
+            });
+          }
+        }
+        bus.emitTransform("agent:response-done", { response: turnText });
+      } catch (err) {
+        bus.emit("agent:error", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        pendingTurnEnd = null;
+        bus.emit("agent:processing-done", {});
+      }
+    };
+
+    const onCancel = async () => {
+      if (!runtime || !sessionId) return;
+      try {
+        await runtime.client.session.abort({ path: { id: sessionId } });
+      } catch { /* abort is best-effort */ }
+    };
+
+    const onReset = async () => {
+      if (!runtime) return;
+      announcedTools.clear();
+      completedTools.clear();
+      partKinds.clear();
+      // /reset is the one moment we deliberately let the project switch.
+      sessionDirectory = cwd();
+      const res = await runtime.client.session.create({ query: { directory: sessionDirectory } });
+      sessionId = res.data?.id ?? null;
+    };
+
+    bus.on("agent:submit", onSubmit);
+    bus.on("agent:cancel-request", onCancel);
+    bus.on("agent:reset-session", onReset);
+    listeners.push(
+      { event: "agent:submit", fn: onSubmit },
+      { event: "agent:cancel-request", fn: onCancel },
+      { event: "agent:reset-session", fn: onReset },
+    );
+  };
+
+  const unwireListeners = () => {
+    for (const { event, fn } of listeners) bus.off(event as any, fn as any);
+    listeners.length = 0;
+  };
+
+  bus.emit("agent:register-backend", {
+    name: "opencode",
+    start: async () => {
+      try {
+        serverAbort = new AbortController();
+        runtime = await createOpencode({ signal: serverAbort.signal });
+
+        streamAbort = new AbortController();
+        // Subscribe before creating the session so we don't miss early events.
+        void consumeEvents(runtime.client, streamAbort.signal);
+
+        sessionDirectory = cwd();
+        const res = await runtime.client.session.create({ query: { directory: sessionDirectory } });
+        sessionId = res.data?.id ?? null;
+        if (!sessionId) throw new Error("session.create returned no id");
+
+        wireListeners();
+        booting = false;
+        bus.emit("agent:info", { name: "opencode", version: "1.x" });
+      } catch (err) {
+        booting = false;
+        bus.emit("ui:error", {
+          message: `opencode-bridge: failed to initialize — ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    },
+    kill: () => {
+      unwireListeners();
+      streamAbort?.abort();
+      serverAbort?.abort();
+      runtime?.server.close();
+      runtime = null;
+      sessionId = null;
+      sessionDirectory = null;
+      announcedTools.clear();
+      completedTools.clear();
+      partKinds.clear();
+      booting = true;
+    },
+  });
+}

--- a/examples/extensions/opencode-bridge/package.json
+++ b/examples/extensions/opencode-bridge/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "agent-sh-opencode-bridge",
+  "version": "0.1.0",
+  "description": "opencode agent backend for agent-sh",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "@opencode-ai/sdk": "^1.14.41",
+    "agent-sh": "^0.12.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a third bundled bridge: runs [opencode](https://opencode.ai/) in-process as agent-sh's backend via [@opencode-ai/sdk](https://www.npmjs.com/package/@opencode-ai/sdk).

The SDK boots an embedded opencode HTTP server we talk to with a generated client; events stream over a global SSE channel filtered by sessionID. Pure protocol translator — opencode's tools (Bash, Read, Edit, Write, Glob, Grep, etc.) are used as opencode ships them.

## Wiring details that aren't obvious from the SDK types

- **Text streaming via undocumented event.** opencode emits text/reasoning chunks as `message.part.delta` events that aren't in the SDK's typed `Event` union. The bridge handles them anyway. The event's `field` only tells you which part attribute updated (e.g. `"text"`) — not the part's *type*. The bridge caches `partID → part.type` from `message.part.updated` and routes deltas by that, so reasoning text is sent to `agent:thinking-chunk` rather than leaking into the response (this happens with GLM-style models that emit reasoning before final text).
- **Turn-end is `session.idle`, not `prompt()` resolution.** The HTTP `prompt()` response and SSE deltas race; SSE often lags. The bridge waits for `session.idle` (with a 60s safety cap) before emitting `agent:response-done`, otherwise late deltas show up under the next turn.
- **Project-pinned cwd.** opencode treats the `directory` query param as a project ID and routes its SSE per-project. If the user `cd`s mid-session and we propagated cwd to the next prompt, opencode's project switches and our existing SSE goes silent (no streaming, no tool events). The bridge pins everything to the directory captured at `session.create`; the agent still learns the user's real cwd via `<shell_events>` and can reach other locations through absolute paths or `cd && cmd` in Bash. `/reset` re-anchors to the current cwd.
- **Auto-approve permission gates.** opencode's `permission.edit = "ask"` config emits `permission.asked` events that block the tool until replied to. The bridge has no UI primitive for an interactive approval prompt, so it auto-approves with `{ response: "once" }` — mirrors claude-code-bridge's `permissionMode: "acceptEdits"`. Documented in the bridge README.
- **Edit/write diffs.** opencode ships a unified-diff string in `ToolStateCompleted.metadata.filediff.patch` for `edit`. The bridge parses it into agent-sh's `DiffResult` shape so the TUI's diff renderer kicks in. For `write` (new file), no patch ships — we synthesize a new-file diff from `input.content` via `computeDiff(null, content)`.

## What's in the PR

- `examples/extensions/opencode-bridge/{index.ts, README.md, package.json}` — the bridge.
- `README.md` — third entry under "Bring your own agent", with `agent-sh install opencode-bridge && agent-sh --backend opencode` snippet, mirroring the existing pi/claude-code rows.

A diagnostic-instrumented copy lives on `debug/opencode-bridge` (env-gated `OPENCODE_BRIDGE_DEBUG_LOG`) for re-investigation if SSE/project/permission shapes change in future opencode releases.

## Test plan
- [ ] `agent-sh install opencode-bridge && agent-sh --backend opencode` (after `opencode auth login`) — first chat turn streams text into the response area, no reasoning leakage.
- [ ] Multi-step request that triggers tool use (e.g. "explain this project" from a non-launch directory) — Read/Glob tool calls render in the TUI as the agent investigates.
- [ ] "create a file at /tmp/test.txt and edit line 2" — write shows `+N` summary diff, edit shows `+A -R` diff with hunk lines, no hang on the permission gate.
- [ ] `/reset` after `cd`ing to a new project — fresh session, tool events flow in the new directory.
- [ ] `/cancel` mid-turn aborts cleanly.