### PR TITLE
Always emit <cwd> in per-query context

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -29,7 +29,7 @@ The key insight: **the agent is a loop, not a single call**. The LLM calls tools
 
 Every query draws on two distinct streams of context:
 
-- **Shell context** — the user's terminal activity (commands + outputs). This is what lets ash understand "fix this" after you ran a failing command. New shell activity since the last turn is wrapped as `<shell_events>` inside the per-query `<query_context>` envelope and prepended to your user message.
+- **Shell context** — the user's terminal activity (commands + outputs) plus the live cwd. This is what lets ash understand "fix this" after you ran a failing command, and what keeps it anchored in the right working directory across compactions. The current cwd is wrapped as `<cwd>` (always) and new shell activity since the last turn as `<shell_events>` (when there is any), both nested inside the per-query `<query_context>` envelope and prepended to your user message.
 - **Conversation state** — the OpenAI chat messages array (`user`/`assistant`/`tool` messages). This is the LLM's memory of what it already said and did within this session.
 
 The two streams don't overlap: agent tool outputs live only in the conversation, and shell context tracks only user-initiated activity. When either stream grows large, ash has escape hatches rather than silent truncation:
@@ -54,7 +54,7 @@ The system prompt is assembled once per `cwd` and cached (invalidated when the w
 
 Per-turn signals live in two symmetric handlers, both empty by default:
 
-- **`query-context:build`** — fires once at user-query start. Output is wrapped in `<query_context>` and frozen into the user message, so it persists in conversation history. Shell events are the canonical example (`<shell_events>` sub-tag); other "what happened between turns" signals (notifications, calendar/inbox deltas) go here too.
+- **`query-context:build`** — fires once at user-query start. Output is wrapped in `<query_context>` and frozen into the user message, so it persists in conversation history. Shell context is the canonical example (`<cwd>` always, `<shell_events>` when there is fresh activity); other "what happened between turns" signals (notifications, calendar/inbox deltas) go here too.
 - **`dynamic-context:build`** — fires on every LLM call (each tool-loop iteration). Output is wrapped in `<dynamic_context>` and ephemerally prepended to the trailing message at request time, so the cacheable prefix stays byte-stable. Use for "current state" signals: in-flight subagents, threshold warnings, active mode markers.
 
 Extensions populate either via `ctx.registerContextProducer(name, fn, { mode: "per-query" | "per-request" })`. When no producer contributes, no envelope tag is emitted at all — vanilla sessions send exactly `[system, ...history]`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ index.ts — interactive terminal frontend:
   │     Shell             — PTY lifecycle (delegates to InputHandler + OutputParser)
   │
   ├── Built-in extensions (loaded via declarative manifest, individually disableable):
-  │     shell-context     — PTY exchange tracking, cwd advisor, <shell_events> producer
+  │     shell-context     — PTY exchange tracking, cwd advisor, <cwd>/<shell_events> producer
   │     agent-backend     — LLM provider resolution, LlmClient, AgentLoop ("ash" backend)
   │     tui-renderer      — markdown rendering, inline diffs, thinking display, spinner
   │     slash-commands    — /help, /model, /backend, /thinking, /compact, /context, /reload

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -28,7 +28,7 @@ Captured and owned by the `shell-context` built-in extension (`src/extensions/sh
 
 Agent tool outputs are **not** here — those live in the conversation stream. The boundary is strict: if the user typed it at the PTY, it goes into shell context; if the agent called a tool, it goes into the conversation.
 
-Frontends without a PTY (e.g. agent-sh-hub) simply don't load this extension — the agent runs cwd-aware via the default `cwd` handler (`process.cwd()`) and no `<shell_events>` envelope is emitted.
+Frontends without a PTY (e.g. agent-sh-hub) simply don't load this extension — the agent runs cwd-aware via the default `cwd` handler (`process.cwd()`) and no `<cwd>` / `<shell_events>` envelope is emitted.
 
 ### Conversation — "what has the agent been working on?"
 
@@ -38,17 +38,17 @@ Owned by `ConversationState`. This is the OpenAI-shaped messages array (`user` /
 - Assistant messages (the LLM's replies)
 - Tool calls and tool results
 
-The two streams merge at one point: when the user submits a new query, new shell events are wrapped inside `<shell_events>` (itself nested in the per-query `<query_context>` envelope) and prepended to that user message. They then live inside the conversation array as regular bytes, but they are never stored separately in both places.
+The two streams merge at one point: when the user submits a new query, the current cwd is wrapped inside `<cwd>` and any new shell events inside `<shell_events>` (both nested in the per-query `<query_context>` envelope) and prepended to that user message. They then live inside the conversation array as regular bytes, but they are never stored separately in both places.
 
 ## How shell activity reaches the LLM
 
 Each exchange (a shell command + output) gets a sequential `id` as it's captured. The shell-context extension keeps an internal `lastSeq` cursor — the highest id it has already sent to the model.
 
-Shell events are registered as a per-query context producer (`ctx.registerContextProducer("shell-events", …, { mode: "per-query" })`):
+Shell context is registered as a per-query context producer (`ctx.registerContextProducer("shell-context", …, { mode: "per-query" })`):
 
-1. The producer returns every exchange with id > `lastSeq`, wrapped as `<shell_events>...</shell_events>`.
-2. The dispatcher composes the result with any other per-query producer output and wraps the whole bundle in `<query_context>...</query_context>`, prepended to the user's query inside a single user message.
-3. The cursor advances to the new high-water mark.
+1. The producer always emits `<cwd>...</cwd>` with the live PTY-tracked cwd, so every user message anchors where the agent is right now (immune to compaction confusion over historical cwds).
+2. If there are exchanges with id > `lastSeq`, it appends `<shell_events>...</shell_events>` with the deltas; the cursor then advances to the new high-water mark.
+3. The dispatcher composes the result with any other per-query producer output and wraps the whole bundle in `<query_context>...</query_context>`, prepended to the user's query inside a single user message.
 
 The delta is sent **once per user query**, not per tool-use step inside the agent loop. Inside the loop (where the LLM calls tools, sees results, calls more tools), no new shell events are injected — injecting mid-loop would break the `tool_call → tool_result` chain some providers require, and per-tool-call shell visibility isn't the right semantic anyway.
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -123,9 +123,9 @@ Extensions may register additional tools — follow their instructions.
 - Always check command exit codes for errors
 
 # Context Envelopes
-- \`<query_context>\` (e.g. \`<shell_events>\`): the user's situation when they sent this turn — ground "fix this" / "what just happened" requests with it.
+- \`<query_context>\` (contains \`<cwd>\` always, and \`<shell_events>\` when there were user shell commands since the last turn): the user's situation when they sent this turn — \`<cwd>\` anchors where they are right now, \`<shell_events>\` grounds "fix this" / "what just happened" requests. Trust the most recent \`<cwd>\` over any cwd referenced in earlier history.
 - \`<dynamic_context>\`: current system state — in-flight work, mode markers, warnings.
-Either may be absent on any turn.
+\`<dynamic_context>\` may be absent on any turn.
 
 # Preference Learning
 

--- a/src/extensions/shell-context.ts
+++ b/src/extensions/shell-context.ts
@@ -1,6 +1,7 @@
 /**
  * Tracks PTY commands and cwd, spills long outputs, contributes the
- * `<shell_events>` per-query envelope. Frontends without a PTY skip this
+ * per-query `<cwd>` (always) and `<shell_events>` (when there are fresh
+ * user-shell exchanges) signals. Frontends without a PTY skip this
  * built-in and the agent runs cwd-aware via core's process.cwd() default.
  */
 import type { ExtensionContext } from "../types.js";
@@ -70,16 +71,18 @@ export default function activate(ctx: ExtensionContext): void {
   // Override core's process.cwd() default with the PTY-tracked value.
   ctx.advise("cwd", () => currentCwd);
 
-  ctx.registerContextProducer("shell-events", () => {
+  ctx.registerContextProducer("shell-context", () => {
+    const cwdTag = `<cwd>${currentCwd}</cwd>`;
+
     const fresh = exchanges.filter(
       (ex) => ex.id > lastSeq && ex.source !== "agent",
     );
-    if (fresh.length === 0) return null;
+    if (fresh.length === 0) return cwdTag;
     lastSeq = exchanges[exchanges.length - 1]!.id;
 
     const text = fresh.map(formatExchangeTruncated).filter(Boolean).join("\n");
-    if (!text) return null;
-    return `<shell_events>\n${text}\n</shell_events>`;
+    if (!text) return cwdTag;
+    return `${cwdTag}\n<shell_events>\n${text}\n</shell_events>`;
   }, { mode: "per-query" });
 
   ctx.define("shell:context-recent", (n: number = 25) => {


### PR DESCRIPTION
## Summary

- The `shell-context` per-query producer previously returned `null` when no fresh user-shell exchanges existed since the last query. On the first turn of a fresh session that meant no `<query_context>` envelope at all, leaving ash to infer the working directory from compacted history of prior sessions — which after a restart could point at a stale cwd from another project.
- Restructured the producer to always emit `<cwd>` with the live PTY-tracked cwd, and append `<shell_events>` only when there are fresh exchanges. Putting cwd in every per-query envelope (rather than only baking it into the cached system prompt) keeps the trailing user message authoritative across compaction, so the agent can't be misled by older cwds referenced in compacted summaries.
- Renamed the producer registration from `"shell-events"` to `"shell-context"` since it now contributes more than just events. Updated the system prompt's Context Envelopes section and docs (`docs/agent.md`, `docs/architecture.md`, `docs/context-management.md`) to describe both `<cwd>` and `<shell_events>`.

## Test plan

- [ ] Start a fresh session in a directory you've never used agent-sh in before; first ash query should reference the correct cwd without running `pwd`.
- [ ] Run a few shell commands, then ask ash about the latest one — `<shell_events>` should still arrive alongside `<cwd>`.
- [ ] `cd` to a different directory and ask ash where it is — `<cwd>` should reflect the new path on the next turn.
- [ ] Send two ash messages back-to-back without any shell command in between — both should still receive `<cwd>`; only the first carries `<shell_events>` if there were fresh exchanges before it.
- [ ] Trigger compaction and verify the agent continues to anchor on the most recent `<cwd>` rather than older cwds in compacted history.