### PR TITLE
Improve auto-compaction: smaller pin window + smarter slim

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1274,7 +1274,7 @@ export class AgentLoop implements AgentBackend {
         // Compact deeply — shallow targets buy only 1–2 turns of runway on
         // tool-heavy workloads.
         const target = Math.floor(threshold * 0.25);
-        const result = this.compactWithHooks(target, 6);
+        const result = this.compactWithHooks(target, 1);
         if (!result) {
           // Auto-compact fired but nothing was evictable. This can happen
           // in short conversations with heavy tool output where the pin
@@ -1674,7 +1674,7 @@ export class AgentLoop implements AgentBackend {
         if (this.isContextOverflow(e)) {
           const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
           const target = Math.floor((contextWindow - RESPONSE_RESERVE) * 0.6);
-          const stats = this.compactWithHooks(target, 6);
+          const stats = this.compactWithHooks(target, 1);
           // If compaction freed nothing, retrying will hit the same error.
           // Surface the real failure instead of looping until exhaustion.
           if (!stats || stats.after >= stats.before) {

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -71,6 +71,20 @@ function recencyWeight(idx: number, total: number): number {
   return Math.max(0.1, 1 - idx / total);
 }
 
+// Head+tail because the start (command, opening lines) and end (final
+// result, exit code) are the informative parts of shell/file output.
+function slimToolContent(content: string, maxLen: number): string {
+  const exitMatch = content.match(/exit code:?\s*(\d+)/i);
+  const exitSuffix = exitMatch ? ` (exit ${exitMatch[1]})` : "";
+  const lines = content.split("\n");
+  if (lines.length > 6) {
+    const head = lines.slice(0, 3).join("\n");
+    const tail = lines.slice(-2).join("\n");
+    return `${head}\n... [${lines.length - 5} lines trimmed by compact]\n${tail}${exitSuffix}`;
+  }
+  return `${content.slice(0, maxLen)}\n... [${content.length - maxLen} chars trimmed by compact]${exitSuffix}`;
+}
+
 /**
  * Conversation state with eager nucleation — shell-history shaped.
  *
@@ -702,6 +716,7 @@ export class ConversationState {
 
   private slimTurn(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
     const MAX_RESULT_LEN = 1500;
+    const MAX_ASSISTANT_LEN = 1500;
     const result: ChatCompletionMessageParam[] = [];
     const droppedToolIds = new Set<string>();
 
@@ -730,10 +745,17 @@ export class ConversationState {
         if (droppedToolIds.has(msg.tool_call_id)) continue;
         const content = typeof msg.content === "string" ? msg.content : "";
         if (content.length > MAX_RESULT_LEN) {
-          result.push({ ...msg, content: content.slice(0, MAX_RESULT_LEN) + "\n... [truncated by compact]" });
+          result.push({ ...msg, content: slimToolContent(content, MAX_RESULT_LEN) });
         } else {
           result.push(msg);
         }
+        continue;
+      }
+      if (msg.role === "assistant" && typeof msg.content === "string" && msg.content.length > MAX_ASSISTANT_LEN) {
+        const head = msg.content.slice(0, Math.floor(MAX_ASSISTANT_LEN * 0.6));
+        const tail = msg.content.slice(-Math.floor(MAX_ASSISTANT_LEN * 0.2));
+        const trimmed = msg.content.length - head.length - tail.length;
+        result.push({ ...msg, content: `${head}\n... [${trimmed} chars trimmed by compact]\n${tail}` });
         continue;
       }
       result.push(msg);


### PR DESCRIPTION
## Summary
- Drop the recent-turn pin window from 6 to 1 on both auto-compact paths. Previously the compactor pinned 7 turns total (first + 5 slimmed + 1 verbatim), which left little headroom on tool-heavy workloads. Now pin only the first and last turn; everything else gets evicted to nuclear one-liners.
- Replace the cliff-cut slim with head + tail truncation. For multi-line tool output (shell, file reads) the start and end are usually the informative parts. The `exit N` line is preserved as a suffix so the agent can still tell whether a command succeeded post-truncation.
- Long assistant prose now gets a head + tail trim too instead of passing through untouched.

Both slim ideas are ported from superash's `context-trim.ts`, which has been running these heuristics in practice.

## Test plan
- [ ] Verify auto-compact still fires at the threshold and produces a sensible message tail
- [ ] Confirm overflow-retry path compacts and retries without hitting `before === after`
- [ ] Eyeball a slimmed shell turn — exit code should survive, head + tail should be readable