### PR TITLE
Make input-mode submit advisable

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -215,6 +215,7 @@ export function createCore(config: AgentShellConfig): AgentShellCore {
         },
         registerCommand: (name, description, handler) =>
           bus.emit("command:register", { name, description, handler }),
+        adviseInputMode: (id, advisor) => handlers.advise(`input-mode:${id}:submit`, advisor as Parameters<typeof handlers.advise>[1]),
         adviseCommand: (name, advisor) => {
           const key = name.startsWith("/") ? name : `/${name}`;
           return handlers.advise(`command:${key}`, advisor as Parameters<typeof handlers.advise>[1]);

--- a/src/extension-loader.ts
+++ b/src/extension-loader.ts
@@ -105,6 +105,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
   const scopedAdviseInstruction: typeof ctx.adviseInstruction = trackUnsub(ctx.adviseInstruction);
   const scopedAdviseSkill: typeof ctx.adviseSkill = trackUnsub(ctx.adviseSkill);
   const scopedAdviseCommand: typeof ctx.adviseCommand = trackUnsub(ctx.adviseCommand);
+  const scopedAdviseInputMode: typeof ctx.adviseInputMode = trackUnsub(ctx.adviseInputMode);
 
   // Track slash command registrations — without this, reloading an
   // extension stacks its commands (old `/status` + new `/status`) in
@@ -130,6 +131,7 @@ function createScopedContext(ctx: ExtensionContext, extensionName: string): { sc
     adviseInstruction: scopedAdviseInstruction,
     adviseSkill: scopedAdviseSkill,
     adviseCommand: scopedAdviseCommand,
+    adviseInputMode: scopedAdviseInputMode,
     registerCommand: scopedRegisterCommand,
     onDispose: (fn: () => void) => { cleanups.push(fn); },
   };

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -19,6 +19,12 @@ export interface InputContext {
   freshPrompt(): void;
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface InputHandlers {
+  define: (name: string, fn: (...a: any[]) => any) => void;
+  call: (name: string, ...a: any[]) => any;
+}
+
 /** Line editor + shell-passthrough buffer. Delegates rendering to TuiInputView. */
 export class InputHandler {
   private ctx: InputContext;
@@ -36,17 +42,20 @@ export class InputHandler {
   private savedBuffer = "";
   private escapeTimer: ReturnType<typeof setTimeout> | null = null;
   private bus: EventBus;
+  private handlers: InputHandlers;
   private onShowAgentInfo: () => { info: string; model?: string };
   private view: TuiInputView;
 
   constructor(opts: {
     ctx: InputContext;
     bus: EventBus;
+    handlers: InputHandlers;
     onShowAgentInfo: () => { info: string; model?: string };
     view?: TuiInputView;
   }) {
     this.ctx = opts.ctx;
     this.bus = opts.bus;
+    this.handlers = opts.handlers;
     this.onShowAgentInfo = opts.onShowAgentInfo;
     this.view = opts.view ?? new TuiInputView();
     this.loadHistory();
@@ -69,6 +78,7 @@ export class InputHandler {
     }
     this.modes.set(config.trigger, config);
     this.modesById.set(config.id, config);
+    this.handlers.define(`input-mode:${config.id}:submit`, config.onSubmit.bind(config));
   }
 
   private loadHistory(): void {
@@ -390,7 +400,7 @@ export class InputHandler {
             }
           } else if (query) {
             this.pendingReturnMode = currentMode.returnToSelf ? currentMode.id : null;
-            currentMode.onSubmit(query, this.bus);
+            this.handlers.call(`input-mode:${currentMode.id}:submit`, query, this.bus);
           } else {
             this.exitMode();
           }

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -236,6 +236,7 @@ export class Shell implements InputContext {
     this.inputHandler = new InputHandler({
       ctx: this,
       bus: opts.bus,
+      handlers: opts.handlers,
       onShowAgentInfo: opts.onShowAgentInfo ?? (() => ({ info: "" })),
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,19 @@ export interface ExtensionContext {
    */
   getStoragePath: (namespace: string) => string;
 
+  // ── Input mode registration ───────────────────────────────
+  /** Wrap an input mode's `onSubmit`. Lets extensions transform queries
+   *  on the way to the agent (logging, redaction, vetoing). The mode
+   *  must already be registered via the `input-mode:register` bus event. */
+  adviseInputMode: (
+    id: string,
+    advisor: (
+      next: (query: string, bus: EventBus) => void,
+      query: string,
+      bus: EventBus,
+    ) => void,
+  ) => () => void;
+
   // ── Slash command registration ─────────────────────────────
   /** Register a slash command available in any input mode. */
   registerCommand: (name: string, description: string, handler: (args: string) => Promise<void> | void) => void;


### PR DESCRIPTION
## Summary
Follow-up to #145, applying the same handler-registry + advice pattern to one more single-owner surface — input modes.

`InputHandler.registerMode` (src/shell/input-handler.ts) used to store each mode in a Map and call `onSubmit` directly at dispatch time. A second extension that wanted to log, redact, or veto queries had no clean way to interpose. After this change, registration also defines an `input-mode:<id>:submit` handler; dispatch routes through the chain; extensions wrap via `ctx.adviseInputMode(id, advisor)`.

`ShellHandlers` (already passed to `Shell`) is threaded through to `InputHandler` so it can `define`/`call` without a new dependency on the full handler-registry.

Use cases that motivated this:
- log every agent query to a remote sink without modifying the agent extension
- redact secrets from queries before they reach the LLM
- gate submission behind a confirm dialog for specific modes

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Run agent-sh, submit normal queries — behavior unchanged when no advisor is installed
- [ ] Throwaway extension calls `ctx.adviseInputMode("agent", (next, query, bus) => { console.error("[intercept]", query); next(query, bus); })` and confirm the log fires before the query reaches the agent
- [ ] Same advisor returns without calling `next` and confirm the query is suppressed
- [ ] Reload the advisor extension via `/reload` and confirm the unadvise hook fires (no stacked wrappers)