### PR TITLE
Make tool registration surface advisable

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -92,7 +92,7 @@ export interface AgentLoopConfig {
 
 export class AgentLoop implements AgentBackend {
   private abortController: AbortController | null = null;
-  private toolRegistry = new ToolRegistry();
+  private toolRegistry: ToolRegistry;
   private history: HistoryAdapter;
   private conversation: ConversationState;
   private fileReadCache: FileReadCache = new Map();
@@ -149,6 +149,7 @@ export class AgentLoop implements AgentBackend {
     this.handlers = config.handlers;
     this.compositor = config.compositor ?? null;
     this.instanceId = config.instanceId ?? "unknown";
+    this.toolRegistry = new ToolRegistry(this.handlers);
 
     // Shell-history-shaped log. Default writes go through the advisable
     // `history:append` handler registered below; extensions swap the
@@ -1161,7 +1162,7 @@ export class AgentLoop implements AgentBackend {
       }
       let result: Awaited<ReturnType<typeof tool.execute>>;
       try {
-        result = await raceAbort(tool.execute(args, onChunk, toolCtx), signal);
+        result = await raceAbort(this.toolRegistry.call(name, args, onChunk, toolCtx), signal);
       } catch (err) {
         if (signal.aborted) {
           try { this.handlers.call("tool:cancel", { name, args, reason: "user-aborted" }); } catch {}

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -482,11 +482,12 @@ export class AgentLoop implements AgentBackend {
   /** Register a named instruction block for the system prompt. */
   registerInstruction(name: string, text: string, extensionName: string): void {
     this.instructions.set(name, { text, extensionName });
+    this.handlers.define(`instruction:${name}`, () => this.instructions.get(name)?.text ?? "");
   }
 
-  /** Remove a named instruction block. */
   removeInstruction(name: string): void {
     this.instructions.delete(name);
+    // Handler entry retained so external advisors survive a reload of the owner.
   }
 
   /** Register a named skill (on-demand reference material). */
@@ -519,8 +520,9 @@ export class AgentLoop implements AgentBackend {
     const ensure = (name: string): ExtensionGroup =>
       groups.get(name) ?? (groups.set(name, { tools: [], skills: [], instructions: [] }).get(name)!);
 
-    // Attribute instructions
-    for (const { text, extensionName } of this.instructions.values()) {
+    // Attribute instructions — read text through the advisor chain
+    for (const [name, { extensionName }] of this.instructions) {
+      const text = this.handlers.call(`instruction:${name}`) as string;
       ensure(extensionName).instructions.push({ text });
     }
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -21,7 +21,7 @@ import * as fsSync from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { computeDiff, computeEditDiff, computeInputDiff } from "../utils/diff.js";
-import type { AgentBackend, ToolDefinition, ToolExecutionContext } from "./types.js";
+import type { AgentBackend, SkillView, ToolDefinition, ToolExecutionContext } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { normalizeToolArgs } from "./normalize-args.js";
 import { ConversationState, type CompactResult } from "./conversation-state.js";
@@ -493,11 +493,15 @@ export class AgentLoop implements AgentBackend {
   /** Register a named skill (on-demand reference material). */
   registerSkill(name: string, description: string, filePath: string, extensionName: string): void {
     this.skills.set(name, { description, filePath, extensionName });
+    this.handlers.define(`skill:${name}:view`, (): SkillView => {
+      const s = this.skills.get(name);
+      return { description: s?.description ?? "", filePath: s?.filePath ?? "" };
+    });
   }
 
-  /** Remove a registered skill. */
   removeSkill(name: string): void {
     this.skills.delete(name);
+    // Handler entry retained so external advisors survive a reload of the owner.
   }
 
   /**
@@ -526,9 +530,10 @@ export class AgentLoop implements AgentBackend {
       ensure(extensionName).instructions.push({ text });
     }
 
-    // Attribute skills
-    for (const [skillName, { description, filePath, extensionName }] of this.skills) {
-      ensure(extensionName).skills.push({ name: skillName, description, filePath });
+    // Attribute skills — read description/filePath through the advisor chain
+    for (const [skillName, { extensionName }] of this.skills) {
+      const view = this.handlers.call(`skill:${skillName}:view`) as SkillView;
+      ensure(extensionName).skills.push({ name: skillName, description: view.description, filePath: view.filePath });
     }
 
     // Attribute tools (skip built-in scratchpad tools).

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -540,7 +540,7 @@ export class AgentLoop implements AgentBackend {
         "bash", "read_file", "write_file", "edit_file", "grep", "glob", "ls",
         "list_skills",
       ]);
-      for (const tool of this.toolRegistry.all()) {
+      for (const tool of this.toolRegistry.allView()) {
         if (builtinTools.has(tool.name)) continue;
         const extName = this.toolExtensions.get(tool.name);
         if (!extName) continue;
@@ -1737,8 +1737,9 @@ export class AgentLoop implements AgentBackend {
     const pendingToolCalls: PendingToolCall[] = [];
 
     // Tool protocol controls what goes in the API tools param vs dynamic context
-    const apiTools = this.toolProtocol.getApiTools(this.toolRegistry.all());
-    const toolPrompt = this.toolProtocol.getToolPrompt(this.toolRegistry.all());
+    const toolView = this.toolRegistry.allView();
+    const apiTools = this.toolProtocol.getApiTools(toolView);
+    const toolPrompt = this.toolProtocol.getToolPrompt(toolView);
 
     // Dynamic context rides on the trailing message — see
     // wrapTrailingWithDynamicContext for the cache-stability rationale.

--- a/src/agent/tool-registry.ts
+++ b/src/agent/tool-registry.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition, ToolResult } from "./types.js";
+import type { ToolDefinition, ToolResult, ToolSchemaView } from "./types.js";
 import type { ChatCompletionTool } from "../utils/llm-client.js";
 import type { HandlerFunctions } from "../utils/handler-registry.js";
 import { registerReadOnlyTool, unregisterReadOnlyTool } from "./nuclear-form.js";
@@ -19,6 +19,10 @@ export class ToolRegistry {
     }
     this.tools.set(tool.name, tool);
     this.handlers.define(`tool:${tool.name}`, tool.execute.bind(tool));
+    this.handlers.define(`tool:${tool.name}:schema`, (): ToolSchemaView => ({
+      description: tool.description,
+      parameters: tool.input_schema,
+    }));
     if (tool.readOnly) registerReadOnlyTool(tool.name);
     else unregisterReadOnlyTool(tool.name);
   }
@@ -26,9 +30,8 @@ export class ToolRegistry {
   unregister(name: string): void {
     this.tools.delete(name);
     unregisterReadOnlyTool(name);
-    // The handler entry is intentionally left in place: any advisors a
-    // user extension installed against `tool:<name>` survive a reload of
-    // the tool's owner, and are picked up when the same name re-registers.
+    // Handler entry intentionally retained so external advisors survive a
+    // reload of the tool's owner and reattach when the name re-registers.
   }
 
   get(name: string): ToolDefinition | undefined {
@@ -39,13 +42,19 @@ export class ToolRegistry {
     return Array.from(this.tools.values());
   }
 
+  allView(): ToolDefinition[] {
+    return this.all().map((t) => {
+      const view = this.handlers.call(`tool:${t.name}:schema`) as ToolSchemaView;
+      return { ...t, description: view.description, input_schema: view.parameters };
+    });
+  }
+
   call(name: string, ...args: Parameters<ToolDefinition["execute"]>): Promise<ToolResult> {
     return this.handlers.call(`tool:${name}`, ...args) as Promise<ToolResult>;
   }
 
-  /** Convert to OpenAI-compatible tool schemas for API calls. */
   toAPITools(): ChatCompletionTool[] {
-    return this.all().map((t) => ({
+    return this.allView().map((t) => ({
       type: "function" as const,
       function: {
         name: t.name,

--- a/src/agent/tool-registry.ts
+++ b/src/agent/tool-registry.ts
@@ -1,16 +1,24 @@
-import type { ToolDefinition } from "./types.js";
+import type { ToolDefinition, ToolResult } from "./types.js";
 import type { ChatCompletionTool } from "../utils/llm-client.js";
+import type { HandlerFunctions } from "../utils/handler-registry.js";
 import { registerReadOnlyTool, unregisterReadOnlyTool } from "./nuclear-form.js";
 
 /**
- * Registry for agent tools. Holds tool definitions and converts them
- * to OpenAI-compatible function schemas for API calls.
+ * Registry for agent tools. Execution is routed through the named-handler
+ * registry under `tool:<name>` so extensions can `advise` a tool without
+ * owning it; duplicate `register` calls throw rather than silently evict.
  */
 export class ToolRegistry {
   private tools = new Map<string, ToolDefinition>();
 
+  constructor(private handlers: HandlerFunctions) {}
+
   register(tool: ToolDefinition): void {
+    if (this.tools.has(tool.name)) {
+      throw new Error(`Tool "${tool.name}" already registered. Use ctx.adviseTool() to wrap it.`);
+    }
     this.tools.set(tool.name, tool);
+    this.handlers.define(`tool:${tool.name}`, tool.execute.bind(tool));
     if (tool.readOnly) registerReadOnlyTool(tool.name);
     else unregisterReadOnlyTool(tool.name);
   }
@@ -18,6 +26,9 @@ export class ToolRegistry {
   unregister(name: string): void {
     this.tools.delete(name);
     unregisterReadOnlyTool(name);
+    // The handler entry is intentionally left in place: any advisors a
+    // user extension installed against `tool:<name>` survive a reload of
+    // the tool's owner, and are picked up when the same name re-registers.
   }
 
   get(name: string): ToolDefinition | undefined {
@@ -26,6 +37,10 @@ export class ToolRegistry {
 
   all(): ToolDefinition[] {
     return Array.from(this.tools.values());
+  }
+
+  call(name: string, ...args: Parameters<ToolDefinition["execute"]>): Promise<ToolResult> {
+    return this.handlers.call(`tool:${name}`, ...args) as Promise<ToolResult>;
   }
 
   /** Convert to OpenAI-compatible tool schemas for API calls. */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -71,6 +71,12 @@ export interface ToolExecutionContext {
   signal?: AbortSignal;
 }
 
+/** LLM-facing view of a tool — what `adviseToolSchema` advisors return. */
+export interface ToolSchemaView {
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
 export interface ToolDefinition {
   name: string;
   /** Short label for TUI display (e.g. "search" instead of "ads_search"). Defaults to name. */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -77,6 +77,12 @@ export interface ToolSchemaView {
   parameters: Record<string, unknown>;
 }
 
+/** LLM-facing view of a skill — what `adviseSkill` advisors return. */
+export interface SkillView {
+  description: string;
+  filePath: string;
+}
+
 export interface ToolDefinition {
   name: string;
   /** Short label for TUI display (e.g. "search" instead of "ads_search"). Defaults to name. */

--- a/src/core.ts
+++ b/src/core.ts
@@ -215,6 +215,10 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         },
         registerCommand: (name, description, handler) =>
           bus.emit("command:register", { name, description, handler }),
+        adviseCommand: (name, advisor) => {
+          const key = name.startsWith("/") ? name : `/${name}`;
+          return handlers.advise(`command:${key}`, advisor as Parameters<typeof handlers.advise>[1]);
+        },
         registerTool: (tool) => bus.emit("agent:register-tool", { tool, extensionName: "" }),
         unregisterTool: (name) => bus.emit("agent:unregister-tool", { name }),
         adviseTool: (name, advisor) => handlers.advise(`tool:${name}`, advisor as Parameters<typeof handlers.advise>[1]),

--- a/src/core.ts
+++ b/src/core.ts
@@ -222,6 +222,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         getTools: () => bus.emitPipe("agent:get-tools", { tools: [] }).tools,
         registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text, extensionName: "" }),
         removeInstruction: (name) => bus.emit("agent:remove-instruction", { name }),
+        adviseInstruction: (name, advisor) => handlers.advise(`instruction:${name}`, advisor as Parameters<typeof handlers.advise>[1]),
         registerSkill: (name, description, filePath) => bus.emit("agent:register-skill", { name, description, filePath, extensionName: "" }),
         removeSkill: (name) => bus.emit("agent:remove-skill", { name }),
         registerContextProducer: (_name, producer, opts) => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -225,6 +225,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         adviseInstruction: (name, advisor) => handlers.advise(`instruction:${name}`, advisor as Parameters<typeof handlers.advise>[1]),
         registerSkill: (name, description, filePath) => bus.emit("agent:register-skill", { name, description, filePath, extensionName: "" }),
         removeSkill: (name) => bus.emit("agent:remove-skill", { name }),
+        adviseSkill: (name, advisor) => handlers.advise(`skill:${name}:view`, advisor as Parameters<typeof handlers.advise>[1]),
         registerContextProducer: (_name, producer, opts) => {
           const handlerName = opts?.mode === "per-query"
             ? "query-context:build"

--- a/src/core.ts
+++ b/src/core.ts
@@ -217,6 +217,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
           bus.emit("command:register", { name, description, handler }),
         registerTool: (tool) => bus.emit("agent:register-tool", { tool, extensionName: "" }),
         unregisterTool: (name) => bus.emit("agent:unregister-tool", { name }),
+        adviseTool: (name, advisor) => handlers.advise(`tool:${name}`, advisor as Parameters<typeof handlers.advise>[1]),
         getTools: () => bus.emitPipe("agent:get-tools", { tools: [] }).tools,
         registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text, extensionName: "" }),
         removeInstruction: (name) => bus.emit("agent:remove-instruction", { name }),

--- a/src/core.ts
+++ b/src/core.ts
@@ -218,6 +218,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         registerTool: (tool) => bus.emit("agent:register-tool", { tool, extensionName: "" }),
         unregisterTool: (name) => bus.emit("agent:unregister-tool", { name }),
         adviseTool: (name, advisor) => handlers.advise(`tool:${name}`, advisor as Parameters<typeof handlers.advise>[1]),
+        adviseToolSchema: (name, advisor) => handlers.advise(`tool:${name}:schema`, advisor as Parameters<typeof handlers.advise>[1]),
         getTools: () => bus.emitPipe("agent:get-tools", { tools: [] }).tools,
         registerInstruction: (name, text) => bus.emit("agent:register-instruction", { name, text, extensionName: "" }),
         removeInstruction: (name) => bus.emit("agent:remove-instruction", { name }),

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -99,6 +99,13 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     cleanups.push(() => bus.emit("agent:unregister-tool", { name: tool.name }));
   };
 
+  // Track adviseTool registrations so /reload tears them down
+  const scopedAdviseTool: typeof ctx.adviseTool = (name, advisor) => {
+    const unadvise = ctx.adviseTool(name, advisor);
+    cleanups.push(unadvise);
+    return unadvise;
+  };
+
   // Track slash command registrations — without this, reloading an
   // extension stacks its commands (old `/status` + new `/status`) in
   // the slash-commands registry.
@@ -118,6 +125,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     registerContextProducer: scopedRegisterContextProducer,
     registerTool: scopedRegisterTool,
     unregisterTool: ctx.unregisterTool,
+    adviseTool: scopedAdviseTool,
     registerCommand: scopedRegisterCommand,
     onDispose: (fn: () => void) => { cleanups.push(fn); },
   };

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -103,6 +103,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
   const scopedAdviseTool: typeof ctx.adviseTool = trackUnsub(ctx.adviseTool);
   const scopedAdviseToolSchema: typeof ctx.adviseToolSchema = trackUnsub(ctx.adviseToolSchema);
   const scopedAdviseInstruction: typeof ctx.adviseInstruction = trackUnsub(ctx.adviseInstruction);
+  const scopedAdviseSkill: typeof ctx.adviseSkill = trackUnsub(ctx.adviseSkill);
 
   // Track slash command registrations — without this, reloading an
   // extension stacks its commands (old `/status` + new `/status`) in
@@ -126,6 +127,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     adviseTool: scopedAdviseTool,
     adviseToolSchema: scopedAdviseToolSchema,
     adviseInstruction: scopedAdviseInstruction,
+    adviseSkill: scopedAdviseSkill,
     registerCommand: scopedRegisterCommand,
     onDispose: (fn: () => void) => { cleanups.push(fn); },
   };

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -104,6 +104,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
   const scopedAdviseToolSchema: typeof ctx.adviseToolSchema = trackUnsub(ctx.adviseToolSchema);
   const scopedAdviseInstruction: typeof ctx.adviseInstruction = trackUnsub(ctx.adviseInstruction);
   const scopedAdviseSkill: typeof ctx.adviseSkill = trackUnsub(ctx.adviseSkill);
+  const scopedAdviseCommand: typeof ctx.adviseCommand = trackUnsub(ctx.adviseCommand);
 
   // Track slash command registrations — without this, reloading an
   // extension stacks its commands (old `/status` + new `/status`) in
@@ -128,6 +129,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     adviseToolSchema: scopedAdviseToolSchema,
     adviseInstruction: scopedAdviseInstruction,
     adviseSkill: scopedAdviseSkill,
+    adviseCommand: scopedAdviseCommand,
     registerCommand: scopedRegisterCommand,
     onDispose: (fn: () => void) => { cleanups.push(fn); },
   };

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -102,6 +102,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
 
   const scopedAdviseTool: typeof ctx.adviseTool = trackUnsub(ctx.adviseTool);
   const scopedAdviseToolSchema: typeof ctx.adviseToolSchema = trackUnsub(ctx.adviseToolSchema);
+  const scopedAdviseInstruction: typeof ctx.adviseInstruction = trackUnsub(ctx.adviseInstruction);
 
   // Track slash command registrations — without this, reloading an
   // extension stacks its commands (old `/status` + new `/status`) in
@@ -124,6 +125,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     unregisterTool: ctx.unregisterTool,
     adviseTool: scopedAdviseTool,
     adviseToolSchema: scopedAdviseToolSchema,
+    adviseInstruction: scopedAdviseInstruction,
     registerCommand: scopedRegisterCommand,
     onDispose: (fn: () => void) => { cleanups.push(fn); },
   };

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -67,12 +67,13 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     cleanups.push(() => bus.offPipe(event, fn));
   }) as typeof bus.onPipe;
 
-  // Track advise registrations
-  const scopedAdvise: typeof ctx.advise = (name, wrapper) => {
-    const unadvise = ctx.advise(name, wrapper);
-    cleanups.push(unadvise);
-    return unadvise;
+  // Wrap any (name, fn) → unsubscribe registrar so its disposer runs on teardown.
+  const trackUnsub = <A, B>(fn: (a: A, b: B) => () => void) => (a: A, b: B) => {
+    const unsub = fn(a, b);
+    cleanups.push(unsub);
+    return unsub;
   };
+  const scopedAdvise: typeof ctx.advise = trackUnsub(ctx.advise);
 
   // Track instruction registrations — extension name captured in scope
   const scopedRegisterInstruction: typeof ctx.registerInstruction = (name, text) => {
@@ -99,12 +100,8 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     cleanups.push(() => bus.emit("agent:unregister-tool", { name: tool.name }));
   };
 
-  // Track adviseTool registrations so /reload tears them down
-  const scopedAdviseTool: typeof ctx.adviseTool = (name, advisor) => {
-    const unadvise = ctx.adviseTool(name, advisor);
-    cleanups.push(unadvise);
-    return unadvise;
-  };
+  const scopedAdviseTool: typeof ctx.adviseTool = trackUnsub(ctx.adviseTool);
+  const scopedAdviseToolSchema: typeof ctx.adviseToolSchema = trackUnsub(ctx.adviseToolSchema);
 
   // Track slash command registrations — without this, reloading an
   // extension stacks its commands (old `/status` + new `/status`) in
@@ -126,6 +123,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     registerTool: scopedRegisterTool,
     unregisterTool: ctx.unregisterTool,
     adviseTool: scopedAdviseTool,
+    adviseToolSchema: scopedAdviseToolSchema,
     registerCommand: scopedRegisterCommand,
     onDispose: (fn: () => void) => { cleanups.push(fn); },
   };

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -27,7 +27,11 @@ export default function activate(ctx: ExtensionContext): void {
 
   const register = (cmd: SlashCommand) => {
     const name = cmd.name.startsWith("/") ? cmd.name : `/${cmd.name}`;
+    if (commands.has(name)) {
+      throw new Error(`Command "${name}" already registered. Use ctx.adviseCommand() to wrap it.`);
+    }
     commands.set(name, { ...cmd, name });
+    ctx.define(`command:${name}`, cmd.handler);
   };
 
   // ── Built-in commands ─────────────────────────────────────────
@@ -118,6 +122,7 @@ export default function activate(ctx: ExtensionContext): void {
   bus.on("command:unregister", ({ name }) => {
     const key = name.startsWith("/") ? name : `/${name}`;
     commands.delete(key);
+    // Handler entry retained so external advisors survive a reload of the owner.
   });
 
   // ── Skill commands (/skill:<name>) ────────────────────────────
@@ -240,7 +245,7 @@ export default function activate(ctx: ExtensionContext): void {
 
     const cmd = commands.get(e.name);
     if (cmd) {
-      const result = cmd.handler(e.args);
+      const result = ctx.call(`command:${e.name}`, e.args);
       if (result instanceof Promise) {
         result.catch((err) => {
           bus.emit("ui:error", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,11 @@ export interface ExtensionContext {
   registerInstruction: (name: string, text: string) => void;
   /** Remove a named instruction block from the system prompt. */
   removeInstruction: (name: string) => void;
+  /** Wrap an already-registered instruction's text. */
+  adviseInstruction: (
+    name: string,
+    advisor: (next: () => string) => string,
+  ) => () => void;
 
   // ── Skill registration ────────────────────────────────────
   /** Register a skill (on-demand reference material) for the agent. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,10 +151,25 @@ export interface ExtensionContext {
   registerCommand: (name: string, description: string, handler: (args: string) => Promise<void> | void) => void;
 
   // ── Tool registration (agent-sh backend only) ─────────────
-  /** Register a tool for the built-in agent. No-op when using bridge backends. */
+  /** Register a tool for the built-in agent. No-op when using bridge backends.
+   *  Throws if a tool with the same name is already registered — use
+   *  `adviseTool` to wrap an existing tool instead of replacing it. */
   registerTool: (tool: ToolDefinition) => void;
   /** Unregister a tool by name. */
   unregisterTool: (name: string) => void;
+  /** Wrap an already-registered tool's execution. The advisor receives
+   *  `next` (the underlying chain) and the original execute() arguments;
+   *  call `next` to delegate, skip it to short-circuit, transform its
+   *  result to post-process. Returns an unadvise function. */
+  adviseTool: (
+    name: string,
+    advisor: (
+      next: ToolDefinition["execute"],
+      args: Record<string, unknown>,
+      onChunk?: (chunk: string) => void,
+      ctx?: import("./agent/types.js").ToolExecutionContext,
+    ) => ReturnType<ToolDefinition["execute"]>,
+  ) => () => void;
   /** Get all registered tools (for subagent tool subsets). Returns [] when using bridge backends. */
   getTools: () => ToolDefinition[];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,15 @@ export interface ExtensionContext {
   // ── Slash command registration ─────────────────────────────
   /** Register a slash command available in any input mode. */
   registerCommand: (name: string, description: string, handler: (args: string) => Promise<void> | void) => void;
+  /** Wrap an already-registered command's handler. Name is normalized
+   *  (leading `/` optional). */
+  adviseCommand: (
+    name: string,
+    advisor: (
+      next: (args: string) => Promise<void> | void,
+      args: string,
+    ) => Promise<void> | void,
+  ) => () => void;
 
   // ── Tool registration (agent-sh backend only) ─────────────
   /** Throws on duplicate name — use `adviseTool` to wrap, not replace.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { EventBus, ContentBlock } from "./event-bus.js";
 import type { ColorPalette } from "./utils/palette.js";
 import type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
-import type { ToolDefinition, ToolSchemaView } from "./agent/types.js";
+import type { SkillView, ToolDefinition, ToolSchemaView } from "./agent/types.js";
 import type { Compositor } from "./utils/compositor.js";
 import type { HistoryAdapter } from "./agent/history-file.js";
 
@@ -189,6 +189,12 @@ export interface ExtensionContext {
   registerSkill: (name: string, description: string, filePath: string) => void;
   /** Remove a registered skill by name. */
   removeSkill: (name: string) => void;
+  /** Wrap an already-registered skill's LLM-facing view. Skill name is
+   *  frozen (dispatch key for the catalog). */
+  adviseSkill: (
+    name: string,
+    advisor: (next: () => SkillView) => SkillView,
+  ) => () => void;
 
   // ── Dynamic context registration ──────────────────────────
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { EventBus, ContentBlock } from "./event-bus.js";
 import type { ColorPalette } from "./utils/palette.js";
 import type { BlockTransformOptions, FencedBlockTransformOptions } from "./utils/stream-transform.js";
-import type { ToolDefinition } from "./agent/types.js";
+import type { ToolDefinition, ToolSchemaView } from "./agent/types.js";
 import type { Compositor } from "./utils/compositor.js";
 import type { HistoryAdapter } from "./agent/history-file.js";
 
@@ -151,16 +151,10 @@ export interface ExtensionContext {
   registerCommand: (name: string, description: string, handler: (args: string) => Promise<void> | void) => void;
 
   // ── Tool registration (agent-sh backend only) ─────────────
-  /** Register a tool for the built-in agent. No-op when using bridge backends.
-   *  Throws if a tool with the same name is already registered — use
-   *  `adviseTool` to wrap an existing tool instead of replacing it. */
+  /** Throws on duplicate name — use `adviseTool` to wrap, not replace.
+   *  No-op under bridge backends. */
   registerTool: (tool: ToolDefinition) => void;
-  /** Unregister a tool by name. */
   unregisterTool: (name: string) => void;
-  /** Wrap an already-registered tool's execution. The advisor receives
-   *  `next` (the underlying chain) and the original execute() arguments;
-   *  call `next` to delegate, skip it to short-circuit, transform its
-   *  result to post-process. Returns an unadvise function. */
   adviseTool: (
     name: string,
     advisor: (
@@ -170,7 +164,13 @@ export interface ExtensionContext {
       ctx?: import("./agent/types.js").ToolExecutionContext,
     ) => ReturnType<ToolDefinition["execute"]>,
   ) => () => void;
-  /** Get all registered tools (for subagent tool subsets). Returns [] when using bridge backends. */
+  /** Tool name is frozen (dispatch key). If an advisor adds a parameter,
+   *  pair with `adviseTool` so the underlying exec accepts it. */
+  adviseToolSchema: (
+    name: string,
+    advisor: (next: () => ToolSchemaView) => ToolSchemaView,
+  ) => () => void;
+  /** Returns [] under bridge backends. */
   getTools: () => ToolDefinition[];
 
   // ── System prompt instructions ────────────────────────────


### PR DESCRIPTION
## Summary
Five commits that turn the agent's registration surface into an advice chain — so two extensions can compose around one name instead of conflicting on it. Same shape applied uniformly: register also `define`s a named handler, the consumer reads through the chain, a typed `advise*` API wraps it, duplicate registrations throw, and the handler entry is retained on unregister so external advisors survive a reload of the owner.

1. **Tool execution** (`adviseTool`) — `tool:<name>` handler; `agent-loop.executeToolCall` invokes through it.
2. **Tool schema** (`adviseToolSchema`) — `tool:<name>:schema` handler returns `{description, parameters}`; `toolRegistry.allView()` materializes per-tool views; LLM-facing call sites read `allView`. Tool name is frozen (it's the dispatch key).
3. **Instructions** (`adviseInstruction`) — `instruction:<name>` handler returns the text; `buildExtensionSections` reads through the chain.
4. **Skills** (`adviseSkill`) — `skill:<name>:view` handler returns a `SkillView` ({description, filePath}); `buildExtensionSections` reads through the chain. Skill name is frozen.
5. **Slash commands** (`adviseCommand`) — `command:<name>` handler holds the command's function; `command:execute` dispatches through the chain.

Context producers were considered but skipped: `registerContextProducer` is already implemented as a `handlers.advise` over the shared `dynamic-context:build`/`query-context:build` chain (core.ts:226-237), so producers are composable by construction.

Result rendering is also already covered by the existing `agent:tool-completed` pipe — no change needed.

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Run agent-sh, exercise core tools (bash, read_file, edit_file, grep, glob, ls) and built-in commands (/help, /model, /reload) — behavior unchanged when no advisor is installed
- [ ] Throwaway extension calls `ctx.adviseTool("edit_file", (next, args, onChunk, c) => next(args, onChunk, c))` and confirm the advisor wraps execution
- [ ] Same extension calls `ctx.adviseToolSchema("edit_file", (next) => { const s = next(); return { ...s, description: s.description + "\n\nNOTE: prefer dry runs." }; })` and confirm the modified description shows up in the next LLM request's tools array
- [ ] `ctx.adviseInstruction("some-instruction", (next) => next() + "\n\nappended.")` — confirm appended text in system prompt
- [ ] `ctx.adviseSkill("some-skill", (next) => ({ ...next(), description: "wrapped: " + next().description }))` — confirm catalog entry reflects it
- [ ] `ctx.adviseCommand("/help", (next, args) => { console.log("intercepted"); return next(args); })` — confirm interception fires before /help runs
- [ ] Reload the advisor extension via `/reload` and confirm all unadvise hooks fire (no stacked wrappers)
- [ ] Try registering a duplicate tool/command name from a second extension and confirm the new error surfaces with the advise* hint