### PR TITLE
Register shell handlers before loading extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import * as path from "node:path";
-import { activateShell, type ShellHandle } from "./shell/index.js";
+import { activateShell, registerShellHandlers, type ShellHandle } from "./shell/index.js";
 import { createCore } from "./core.js";
 import { palette as p } from "./utils/palette.js";
 import { loadBuiltinExtensions } from "./extensions/index.js";
@@ -250,6 +250,9 @@ async function main(): Promise<void> {
   };
 
   const extCtx = core.extensionContext({ quit: cleanup });
+
+  // Before loadExtensions: extensions look up shell handlers at activation.
+  registerShellHandlers(extCtx);
 
   // Load before spawning the shell so PS1 lands below the banner.
   await loadBuiltinExtensions(extCtx, getSettings().disabledBuiltins);

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -28,6 +28,19 @@ export interface ShellHandle {
 }
 
 /**
+ * Register shell-owned handlers extensions can `ctx.call`. Must run before
+ * `loadExtensions`; the handlers only need the bus, not the PTY.
+ */
+export function registerShellHandlers(ctx: ExtensionContext): void {
+  let terminalBufferSingleton: TerminalBuffer | null | undefined;
+  ctx.define("terminal-buffer", (): TerminalBuffer | null => {
+    if (terminalBufferSingleton !== undefined) return terminalBufferSingleton;
+    terminalBufferSingleton = TerminalBuffer.createWired(ctx.bus);
+    return terminalBufferSingleton;
+  });
+}
+
+/**
  * Construct the Shell, wire resize forwarding, and register cleanup with the
  * provided ExtensionContext. Returns a handle the caller (typically
  * `src/index.ts`) uses to drive lifecycle from process-level events.
@@ -42,14 +55,6 @@ export function activateShell(
   ctx.compositor.setDefault("agent", stdoutSurface);
   ctx.compositor.setDefault("query", stdoutSurface);
   ctx.compositor.setDefault("status", stdoutSurface);
-
-  // Lazy because @xterm/headless is optional; null when not installed.
-  let terminalBufferSingleton: TerminalBuffer | null | undefined;
-  ctx.define("terminal-buffer", (): TerminalBuffer | null => {
-    if (terminalBufferSingleton !== undefined) return terminalBufferSingleton;
-    terminalBufferSingleton = TerminalBuffer.createWired(ctx.bus);
-    return terminalBufferSingleton;
-  });
 
   const shell = new Shell({
     bus: ctx.bus,


### PR DESCRIPTION
## Summary

- Commit 5f8ac4e moved `activateShell` past `loadExtensions` so the startup banner prints before the PTY's PS1. Side effect: `ctx.define("terminal-buffer", …)` also moved past extension activation, so any extension that calls `ctx.call("terminal-buffer")` at activation time received `null` and silently early-returned.
- That broke `terminal_read` / `terminal_keys` registration in `examples/extensions/terminal-buffer.ts`, and the same trap also affects `overlay-agent.ts` and `peer-mesh.ts`.
- Split `src/shell/index.ts` into a register phase (`registerShellHandlers`, bus-only, runs before `loadExtensions`) and the existing activate phase (PTY spawn, runs after the banner). Banner-before-PS1 ordering is preserved; handlers are available when extensions activate.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Launch agent-sh, ask the agent to call `terminal_read` — tools are registered and work
- [x] Verify banner still prints before the shell PS1
- [x] Sanity-check `overlay-agent` and `peer-mesh` no longer hit the same null lookup