### PR TITLE
Batch input-prompt redraws into one frame to kill flicker

### DIFF
--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -236,9 +236,14 @@ export class InputHandler {
   }
 
   private renderModeInput(): void {
-    this.view.clearAutocomplete();
-    this.drawPrompt();
-    this.updateAutocomplete();
+    this.view.beginFrame();
+    try {
+      this.view.clearAutocomplete();
+      this.drawPrompt();
+      this.updateAutocomplete();
+    } finally {
+      this.view.endFrame();
+    }
   }
 
   private updateAutocomplete(): void {
@@ -287,13 +292,18 @@ export class InputHandler {
       this.editor.setText(selected.name);
     }
 
-    this.view.clearAutocomplete();
-    this.autocompleteActive = false;
-    this.autocompleteItems = [];
-    this.autocompleteIndex = 0;
+    this.view.beginFrame();
+    try {
+      this.view.clearAutocomplete();
+      this.autocompleteActive = false;
+      this.autocompleteItems = [];
+      this.autocompleteIndex = 0;
 
-    this.drawPrompt();
-    if (isFileAc) this.updateAutocomplete();
+      this.drawPrompt();
+      if (isFileAc) this.updateAutocomplete();
+    } finally {
+      this.view.endFrame();
+    }
   }
 
   private dismissAutocomplete(): void {
@@ -328,11 +338,16 @@ export class InputHandler {
         case "changed": {
           const switchMode = this.modes.get(this.editor.text);
           if (this.editor.text.length === 1 && switchMode && switchMode !== this.activeMode) {
-            this.dismissAutocomplete();
-            this.view.clearPromptArea();
-            this.activeMode = switchMode;
-            this.editor.clear();
-            this.drawPrompt(false);
+            this.view.beginFrame();
+            try {
+              this.dismissAutocomplete();
+              this.view.clearPromptArea();
+              this.activeMode = switchMode;
+              this.editor.clear();
+              this.drawPrompt(false);
+            } finally {
+              this.view.endFrame();
+            }
             break;
           }
           this.historyIndex = -1;
@@ -384,8 +399,13 @@ export class InputHandler {
 
         case "cancel":
           if (this.autocompleteActive) {
-            this.dismissAutocomplete();
-            this.drawPrompt();
+            this.view.beginFrame();
+            try {
+              this.dismissAutocomplete();
+              this.drawPrompt();
+            } finally {
+              this.view.endFrame();
+            }
           } else {
             this.exitMode();
           }
@@ -408,9 +428,14 @@ export class InputHandler {
               this.autocompleteIndex === 0
                 ? this.autocompleteItems.length - 1
                 : this.autocompleteIndex - 1;
-            this.view.clearAutocomplete();
-            this.drawPrompt();
-            this.view.drawAutocomplete({ items: this.autocompleteItems, selected: this.autocompleteIndex });
+            this.view.beginFrame();
+            try {
+              this.view.clearAutocomplete();
+              this.drawPrompt();
+              this.view.drawAutocomplete({ items: this.autocompleteItems, selected: this.autocompleteIndex });
+            } finally {
+              this.view.endFrame();
+            }
           } else if (this.history.length > 0) {
             if (this.historyIndex === -1) {
               this.savedBuffer = this.editor.text;
@@ -419,8 +444,13 @@ export class InputHandler {
               this.historyIndex--;
             }
             this.editor.setText(this.history[this.historyIndex]!);
-            this.view.clearAutocomplete();
-            this.drawPrompt();
+            this.view.beginFrame();
+            try {
+              this.view.clearAutocomplete();
+              this.drawPrompt();
+            } finally {
+              this.view.endFrame();
+            }
           }
           break;
 
@@ -430,9 +460,14 @@ export class InputHandler {
               this.autocompleteIndex === this.autocompleteItems.length - 1
                 ? 0
                 : this.autocompleteIndex + 1;
-            this.view.clearAutocomplete();
-            this.drawPrompt();
-            this.view.drawAutocomplete({ items: this.autocompleteItems, selected: this.autocompleteIndex });
+            this.view.beginFrame();
+            try {
+              this.view.clearAutocomplete();
+              this.drawPrompt();
+              this.view.drawAutocomplete({ items: this.autocompleteItems, selected: this.autocompleteIndex });
+            } finally {
+              this.view.endFrame();
+            }
           } else if (this.historyIndex !== -1) {
             if (this.historyIndex < this.history.length - 1) {
               this.historyIndex++;
@@ -441,8 +476,13 @@ export class InputHandler {
               this.historyIndex = -1;
               this.editor.setText(this.savedBuffer);
             }
-            this.view.clearAutocomplete();
-            this.drawPrompt();
+            this.view.beginFrame();
+            try {
+              this.view.clearAutocomplete();
+              this.drawPrompt();
+            } finally {
+              this.view.endFrame();
+            }
           }
           break;
       }

--- a/src/shell/tui-input-view.ts
+++ b/src/shell/tui-input-view.ts
@@ -28,9 +28,35 @@ export class TuiInputView {
   private cursorTermCol = 1;
   private autocompleteLines = 0;
   private readonly surface: RenderSurface;
+  private frameBuf: string | null = null;
 
   constructor(surface?: RenderSurface) {
     this.surface = surface ?? new StdoutSurface();
+  }
+
+  // Frame buffering: coalesces all emit() calls until endFrame() into one
+  // surface.write, bracketed by cursor hide/show so intermediate redraw
+  // states never flicker through.
+  beginFrame(): void {
+    if (this.frameBuf === null) this.frameBuf = "\x1b[?25l";
+  }
+
+  endFrame(): void {
+    if (this.frameBuf === null) return;
+    const out = this.frameBuf + "\x1b[?25h";
+    this.frameBuf = null;
+    this.surface.write(out);
+  }
+
+  private emit(s: string): void {
+    if (this.frameBuf !== null) this.frameBuf += s;
+    else this.surface.write(s);
+  }
+
+  private autoFrame<T>(fn: () => T): T {
+    const owned = this.frameBuf === null;
+    if (owned) this.beginFrame();
+    try { return fn(); } finally { if (owned) this.endFrame(); }
   }
 
   resetCursor(): void {
@@ -40,139 +66,146 @@ export class TuiInputView {
 
   enableModeKeys(): void {
     // Kitty progressive enhancement + bracket paste (Shift+Enter → \x1b[13;2u).
-    this.surface.write("\x1b[>1u\x1b[?2004h");
+    this.emit("\x1b[>1u\x1b[?2004h");
   }
 
   disableModeKeys(): void {
-    this.surface.write("\x1b[<u\x1b[?2004l");
+    this.emit("\x1b[<u\x1b[?2004l");
   }
 
   clearPromptArea(): void {
-    if (this.cursorRowsBelow > 0) {
-      this.surface.write(`\x1b[${this.cursorRowsBelow}A`);
-    }
-    this.surface.write("\r\x1b[J");
-    this.cursorRowsBelow = 0;
+    this.autoFrame(() => {
+      if (this.cursorRowsBelow > 0) {
+        this.emit(`\x1b[${this.cursorRowsBelow}A`);
+      }
+      this.emit("\r\x1b[J");
+      this.cursorRowsBelow = 0;
+    });
   }
 
   drawPrompt(vm: PromptVM): void {
-    const termW = this.surface.columns;
+    this.autoFrame(() => {
+      const termW = this.surface.columns;
 
-    if (this.cursorRowsBelow > 0) {
-      this.surface.write(`\x1b[${this.cursorRowsBelow}A`);
-    }
-    this.surface.write("\r\x1b[J");
-
-    const infoPrefix = vm.agentInfo.info
-      ? `${vm.agentInfo.info} ${p.success}${vm.indicator}${p.reset} `
-      : `${p.success}${vm.indicator}${p.reset} `;
-    const promptPrefix = infoPrefix + p.warning + p.bold + vm.promptIcon + " " + p.reset;
-    const promptVisLen = visibleLen(infoPrefix) + visibleLen(vm.promptIcon) + 1;
-
-    const display = vm.showBuffer ? vm.displayText : "";
-    const dCursor = vm.showBuffer ? vm.displayCursor : 0;
-
-    if (!vm.showBuffer) {
-      this.surface.write(promptPrefix);
-      const N = promptVisLen;
-      this.cursorRowsBelow = N > 0 ? Math.ceil(N / termW) - 1 : 0;
-      this.cursorTermCol = N === 0 ? 1 : (N % termW === 0 ? termW : (N % termW) + 1);
-    } else if (!display.includes("\n")) {
-      // DECSC/DECRC bracket the after-cursor text so the cursor lands mid-line.
-      const before = display.slice(0, dCursor);
-      const after = display.slice(dCursor);
-      this.surface.write(
-        promptPrefix + p.accent + before + p.reset +
-        "\x1b7" +
-        p.accent + after + p.reset +
-        "\x1b8"
-      );
-      const cursorVisCol = promptVisLen + visibleLen(before);
-      this.cursorRowsBelow = cursorVisCol > 0 ? Math.ceil(cursorVisCol / termW) - 1 : 0;
-      this.cursorTermCol = cursorVisCol === 0 ? 1 : (cursorVisCol % termW === 0 ? termW : (cursorVisCol % termW) + 1);
-    } else {
-      const lines = display.split("\n");
-      const indent = " ".repeat(promptVisLen);
-
-      let charsRemaining = dCursor;
-      let cursorLine = 0;
-      for (let li = 0; li < lines.length; li++) {
-        if (charsRemaining <= lines[li]!.length) {
-          cursorLine = li;
-          break;
-        }
-        charsRemaining -= lines[li]!.length + 1;
-        cursorLine = li + 1;
+      if (this.cursorRowsBelow > 0) {
+        this.emit(`\x1b[${this.cursorRowsBelow}A`);
       }
+      this.emit("\r\x1b[J");
 
-      let output = "";
-      let cursorRowFromTop = 0;
-      let rowsSoFar = 0;
+      const infoPrefix = vm.agentInfo.info
+        ? `${vm.agentInfo.info} ${p.success}${vm.indicator}${p.reset} `
+        : `${p.success}${vm.indicator}${p.reset} `;
+      const promptPrefix = infoPrefix + p.warning + p.bold + vm.promptIcon + " " + p.reset;
+      const promptVisLen = visibleLen(infoPrefix) + visibleLen(vm.promptIcon) + 1;
 
-      for (let li = 0; li < lines.length; li++) {
-        const prefix = li === 0 ? promptPrefix : indent;
-        const lineText = lines[li]!;
-        const lineVisLen = promptVisLen + visibleLen(lineText);
-        const lineTermRows = lineVisLen > 0 ? Math.ceil(lineVisLen / termW) : 1;
+      const display = vm.showBuffer ? vm.displayText : "";
+      const dCursor = vm.showBuffer ? vm.displayCursor : 0;
 
-        if (li === cursorLine) {
-          const before = lineText.slice(0, charsRemaining);
-          const after = lineText.slice(charsRemaining);
-          output += prefix + p.accent + before + p.reset;
-          output += "\x1b7";
-          output += p.accent + after + p.reset;
+      if (!vm.showBuffer) {
+        this.emit(promptPrefix);
+        const N = promptVisLen;
+        this.cursorRowsBelow = N > 0 ? Math.ceil(N / termW) - 1 : 0;
+        this.cursorTermCol = N === 0 ? 1 : (N % termW === 0 ? termW : (N % termW) + 1);
+      } else if (!display.includes("\n")) {
+        // DECSC/DECRC bracket the after-cursor text so the cursor lands mid-line.
+        const before = display.slice(0, dCursor);
+        const after = display.slice(dCursor);
+        this.emit(
+          promptPrefix + p.accent + before + p.reset +
+          "\x1b7" +
+          p.accent + after + p.reset +
+          "\x1b8"
+        );
+        const cursorVisCol = promptVisLen + visibleLen(before);
+        this.cursorRowsBelow = cursorVisCol > 0 ? Math.ceil(cursorVisCol / termW) - 1 : 0;
+        this.cursorTermCol = cursorVisCol === 0 ? 1 : (cursorVisCol % termW === 0 ? termW : (cursorVisCol % termW) + 1);
+      } else {
+        const lines = display.split("\n");
+        const indent = " ".repeat(promptVisLen);
 
-          const beforeVisCol = promptVisLen + visibleLen(before);
-          cursorRowFromTop = rowsSoFar + (beforeVisCol > 0 ? Math.ceil(beforeVisCol / termW) - 1 : 0);
-          this.cursorTermCol = beforeVisCol === 0 ? 1 : (beforeVisCol % termW === 0 ? termW : (beforeVisCol % termW) + 1);
-        } else {
-          output += prefix + p.accent + lineText + p.reset;
+        let charsRemaining = dCursor;
+        let cursorLine = 0;
+        for (let li = 0; li < lines.length; li++) {
+          if (charsRemaining <= lines[li]!.length) {
+            cursorLine = li;
+            break;
+          }
+          charsRemaining -= lines[li]!.length + 1;
+          cursorLine = li + 1;
         }
 
-        if (li < lines.length - 1) output += "\n";
-        rowsSoFar += lineTermRows;
-      }
+        let output = "";
+        let cursorRowFromTop = 0;
+        let rowsSoFar = 0;
 
-      this.surface.write(output + "\x1b8");
-      this.cursorRowsBelow = cursorRowFromTop;
-    }
+        for (let li = 0; li < lines.length; li++) {
+          const prefix = li === 0 ? promptPrefix : indent;
+          const lineText = lines[li]!;
+          const lineVisLen = promptVisLen + visibleLen(lineText);
+          const lineTermRows = lineVisLen > 0 ? Math.ceil(lineVisLen / termW) : 1;
+
+          if (li === cursorLine) {
+            const before = lineText.slice(0, charsRemaining);
+            const after = lineText.slice(charsRemaining);
+            output += prefix + p.accent + before + p.reset;
+            output += "\x1b7";
+            output += p.accent + after + p.reset;
+
+            const beforeVisCol = promptVisLen + visibleLen(before);
+            cursorRowFromTop = rowsSoFar + (beforeVisCol > 0 ? Math.ceil(beforeVisCol / termW) - 1 : 0);
+            this.cursorTermCol = beforeVisCol === 0 ? 1 : (beforeVisCol % termW === 0 ? termW : (beforeVisCol % termW) + 1);
+          } else {
+            output += prefix + p.accent + lineText + p.reset;
+          }
+
+          if (li < lines.length - 1) output += "\n";
+          rowsSoFar += lineTermRows;
+        }
+
+        this.emit(output + "\x1b8");
+        this.cursorRowsBelow = cursorRowFromTop;
+      }
+    });
   }
 
   drawAutocomplete(vm: AutocompleteVM): void {
     if (vm.items.length === 0) return;
-
-    const lines: string[] = [];
-    for (let i = 0; i < vm.items.length; i++) {
-      const item = vm.items[i]!;
-      const selected = i === vm.selected;
-      if (selected) {
-        lines.push(
-          `  \x1b[7m ${p.accent}${item.name.padEnd(12)}${p.reset}\x1b[7m ${item.description} ${p.reset}`
-        );
-      } else {
-        lines.push(
-          `   ${p.muted}${item.name.padEnd(12)} ${item.description}${p.reset}`
-        );
+    this.autoFrame(() => {
+      const lines: string[] = [];
+      for (let i = 0; i < vm.items.length; i++) {
+        const item = vm.items[i]!;
+        const selected = i === vm.selected;
+        if (selected) {
+          lines.push(
+            `  \x1b[7m ${p.accent}${item.name.padEnd(12)}${p.reset}\x1b[7m ${item.description} ${p.reset}`
+          );
+        } else {
+          lines.push(
+            `   ${p.muted}${item.name.padEnd(12)} ${item.description}${p.reset}`
+          );
+        }
       }
-    }
 
-    this.surface.write("\n" + lines.join("\n"));
-    this.autocompleteLines = lines.length;
+      this.emit("\n" + lines.join("\n"));
+      this.autocompleteLines = lines.length;
 
-    if (this.autocompleteLines > 0) {
-      this.surface.write(`\x1b[${this.autocompleteLines}A`);
-    }
-    // Absolute column set — preceding \n may have scrolled, invalidating DECSC.
-    this.surface.write(`\x1b[${this.cursorTermCol}G`);
+      if (this.autocompleteLines > 0) {
+        this.emit(`\x1b[${this.autocompleteLines}A`);
+      }
+      // Absolute column set — preceding \n may have scrolled, invalidating DECSC.
+      this.emit(`\x1b[${this.cursorTermCol}G`);
+    });
   }
 
   clearAutocomplete(): void {
     if (this.autocompleteLines <= 0) return;
-    // CSI B (cursor down, bounded) so we don't scroll on the last row.
-    for (let i = 0; i < this.autocompleteLines; i++) {
-      this.surface.write("\x1b[B\x1b[2K");
-    }
-    this.surface.write(`\x1b[${this.autocompleteLines}A\x1b[${this.cursorTermCol}G`);
-    this.autocompleteLines = 0;
+    this.autoFrame(() => {
+      // CSI B (cursor down, bounded) so we don't scroll on the last row.
+      for (let i = 0; i < this.autocompleteLines; i++) {
+        this.emit("\x1b[B\x1b[2K");
+      }
+      this.emit(`\x1b[${this.autocompleteLines}A\x1b[${this.cursorTermCol}G`);
+      this.autocompleteLines = 0;
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Each keystroke in agent query mode flickered because `TuiInputView` issued 3–5 separate `process.stdout.write` calls per render (cursor up, `\r\x1b[J`, prompt prefix, buffer text, optional autocomplete). Slower terminals/multiplexers rendered the intermediate states — visible blink and cursor briefly snapping to column 1.
- `TuiInputView` now buffers `emit()` calls between `beginFrame`/`endFrame` and flushes as one write, bracketed by cursor hide (`\x1b[?25l`) / show (`\x1b[?25h`) so the cursor never traverses intermediate positions.
- Each public draw method auto-frames so standalone callers stay flicker-free; `InputHandler` wraps multi-method sequences (`renderModeInput`, `applyAutocomplete`, autocomplete cycling, history nav, mode switch, cancel) so the whole keystroke is one atomic write.

## Test plan

- [x] Type into agent query mode (`>`) — prompt no longer blinks per character.
- [x] Cycle autocomplete with arrow keys — no flicker between selections.
- [x] Navigate history (up/down) — clean redraws.
- [x] Trigger mode switch by typing the trigger char first — no flash.
- [x] Multi-line buffer (Shift+Enter) — cursor still lands correctly mid-line.
- [x] Apply autocomplete with Tab/Enter — buffer updates atomically.
- [ ] Verify under tmux and ssh, where flicker was most visible before.