### PR TITLE
Add ashi: ash backend with pi-tui frontend, no shell

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -46,14 +46,25 @@ CLI flags mirror `agent-sh`:
 -e, --extensions     Extra extensions to load (comma-separated)
 ```
 
+## Keybindings
+
+Match pi-coding-agent's convention:
+
+```
+Esc      Cancel active turn
+Ctrl+C   Clear editor
+Ctrl+D   Quit (when editor is empty)
+```
+
 ## What's intentionally missing
 
 This is a spike, not a clone of pi's full UI. The MVP renders:
 
 - User submissions, streaming assistant Markdown
 - Tool invocations with start/complete state
+- Slash commands with autocomplete (`/help`, `/model`, `/backend`, …)
 - Loader, errors, info messages
 
-Out of scope for v0: permission dialogs, diff renderer, slash-command autocomplete, session
+Out of scope for v0: permission dialogs, diff renderer, file-path autocomplete, session
 selector, theme selector, image rendering. Each can be added by writing a pi-tui Component and
 subscribing to the corresponding bus event.

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -1,0 +1,59 @@
+# ashi
+
+`ash` (agent-sh's built-in agent) running inside pi's TUI substrate, with no shell underneath.
+
+A test of agent-sh's claim that the kernel is a frontend-agnostic communication layer: `ashi`
+uses `createCore()` from agent-sh, skips `activateShell()`, disables the shell-coupled built-ins
+(`shell-context`, `tui-renderer`, `file-autocomplete`), and mounts `@earendil-works/pi-tui` as
+the only frontend. Backend, tools, slash commands, providers, and skills come along unchanged.
+
+## Setup
+
+```bash
+cd examples/extensions/ashi
+npm install
+npm run build   # or `npm run dev` for a tsx-driven run without compiling
+```
+
+`file:../../..` wires `agent-sh` to the parent checkout; run `npm run build` at the repo root
+first if you haven't already.
+
+## Install
+
+```bash
+agent-sh install ashi
+export PATH="$HOME/.agent-sh/bin:$PATH"
+ashi
+```
+
+`agent-sh install` copies this directory into `~/.agent-sh/extensions/ashi/` (preserving
+`node_modules/`, so the local `agent-sh` symlink resolves), then symlinks the built bin into
+`~/.agent-sh/bin/`.
+
+## Configure
+
+Reads `~/.agent-sh/settings.json` for providers and defaults, same as `agent-sh` itself. The
+quickest path is exporting `OPENROUTER_API_KEY` or `OPENAI_API_KEY` and running `ashi`.
+
+CLI flags mirror `agent-sh`:
+
+```
+--provider <name>    Provider profile from ~/.agent-sh/settings.json
+--model <id>         Override model
+--api-key <key>      Direct API key
+--base-url <url>     OpenAI-compatible base URL
+--backend <name>     Agent backend (default: ash)
+-e, --extensions     Extra extensions to load (comma-separated)
+```
+
+## What's intentionally missing
+
+This is a spike, not a clone of pi's full UI. The MVP renders:
+
+- User submissions, streaming assistant Markdown
+- Tool invocations with start/complete state
+- Loader, errors, info messages
+
+Out of scope for v0: permission dialogs, diff renderer, slash-command autocomplete, session
+selector, theme selector, image rendering. Each can be added by writing a pi-tui Component and
+subscribing to the corresponding bus event.

--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "agent-sh-ashi",
+  "version": "0.1.0",
+  "description": "Ash with a pi-tui frontend — agent-sh's kernel without the shell, rendered through pi's TUI library",
+  "type": "module",
+  "main": "dist/cli.js",
+  "bin": {
+    "ashi": "dist/cli.js"
+  },
+  "scripts": {
+    "dev": "tsx src/cli.ts",
+    "build": "tsc",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "@earendil-works/pi-tui": "^0.74.0",
+    "agent-sh": "file:../../..",
+    "chalk": "^5.5.0",
+    "cli-highlight": "^2.1.11",
+    "tsx": "^4.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/extensions/ashi/src/autocomplete.ts
+++ b/examples/extensions/ashi/src/autocomplete.ts
@@ -1,0 +1,69 @@
+import type {
+  AutocompleteItem,
+  AutocompleteProvider,
+  AutocompleteSuggestions,
+} from "@earendil-works/pi-tui";
+import type { EventBus } from "agent-sh/event-bus";
+
+/** Adapt pi-tui's AutocompleteProvider to agent-sh's autocomplete:request pipe.
+ *  Reads the line up to the cursor, asks the bus for suggestions, returns them. */
+export class BusAutocompleteProvider implements AutocompleteProvider {
+  constructor(private bus: EventBus) {}
+
+  async getSuggestions(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+  ): Promise<AutocompleteSuggestions | null> {
+    if (cursorLine !== 0) return null;
+    const line = lines[0] ?? "";
+    const before = line.slice(0, cursorCol);
+    if (!before.startsWith("/")) return null;
+
+    // Split command from args. "/backend " → command="/backend", args=""
+    const sp = before.indexOf(" ");
+    const command = sp === -1 ? null : before.slice(0, sp);
+    const commandArgs = sp === -1 ? null : before.slice(sp + 1);
+
+    const result = this.bus.emitPipe("autocomplete:request", {
+      buffer: before,
+      command,
+      commandArgs,
+      items: [],
+    });
+    if (result.items.length === 0) return null;
+
+    const items: AutocompleteItem[] = result.items.map((it) => ({
+      value: it.name,
+      label: it.name,
+      description: it.description,
+    }));
+    // pi-tui matches selected completion against this prefix. When in arg
+    // context, the prefix is the whole line so far ("/backend cla"); when
+    // matching command names, the prefix is just the slash word.
+    const prefix = command === null ? before : before;
+    return { items, prefix };
+  }
+
+  applyCompletion(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    item: AutocompleteItem,
+    prefix: string,
+  ): { lines: string[]; cursorLine: number; cursorCol: number } {
+    const line = lines[cursorLine] ?? "";
+    // Replace the prefix span (the leading slash-word + args we sent) with
+    // the completion value. Anything after the cursor is preserved.
+    const head = line.slice(0, cursorCol - prefix.length);
+    const tail = line.slice(cursorCol);
+    const newLine = `${head}${item.value}${tail}`;
+    const out = lines.slice();
+    out[cursorLine] = newLine;
+    return {
+      lines: out,
+      cursorLine,
+      cursorCol: (head + item.value).length,
+    };
+  }
+}

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * ashi — agent-sh's ash backend with a pi-tui frontend, no shell.
+ *
+ * Boots the agent-sh kernel directly, skips the PTY shell and the
+ * default streaming tui-renderer, and mounts pi-tui as the sole
+ * frontend. Demonstrates that the kernel is frontend-agnostic — same
+ * backend, tools, slash commands, providers; different presentation.
+ */
+import { createCore } from "agent-sh/core";
+import { loadBuiltinExtensions } from "agent-sh/extensions";
+import { loadExtensions } from "agent-sh/extension-loader";
+import { getSettings } from "agent-sh/settings";
+import type { AgentShellConfig } from "agent-sh/types";
+
+import { mountAshi } from "./frontend.js";
+
+function parseArgs(argv: string[]): AgentShellConfig & { extensions?: string[] } {
+  let model: string | undefined;
+  let apiKey: string | undefined = process.env.OPENAI_API_KEY ?? process.env.OPENROUTER_API_KEY;
+  let baseURL: string | undefined = process.env.OPENAI_BASE_URL;
+  let provider: string | undefined;
+  let backend: string | undefined;
+  const extensions: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--model" && argv[i + 1]) model = argv[++i];
+    else if (a === "--api-key" && argv[i + 1]) apiKey = argv[++i];
+    else if (a === "--base-url" && argv[i + 1]) baseURL = argv[++i];
+    else if (a === "--provider" && argv[i + 1]) provider = argv[++i];
+    else if (a === "--backend" && argv[i + 1]) backend = argv[++i];
+    else if ((a === "-e" || a === "--extensions") && argv[i + 1]) {
+      extensions.push(...argv[++i]!.split(",").map(s => s.trim()).filter(Boolean));
+    } else if (a === "-h" || a === "--help") {
+      process.stdout.write(`ashi — ash backend, pi-tui frontend\n\n` +
+        `Usage: ashi [--provider <name>] [--model <id>] [--api-key <key>] [--base-url <url>]\n` +
+        `            [--backend <name>] [-e <ext>[,<ext>...]]\n\n` +
+        `Reads ~/.agent-sh/settings.json for providers and defaults.\n`);
+      process.exit(0);
+    }
+  }
+
+  // shell is required by AgentShellConfig's type but unused without the PTY frontend.
+  return { shell: "/bin/sh", model, apiKey, baseURL, provider, backend, extensions };
+}
+
+async function main(): Promise<void> {
+  // parseArgs handles --help by exiting before we reach the TTY check.
+  const config = parseArgs(process.argv.slice(2));
+
+  if (!process.stdin.isTTY) {
+    process.stderr.write("ashi requires a TTY for interactive rendering.\n");
+    process.exit(1);
+  }
+  const core = createCore(config);
+
+  // Built by frontend.ts; declared up here so cleanup can reach it.
+  let stopFrontend: (() => void) | null = null;
+
+  const cleanup = (): void => {
+    try { stopFrontend?.(); } catch { /* ignore */ }
+    try { core.kill(); } catch { /* ignore */ }
+    if (process.stdin.isTTY) {
+      try { process.stdin.setRawMode(false); } catch { /* ignore */ }
+    }
+    process.exit(0);
+  };
+
+  const ctx = core.extensionContext({ quit: cleanup });
+
+  // Skip shell-context (no PTY → no cwd tracking via shell events; core's
+  // process.cwd() default is fine), the default streaming tui-renderer
+  // (pi-tui replaces it), and file-autocomplete (it advises the shell's
+  // input handler, which doesn't exist here).
+  const disabled = ["shell-context", "tui-renderer", "file-autocomplete"];
+  await loadBuiltinExtensions(ctx, disabled);
+
+  const loaded = await loadExtensions(ctx, config.extensions);
+  core.bus.emit("core:extensions-loaded", { names: loaded });
+
+  const { names: backendNames } = core.bus.emitPipe("config:get-backends", {
+    names: [] as string[], active: null as string | null,
+  });
+  if (backendNames.length === 0) {
+    process.stderr.write("ashi: no agent backend registered. Set OPENAI_API_KEY or OPENROUTER_API_KEY, or configure ~/.agent-sh/settings.json.\n");
+    process.exit(1);
+  }
+
+  const handle = mountAshi(ctx);
+  stopFrontend = handle.stop;
+
+  await core.activateBackend(config.backend ?? getSettings().defaultBackend);
+
+  process.on("SIGTERM", cleanup);
+  process.on("SIGHUP", cleanup);
+}
+
+main().catch((err) => {
+  process.stderr.write(`ashi fatal: ${err?.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -1,88 +1,144 @@
-import { Markdown, Text, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
-import { c } from "./theme.js";
+import {
+  Box,
+  Container,
+  Markdown,
+  type MarkdownTheme,
+  Spacer,
+  Text,
+  type Component,
+} from "@earendil-works/pi-tui";
+import { iconFor, markdownTheme, theme } from "./theme.js";
 
-export class UserMessage implements Component {
-  private text: Text;
-  constructor(query: string) {
-    this.text = new Text(`${c.user("> ")}${query}`, 1, 0);
+const OSC133_ZONE_START = "\x1b]133;A\x07";
+const OSC133_ZONE_END = "\x1b]133;B\x07";
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+
+export class UserMessage extends Container {
+  constructor(text: string, md: MarkdownTheme = markdownTheme()) {
+    super();
+    this.addChild(new Spacer(1));
+    this.addChild(
+      new Markdown(text, 1, 1, md, {
+        bgColor: (t) => theme.bg("userMessageBg", t),
+        color: (t) => theme.fg("userMessageText", t),
+      }),
+    );
   }
-  render(width: number) { return this.text.render(width); }
-  invalidate() { this.text.invalidate(); }
+  override render(width: number): string[] {
+    const lines = super.render(width);
+    if (lines.length === 0) return lines;
+    lines[0] = OSC133_ZONE_START + lines[0];
+    lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
+    return lines;
+  }
 }
 
-export class AssistantMessage implements Component {
+/** paddingY=0 so the Markdown sits flush against the following tool box,
+ *  matching pi's vertical rhythm. */
+export class AssistantMessage extends Container {
   private md: Markdown;
   private buffer = "";
-  constructor(theme: MarkdownTheme) {
-    this.md = new Markdown("", 1, 0, theme);
+  constructor(mdTheme: MarkdownTheme = markdownTheme()) {
+    super();
+    this.md = new Markdown("", 1, 0, mdTheme);
+    this.addChild(new Spacer(1));
+    this.addChild(this.md);
   }
-  appendText(t: string) {
+  appendText(t: string): void {
     this.buffer += t;
     this.md.setText(this.buffer);
   }
-  appendCodeBlock(language: string, code: string) {
-    const fence = "```";
+  appendCodeBlock(language: string, code: string): void {
     const prefix = this.buffer && !this.buffer.endsWith("\n") ? "\n" : "";
-    this.buffer += `${prefix}${fence}${language}\n${code}\n${fence}\n`;
+    this.buffer += `${prefix}\`\`\`${language}\n${code}\n\`\`\`\n`;
     this.md.setText(this.buffer);
   }
-  finalize() {
+  finalize(): void {
     if (this.buffer === "") this.buffer = " ";
     this.md.setText(this.buffer);
   }
-  hasContent() { return this.buffer.trim().length > 0; }
-  render(width: number) { return this.md.render(width); }
-  invalidate() { this.md.invalidate(); }
+  hasContent(): boolean {
+    return this.buffer.trim().length > 0;
+  }
 }
 
-export class ToolExecution implements Component {
+export class ToolExecution extends Container {
+  private box: Box;
+  private header: Text;
+  private outputText: Text;
+  private outputBuffer = "";
   private title: string;
   private detail?: string;
+  private kind?: string;
+  private startedAt: number;
   private exitCode: number | null | undefined;
   private elapsedMs?: number;
-  private startedAt: number;
   private summary?: string;
-  constructor(title: string, detail?: string) {
+
+  constructor(title: string, kind?: string, detail?: string) {
+    super();
     this.title = title;
+    this.kind = kind;
     this.detail = detail;
     this.startedAt = Date.now();
+    this.box = new Box(1, 1, (t) => theme.bg("toolPendingBg", t));
+    this.header = new Text("", 0, 0);
+    this.outputText = new Text("", 0, 0);
+    this.box.addChild(this.header);
+    this.box.addChild(this.outputText);
+    this.addChild(new Spacer(1));
+    this.addChild(this.box);
+    this.repaint();
   }
-  complete(exitCode: number | null, summary?: string) {
+
+  appendOutput(chunk: string): void {
+    this.outputBuffer += chunk;
+    this.repaint();
+  }
+
+  complete(exitCode: number | null, summary?: string): void {
     this.exitCode = exitCode;
     this.elapsedMs = Date.now() - this.startedAt;
     this.summary = summary;
+    const ok = exitCode === null || exitCode === 0;
+    this.box.setBgFn((t) => theme.bg(ok ? "toolSuccessBg" : "toolErrorBg", t));
+    this.repaint();
   }
-  render(_width: number): string[] {
-    const head = `${c.toolName("◆")} ${c.toolName(this.title)}${this.detail ? ` ${c.toolDetail(this.detail)}` : ""}`;
-    const lines = [` ${head}`];
-    if (this.exitCode === undefined) {
-      lines.push(`   ${c.muted("…")}`);
-    } else {
+
+  private repaint(): void {
+    const icon = iconFor(this.kind);
+    const titlePart = theme.bold(theme.fg("toolTitle", `${icon} ${this.title}`));
+    const detailPart = this.detail ? ` ${theme.fg("muted", this.detail)}` : "";
+    let tailPart = "";
+    if (this.exitCode !== undefined) {
       const ok = this.exitCode === null || this.exitCode === 0;
-      const mark = ok ? c.ok("✓") : c.error("✗");
-      const elapsed = this.elapsedMs !== undefined ? c.muted(`${(this.elapsedMs / 1000).toFixed(1)}s`) : "";
-      const tail = this.summary ? ` ${c.muted(this.summary)}` : "";
-      lines.push(`   ${mark} ${elapsed}${tail}`);
+      const mark = ok ? theme.fg("success", "✓") : theme.fg("error", "✗");
+      const elapsed = this.elapsedMs !== undefined ? ` ${theme.fg("muted", `${(this.elapsedMs / 1000).toFixed(1)}s`)}` : "";
+      const sum = this.summary ? ` ${theme.fg("muted", this.summary)}` : "";
+      tailPart = `   ${mark}${elapsed}${sum}`;
+    } else {
+      tailPart = `   ${theme.fg("muted", "…")}`;
     }
-    return lines;
+    this.header.setText(`${titlePart}${detailPart}\n${tailPart}`);
+    if (this.outputBuffer) {
+      const trimmed = this.outputBuffer.split("\n").slice(-8).join("\n");
+      this.outputText.setText(theme.fg("toolOutput", trimmed));
+    } else {
+      this.outputText.setText("");
+    }
   }
-  invalidate() {}
 }
 
-export class ErrorLine implements Component {
-  private text: Text;
+export class ErrorLine extends Container {
   constructor(message: string) {
-    this.text = new Text(` ${c.error("✗")} ${c.error(message)}`, 0, 0);
+    super();
+    this.addChild(new Text(`${theme.fg("error", "✗")} ${theme.fg("error", message)}`, 1, 0));
   }
-  render(width: number) { return this.text.render(width); }
-  invalidate() { this.text.invalidate(); }
 }
 
-export class InfoLine implements Component {
-  private text: Text;
+export class InfoLine extends Container {
   constructor(message: string) {
-    this.text = new Text(` ${c.muted(message)}`, 0, 0);
+    super();
+    this.addChild(new Text(theme.fg("muted", message), 1, 0));
   }
-  render(width: number) { return this.text.render(width); }
-  invalidate() { this.text.invalidate(); }
 }

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -1,0 +1,88 @@
+import { Markdown, Text, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { c } from "./theme.js";
+
+export class UserMessage implements Component {
+  private text: Text;
+  constructor(query: string) {
+    this.text = new Text(`${c.user("> ")}${query}`, 1, 0);
+  }
+  render(width: number) { return this.text.render(width); }
+  invalidate() { this.text.invalidate(); }
+}
+
+export class AssistantMessage implements Component {
+  private md: Markdown;
+  private buffer = "";
+  constructor(theme: MarkdownTheme) {
+    this.md = new Markdown("", 1, 0, theme);
+  }
+  appendText(t: string) {
+    this.buffer += t;
+    this.md.setText(this.buffer);
+  }
+  appendCodeBlock(language: string, code: string) {
+    const fence = "```";
+    const prefix = this.buffer && !this.buffer.endsWith("\n") ? "\n" : "";
+    this.buffer += `${prefix}${fence}${language}\n${code}\n${fence}\n`;
+    this.md.setText(this.buffer);
+  }
+  finalize() {
+    if (this.buffer === "") this.buffer = " ";
+    this.md.setText(this.buffer);
+  }
+  hasContent() { return this.buffer.trim().length > 0; }
+  render(width: number) { return this.md.render(width); }
+  invalidate() { this.md.invalidate(); }
+}
+
+export class ToolExecution implements Component {
+  private title: string;
+  private detail?: string;
+  private exitCode: number | null | undefined;
+  private elapsedMs?: number;
+  private startedAt: number;
+  private summary?: string;
+  constructor(title: string, detail?: string) {
+    this.title = title;
+    this.detail = detail;
+    this.startedAt = Date.now();
+  }
+  complete(exitCode: number | null, summary?: string) {
+    this.exitCode = exitCode;
+    this.elapsedMs = Date.now() - this.startedAt;
+    this.summary = summary;
+  }
+  render(_width: number): string[] {
+    const head = `${c.toolName("◆")} ${c.toolName(this.title)}${this.detail ? ` ${c.toolDetail(this.detail)}` : ""}`;
+    const lines = [` ${head}`];
+    if (this.exitCode === undefined) {
+      lines.push(`   ${c.muted("…")}`);
+    } else {
+      const ok = this.exitCode === null || this.exitCode === 0;
+      const mark = ok ? c.ok("✓") : c.error("✗");
+      const elapsed = this.elapsedMs !== undefined ? c.muted(`${(this.elapsedMs / 1000).toFixed(1)}s`) : "";
+      const tail = this.summary ? ` ${c.muted(this.summary)}` : "";
+      lines.push(`   ${mark} ${elapsed}${tail}`);
+    }
+    return lines;
+  }
+  invalidate() {}
+}
+
+export class ErrorLine implements Component {
+  private text: Text;
+  constructor(message: string) {
+    this.text = new Text(` ${c.error("✗")} ${c.error(message)}`, 0, 0);
+  }
+  render(width: number) { return this.text.render(width); }
+  invalidate() { this.text.invalidate(); }
+}
+
+export class InfoLine implements Component {
+  private text: Text;
+  constructor(message: string) {
+    this.text = new Text(` ${c.muted(message)}`, 0, 0);
+  }
+  render(width: number) { return this.text.render(width); }
+  invalidate() { this.text.invalidate(); }
+}

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -196,24 +196,26 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
     tui.requestRender();
   });
 
-  // Ctrl-C: cancel active turn first; on a second press with nothing running, quit.
-  // Registered before tui.start() so it sees raw input ahead of the editor.
-  let lastCtrlC = 0;
+  // Match pi-coding-agent's keybindings:
+  //   Esc    — cancel active turn (when autocomplete is closed, which the
+  //            editor handles itself; we only fire during processing)
+  //   Ctrl+C — clear editor
+  //   Ctrl+D — quit when editor is empty
+  // Registered before tui.start() so the listener sees raw input ahead of the editor.
   tui.addInputListener((data) => {
-    if (data !== "\x03") return undefined;
-    if (processing) {
+    if (data === "\x1b" && processing) {
       bus.emit("agent:cancel-request", {});
       return { consume: true };
     }
-    const now = Date.now();
-    if (now - lastCtrlC < 1500) {
+    if (data === "\x03") {
+      editor.setText("");
+      return { consume: true };
+    }
+    if (data === "\x04" && editor.getText().length === 0) {
       ctx.quit();
       return { consume: true };
     }
-    lastCtrlC = now;
-    chat.addChild(new InfoLine("press Ctrl-C again to exit"));
-    tui.requestRender();
-    return { consume: true };
+    return undefined;
   });
 
   tui.start();

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -4,6 +4,7 @@ import {
   Container,
   Editor,
   Loader,
+  matchesKey,
 } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
 import { editorTheme, theme } from "./theme.js";
@@ -206,17 +207,19 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
   //            editor handles itself; we only fire during processing)
   //   Ctrl+C — clear editor
   //   Ctrl+D — quit when editor is empty
-  // Registered before tui.start() so the listener sees raw input ahead of the editor.
+  // matchesKey() covers both legacy bytes (\x03, \x04, \x1b) and the Kitty
+  // keyboard protocol CSI encodings used by Ghostty/Kitty/iTerm. Direct byte
+  // comparison would miss Kitty-mode terminals.
   tui.addInputListener((data) => {
-    if (data === "\x1b" && processing) {
+    if (matchesKey(data, "escape") && processing) {
       bus.emit("agent:cancel-request", {});
       return { consume: true };
     }
-    if (data === "\x03") {
+    if (matchesKey(data, "ctrl+c")) {
       editor.setText("");
       return { consume: true };
     }
-    if (data === "\x04" && editor.getText().length === 0) {
+    if (matchesKey(data, "ctrl+d") && editor.getText().length === 0) {
       ctx.quit();
       return { consume: true };
     }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -4,10 +4,9 @@ import {
   Container,
   Editor,
   Loader,
-  Spacer,
 } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
-import { editorTheme, markdownTheme, c } from "./theme.js";
+import { editorTheme, theme } from "./theme.js";
 import {
   AssistantMessage,
   ErrorLine,
@@ -15,6 +14,9 @@ import {
   ToolExecution,
   UserMessage,
 } from "./components.js";
+
+const fgAccent = (t: string): string => theme.fg("accent", t);
+const fgMuted = (t: string): string => theme.fg("muted", t);
 
 export interface AshiHandle {
   tui: TUI;
@@ -49,8 +51,7 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   const ensureAssistant = (): AssistantMessage => {
     if (!activeAssistant) {
-      activeAssistant = new AssistantMessage(markdownTheme());
-      chat.addChild(new Spacer(1));
+      activeAssistant = new AssistantMessage();
       chat.addChild(activeAssistant);
     }
     return activeAssistant;
@@ -58,7 +59,7 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   const startLoader = () => {
     if (loader) return;
-    loader = new Loader(tui, c.accent, c.muted, "thinking…");
+    loader = new Loader(tui, fgAccent, fgMuted, "thinking…");
     footerSlot.addChild(loader);
   };
   const stopLoader = () => {
@@ -70,7 +71,6 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   // ── Bus wiring ───────────────────────────────────────────────
   bus.on("agent:query", ({ query }) => {
-    chat.addChild(new Spacer(1));
     chat.addChild(new UserMessage(query));
     activeAssistant = null;
     tui.requestRender();
@@ -98,9 +98,16 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   bus.on("agent:tool-started", (e) => {
     const id = e.toolCallId ?? `${e.title}-${Date.now()}`;
-    const tool = new ToolExecution(e.title, e.displayDetail);
+    const tool = new ToolExecution(e.title, e.kind, e.displayDetail);
     activeTools.set(id, tool);
     chat.addChild(tool);
+    tui.requestRender();
+  });
+
+  bus.on("agent:tool-output-chunk", ({ chunk }) => {
+    if (activeTools.size === 0) return;
+    const last = [...activeTools.values()].pop();
+    last?.appendOutput(chunk);
     tui.requestRender();
   });
 

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -135,8 +135,13 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   bus.on("agent:tool-started", (e) => {
     const id = e.toolCallId ?? `${e.title}-${Date.now()}`;
+    // Kernel composes title as "<toolName>: <args.description>" when the
+    // tool's args carry a description. The command/path shown right next
+    // to the title already conveys what the call is doing — strip the
+    // suffix so the header reads as "bash" / "read_file" / etc.
+    const title = e.title.split(":")[0]!.trim();
     const detail = e.displayDetail || detailFor(e.rawInput, e.locations, ctx.call("cwd"));
-    const tool = new ToolExecution(e.title, e.kind, detail);
+    const tool = new ToolExecution(title, e.kind, detail);
     activeTools.set(id, tool);
     chat.addChild(tool);
     tui.requestRender();

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -1,0 +1,180 @@
+import {
+  TUI,
+  ProcessTerminal,
+  Container,
+  Editor,
+  Loader,
+  Spacer,
+} from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "agent-sh/types";
+import { editorTheme, markdownTheme, c } from "./theme.js";
+import {
+  AssistantMessage,
+  ErrorLine,
+  InfoLine,
+  ToolExecution,
+  UserMessage,
+} from "./components.js";
+
+export interface AshiHandle {
+  tui: TUI;
+  stop: () => void;
+}
+
+export function mountAshi(ctx: ExtensionContext): AshiHandle {
+  const { bus } = ctx;
+  const terminal = new ProcessTerminal();
+  const tui = new TUI(terminal);
+
+  const chat = new Container();
+  const footerSlot = new Container();
+  const editor = new Editor(tui, editorTheme(), { paddingX: 1 });
+  editor.onSubmit = (text) => {
+    const query = text.trim();
+    if (!query) return;
+    editor.setText("");
+    bus.emit("agent:submit", { query });
+  };
+
+  tui.addChild(chat);
+  tui.addChild(footerSlot);
+  tui.addChild(editor);
+  tui.setFocus(editor);
+
+  // ── Active render targets ────────────────────────────────────
+  let activeAssistant: AssistantMessage | null = null;
+  const activeTools = new Map<string, ToolExecution>(); // keyed by toolCallId
+  let loader: Loader | null = null;
+  let processing = false;
+
+  const ensureAssistant = (): AssistantMessage => {
+    if (!activeAssistant) {
+      activeAssistant = new AssistantMessage(markdownTheme());
+      chat.addChild(new Spacer(1));
+      chat.addChild(activeAssistant);
+    }
+    return activeAssistant;
+  };
+
+  const startLoader = () => {
+    if (loader) return;
+    loader = new Loader(tui, c.accent, c.muted, "thinking…");
+    footerSlot.addChild(loader);
+  };
+  const stopLoader = () => {
+    if (!loader) return;
+    loader.stop();
+    footerSlot.removeChild(loader);
+    loader = null;
+  };
+
+  // ── Bus wiring ───────────────────────────────────────────────
+  bus.on("agent:query", ({ query }) => {
+    chat.addChild(new Spacer(1));
+    chat.addChild(new UserMessage(query));
+    activeAssistant = null;
+    tui.requestRender();
+  });
+
+  bus.on("agent:processing-start", () => {
+    processing = true;
+    startLoader();
+    tui.requestRender();
+  });
+
+  bus.on("agent:response-chunk", ({ blocks }) => {
+    const msg = ensureAssistant();
+    for (const b of blocks) {
+      if (b.type === "text") msg.appendText(b.text);
+      else if (b.type === "code-block") msg.appendCodeBlock(b.language, b.code);
+    }
+    tui.requestRender();
+  });
+
+  bus.on("agent:thinking-chunk", () => {
+    // Thinking is currently not surfaced as its own component; keep
+    // the loader spinning. A future ThinkingPanel could subscribe here.
+  });
+
+  bus.on("agent:tool-started", (e) => {
+    const id = e.toolCallId ?? `${e.title}-${Date.now()}`;
+    const tool = new ToolExecution(e.title, e.displayDetail);
+    activeTools.set(id, tool);
+    chat.addChild(tool);
+    tui.requestRender();
+  });
+
+  bus.on("agent:tool-completed", (e) => {
+    const id = e.toolCallId;
+    if (!id) return;
+    const tool = activeTools.get(id);
+    if (!tool) return;
+    const summary = e.resultDisplay?.summary;
+    tool.complete(e.exitCode, summary);
+    activeTools.delete(id);
+    tui.requestRender();
+  });
+
+  bus.on("agent:processing-done", () => {
+    processing = false;
+    stopLoader();
+    if (activeAssistant) activeAssistant.finalize();
+    tui.requestRender();
+  });
+
+  bus.on("agent:cancelled", () => {
+    processing = false;
+    stopLoader();
+    chat.addChild(new InfoLine("cancelled"));
+    tui.requestRender();
+  });
+
+  bus.on("agent:error", ({ message }) => {
+    processing = false;
+    stopLoader();
+    chat.addChild(new ErrorLine(message));
+    tui.requestRender();
+  });
+
+  bus.on("ui:info", ({ message }) => {
+    chat.addChild(new InfoLine(message));
+    tui.requestRender();
+  });
+
+  bus.on("ui:error", ({ message }) => {
+    chat.addChild(new ErrorLine(message));
+    tui.requestRender();
+  });
+
+  bus.on("agent:info", (info) => {
+    chat.addChild(new InfoLine(`${info.name}${info.model ? ` · ${info.model}` : ""}`));
+    tui.requestRender();
+  });
+
+  // Ctrl-C: cancel active turn first; on a second press with nothing running, quit.
+  // Registered before tui.start() so it sees raw input ahead of the editor.
+  let lastCtrlC = 0;
+  tui.addInputListener((data) => {
+    if (data !== "\x03") return undefined;
+    if (processing) {
+      bus.emit("agent:cancel-request", {});
+      return { consume: true };
+    }
+    const now = Date.now();
+    if (now - lastCtrlC < 1500) {
+      ctx.quit();
+      return { consume: true };
+    }
+    lastCtrlC = now;
+    chat.addChild(new InfoLine("press Ctrl-C again to exit"));
+    tui.requestRender();
+    return { consume: true };
+  });
+
+  tui.start();
+
+  return {
+    tui,
+    stop: () => { tui.stop(); },
+  };
+}

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -63,6 +63,13 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
     const query = text.trim();
     if (!query) return;
     editor.setText("");
+    if (query.startsWith("/")) {
+      const sp = query.indexOf(" ");
+      const name = sp === -1 ? query : query.slice(0, sp);
+      const args = sp === -1 ? "" : query.slice(sp + 1).trim();
+      bus.emit("command:execute", { name, args });
+      return;
+    }
     bus.emit("agent:submit", { query });
   };
 

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -18,6 +18,34 @@ import {
 const fgAccent = (t: string): string => theme.fg("accent", t);
 const fgMuted = (t: string): string => theme.fg("muted", t);
 
+/** Tools without a `formatCall` rely on the renderer to surface the
+ *  meaningful bit of their rawInput (the command, the file path, the
+ *  search pattern). Mirrors src/extensions/tui-renderer.ts extractDetail. */
+function detailFor(
+  rawInput: unknown,
+  locations: { path: string; line?: number | null }[] | undefined,
+  cwd: string,
+): string {
+  const home = process.env.HOME;
+  const relativize = (fp: string): string => {
+    if (fp.startsWith(`${cwd}/`)) return fp.slice(cwd.length + 1);
+    if (home && fp.startsWith(`${home}/`)) return `~/${fp.slice(home.length + 1)}`;
+    return fp;
+  };
+  if (locations && locations.length > 0) {
+    const loc = locations[0]!;
+    const fp = relativize(loc.path);
+    return loc.line ? `${fp}:${loc.line}` : fp;
+  }
+  const raw = rawInput as Record<string, unknown> | undefined;
+  if (!raw) return "";
+  if (typeof raw.command === "string") return `$ ${raw.command}`;
+  if (typeof raw.pattern === "string") return raw.pattern;
+  if (typeof raw.path === "string") return relativize(raw.path);
+  if (typeof raw.query === "string") return `"${raw.query}"`;
+  return "";
+}
+
 export interface AshiHandle {
   tui: TUI;
   stop: () => void;
@@ -98,7 +126,8 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   bus.on("agent:tool-started", (e) => {
     const id = e.toolCallId ?? `${e.title}-${Date.now()}`;
-    const tool = new ToolExecution(e.title, e.kind, e.displayDetail);
+    const detail = e.displayDetail || detailFor(e.rawInput, e.locations, ctx.call("cwd"));
+    const tool = new ToolExecution(e.title, e.kind, detail);
     activeTools.set(id, tool);
     chat.addChild(tool);
     tui.requestRender();

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -14,6 +14,7 @@ import {
   ToolExecution,
   UserMessage,
 } from "./components.js";
+import { BusAutocompleteProvider } from "./autocomplete.js";
 
 const fgAccent = (t: string): string => theme.fg("accent", t);
 const fgMuted = (t: string): string => theme.fg("muted", t);
@@ -59,6 +60,7 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
   const chat = new Container();
   const footerSlot = new Container();
   const editor = new Editor(tui, editorTheme(), { paddingX: 1 });
+  editor.setAutocompleteProvider(new BusAutocompleteProvider(bus));
   editor.onSubmit = (text) => {
     const query = text.trim();
     if (!query) return;

--- a/examples/extensions/ashi/src/theme.ts
+++ b/examples/extensions/ashi/src/theme.ts
@@ -2,76 +2,165 @@ import chalk from "chalk";
 import { highlight, supportsLanguage } from "cli-highlight";
 import type { EditorTheme, MarkdownTheme, SelectListTheme } from "@earendil-works/pi-tui";
 
-const muted = chalk.gray;
-const dim = chalk.gray.dim;
-const accent = chalk.cyan;
-const error = chalk.red;
-const warning = chalk.yellow;
-const ok = chalk.green;
-const heading = chalk.bold.cyan;
-const link = chalk.cyan.underline;
-const code = chalk.yellow;
-const codeBlock = (t: string) => t;
-const codeBlockBorder = chalk.gray;
-const quote = chalk.italic.gray;
-const quoteBorder = chalk.gray;
-const listBullet = chalk.cyan;
-
-export const c = {
-  muted,
-  dim,
-  accent,
-  error,
-  warning,
-  ok,
-  heading,
-  borderMuted: chalk.gray,
-  borderAccent: chalk.cyan,
-  user: chalk.green,
-  assistant: chalk.white,
-  toolName: chalk.cyan,
-  toolDetail: chalk.gray,
+/** Bundled dark palette, lifted from pi-coding-agent's dark.json. */
+const VARS: Record<string, string> = {
+  cyan: "#00d7ff",
+  blue: "#5f87ff",
+  green: "#b5bd68",
+  red: "#cc6666",
+  yellow: "#ffff00",
+  gray: "#808080",
+  dimGray: "#666666",
+  darkGray: "#505050",
+  accent: "#8abeb7",
+  selectedBg: "#3a3a4a",
+  userMsgBg: "#343541",
+  toolPendingBg: "#282832",
+  toolSuccessBg: "#283228",
+  toolErrorBg: "#3c2828",
 };
+
+const RAW = {
+  accent: "accent",
+  border: "blue",
+  borderAccent: "cyan",
+  borderMuted: "darkGray",
+  success: "green",
+  error: "red",
+  warning: "yellow",
+  muted: "gray",
+  dim: "dimGray",
+  text: "",
+  thinkingText: "gray",
+  selectedBg: "selectedBg",
+  userMessageBg: "userMsgBg",
+  userMessageText: "",
+  toolPendingBg: "toolPendingBg",
+  toolSuccessBg: "toolSuccessBg",
+  toolErrorBg: "toolErrorBg",
+  toolTitle: "",
+  toolOutput: "gray",
+  mdHeading: "#f0c674",
+  mdLink: "#81a2be",
+  mdLinkUrl: "dimGray",
+  mdCode: "accent",
+  mdCodeBlock: "green",
+  mdCodeBlockBorder: "gray",
+  mdQuote: "gray",
+  mdQuoteBorder: "gray",
+  mdHr: "gray",
+  mdListBullet: "accent",
+  toolDiffAdded: "green",
+  toolDiffRemoved: "red",
+  toolDiffContext: "gray",
+  bashMode: "green",
+} as const;
+
+export type ThemeColor = keyof typeof RAW;
+
+function resolve(v: string): string {
+  if (v === "") return "";
+  if (v.startsWith("#")) return v;
+  const hex = VARS[v];
+  if (!hex) throw new Error(`Unknown theme var: ${v}`);
+  return hex;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const c = hex.replace("#", "");
+  return [parseInt(c.slice(0, 2), 16), parseInt(c.slice(2, 4), 16), parseInt(c.slice(4, 6), 16)];
+}
+
+function fgAnsi(hex: string): string {
+  if (hex === "") return "\x1b[39m";
+  const [r, g, b] = hexToRgb(hex);
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+function bgAnsi(hex: string): string {
+  if (hex === "") return "\x1b[49m";
+  const [r, g, b] = hexToRgb(hex);
+  return `\x1b[48;2;${r};${g};${b}m`;
+}
+
+class Theme {
+  private fgCodes = new Map<ThemeColor, string>();
+  private bgCodes = new Map<ThemeColor, string>();
+  constructor() {
+    for (const k of Object.keys(RAW) as ThemeColor[]) {
+      const hex = resolve(RAW[k]);
+      this.fgCodes.set(k, fgAnsi(hex));
+      this.bgCodes.set(k, bgAnsi(hex));
+    }
+  }
+  fg(color: ThemeColor, text: string): string { return `${this.fgCodes.get(color)}${text}\x1b[39m`; }
+  bg(color: ThemeColor, text: string): string { return `${this.bgCodes.get(color)}${text}\x1b[49m`; }
+  bold(text: string): string { return chalk.bold(text); }
+  italic(text: string): string { return chalk.italic(text); }
+  underline(text: string): string { return chalk.underline(text); }
+  strikethrough(text: string): string { return chalk.strikethrough(text); }
+}
+
+export const theme = new Theme();
 
 export function markdownTheme(): MarkdownTheme {
   return {
-    heading,
-    link,
-    linkUrl: chalk.gray,
-    code,
-    codeBlock,
-    codeBlockBorder,
-    quote,
-    quoteBorder,
-    hr: chalk.gray,
-    listBullet,
-    bold: chalk.bold,
-    italic: chalk.italic,
-    underline: chalk.underline,
-    strikethrough: chalk.strikethrough,
+    heading: (t) => theme.fg("mdHeading", t),
+    link: (t) => theme.fg("mdLink", t),
+    linkUrl: (t) => theme.fg("mdLinkUrl", t),
+    code: (t) => theme.fg("mdCode", t),
+    codeBlock: (t) => theme.fg("mdCodeBlock", t),
+    codeBlockBorder: (t) => theme.fg("mdCodeBlockBorder", t),
+    quote: (t) => theme.fg("mdQuote", t),
+    quoteBorder: (t) => theme.fg("mdQuoteBorder", t),
+    hr: (t) => theme.fg("mdHr", t),
+    listBullet: (t) => theme.fg("mdListBullet", t),
+    bold: (t) => theme.bold(t),
+    italic: (t) => theme.italic(t),
+    underline: (t) => theme.underline(t),
+    strikethrough: (t) => theme.strikethrough(t),
     highlightCode: (src: string, lang?: string): string[] => {
       const validLang = lang && supportsLanguage(lang) ? lang : undefined;
-      if (!validLang) return src.split("\n").map((l) => chalk.gray(l));
+      if (!validLang) return src.split("\n").map((l) => theme.fg("mdCodeBlock", l));
       try {
         return highlight(src, { language: validLang, ignoreIllegals: true }).split("\n");
       } catch {
-        return src.split("\n").map((l) => chalk.gray(l));
+        return src.split("\n").map((l) => theme.fg("mdCodeBlock", l));
       }
     },
   };
 }
 
-const selectListTheme: SelectListTheme = {
-  selectedPrefix: accent,
-  selectedText: accent,
-  description: muted,
-  scrollInfo: muted,
-  noMatch: muted,
-};
+export function selectListTheme(): SelectListTheme {
+  return {
+    selectedPrefix: (t) => theme.fg("accent", t),
+    selectedText: (t) => theme.fg("accent", t),
+    description: (t) => theme.fg("muted", t),
+    scrollInfo: (t) => theme.fg("muted", t),
+    noMatch: (t) => theme.fg("muted", t),
+  };
+}
 
 export function editorTheme(): EditorTheme {
   return {
-    borderColor: chalk.gray,
-    selectList: selectListTheme,
+    borderColor: (t) => theme.fg("borderMuted", t),
+    selectList: selectListTheme(),
   };
+}
+
+/** Kind icon table — kept in sync with agent-sh/src/utils/tool-display.ts KIND_ICONS. */
+export const KIND_ICONS: Record<string, string> = {
+  read: "◆",
+  edit: "✎",
+  delete: "✕",
+  move: "↗",
+  search: "⌕",
+  execute: "▶",
+  think: "◇",
+  fetch: "↓",
+  switch_mode: "⇄",
+};
+
+export function iconFor(kind?: string): string {
+  return kind ? (KIND_ICONS[kind] ?? "▶") : "▶";
 }

--- a/examples/extensions/ashi/src/theme.ts
+++ b/examples/extensions/ashi/src/theme.ts
@@ -1,0 +1,77 @@
+import chalk from "chalk";
+import { highlight, supportsLanguage } from "cli-highlight";
+import type { EditorTheme, MarkdownTheme, SelectListTheme } from "@earendil-works/pi-tui";
+
+const muted = chalk.gray;
+const dim = chalk.gray.dim;
+const accent = chalk.cyan;
+const error = chalk.red;
+const warning = chalk.yellow;
+const ok = chalk.green;
+const heading = chalk.bold.cyan;
+const link = chalk.cyan.underline;
+const code = chalk.yellow;
+const codeBlock = (t: string) => t;
+const codeBlockBorder = chalk.gray;
+const quote = chalk.italic.gray;
+const quoteBorder = chalk.gray;
+const listBullet = chalk.cyan;
+
+export const c = {
+  muted,
+  dim,
+  accent,
+  error,
+  warning,
+  ok,
+  heading,
+  borderMuted: chalk.gray,
+  borderAccent: chalk.cyan,
+  user: chalk.green,
+  assistant: chalk.white,
+  toolName: chalk.cyan,
+  toolDetail: chalk.gray,
+};
+
+export function markdownTheme(): MarkdownTheme {
+  return {
+    heading,
+    link,
+    linkUrl: chalk.gray,
+    code,
+    codeBlock,
+    codeBlockBorder,
+    quote,
+    quoteBorder,
+    hr: chalk.gray,
+    listBullet,
+    bold: chalk.bold,
+    italic: chalk.italic,
+    underline: chalk.underline,
+    strikethrough: chalk.strikethrough,
+    highlightCode: (src: string, lang?: string): string[] => {
+      const validLang = lang && supportsLanguage(lang) ? lang : undefined;
+      if (!validLang) return src.split("\n").map((l) => chalk.gray(l));
+      try {
+        return highlight(src, { language: validLang, ignoreIllegals: true }).split("\n");
+      } catch {
+        return src.split("\n").map((l) => chalk.gray(l));
+      }
+    },
+  };
+}
+
+const selectListTheme: SelectListTheme = {
+  selectedPrefix: accent,
+  selectedText: accent,
+  description: muted,
+  scrollInfo: muted,
+  noMatch: muted,
+};
+
+export function editorTheme(): EditorTheme {
+  return {
+    borderColor: chalk.gray,
+    selectList: selectListTheme,
+  };
+}

--- a/examples/extensions/ashi/tsconfig.json
+++ b/examples/extensions/ashi/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

A bundled example extension that exercises agent-sh as a frontend-agnostic communication layer. `ashi` boots the kernel via `createCore()`, disables the shell-coupled built-ins (`shell-context`, `tui-renderer`, `file-autocomplete`), and mounts `@earendil-works/pi-tui` as the sole frontend. Same backend, tools, slash commands, providers, skills — different presentation, no PTY.

The point isn't a feature-complete pi clone; it's a load-bearing test of the "kernel = bus + handlers + LLM" claim. If ashi runs, the kernel really is shell-agnostic.

## What's wired

- **MVP frontend:** streaming Markdown response, tool start/complete with shaded boxes that swap bg between pending/success/error, kind-keyed tool icons, live `agent:tool-output-chunk` rendering inside the box, themed loader/error/info.
- **Pi dark palette:** ~150 LOC `theme.ts` inlines pi-coding-agent's `dark.json` color scheme and exposes the same `theme.fg()` / `theme.bg()` / `markdownTheme()` / `editorTheme()` API pi components expect — without depending on `@mariozechner/pi-coding-agent`.
- **Slash commands:** Editor onSubmit splits `/` queries off and emits `command:execute` instead of `agent:submit`, so `/help`, `/model`, `/backend`, etc. dispatch the same way they do in the shell frontend.
- **Slash autocomplete:** `BusAutocompleteProvider` bridges pi-tui's `AutocompleteProvider` interface to agent-sh's `autocomplete:request` pipe — typing `/he` pops `/help`, `/backend cla` pops `/backend claude-code`, etc.
- **Pi-convention keybindings:** Esc cancels active turn, Ctrl+C clears the editor, Ctrl+D quits when the editor is empty. `matchesKey()` covers both legacy bytes and Kitty-protocol CSI encodings (Ghostty / Kitty / iTerm2 in Kitty mode).
- **Tool detail extractor:** mirrors the canonical `extractDetail` in `src/extensions/tui-renderer.ts` — tools without a `formatCall` (bash, ls, grep, read-file, write-file) get the meaningful field surfaced from `rawInput` (\`\$ cmd\`, relative path, pattern, quoted query). The AI's description suffix from the title is dropped since the detail line already conveys the call.

## Layout

```
examples/extensions/ashi/
├── src/
│   ├── cli.ts          # createCore → disable shell built-ins → mountAshi → activateBackend
│   ├── frontend.ts     # pi-tui mount, Editor → agent:submit / command:execute, bus → Components
│   ├── components.ts   # UserMessage, AssistantMessage, ToolExecution, Error/InfoLine
│   ├── theme.ts        # Dark palette, MarkdownTheme/EditorTheme, kind icon table
│   └── autocomplete.ts # BusAutocompleteProvider — pipes pi-tui's API to autocomplete:request
├── tsconfig.json
├── package.json        # bin: dist/cli.js; agent-sh wired as file:../../..
└── README.md
```

Matches the `ash-acp-bridge` convention: src/ compiled by tsc into dist/, bin is the compiled JS with shebang preserved, `agent-sh` is a local `file:` dep that #147's `rewriteFileDeps` resolves to an absolute path at install time.

## Out of scope for this PR

- Permission dialogs, diff renderer, file-path autocomplete, session selector, theme selector, image rendering — each needs a pi-tui Component or overlay wired to the corresponding bus event, deferred.
- Pi-style tree-structured session history. Agent-sh's `HistoryAdapter` interface is flexible enough to land that as a follow-up (a SessionManager-backed adapter passed via `createCore({ history })`, with tree UI in the frontend).

## Test plan

- [x] `tsc` clean (root + ashi).
- [x] Headless smoke: kernel boots with shell built-ins disabled, backends register, all loaded extensions activate without the shell.
- [x] TUI mount + teardown: `mountAshi(ctx)` instantiates pi-tui, draws editor, stops cleanly.
- [x] Slash dispatch: `/help` returns the command list via `ui:info`.
- [x] Slash autocomplete: typing `/he` → `["/help"]`, `/backend ` → `["/backend <name>"]`.
- [x] Keybindings: `matchesKey` resolves both legacy bytes and Kitty CSI for ctrl+c / ctrl+d / escape.
- [ ] Live interactive smoke: `cd examples/extensions/ashi && ./dist/cli.js` — eyeball the dark palette, exercise a query that triggers tool calls, verify Ctrl+D quits in a Kitty-protocol terminal.

## Commits

1. Add ashi example: ash backend with pi-tui frontend, no shell
2. Theme ashi after pi-coding-agent's dark palette
3. Fall back to rawInput when a tool has no formatCall
4. Dispatch slash commands instead of sending them to the LLM
5. Wire slash-command autocomplete to the bus
6. Follow pi-coding-agent's keybinding convention
7. Drop AI description from the tool header
8. Use matchesKey() for keybindings to cover Kitty protocol