### PR TITLE
Propagate tool detail through ash-acp-bridge; link bins on install

### DIFF
--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -92,8 +92,9 @@ function sendToolCall(
   title: string,
   kind: string,
   rawInput?: unknown,
+  locations?: { path: string; line?: number | null }[],
 ): void {
-  sendSessionUpdate({
+  const update: Record<string, unknown> = {
     sessionUpdate: "tool_call",
     toolCallId,
     title,
@@ -101,7 +102,59 @@ function sendToolCall(
     kind,
     content: [],
     rawInput,
-  });
+  };
+  if (locations && locations.length > 0) update.locations = locations;
+  sendSessionUpdate(update);
+}
+
+// ── Tool title enrichment ───────────────────────────────────────────
+// ACP clients typically only render title + kind, so the bare tool name
+// ("read_file") is unhelpful. Append path/command/pattern detail.
+
+function shortenPath(p: string): string {
+  const cwd = process.cwd();
+  if (p.startsWith(cwd + "/")) return p.slice(cwd.length + 1);
+  const home = process.env.HOME;
+  if (home && p.startsWith(home + "/")) return "~/" + p.slice(home.length + 1);
+  return p;
+}
+
+function extractDetail(
+  displayDetail: string | undefined,
+  rawInput: unknown,
+  locations: { path: string; line?: number | null }[] | undefined,
+): string {
+  if (displayDetail) return displayDetail;
+  if (locations && locations.length > 0) {
+    const loc = locations.find((l) => l?.path) ?? locations[0]!;
+    const line = loc.line ? `:${loc.line}` : "";
+    return `${shortenPath(loc.path)}${line}`;
+  }
+  if (rawInput && typeof rawInput === "object") {
+    const raw = rawInput as Record<string, unknown>;
+    if (typeof raw.command === "string") return `$ ${raw.command}`;
+    if (typeof raw.pattern === "string") {
+      const target = typeof raw.path === "string" ? ` ${shortenPath(raw.path)}` : "";
+      return `${raw.pattern}${target}`;
+    }
+    if (typeof raw.path === "string") return shortenPath(raw.path);
+    if (typeof raw.file_path === "string") return shortenPath(raw.file_path);
+    if (typeof raw.url === "string") return raw.url;
+    if (typeof raw.query === "string") return `"${raw.query}"`;
+  }
+  return "";
+}
+
+function enrichTitle(
+  title: string,
+  displayDetail: string | undefined,
+  rawInput: unknown,
+  locations: { path: string; line?: number | null }[] | undefined,
+): string {
+  const detail = extractDetail(displayDetail, rawInput, locations);
+  if (!detail) return title;
+  if (title.includes(detail)) return title;
+  return `${title}: ${detail}`;
 }
 
 function sendToolCallUpdate(
@@ -300,7 +353,8 @@ function wireEvents(core: AgentShellCore): void {
   bus.on("agent:tool-started", (e) => {
     const id = e.toolCallId ?? `tool-${Date.now()}`;
     toolOutputBuffers.set(id, "");
-    sendToolCall(id, e.title, e.kind ?? "tool", e.rawInput);
+    const title = enrichTitle(e.title, e.displayDetail, e.rawInput, e.locations);
+    sendToolCall(id, title, e.kind ?? "tool", e.rawInput, e.locations);
   });
 
   bus.on("agent:tool-output-chunk", ({ chunk }) => {
@@ -365,6 +419,11 @@ function wireEvents(core: AgentShellCore): void {
   bus.onPipeAsync("permission:request", async (payload) => {
     payload.decision = { outcome: "approved" };
     return payload;
+  });
+
+  // Surface ui:error to stderr — extension load failures are otherwise silent.
+  bus.on("ui:error", ({ message }) => {
+    process.stderr.write(`[ash-acp-bridge] ${message}\n`);
   });
 }
 
@@ -444,7 +503,7 @@ async function handleSessionNew(id: number | string, params: Record<string, unkn
     const headlessDisabled = [
       "tui-renderer",
       "file-autocomplete",
-      "overlay-agent",
+      "shell-context",
       ...(settings.disabledBuiltins ?? []),
     ];
     await loadBuiltinExtensions(extCtx, headlessDisabled);
@@ -462,7 +521,7 @@ async function handleSessionNew(id: number | string, params: Record<string, unkn
 
     // Signal deferred-init listeners (agent-backend) that the provider
     // registry is complete — they resolve their LLM config on this event.
-    core.bus.emit("core:extensions-loaded", {});
+    core.bus.emit("core:extensions-loaded", { names: [] });
 
     core.activateBackend();
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -97,10 +97,21 @@ function pickResolver(spec: string): Resolver {
   return bundledResolver;
 }
 
-function maybeNpmInstall(target: string): void {
+interface PackageJson {
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  bin?: string | Record<string, string>;
+  name?: string;
+}
+
+function readPackageJson(target: string): PackageJson | null {
   const pkgJson = path.join(target, "package.json");
-  if (!fs.existsSync(pkgJson)) return;
-  const pkg = JSON.parse(fs.readFileSync(pkgJson, "utf-8"));
+  if (!fs.existsSync(pkgJson)) return null;
+  return JSON.parse(fs.readFileSync(pkgJson, "utf-8")) as PackageJson;
+}
+
+function maybeNpmInstall(target: string, pkg: PackageJson): void {
   const deps = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}) };
   if (Object.keys(deps).length === 0) return;
   if (fs.existsSync(path.join(target, "node_modules"))) return;
@@ -112,6 +123,48 @@ function maybeNpmInstall(target: string): void {
   if (result.status !== 0) {
     throw new Error(`npm install failed in ${target}; run it manually.`);
   }
+}
+
+function normalizeBin(pkg: PackageJson): Record<string, string> {
+  if (!pkg.bin) return {};
+  if (typeof pkg.bin === "string") {
+    const name = pkg.name?.startsWith("@") ? pkg.name.split("/")[1]! : pkg.name;
+    return name ? { [name]: pkg.bin } : {};
+  }
+  return pkg.bin;
+}
+
+function maybeNpmBuild(target: string, pkg: PackageJson): void {
+  if (!pkg.scripts?.build) return;
+  const binPaths = Object.values(normalizeBin(pkg)).map((p) => path.join(target, p));
+  if (binPaths.length === 0) return;
+  if (binPaths.every((p) => fs.existsSync(p))) return;
+  console.log(`Running npm run build in ${target}...`);
+  const result = spawnSync("npm", ["run", "build"], { cwd: target, stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error(`npm run build failed in ${target}; run it manually.`);
+  }
+}
+
+function linkBins(target: string, pkg: PackageJson): string[] {
+  const bins = normalizeBin(pkg);
+  if (Object.keys(bins).length === 0) return [];
+  const binDir = path.join(CONFIG_DIR, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const linked: string[] = [];
+  for (const [name, relPath] of Object.entries(bins)) {
+    const src = path.resolve(target, relPath);
+    if (!fs.existsSync(src)) {
+      console.error(`agent-sh: skipping bin "${name}" — ${src} not found`);
+      continue;
+    }
+    try { fs.chmodSync(src, 0o755); } catch { /* ignore */ }
+    const linkPath = path.join(binDir, name);
+    try { fs.unlinkSync(linkPath); } catch { /* ignore */ }
+    fs.symlinkSync(src, linkPath);
+    linked.push(name);
+  }
+  return linked;
 }
 
 export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<void> {
@@ -145,10 +198,16 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
     fs.rmSync(target, { recursive: true, force: true });
   }
 
+  let linkedBins: string[] = [];
   if (resolved.isDirectory) {
     fs.cpSync(resolved.sourcePath, target, { recursive: true });
     try {
-      maybeNpmInstall(target);
+      const pkg = readPackageJson(target);
+      if (pkg) {
+        maybeNpmInstall(target, pkg);
+        maybeNpmBuild(target, pkg);
+        linkedBins = linkBins(target, pkg);
+      }
     } catch (err) {
       console.error(`agent-sh: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
@@ -158,6 +217,11 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
   }
 
   console.log(`Installed: ${resolved.name} -> ${target}`);
+  if (linkedBins.length > 0) {
+    const binDir = path.join(CONFIG_DIR, "bin");
+    console.log(`Linked bins: ${linkedBins.join(", ")} -> ${binDir}`);
+    console.log(`Add to PATH: export PATH="${binDir}:$PATH"`);
+  }
 }
 
 export async function runUninstall(name: string): Promise<void> {
@@ -176,6 +240,20 @@ export async function runUninstall(name: string): Promise<void> {
   if (!fs.lstatSync(target, { throwIfNoEntry: false })) {
     console.error(`agent-sh: not installed: ${name}`);
     process.exit(1);
+  }
+  const pkg = readPackageJson(target);
+  if (pkg) {
+    const binDir = path.join(CONFIG_DIR, "bin");
+    const targetPrefix = path.resolve(target) + path.sep;
+    for (const binName of Object.keys(normalizeBin(pkg))) {
+      const linkPath = path.join(binDir, binName);
+      try {
+        const stat = fs.lstatSync(linkPath, { throwIfNoEntry: false });
+        if (!stat?.isSymbolicLink()) continue;
+        const dest = path.resolve(binDir, fs.readlinkSync(linkPath));
+        if (dest.startsWith(targetPrefix)) fs.unlinkSync(linkPath);
+      } catch { /* ignore */ }
+    }
   }
   fs.rmSync(target, { recursive: true, force: true });
   console.log(`Uninstalled: ${name}`);


### PR DESCRIPTION
## Summary

- **Bridge**: forward `displayDetail` / `rawInput` / `locations` on `agent:tool-started` so ACP clients (agent-shell in Emacs, etc.) render the file path or command instead of only the bare tool name. Drop `overlay-agent` from `headlessDisabled` (it's a user extension, not a built-in), add `shell-context` (no PTY in headless mode), and pipe `ui:error` to stderr so silent extension-load failures are visible. Also fix the now-typed `core:extensions-loaded` payload.
- **Install**: when a target package declares `bin`, run `npm run build` if the bin output is missing, symlink each bin into `~/.agent-sh/bin/`, and print a PATH hint. `agent-sh uninstall` removes matching symlinks. This makes `agent-sh install ash-acp-bridge` produce a directly invokable `ash-acp-bridge` binary instead of an unreachable `dist/index.js`.

## Test plan

- [ ] `npm run build` at repo root and in `examples/extensions/ash-acp-bridge/`
- [ ] `agent-sh install ash-acp-bridge` (fresh) — confirm `~/.agent-sh/bin/ash-acp-bridge` is a working symlink
- [ ] `agent-sh uninstall ash-acp-bridge` — confirm the symlink is removed
- [ ] Drive the bridge from agent-shell — confirm tool calls show file paths / commands, not just `read_file` / `edit_file`