### PR TITLE
Make bundled extensions installable from a published agent-sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "examples/extensions/*/package.json",
     "examples/extensions/*/tsconfig.json",
     "examples/extensions/*/README.md",
-    "examples/extensions/*/src",
+    "examples/extensions/*/src/**",
     "examples/extensions/*/index.ts",
     "examples/extensions/*/index.js"
   ],
@@ -101,7 +101,7 @@
     "dev": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "prepare": "npm run build"
+    "prepare": "test -d dist || npm run build"
   },
   "keywords": [
     "terminal",

--- a/src/install.ts
+++ b/src/install.ts
@@ -111,6 +111,30 @@ function readPackageJson(target: string): PackageJson | null {
   return JSON.parse(fs.readFileSync(pkgJson, "utf-8")) as PackageJson;
 }
 
+/** Relative `file:` deps in bundled extensions (e.g. `"agent-sh": "file:../../.."`)
+ *  point at the wrong location after the source is copied into ~/.agent-sh/extensions/.
+ *  Resolve them against the original source dir so npm install in the target succeeds. */
+function rewriteFileDeps(target: string, sourcePath: string): void {
+  const pkgJson = path.join(target, "package.json");
+  if (!fs.existsSync(pkgJson)) return;
+  const raw = fs.readFileSync(pkgJson, "utf-8");
+  const pkg = JSON.parse(raw) as Record<string, unknown>;
+  const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+  let changed = false;
+  for (const section of sections) {
+    const deps = pkg[section];
+    if (!deps || typeof deps !== "object") continue;
+    for (const [name, spec] of Object.entries(deps as Record<string, string>)) {
+      if (typeof spec !== "string" || !spec.startsWith("file:")) continue;
+      const rel = spec.slice("file:".length);
+      if (path.isAbsolute(rel)) continue;
+      (deps as Record<string, string>)[name] = `file:${path.resolve(sourcePath, rel)}`;
+      changed = true;
+    }
+  }
+  if (changed) fs.writeFileSync(pkgJson, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
 function maybeNpmInstall(target: string, pkg: PackageJson): void {
   const deps = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}) };
   if (Object.keys(deps).length === 0) return;
@@ -202,6 +226,7 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
   if (resolved.isDirectory) {
     fs.cpSync(resolved.sourcePath, target, { recursive: true });
     try {
+      rewriteFileDeps(target, resolved.sourcePath);
       const pkg = readPackageJson(target);
       if (pkg) {
         maybeNpmInstall(target, pkg);


### PR DESCRIPTION
## Summary

Three small changes that together let `agent-sh install <name>` work for an end user who only has the published npm package, not a local checkout. Currently bundled extensions with a build step (e.g. `ash-acp-bridge`) work only when installed from a source clone — they break for npm-tarball users in three distinct ways, each fixed here.

- **`files` glob:** `examples/extensions/*/src` → `examples/extensions/*/src/**`. Without the trailing `**`, npm matches the directory entry but doesn't recurse, so nested `src/*.ts` is silently dropped from the tarball. Verified via `npm pack --dry-run` that `ash-acp-bridge/src/index.ts` now ships.
- **`prepare` guard:** `test -d dist || npm run build`. `prepare` is intended for fresh dev clones (where `dist/` is absent and tsc is on devDeps). When agent-sh is re-installed as a `file:` dep on an end-user machine, the existing `dist/` from the tarball is sufficient — but `prepare` would re-fire `tsc`, which isn't available since devDependencies aren't installed for end users.
- **`rewriteFileDeps` in `src/install.ts`:** before `maybeNpmInstall`, walks the copied `package.json` and rewrites any `file:<relative>` dep to an absolute path resolved against the original source dir. Generic — applies to any bundled extension carrying a `file:` agent-sh dep. Without this, `"agent-sh": "file:../../.."` in an extension's package.json points at the user's `~/` after the dir is copied to `~/.agent-sh/extensions/<name>/`.

## Test plan

- [x] `npm pack --dry-run` shows `examples/extensions/ash-acp-bridge/src/index.ts` (and ashi's nested sources) in the tarball.
- [x] Sandbox end-user simulation: `npm pack` agent-sh → `npm install -g <tgz>` into a temp prefix with fake `HOME` → `agent-sh install ash-acp-bridge` → npm install + npm run build succeed → bin links → bin responds to a JSON-RPC `initialize` probe with the expected capabilities envelope.
- [x] Dev-tree install (`node dist/index.js install ash-acp-bridge` from the repo) still works; rewritten `file:` dep resolves to the absolute path of the agent-sh checkout.
- [x] `tsc` clean.

## Notes

- Pre-existing extension installs at `~/.agent-sh/extensions/*` won't auto-migrate; users would `agent-sh install --force <name>` to pick up the rewrite. Not a regression — those installs were already working from a dev clone via the same absolute-symlink-after-copy accident this PR formalises.
- `rewriteFileDeps` is idempotent (already-absolute `file:` paths are skipped).