### PR TITLE
Extract per-shell logic into ShellStrategy modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import * as path from "node:path";
 import { activateShell, registerShellHandlers, type ShellHandle } from "./shell/index.js";
+import { pickStrategy, FALLBACK_STRATEGY } from "./shell/strategies/index.js";
 import { createCore } from "./core.js";
 import { palette as p } from "./utils/palette.js";
 import { loadBuiltinExtensions } from "./extensions/index.js";
@@ -27,13 +27,10 @@ async function captureShellEnvAsync(shell: string): Promise<Record<string, strin
     };
 
     try {
-      const shellName = path.basename(shell);
-      const isZsh = shellName.includes("zsh");
-      const sourceRc = isZsh
-        ? 'source ~/.zshrc 2>/dev/null;'
-        : '[ -f ~/.bashrc ] && source ~/.bashrc 2>/dev/null;';
+      const strategy = pickStrategy(shell) ?? FALLBACK_STRATEGY;
+      const captureCmd = strategy.envCaptureCommand();
 
-      const child = spawn(shell, ["-l", "-c", `${sourceRc} env -0`], {
+      const child = spawn(shell, ["-l", "-c", captureCmd], {
         stdio: ["ignore", "pipe", "ignore"],
         timeout: 5000,
       });

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -1,11 +1,16 @@
 import * as fs from "fs";
 import * as os from "os";
-import * as path from "path";
 import * as pty from "node-pty";
 import type { EventBus } from "../event-bus.js";
 import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
 import { getSettings } from "../settings.js";
+import {
+  pickStrategy,
+  FALLBACK_STRATEGY,
+  SUPPORTED_SHELL_NAMES,
+  type ShellStrategy,
+} from "./strategies/index.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface ShellHandlers {
@@ -37,7 +42,7 @@ export class Shell implements InputContext {
   private unmuteScopes = new Set<ShellScope>();
   private pendingEchoSkips = 0;
   private agentActive = false;
-  private isZsh = false;
+  private strategy: ShellStrategy;
   private tmpDir?: string;
 
   constructor(opts: {
@@ -64,129 +69,31 @@ export class Shell implements InputContext {
     //   - OSC 7: cwd tracking (required by OutputParser)
     //   - OSC 9999: prompt start marker (command boundary detection)
     //   - OSC 9998: prompt end marker (bracketed prompt capture)
-    // Prompt theming is left entirely to the user's shell config.
-    const shellName = path.basename(opts.shell);
-    const isZsh = shellName.includes("zsh");
-    const isBash = shellName.includes("bash");
-    if (!isZsh && !isBash) {
+    // Prompt theming is left entirely to the user's shell config. Per-shell
+    // rc-file generation lives in src/shell/strategies/.
+    const matched = pickStrategy(opts.shell);
+    if (!matched) {
       console.warn(
-        `Warning: agent-sh only supports zsh and bash. ` +
+        `Warning: agent-sh only supports ${SUPPORTED_SHELL_NAMES.join(", ")}. ` +
         `"${opts.shell}" may not work correctly — falling back to /bin/bash.`
       );
     }
-    const shellBin = (isZsh || isBash) ? opts.shell : "/bin/bash";
-    let shellArgs: string[];
+    this.strategy = matched ?? FALLBACK_STRATEGY;
+    const shellBin = matched ? opts.shell : "/bin/bash";
 
     // Per-instance tag so nested agent-sh hooks don't cross-trigger.
     const instanceTag = `id=${opts.instanceId}`;
-    const osc7Cmd = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
-    const promptMarker = `printf "\\e]9999;${instanceTag};PROMPT\\a"`;
-    const titleCmd = 'printf "\\e]0;⚡ agent-sh: %s\\a" "${PWD/#$HOME/~}"';
-
-    this.isZsh = isZsh;
     const settings = getSettings();
-    const showIndicator = settings.promptIndicator !== false;
-
-    if (isZsh) {
-      // For zsh: use ZDOTDIR to source user's real config, then append
-      // our hooks via precmd_functions (additive — doesn't clobber p10k/omz).
-      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-"));
-      const userZdotdir = env.ZDOTDIR || env.HOME || os.homedir();
-      const zshrcLines = [
-        `ZDOTDIR="${userZdotdir}"`,
-        `[ -f "${userZdotdir}/.zshrc" ] && source "${userZdotdir}/.zshrc"`,
-        "",
-        "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
-        "__agent_sh_precmd() {",
-        `  ${osc7Cmd}`,
-        `  ${promptMarker}`,
-        ...(showIndicator ? [`  ${titleCmd}`] : []),
-        "}",
-        "precmd_functions+=(__agent_sh_precmd)",
-        "",
-        "# Preexec hook: emit actual command text so agent-sh can track",
-        "# history-recalled and tab-completed commands accurately",
-        "__agent_sh_preexec() {",
-        `  printf "\\e]9997;${instanceTag};%s\\a" "$1"`,
-        "}",
-        "preexec_functions+=(__agent_sh_preexec)",
-      ];
-
-      zshrcLines.push(
-        "",
-        "# End-of-prompt marker via zle-line-init (fires after prompt is rendered)",
-        "# Chain onto existing widget (p10k uses zle-line-init) rather than clobbering",
-        'if (( ${+widgets[zle-line-init]} )); then',
-        "  zle -A zle-line-init __agent_sh_orig_line_init",
-        "  __agent_sh_line_init() {",
-        "    zle __agent_sh_orig_line_init",
-        `    printf "\\e]9998;${instanceTag};READY\\a"`,
-        "  }",
-        "else",
-        "  __agent_sh_line_init() {",
-        `    printf "\\e]9998;${instanceTag};READY\\a"`,
-        "  }",
-        "fi",
-        "zle -N zle-line-init __agent_sh_line_init",
-        "",
-        "# Hidden widget to trigger prompt redraw from Node.js side",
-        "# Bound to an unused escape sequence that no real key produces",
-        "__agent_sh_redraw() {",
-        "  zle reset-prompt",
-        "}",
-        "zle -N __agent_sh_redraw",
-        "bindkey '\\e[9999~' __agent_sh_redraw",
-      );
-
-      fs.writeFileSync(path.join(this.tmpDir, ".zshrc"), zshrcLines.join("\n") + "\n");
-      env.ZDOTDIR = this.tmpDir;
-      shellArgs = ["--no-globalrcs"];
-    } else {
-      // For bash: use --rcfile to source our wrapper, which sources the user's
-      // real bashrc then appends our hooks. No HOME override needed.
-      this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-"));
-      const userHome = env.HOME || os.homedir();
-      const bashrcLines = [
-        `[ -f "${userHome}/.bashrc" ] && source "${userHome}/.bashrc"`,
-        "",
-        "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
-        "# Wrapped in a function because inlining printf \"...\" into",
-        "# PROMPT_COMMAND=\"...\" breaks the outer quoting.",
-        "__agent_sh_precmd() {",
-        `  ${osc7Cmd}`,
-        `  ${promptMarker}`,
-        ...(showIndicator ? [`  ${titleCmd}`] : []),
-        "  __agent_sh_preexec_ran=0",
-        "}",
-        `PROMPT_COMMAND="\${PROMPT_COMMAND%;}"`,
-        `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}__agent_sh_precmd"`,
-        "",
-        "# Preexec hook via DEBUG trap: emit actual command text so agent-sh",
-        "# can track history-recalled and tab-completed commands accurately",
-        "__agent_sh_preexec_ran=0",
-        "__agent_sh_emit_preexec() {",
-        '  [[ $__agent_sh_preexec_ran == 1 ]] && return',
-        '  [[ -n $COMP_LINE ]] && return',
-        "  __agent_sh_preexec_ran=1",
-        "  local this_cmd",
-        `  this_cmd=$(HISTTIMEFORMAT='' builtin history 1 | command sed 's/^ *[0-9]* *//')`,
-        `  printf '\\e]9997;${instanceTag};%s\\a' "$this_cmd"`,
-        "}",
-        "trap '__agent_sh_emit_preexec' DEBUG",
-        "",
-        "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",
-        `case "$PS1" in *9998*) ;; *) PS1="\${PS1}\\[\\e]9998;${instanceTag};READY\\a\\]";; esac`,
-        "",
-        "# Mirrors the zsh \\e[9999~ reset-prompt widget — used by agent-sh",
-        "# to repaint the prompt in place. All keymaps so `set -o vi` works.",
-        `bind -m emacs '"\\e[9999~":redraw-current-line' 2>/dev/null`,
-        `bind -m vi-insert '"\\e[9999~":redraw-current-line' 2>/dev/null`,
-        `bind -m vi-command '"\\e[9999~":redraw-current-line' 2>/dev/null`,
-      ];
-
-      fs.writeFileSync(path.join(this.tmpDir, ".bashrc"), bashrcLines.join("\n") + "\n");
-      shellArgs = ["--rcfile", path.join(this.tmpDir, ".bashrc")];
-    }
+    const spawnConfig = this.strategy.prepareSpawn({
+      tmpDirRoot: os.tmpdir(),
+      instanceTag,
+      showIndicator: settings.promptIndicator !== false,
+      userHome: env.HOME || os.homedir(),
+      env,
+    });
+    this.tmpDir = spawnConfig.tmpDir;
+    Object.assign(env, spawnConfig.envOverrides);
+    const shellArgs = spawnConfig.args;
 
     // Pause stdin before spawning PTY to avoid TTY contention on macOS.
     // The PTY will become the controlling terminal for the child shell.
@@ -340,8 +247,10 @@ export class Shell implements InputContext {
   }
 
   /**
-   * Ask the shell to redraw its own prompt in place via \e[9999~, which both
-   * zsh (ZLE widget) and bash (readline redraw-current-line) bind to repaint.
+   * Ask the shell to redraw its own prompt in place. The escape sequence is
+   * defined per-strategy and bound in the generated rc file (zsh: ZLE widget,
+   * bash: readline redraw-current-line). When the strategy returns null we
+   * skip the in-place redraw and let freshPrompt do a heavy redraw instead.
    */
   redrawPrompt(): void {
     const result = this.bus.emitPipe("shell:redraw-prompt", {
@@ -349,9 +258,9 @@ export class Shell implements InputContext {
       kind: "redraw",
       handled: false,
     });
-    if (!result.handled) {
-      this.ptyProcess.write("\x1b[9999~");
-    }
+    if (result.handled) return;
+    const escape = this.strategy.redrawEscape();
+    if (escape) this.ptyProcess.write(escape);
   }
 
   /**

--- a/src/shell/strategies/bash.ts
+++ b/src/shell/strategies/bash.ts
@@ -1,0 +1,79 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
+
+const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
+const TITLE_CMD = 'printf "\\e]0;⚡ agent-sh: %s\\a" "${PWD/#$HOME/~}"';
+
+export const bashStrategy: ShellStrategy = {
+  name: "bash",
+
+  matches(shellPath: string): boolean {
+    return path.basename(shellPath).includes("bash");
+  },
+
+  prepareSpawn(opts: PrepareSpawnOpts): ShellSpawnConfig {
+    const { tmpDirRoot, instanceTag, showIndicator, env, userHome } = opts;
+
+    // Use --rcfile to source our wrapper, which sources the user's real
+    // bashrc then appends our hooks. No HOME override needed.
+    const tmpDir = fs.mkdtempSync(path.join(tmpDirRoot, "agent-sh-"));
+    const home = env.HOME || userHome;
+    const promptMarker = `printf "\\e]9999;${instanceTag};PROMPT\\a"`;
+
+    const lines = [
+      `[ -f "${home}/.bashrc" ] && source "${home}/.bashrc"`,
+      "",
+      "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
+      "# Wrapped in a function because inlining printf \"...\" into",
+      "# PROMPT_COMMAND=\"...\" breaks the outer quoting.",
+      "__agent_sh_precmd() {",
+      `  ${OSC7_CMD}`,
+      `  ${promptMarker}`,
+      ...(showIndicator ? [`  ${TITLE_CMD}`] : []),
+      "  __agent_sh_preexec_ran=0",
+      "}",
+      `PROMPT_COMMAND="\${PROMPT_COMMAND%;}"`,
+      `PROMPT_COMMAND="\${PROMPT_COMMAND:+\$PROMPT_COMMAND;}__agent_sh_precmd"`,
+      "",
+      "# Preexec hook via DEBUG trap: emit actual command text so agent-sh",
+      "# can track history-recalled and tab-completed commands accurately",
+      "__agent_sh_preexec_ran=0",
+      "__agent_sh_emit_preexec() {",
+      '  [[ $__agent_sh_preexec_ran == 1 ]] && return',
+      '  [[ -n $COMP_LINE ]] && return',
+      "  __agent_sh_preexec_ran=1",
+      "  local this_cmd",
+      `  this_cmd=$(HISTTIMEFORMAT='' builtin history 1 | command sed 's/^ *[0-9]* *//')`,
+      `  printf '\\e]9997;${instanceTag};%s\\a' "$this_cmd"`,
+      "}",
+      "trap '__agent_sh_emit_preexec' DEBUG",
+      "",
+      "# End-of-prompt marker: append to PS1 (\\[...\\] marks it zero-width)",
+      `case "$PS1" in *9998*) ;; *) PS1="\${PS1}\\[\\e]9998;${instanceTag};READY\\a\\]";; esac`,
+      "",
+      "# Mirrors the zsh \\e[9999~ reset-prompt widget — used by agent-sh",
+      "# to repaint the prompt in place. All keymaps so `set -o vi` works.",
+      `bind -m emacs '"\\e[9999~":redraw-current-line' 2>/dev/null`,
+      `bind -m vi-insert '"\\e[9999~":redraw-current-line' 2>/dev/null`,
+      `bind -m vi-command '"\\e[9999~":redraw-current-line' 2>/dev/null`,
+    ];
+
+    const rcPath = path.join(tmpDir, ".bashrc");
+    fs.writeFileSync(rcPath, lines.join("\n") + "\n");
+
+    return {
+      args: ["--rcfile", rcPath],
+      envOverrides: {},
+      tmpDir,
+    };
+  },
+
+  envCaptureCommand(): string {
+    return "[ -f ~/.bashrc ] && source ~/.bashrc 2>/dev/null; env -0";
+  },
+
+  redrawEscape(): string {
+    return "\x1b[9999~";
+  },
+};

--- a/src/shell/strategies/index.ts
+++ b/src/shell/strategies/index.ts
@@ -1,0 +1,23 @@
+import { zshStrategy } from "./zsh.js";
+import { bashStrategy } from "./bash.js";
+import type { ShellStrategy } from "./types.js";
+
+export type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
+
+const STRATEGIES: ShellStrategy[] = [zshStrategy, bashStrategy];
+
+/** Strategy used when the requested shell isn't recognized. */
+export const FALLBACK_STRATEGY: ShellStrategy = bashStrategy;
+
+/** Names of supported shells, used for warning messages. */
+export const SUPPORTED_SHELL_NAMES: readonly string[] = STRATEGIES.map((s) => s.name);
+
+/**
+ * Pick the strategy that matches the given shell binary path. Returns null
+ * when no strategy claims the path — caller decides whether to warn and how
+ * to fall back (e.g. shell.ts swaps the binary to /bin/bash; env capture
+ * just runs the fallback strategy's syntax against the original binary).
+ */
+export function pickStrategy(shellPath: string): ShellStrategy | null {
+  return STRATEGIES.find((s) => s.matches(shellPath)) ?? null;
+}

--- a/src/shell/strategies/types.ts
+++ b/src/shell/strategies/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-shell adapter for the bits of agent-sh that are inherently shell-syntax
+ * specific: rc-file generation, spawn args/env, env-capture command, and the
+ * escape sequence used to repaint the prompt in place.
+ *
+ * Everything else (PTY I/O, OSC parsing, mute scopes, prompt boundary
+ * detection) is shell-agnostic and lives in shell.ts / output-parser.ts.
+ */
+
+export interface PrepareSpawnOpts {
+  /** Root for mkdtemp — typically os.tmpdir(). */
+  tmpDirRoot: string;
+  /** Per-instance tag (e.g. "id=abc123") so nested agent-sh hooks don't cross-trigger. */
+  instanceTag: string;
+  /** Whether to emit the terminal title indicator from the prompt hook. */
+  showIndicator: boolean;
+  /** Resolved user home (env.HOME ?? os.homedir()). */
+  userHome: string;
+  /** Inherited env at spawn time — strategies may read ZDOTDIR etc. */
+  env: Record<string, string>;
+}
+
+export interface ShellSpawnConfig {
+  /** Args to pass to pty.spawn after the shell binary. */
+  args: string[];
+  /** Env vars the strategy needs to set on the child (e.g. ZDOTDIR, XDG_CONFIG_HOME). */
+  envOverrides: Record<string, string>;
+  /** Temp directory the strategy created, if any — caller cleans up on exit. */
+  tmpDir?: string;
+}
+
+export interface ShellStrategy {
+  /** Short name used for fallback warnings ("zsh", "bash", "fish"). */
+  readonly name: string;
+
+  /** Does this strategy claim the binary at `shellPath`? */
+  matches(shellPath: string): boolean;
+
+  /**
+   * Generate any rc files and return spawn args + env overrides. May create
+   * a tmp directory; caller is responsible for cleanup via the returned path.
+   */
+  prepareSpawn(opts: PrepareSpawnOpts): ShellSpawnConfig;
+
+  /**
+   * Shell-syntax command run via `<shell> -l -c "<cmd>"` to source the user's
+   * config and dump env. Used at startup to inherit shell-only env vars.
+   */
+  envCaptureCommand(): string;
+
+  /**
+   * Escape sequence to write to the PTY to ask the shell to repaint its
+   * prompt in place. The corresponding binding is set up in prepareSpawn.
+   * Returns null if the shell can't redraw — caller falls back to freshPrompt.
+   */
+  redrawEscape(): string | null;
+}

--- a/src/shell/strategies/zsh.ts
+++ b/src/shell/strategies/zsh.ts
@@ -1,0 +1,83 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
+
+const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
+const TITLE_CMD = 'printf "\\e]0;⚡ agent-sh: %s\\a" "${PWD/#$HOME/~}"';
+
+export const zshStrategy: ShellStrategy = {
+  name: "zsh",
+
+  matches(shellPath: string): boolean {
+    return path.basename(shellPath).includes("zsh");
+  },
+
+  prepareSpawn(opts: PrepareSpawnOpts): ShellSpawnConfig {
+    const { tmpDirRoot, instanceTag, showIndicator, env, userHome } = opts;
+
+    // Use ZDOTDIR to source user's real config, then append our hooks via
+    // precmd_functions (additive — doesn't clobber p10k/omz).
+    const tmpDir = fs.mkdtempSync(path.join(tmpDirRoot, "agent-sh-"));
+    const userZdotdir = env.ZDOTDIR || env.HOME || userHome;
+    const promptMarker = `printf "\\e]9999;${instanceTag};PROMPT\\a"`;
+
+    const lines = [
+      `ZDOTDIR="${userZdotdir}"`,
+      `[ -f "${userZdotdir}/.zshrc" ] && source "${userZdotdir}/.zshrc"`,
+      "",
+      "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
+      "__agent_sh_precmd() {",
+      `  ${OSC7_CMD}`,
+      `  ${promptMarker}`,
+      ...(showIndicator ? [`  ${TITLE_CMD}`] : []),
+      "}",
+      "precmd_functions+=(__agent_sh_precmd)",
+      "",
+      "# Preexec hook: emit actual command text so agent-sh can track",
+      "# history-recalled and tab-completed commands accurately",
+      "__agent_sh_preexec() {",
+      `  printf "\\e]9997;${instanceTag};%s\\a" "$1"`,
+      "}",
+      "preexec_functions+=(__agent_sh_preexec)",
+      "",
+      "# End-of-prompt marker via zle-line-init (fires after prompt is rendered)",
+      "# Chain onto existing widget (p10k uses zle-line-init) rather than clobbering",
+      'if (( ${+widgets[zle-line-init]} )); then',
+      "  zle -A zle-line-init __agent_sh_orig_line_init",
+      "  __agent_sh_line_init() {",
+      "    zle __agent_sh_orig_line_init",
+      `    printf "\\e]9998;${instanceTag};READY\\a"`,
+      "  }",
+      "else",
+      "  __agent_sh_line_init() {",
+      `    printf "\\e]9998;${instanceTag};READY\\a"`,
+      "  }",
+      "fi",
+      "zle -N zle-line-init __agent_sh_line_init",
+      "",
+      "# Hidden widget to trigger prompt redraw from Node.js side",
+      "# Bound to an unused escape sequence that no real key produces",
+      "__agent_sh_redraw() {",
+      "  zle reset-prompt",
+      "}",
+      "zle -N __agent_sh_redraw",
+      "bindkey '\\e[9999~' __agent_sh_redraw",
+    ];
+
+    fs.writeFileSync(path.join(tmpDir, ".zshrc"), lines.join("\n") + "\n");
+
+    return {
+      args: ["--no-globalrcs"],
+      envOverrides: { ZDOTDIR: tmpDir },
+      tmpDir,
+    };
+  },
+
+  envCaptureCommand(): string {
+    return "source ~/.zshrc 2>/dev/null; env -0";
+  },
+
+  redrawEscape(): string {
+    return "\x1b[9999~";
+  },
+};


### PR DESCRIPTION
## Summary
Refactor that prepares for fish shell support (#TBD). No behavior change.

- New `src/shell/strategies/{types,zsh,bash,index}.ts` define a `ShellStrategy` interface and lift the zsh and bash rc-file generators out of `Shell`'s constructor verbatim.
- `Shell` constructor's 120-line `if (isZsh) { ... } else { ... }` collapses into ~10 lines of `strategy.prepareSpawn(...)`, `strategy.redrawEscape()`, etc.
- `captureShellEnvAsync` in `src/index.ts` uses `strategy.envCaptureCommand()` instead of an inline ternary.
- Drops the now-unused `Shell.isZsh` field and the unused `node:path` import in `src/index.ts`.

The `ShellStrategy` surface area:

```ts
matches(shellPath): boolean
prepareSpawn(opts): { args, envOverrides, tmpDir? }
envCaptureCommand(): string
redrawEscape(): string | null
```

Adding fish becomes a single new file under `src/shell/strategies/` plus one line in the registry — no further changes to `shell.ts`.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Manual smoke: zsh session — cwd tracking, prompt detection, agent turn redraw
- [ ] Manual smoke: bash session — same
- [ ] Manual smoke: unknown shell falls back to bash with warning

## Notes for reviewers
- This is intentionally pure-refactor; rc-file contents are byte-for-byte the same as before. Diff is large because of the lift, not because behavior changed.
- One cosmetic change: bash env-capture is now `[ -f ~/.bashrc ] && source ~/.bashrc 2>/dev/null; env -0` as one string instead of the previous `${sourceRc} env -0` template — functionally identical.

Marked draft until manual smoke testing on a real bash + zsh session.