### PR TITLE
Drop Z.AI reader from web-access example, default to Jina

### DIFF
--- a/examples/extensions/web-access.ts
+++ b/examples/extensions/web-access.ts
@@ -4,9 +4,7 @@
  * Provides two tools:
  *   - web_search:  Search the web via Exa MCP (free, no API key)
  *   - web_fetch:   Extract page content as clean markdown
- *                   Fallback chain: Z.AI reader → Jina Reader → direct fetch
- *
- * Optional: ZAI_API_KEY environment variable (for Z.AI reader, best quality)
+ *                   Fallback chain: Jina Reader → direct fetch
  *
  * Optional configuration (~/.agent-sh/settings.json):
  *   {
@@ -23,9 +21,6 @@ import type { ExtensionContext } from "agent-sh/types";
 // ── Constants ────────────────────────────────────────────────────────
 
 const EXA_MCP_URL = "https://mcp.exa.ai/mcp";
-
-const ZAI_BASE = "https://api.z.ai";
-const ZAI_READER_PATH = "/api/mcp/web_reader/mcp";
 
 const JINA_READER_URL = "https://r.jina.ai";
 
@@ -97,97 +92,6 @@ async function exaSearch(
   return text;
 }
 
-// ── Z.AI MCP reader (requires API key + session) ────────────────────
-
-let zaiRpcId = 0;
-const zaiSessionId = { current: "" };
-
-async function zaiMcpPost(
-  apiKey: string,
-  body: Record<string, unknown>,
-  timeout: number,
-): Promise<any> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-    Authorization: `Bearer ${apiKey}`,
-  };
-  if (zaiSessionId.current) headers["mcp-session-id"] = zaiSessionId.current;
-
-  const res = await fetch(`${ZAI_BASE}${ZAI_READER_PATH}`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(timeout),
-  });
-
-  if (!res.ok) throw new Error(`Z.AI MCP ${res.status}`);
-
-  const sid = res.headers.get("mcp-session-id");
-  if (sid) zaiSessionId.current = sid;
-
-  const ct = res.headers.get("content-type") ?? "";
-  if (ct.includes("text/event-stream")) {
-    const text = await res.text();
-    for (const line of text.split("\n")) {
-      if (!line.startsWith("data:")) continue;
-      const payload = line.slice(line.charAt(5) === " " ? 6 : 5);
-      if (!payload) continue;
-      const parsed = JSON.parse(payload);
-      if (parsed.error) throw new Error(parsed.error.message);
-      return parsed.result;
-    }
-    throw new Error("No data in Z.AI SSE response");
-  }
-
-  const json = await res.json();
-  const response = Array.isArray(json) ? json[0] : json;
-  if (response?.error) throw new Error(response.error.message);
-  return response?.result;
-}
-
-async function zaiRead(apiKey: string, url: string, timeout: number): Promise<string> {
-  // Initialize session if needed
-  if (!zaiSessionId.current) {
-    await zaiMcpPost(apiKey, {
-      jsonrpc: "2.0", id: ++zaiRpcId, method: "initialize",
-      params: {
-        protocolVersion: "2024-11-05", capabilities: {},
-        clientInfo: { name: "ash-web-access", version: "1.0.0" },
-      },
-    }, timeout);
-    await zaiMcpPost(apiKey, {
-      jsonrpc: "2.0", method: "notifications/initialized",
-    }, timeout);
-  }
-
-  const result = await zaiMcpPost(apiKey, {
-    jsonrpc: "2.0", id: ++zaiRpcId, method: "tools/call",
-    params: { name: "webReader", arguments: { url } },
-  }, timeout);
-
-  // Unwrap double-encoded JSON response
-  const textBlock = result?.content?.find((c: any) => c.type === "text" && c.text);
-  if (!textBlock) return JSON.stringify(result, null, 2);
-
-  let data: any;
-  try {
-    data = JSON.parse(textBlock.text);
-    if (typeof data === "string") data = JSON.parse(data);
-  } catch {
-    return textBlock.text;
-  }
-
-  if (data && typeof data === "object" && !Array.isArray(data)) {
-    const title = data.title ? `# ${data.title}\n\n` : "";
-    const source = data.url ? `**Source:** ${data.url}\n\n` : "";
-    const body = data.content ?? data.markdown ?? data.text ?? JSON.stringify(data, null, 2);
-    return `${title}${source}${body}`;
-  }
-
-  return typeof data === "string" ? data : JSON.stringify(data, null, 2);
-}
-
 // ── Jina Reader (free, no key) ───────────────────────────────────────
 
 async function jinaRead(url: string, timeout: number): Promise<string> {
@@ -220,8 +124,6 @@ async function directFetch(url: string, timeout: number): Promise<string> {
 // ── Extension entry point ────────────────────────────────────────────
 
 export default function activate(ctx: ExtensionContext) {
-  const apiKey = process.env.ZAI_API_KEY ?? "";
-
   const config = ctx.getExtensionSettings("web-access", {
     timeout: 30000,
     searchNumResults: 5,
@@ -282,7 +184,7 @@ export default function activate(ctx: ExtensionContext) {
     description:
       "Fetch a URL and extract its content as clean markdown. " +
       "Handles web pages, articles, and documentation. " +
-      "Uses Z.AI reader (best quality), Jina Reader, or direct fetch as fallback.",
+      "Uses Jina Reader, with direct fetch as fallback.",
     input_schema: {
       type: "object" as const,
       properties: {
@@ -308,14 +210,7 @@ export default function activate(ctx: ExtensionContext) {
         }
       }
 
-      // Fallback chain: Z.AI reader → Jina Reader → direct fetch
-      if (apiKey) {
-        try {
-          const content = await zaiRead(apiKey, args.url, timeout);
-          return { content, exitCode: 0, isError: false };
-        } catch { /* fall through */ }
-      }
-
+      // Fallback chain: Jina Reader → direct fetch
       try {
         const content = await jinaRead(args.url, timeout);
         return { content, exitCode: 0, isError: false };


### PR DESCRIPTION
## Summary
- Removes the Z.AI MCP reader path from `examples/extensions/web-access.ts` (constants, session state, `zaiMcpPost`, `zaiRead`, the `ZAI_API_KEY` env read).
- `web_fetch` is now unconditionally Jina Reader → direct fetch — no API key required for any code path.
- Header doc and tool description updated to match.

The Z.AI branch was opt-in (only ran when `ZAI_API_KEY` was set) but carried ~90 lines of MCP init/session plumbing for an extension that already advertised itself as free/no-key. Net diff: +3/-108.

## Test plan
- [ ] `npm run build` (tsc) clean
- [ ] Smoke `web_fetch` against a known URL
- [ ] Smoke `web_fetch` with `raw: true` against a JSON endpoint
- [ ] Smoke `web_search` against any query