### PR TITLE
Unstick opencode bridge on errors and handle the question tool

### DIFF
--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -245,12 +245,43 @@ export default function activate(ctx: ExtensionContext): void {
         const ui = createToolUI(bus, compositor.surface("agent"));
         ui.custom(createQuestionSession(req.questions)).then(async (result: QuestionResult) => {
           if (!runtime) return;
+          // Record the question + answer as a synthetic tool entry so the
+          // timeline shows what was asked and what the user picked.
+          const callID = `question-${req.id}`;
+          const detail = req.questions.length === 1
+            ? req.questions[0]!.question
+            : req.questions.map((q, i) => `${q.header || `Q${i + 1}`}: ${q.question}`).join("; ");
+          bus.emit("agent:tool-started", {
+            title: "question",
+            toolCallId: callID,
+            kind: "execute",
+            displayDetail: detail,
+          });
           if (result.cancelled) {
+            bus.emitTransform("agent:tool-completed", {
+              toolCallId: callID,
+              exitCode: 1,
+              rawOutput: "cancelled",
+              kind: "execute",
+              resultDisplay: { summary: "cancelled" },
+            });
             runtime.client.question
               .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
               .catch(() => { /* best-effort */ });
             return;
           }
+          const summary = result.answers.length === 1
+            ? result.answers[0]!.join(", ")
+            : result.answers
+                .map((ans, i) => `${req.questions[i]!.header || `Q${i + 1}`}: ${ans.join(", ")}`)
+                .join("; ");
+          bus.emitTransform("agent:tool-completed", {
+            toolCallId: callID,
+            exitCode: 0,
+            rawOutput: summary,
+            kind: "execute",
+            resultDisplay: { summary },
+          });
           try {
             await runtime.client.question.reply({
               requestID: req.id,

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -5,7 +5,15 @@
  *
  * Requires opencode authenticated locally (`opencode auth login`).
  */
-import { createOpencode, type OpencodeClient, type Event, type Part, type ToolPart } from "@opencode-ai/sdk";
+import {
+  createOpencode,
+  type OpencodeClient,
+  type Event,
+  type Part,
+  type ToolPart,
+  type QuestionRequest,
+  type QuestionInfo,
+} from "@opencode-ai/sdk/v2";
 import type { ExtensionContext } from "agent-sh/types";
 import { computeDiff, type DiffResult } from "agent-sh/utils/diff";
 
@@ -82,6 +90,9 @@ export default function activate(ctx: ExtensionContext): void {
   let pendingTurnEnd: (() => void) | null = null;
   let turnIdleSeen = false;
   let turnError: string | null = null;
+
+  // Set while opencode is awaiting a reply; next submit becomes the answer.
+  let pendingQuestion: { requestID: string; info: QuestionInfo } | null = null;
 
   const listeners: Array<{ event: string; fn: Function }> = [];
 
@@ -178,6 +189,43 @@ export default function activate(ctx: ExtensionContext): void {
     turnText += text;
   }
 
+  function renderQuestion(info: QuestionInfo): string {
+    const lines = ["", `❓ ${info.question}`];
+    if (info.options.length > 0) {
+      info.options.forEach((opt, i) => {
+        const desc = opt.description ? ` — ${opt.description}` : "";
+        lines.push(`  ${i + 1}. ${opt.label}${desc}`);
+      });
+      const hints: string[] = [];
+      if (info.multiple) hints.push("comma-separated for multiple");
+      if (info.custom) hints.push("or type your own answer");
+      if (hints.length > 0) lines.push(`  (${hints.join("; ")})`);
+    } else if (info.custom) {
+      lines.push("  (type your answer)");
+    }
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  function mapAnswerToken(token: string, info: QuestionInfo): string {
+    const idx = parseInt(token, 10);
+    if (!Number.isNaN(idx) && idx >= 1 && idx <= info.options.length) {
+      return info.options[idx - 1]!.label;
+    }
+    const match = info.options.find((o) => o.label.toLowerCase() === token.toLowerCase());
+    if (match) return match.label;
+    return token; // free-text — opencode will validate against `custom`
+  }
+
+  function parseQuestionAnswer(input: string, info: QuestionInfo): string[] {
+    const trimmed = input.trim();
+    if (info.options.length === 0) return [trimmed];
+    if (info.multiple) {
+      return trimmed.split(",").map((s) => s.trim()).filter(Boolean).map((t) => mapAnswerToken(t, info));
+    }
+    return [mapAnswerToken(trimmed, info)];
+  }
+
   function handleEvent(event: Event): void {
     if (!sessionId) return;
     const evType = (event as any).type as string;
@@ -219,25 +267,44 @@ export default function activate(ctx: ExtensionContext): void {
         pendingTurnEnd?.();
         if (runtime && sessionId) {
           runtime.client.session
-            .abort({ path: { id: sessionId }, query: sessionDirectory ? { directory: sessionDirectory } : undefined })
+            .abort({ sessionID: sessionId, directory: sessionDirectory ?? undefined })
             .catch(() => { /* abort is best-effort */ });
         }
+        break;
+      }
+      case "question.asked": {
+        const req = props as QuestionRequest;
+        if (!runtime) break;
+        if (req.questions.length !== 1) {
+          // Multi-question needs richer input than one line; reject so the agent can adapt.
+          runtime.client.question
+            .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
+            .catch(() => { /* best-effort */ });
+          break;
+        }
+        pendingQuestion = { requestID: req.id, info: req.questions[0]! };
+        bus.emitTransform("agent:response-chunk", {
+          blocks: [{ type: "text" as const, text: renderQuestion(req.questions[0]!) }],
+        });
+        // Release the spinner while waiting on the user; the active
+        // prompt() is still in flight and will continue once we reply.
+        bus.emit("agent:processing-done", {});
+        break;
+      }
+      case "question.replied":
+      case "question.rejected": {
+        pendingQuestion = null;
         break;
       }
       // Without a reply the gated tool hangs forever. The bridge has no
       // interactive approval UI, so auto-approve — mirrors claude-code-
       // bridge's permissionMode: "acceptEdits". Set permission.edit:
       // "allow" in opencode.json to skip the round-trip entirely.
-      case "permission.asked":
-      case "permission.updated": {
-        const permissionID = props.id as string | undefined;
-        if (!permissionID || !runtime || !sessionId) break;
-        runtime.client
-          .postSessionIdPermissionsPermissionId({
-            path: { id: sessionId, permissionID },
-            query: sessionDirectory ? { directory: sessionDirectory } : undefined,
-            body: { response: "once" },
-          })
+      case "permission.asked": {
+        const requestID = props.id as string | undefined;
+        if (!requestID || !runtime) break;
+        runtime.client.permission
+          .reply({ requestID, reply: "once", directory: sessionDirectory ?? undefined })
           .catch(() => { /* approval is best-effort */ });
         break;
       }
@@ -247,7 +314,7 @@ export default function activate(ctx: ExtensionContext): void {
   async function consumeEvents(client: OpencodeClient, signal: AbortSignal): Promise<void> {
     while (!signal.aborted) {
       try {
-        const result = await client.event.subscribe({ signal });
+        const result = await client.event.subscribe({}, { signal });
         for await (const ev of result.stream) {
           if (signal.aborted) return;
           handleEvent(ev as Event);
@@ -269,6 +336,27 @@ export default function activate(ctx: ExtensionContext): void {
         return;
       }
 
+      if (pendingQuestion) {
+        // The original prompt() is still in flight; reply continues that turn.
+        const pq = pendingQuestion;
+        pendingQuestion = null;
+        bus.emit("agent:query", { query: userQuery });
+        bus.emit("agent:processing-start", {});
+        try {
+          await runtime.client.question.reply({
+            requestID: pq.requestID,
+            answers: [parseQuestionAnswer(userQuery, pq.info)],
+            directory: sessionDirectory ?? undefined,
+          });
+        } catch (err) {
+          bus.emit("agent:error", {
+            message: err instanceof Error ? err.message : String(err),
+          });
+          bus.emit("agent:processing-done", {});
+        }
+        return;
+      }
+
       bus.emit("agent:query", { query: userQuery });
       bus.emit("agent:processing-start", {});
       turnText = "";
@@ -285,11 +373,9 @@ export default function activate(ctx: ExtensionContext): void {
 
       try {
         const res = await runtime.client.session.prompt({
-          path: { id: sessionId },
-          query: sessionDirectory ? { directory: sessionDirectory } : undefined,
-          body: {
-            parts: [{ type: "text", text: finalPrompt }],
-          },
+          sessionID: sessionId,
+          directory: sessionDirectory ?? undefined,
+          parts: [{ type: "text", text: finalPrompt }],
         });
         if (!turnIdleSeen) {
           await Promise.race([
@@ -328,8 +414,19 @@ export default function activate(ctx: ExtensionContext): void {
 
     const onCancel = async () => {
       if (!runtime || !sessionId) return;
+      if (pendingQuestion) {
+        const pq = pendingQuestion;
+        pendingQuestion = null;
+        try {
+          await runtime.client.question.reject({
+            requestID: pq.requestID,
+            directory: sessionDirectory ?? undefined,
+          });
+        } catch { /* best-effort */ }
+        return;
+      }
       try {
-        await runtime.client.session.abort({ path: { id: sessionId } });
+        await runtime.client.session.abort({ sessionID: sessionId, directory: sessionDirectory ?? undefined });
       } catch { /* abort is best-effort */ }
     };
 
@@ -338,9 +435,10 @@ export default function activate(ctx: ExtensionContext): void {
       announcedTools.clear();
       completedTools.clear();
       partKinds.clear();
+      pendingQuestion = null;
       // /reset is the one moment we deliberately let the project switch.
       sessionDirectory = cwd();
-      const res = await runtime.client.session.create({ query: { directory: sessionDirectory } });
+      const res = await runtime.client.session.create({ directory: sessionDirectory });
       sessionId = res.data?.id ?? null;
     };
 
@@ -371,13 +469,13 @@ export default function activate(ctx: ExtensionContext): void {
         void consumeEvents(runtime.client, streamAbort.signal);
 
         sessionDirectory = cwd();
-        const res = await runtime.client.session.create({ query: { directory: sessionDirectory } });
+        const res = await runtime.client.session.create({ directory: sessionDirectory });
         sessionId = res.data?.id ?? null;
         if (!sessionId) throw new Error("session.create returned no id");
 
         wireListeners();
         booting = false;
-        bus.emit("agent:info", { name: "opencode", version: "1.x" });
+        bus.emit("agent:info", { name: "opencode", version: "2.x" });
       } catch (err) {
         booting = false;
         bus.emit("ui:error", {
@@ -396,6 +494,7 @@ export default function activate(ctx: ExtensionContext): void {
       announcedTools.clear();
       completedTools.clear();
       partKinds.clear();
+      pendingQuestion = null;
       booting = true;
     },
   });

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -15,7 +15,10 @@ import {
   type QuestionInfo,
 } from "@opencode-ai/sdk/v2";
 import type { ExtensionContext } from "agent-sh/types";
+import type { InteractiveSession } from "agent-sh/agent/types";
 import { computeDiff, type DiffResult } from "agent-sh/utils/diff";
+import { createToolUI } from "agent-sh/utils/tool-interactive";
+import { palette as p } from "agent-sh/utils/palette";
 
 function parseUnifiedDiff(patch: string): DiffResult | null {
   if (!patch) return null;
@@ -57,7 +60,7 @@ function parseUnifiedDiff(patch: string): DiffResult | null {
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, call } = ctx;
+  const { bus, call, compositor } = ctx;
 
   const cwd = (): string => {
     const v = call("cwd");
@@ -91,9 +94,6 @@ export default function activate(ctx: ExtensionContext): void {
   let turnIdleSeen = false;
   let turnError: string | null = null;
 
-  // Set while opencode is awaiting a reply; next submit becomes the answer.
-  let pendingQuestion: { requestID: string; info: QuestionInfo } | null = null;
-
   const listeners: Array<{ event: string; fn: Function }> = [];
 
   function toolKind(name: string): string {
@@ -124,6 +124,9 @@ export default function activate(ctx: ExtensionContext): void {
 
   function handleToolPart(part: ToolPart): void {
     const { callID, tool: toolName, state } = part;
+    // Question tool is presented via an interactive picker (see question.asked) —
+    // skip the timeline entry to avoid a duplicate "running" bar.
+    if (toolName === "question") return;
     const kind = toolKind(toolName);
 
     if (state.status !== "pending" && !announcedTools.has(callID)) {
@@ -189,42 +192,6 @@ export default function activate(ctx: ExtensionContext): void {
     turnText += text;
   }
 
-  function renderQuestion(info: QuestionInfo): string {
-    const lines = ["", `❓ ${info.question}`];
-    if (info.options.length > 0) {
-      info.options.forEach((opt, i) => {
-        const desc = opt.description ? ` — ${opt.description}` : "";
-        lines.push(`  ${i + 1}. ${opt.label}${desc}`);
-      });
-      const hints: string[] = [];
-      if (info.multiple) hints.push("comma-separated for multiple");
-      if (info.custom) hints.push("or type your own answer");
-      if (hints.length > 0) lines.push(`  (${hints.join("; ")})`);
-    } else if (info.custom) {
-      lines.push("  (type your answer)");
-    }
-    lines.push("");
-    return lines.join("\n");
-  }
-
-  function mapAnswerToken(token: string, info: QuestionInfo): string {
-    const idx = parseInt(token, 10);
-    if (!Number.isNaN(idx) && idx >= 1 && idx <= info.options.length) {
-      return info.options[idx - 1]!.label;
-    }
-    const match = info.options.find((o) => o.label.toLowerCase() === token.toLowerCase());
-    if (match) return match.label;
-    return token; // free-text — opencode will validate against `custom`
-  }
-
-  function parseQuestionAnswer(input: string, info: QuestionInfo): string[] {
-    const trimmed = input.trim();
-    if (info.options.length === 0) return [trimmed];
-    if (info.multiple) {
-      return trimmed.split(",").map((s) => s.trim()).filter(Boolean).map((t) => mapAnswerToken(t, info));
-    }
-    return [mapAnswerToken(trimmed, info)];
-  }
 
   function handleEvent(event: Event): void {
     if (!sessionId) return;
@@ -275,25 +242,27 @@ export default function activate(ctx: ExtensionContext): void {
       case "question.asked": {
         const req = props as QuestionRequest;
         if (!runtime) break;
-        if (req.questions.length !== 1) {
-          // Multi-question needs richer input than one line; reject so the agent can adapt.
-          runtime.client.question
-            .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
-            .catch(() => { /* best-effort */ });
-          break;
-        }
-        pendingQuestion = { requestID: req.id, info: req.questions[0]! };
-        bus.emitTransform("agent:response-chunk", {
-          blocks: [{ type: "text" as const, text: renderQuestion(req.questions[0]!) }],
+        const ui = createToolUI(bus, compositor.surface("agent"));
+        ui.custom(createQuestionSession(req.questions)).then(async (result: QuestionResult) => {
+          if (!runtime) return;
+          if (result.cancelled) {
+            runtime.client.question
+              .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
+              .catch(() => { /* best-effort */ });
+            return;
+          }
+          try {
+            await runtime.client.question.reply({
+              requestID: req.id,
+              answers: result.answers,
+              directory: sessionDirectory ?? undefined,
+            });
+          } catch (err) {
+            bus.emit("agent:error", {
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
         });
-        // Release the spinner while waiting on the user; the active
-        // prompt() is still in flight and will continue once we reply.
-        bus.emit("agent:processing-done", {});
-        break;
-      }
-      case "question.replied":
-      case "question.rejected": {
-        pendingQuestion = null;
         break;
       }
       // Without a reply the gated tool hangs forever. The bridge has no
@@ -333,27 +302,6 @@ export default function activate(ctx: ExtensionContext): void {
           message: booting ? "opencode is still starting up..." : "opencode session not initialized",
         });
         bus.emit("agent:processing-done", {});
-        return;
-      }
-
-      if (pendingQuestion) {
-        // The original prompt() is still in flight; reply continues that turn.
-        const pq = pendingQuestion;
-        pendingQuestion = null;
-        bus.emit("agent:query", { query: userQuery });
-        bus.emit("agent:processing-start", {});
-        try {
-          await runtime.client.question.reply({
-            requestID: pq.requestID,
-            answers: [parseQuestionAnswer(userQuery, pq.info)],
-            directory: sessionDirectory ?? undefined,
-          });
-        } catch (err) {
-          bus.emit("agent:error", {
-            message: err instanceof Error ? err.message : String(err),
-          });
-          bus.emit("agent:processing-done", {});
-        }
         return;
       }
 
@@ -414,17 +362,6 @@ export default function activate(ctx: ExtensionContext): void {
 
     const onCancel = async () => {
       if (!runtime || !sessionId) return;
-      if (pendingQuestion) {
-        const pq = pendingQuestion;
-        pendingQuestion = null;
-        try {
-          await runtime.client.question.reject({
-            requestID: pq.requestID,
-            directory: sessionDirectory ?? undefined,
-          });
-        } catch { /* best-effort */ }
-        return;
-      }
       try {
         await runtime.client.session.abort({ sessionID: sessionId, directory: sessionDirectory ?? undefined });
       } catch { /* abort is best-effort */ }
@@ -435,7 +372,6 @@ export default function activate(ctx: ExtensionContext): void {
       announcedTools.clear();
       completedTools.clear();
       partKinds.clear();
-      pendingQuestion = null;
       // /reset is the one moment we deliberately let the project switch.
       sessionDirectory = cwd();
       const res = await runtime.client.session.create({ directory: sessionDirectory });
@@ -494,8 +430,141 @@ export default function activate(ctx: ExtensionContext): void {
       announcedTools.clear();
       completedTools.clear();
       partKinds.clear();
-      pendingQuestion = null;
       booting = true;
     },
   });
+}
+
+// ── Interactive question picker ──────────────────────────────────
+
+type QuestionResult = { answers: string[][]; cancelled: boolean };
+
+function isKey(data: string, key: string): boolean {
+  switch (key) {
+    case "up":     return data === "\x1b[A" || data === "\x1bOA";
+    case "down":   return data === "\x1b[B" || data === "\x1bOB";
+    case "left":   return data === "\x1b[D" || data === "\x1bOD";
+    case "right":  return data === "\x1b[C" || data === "\x1bOC";
+    case "enter":  return data === "\r" || data === "\n";
+    case "escape": return data === "\x1b";
+    case "tab":    return data === "\t";
+    default:       return data === key;
+  }
+}
+
+function createQuestionSession(questions: QuestionInfo[]): InteractiveSession<QuestionResult> {
+  const isMulti = questions.length > 1;
+  let tab = 0;
+  let optionIdx = 0;
+  // Per-question selected option indices (set, to support `multiple`).
+  const selections: Set<number>[] = questions.map(() => new Set());
+
+  return {
+    render(width) {
+      const w = Math.min(80, width);
+      const lines: string[] = [];
+      const q = questions[tab]!;
+      const sel = selections[tab]!;
+
+      lines.push(`${p.muted}${"─".repeat(w)}${p.reset}`);
+
+      if (isMulti) {
+        const tabs = questions.map((qq, i) => {
+          const answered = selections[i]!.size > 0;
+          const active = i === tab;
+          const box = answered ? "■" : "□";
+          const label = ` ${box} ${qq.header || `Q${i + 1}`} `;
+          return active
+            ? `${p.accent}${p.bold}${label}${p.reset}`
+            : `${p.muted}${label}${p.reset}`;
+        });
+        lines.push(` ${tabs.join(" ")}`);
+        lines.push("");
+      }
+
+      lines.push(` ${q.question}`);
+      lines.push("");
+      for (let i = 0; i < q.options.length; i++) {
+        const opt = q.options[i]!;
+        const cursor = i === optionIdx ? p.accent : "";
+        const reset = i === optionIdx ? p.reset : "";
+        const arrow = i === optionIdx ? `${p.accent}>${p.reset} ` : "  ";
+        const mark = q.multiple
+          ? (sel.has(i) ? "[x]" : "[ ]")
+          : (sel.has(i) ? "(o)" : "( )");
+        lines.push(`${arrow}${cursor}${mark} ${i + 1}. ${opt.label}${reset}`);
+        if (opt.description) {
+          lines.push(`     ${p.muted}${opt.description}${p.reset}`);
+        }
+      }
+
+      lines.push("");
+      const navKeys = isMulti ? "Tab/←→ switch • " : "";
+      const actionKeys = q.multiple
+        ? "↑↓ navigate • Space toggle • Enter confirm • Esc cancel"
+        : "↑↓ navigate • Enter select • Esc cancel";
+      lines.push(` ${p.dim}${navKeys}${actionKeys}${p.reset}`);
+      lines.push(`${p.muted}${"─".repeat(w)}${p.reset}`);
+      return lines;
+    },
+
+    handleInput(data, done) {
+      const q = questions[tab]!;
+      const sel = selections[tab]!;
+
+      if (isKey(data, "escape")) {
+        done({ answers: [], cancelled: true });
+        return;
+      }
+
+      if (isMulti) {
+        if (isKey(data, "tab") || isKey(data, "right")) {
+          tab = (tab + 1) % questions.length;
+          optionIdx = 0;
+          return;
+        }
+        if (isKey(data, "left")) {
+          tab = (tab - 1 + questions.length) % questions.length;
+          optionIdx = 0;
+          return;
+        }
+      }
+
+      if (isKey(data, "up")) {
+        optionIdx = Math.max(0, optionIdx - 1);
+        return;
+      }
+      if (isKey(data, "down")) {
+        optionIdx = Math.min(q.options.length - 1, optionIdx + 1);
+        return;
+      }
+
+      if (q.multiple && data === " ") {
+        if (sel.has(optionIdx)) sel.delete(optionIdx); else sel.add(optionIdx);
+        return;
+      }
+
+      if (isKey(data, "enter")) {
+        if (!q.multiple) {
+          sel.clear();
+          sel.add(optionIdx);
+        }
+        if (sel.size === 0) return;
+
+        const allAnswered = selections.every((s) => s.size > 0);
+        if (!isMulti || allAnswered) {
+          const answers = questions.map((qq, i) =>
+            Array.from(selections[i]!).map((idx) => qq.options[idx]!.label),
+          );
+          done({ answers, cancelled: false });
+          return;
+        }
+        const next = selections.findIndex((s) => s.size === 0);
+        if (next !== -1) {
+          tab = next;
+          optionIdx = 0;
+        }
+      }
+    },
+  };
 }

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -81,6 +81,7 @@ export default function activate(ctx: ExtensionContext): void {
   // prompt() and SSE deltas race; resolve the turn on session.idle.
   let pendingTurnEnd: (() => void) | null = null;
   let turnIdleSeen = false;
+  let turnError: string | null = null;
 
   const listeners: Array<{ event: string; fn: Function }> = [];
 
@@ -209,7 +210,18 @@ export default function activate(ctx: ExtensionContext): void {
       }
       case "session.error": {
         const err = props.error as { message?: string } | undefined;
-        bus.emit("agent:error", { message: err?.message ?? "opencode session error" });
+        const message = err?.message ?? "opencode session error";
+        // session.prompt() does not always reject on session error;
+        // drive turn-end ourselves and abort to unstick a hanging prompt().
+        turnError = message;
+        bus.emit("agent:error", { message });
+        turnIdleSeen = true;
+        pendingTurnEnd?.();
+        if (runtime && sessionId) {
+          runtime.client.session
+            .abort({ path: { id: sessionId }, query: sessionDirectory ? { directory: sessionDirectory } : undefined })
+            .catch(() => { /* abort is best-effort */ });
+        }
         break;
       }
       // Without a reply the gated tool hangs forever. The bridge has no
@@ -261,6 +273,7 @@ export default function activate(ctx: ExtensionContext): void {
       bus.emit("agent:processing-start", {});
       turnText = "";
       turnIdleSeen = false;
+      turnError = null;
       // Set the idle waiter BEFORE prompt() so a fast session.idle can't
       // race in before we're listening.
       const idlePromise = new Promise<void>((resolve) => {
@@ -284,23 +297,29 @@ export default function activate(ctx: ExtensionContext): void {
             new Promise<void>((r) => setTimeout(r, 60_000)),
           ]);
         }
-        // Fallback if SSE never delivered text (network blip, missed
-        // partKinds entry); the prompt response always carries the final.
-        if (!turnText && res.data?.parts) {
-          for (const p of res.data.parts) {
-            if (p.type === "text" && p.text) turnText += p.text;
+        if (turnError) {
+          bus.emitTransform("agent:response-done", { response: "" });
+        } else {
+          // Fallback if SSE never delivered text (network blip, missed
+          // partKinds entry); the prompt response always carries the final.
+          if (!turnText && res.data?.parts) {
+            for (const p of res.data.parts) {
+              if (p.type === "text" && p.text) turnText += p.text;
+            }
+            if (turnText) {
+              bus.emitTransform("agent:response-chunk", {
+                blocks: [{ type: "text" as const, text: turnText }],
+              });
+            }
           }
-          if (turnText) {
-            bus.emitTransform("agent:response-chunk", {
-              blocks: [{ type: "text" as const, text: turnText }],
-            });
-          }
+          bus.emitTransform("agent:response-done", { response: turnText });
         }
-        bus.emitTransform("agent:response-done", { response: turnText });
       } catch (err) {
-        bus.emit("agent:error", {
-          message: err instanceof Error ? err.message : String(err),
-        });
+        if (!turnError) {
+          bus.emit("agent:error", {
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
       } finally {
         pendingTurnEnd = null;
         bus.emit("agent:processing-done", {});


### PR DESCRIPTION
## Summary
- End the turn cleanly when opencode emits `session.error` — `session.prompt()` does not always reject, so the spinner could spin forever (the bug shown in the screenshot). Now we drive turn-end from the error path and abort to unstick a hanging `prompt()`.
- Migrate the bridge to opencode SDK v2 (`@opencode-ai/sdk/v2`, same package, no dep change). v1 had no `question.asked` event or reply/reject endpoints, so the `question` tool just hung. v2 exposes both.
- Handle `question.asked` inline: render the question + numbered options, drop the spinner while waiting, and treat the next user submit as the answer via `client.question.reply`. `/cancel` while a question is pending now rejects via `client.question.reject` instead of aborting the whole session.

## Test plan
- [ ] Normal turn against opencode runs end-to-end without changes
- [ ] A turn that fails (e.g. provider auth error) surfaces the error and the spinner clears within a few seconds
- [ ] A question with a single-select option list renders inline; typing `1`, `2`, etc. submits the chosen label as the answer; opencode resumes the same turn
- [ ] A question with `custom: true` accepts free-text input
- [ ] A question with `multiple: true` accepts comma-separated indices
- [ ] `/cancel` during a pending question rejects without aborting the rest of the session
- [ ] Multi-question requests are rejected up-front (no UI for them yet) — verify the agent recovers gracefully

## Notes
- Multi-question requests are intentionally rejected for now; one line of input can't disambiguate N answers. If this comes up in practice, we can add a richer UI as a follow-up.
- `agent:info` version bumped from `"1.x"` → `"2.x"` to reflect the SDK API generation.