### PR TITLE
Demonstrate pi-clone capability: tree history, LLM compaction, session restore in ashi

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -56,15 +56,35 @@ Ctrl+C   Clear editor
 Ctrl+D   Quit (when editor is empty)
 ```
 
+## History tree
+
+ashi swaps the linear `~/.agent-sh/history` JSONL for a pi-style tree, persisted at
+`~/.agent-sh/extensions/ashi/tree.jsonl`. Each entry carries a `parentSeq`; sibling branches
+live on disk so you can navigate between them.
+
+```
+/tree      Show the whole tree, marking the active branch and fork points
+/branch    Show the active branch (root → leaf)
+/fork <seq> Reparent the next turn off <seq> instead of the current leaf
+```
+
+`/fork` only changes the on-disk parent pointer for the *next* batch — it doesn't rewind the
+agent's in-context messages. Full conversation replay from a branch is a follow-up.
+
+The kernel side of this is just three lines: an optional `parentSeq` on `NuclearEntry` plus
+optional `getBranch` / `getTree` / `setLeaf` on `HistoryAdapter`. Everything else (storage,
+walk, slash commands) lives in this extension.
+
 ## What's intentionally missing
 
 This is a spike, not a clone of pi's full UI. The MVP renders:
 
 - User submissions, streaming assistant Markdown
 - Tool invocations with start/complete state
-- Slash commands with autocomplete (`/help`, `/model`, `/backend`, …)
+- Slash commands with autocomplete (`/help`, `/model`, `/backend`, `/tree`, `/fork`, …)
+- Tree-shaped on-disk history with `/fork` divergence
 - Loader, errors, info messages
 
 Out of scope for v0: permission dialogs, diff renderer, file-path autocomplete, session
-selector, theme selector, image rendering. Each can be added by writing a pi-tui Component and
-subscribing to the corresponding bus event.
+selector, theme selector, image rendering, full conversation rewind on fork. Each can be
+added by writing a pi-tui Component and subscribing to the corresponding bus event.

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -97,6 +97,18 @@ The kernel exposes one extra handler (`conversation:allocate-seq`) so the compac
 gets a fresh seq from the same counter as kernel-produced entries. Everything else
 (prompt template, cut-point walker, serialization, LLM call) lives in this extension.
 
+## Session restore
+
+After every turn, ashi snapshots the live message array to
+`history/<cwd-slug>/snapshots/<leaf-seq>.json`. On startup, it reloads the snapshot for
+the active leaf and calls `conversation:replace-messages`, so the agent resumes with the
+exact same context it had at shutdown — including the post-compaction `[summary, ...kept]`
+shape that pi preserves on reload.
+
+`/fork <seq>` now also rewinds the agent context: if a snapshot exists at that seq, it's
+loaded; otherwise the on-disk parent pointer changes but the in-memory messages stay put
+(degraded mode for forks to leaves that predate snapshotting).
+
 ## What's intentionally missing
 
 This is a spike, not a clone of pi's full UI. The MVP renders:

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -58,9 +58,9 @@ Ctrl+D   Quit (when editor is empty)
 
 ## History tree
 
-ashi swaps the linear `~/.agent-sh/history` JSONL for a pi-style tree, persisted at
-`~/.agent-sh/extensions/ashi/tree.jsonl`. Each entry carries a `parentSeq`; sibling branches
-live on disk so you can navigate between them.
+ashi swaps the linear `~/.agent-sh/history` JSONL for a pi-style tree, persisted per-cwd
+under `~/.agent-sh/extensions/ashi/history/<cwd-slug>/tree.jsonl`. Each entry carries a
+`parentSeq`; sibling branches live on disk so you can navigate between them.
 
 ```
 /tree      Show the whole tree, marking the active branch and fork points

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -75,6 +75,28 @@ The kernel side of this is just three lines: an optional `parentSeq` on `Nuclear
 optional `getBranch` / `getTree` / `setLeaf` on `HistoryAdapter`. Everything else (storage,
 walk, slash commands) lives in this extension.
 
+## Compaction
+
+ashi replaces agent-sh's default deterministic two-tier-pin compaction with a pi-style
+LLM-driven path:
+
+1. Cut point: walk back from the newest message until ~20K tokens are kept; never cut at
+   tool results or in the middle of an assistant→tool call group.
+2. LLM summarizes the older span into the pi structured format (Goal / Constraints /
+   Progress / Decisions / Next Steps / Critical Context).
+3. The live message array becomes `[summary, ...kept messages]`.
+4. The summary lands in the tree as a `compaction` `NuclearEntry`, parented at the
+   pre-compaction leaf. Subsequent compactions reference the previous one's summary so
+   chains stay coherent.
+
+Triggered automatically when prompt tokens cross agent-sh's threshold, or manually with
+`/compact`. If the LLM call fails or the conversation is too short, falls through to the
+default eviction.
+
+The kernel exposes one extra handler (`conversation:allocate-seq`) so the compaction entry
+gets a fresh seq from the same counter as kernel-produced entries. Everything else
+(prompt template, cut-point walker, serialization, LLM call) lives in this extension.
+
 ## What's intentionally missing
 
 This is a spike, not a clone of pi's full UI. The MVP renders:

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -57,9 +57,10 @@ async function main(): Promise<void> {
     process.stderr.write("ashi requires a TTY for interactive rendering.\n");
     process.exit(1);
   }
-  // Separate dir so the tree doesn't share state with the shell's linear ~/.agent-sh/history.
-  const ashiDir = path.join(os.homedir(), ".agent-sh", "extensions", "ashi");
-  const treeHistory = new TreeHistoryAdapter(ashiDir);
+  // Per-cwd tree so different projects don't share branches.
+  const cwdSlug = process.cwd().replace(/\//g, "-").replace(/^-/, "");
+  const historyDir = path.join(os.homedir(), ".agent-sh", "extensions", "ashi", "history", cwdSlug);
+  const treeHistory = new TreeHistoryAdapter(historyDir);
   const core = createCore({ ...config, history: treeHistory });
 
   // Built by frontend.ts; declared up here so cleanup can reach it.

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -16,6 +16,7 @@ import type { AgentShellConfig } from "agent-sh/types";
 import { mountAshi } from "./frontend.js";
 import { TreeHistoryAdapter } from "./tree-history.js";
 import { registerTreeCommands } from "./commands.js";
+import { registerCompaction } from "./compaction.js";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -96,6 +97,7 @@ async function main(): Promise<void> {
   }
 
   registerTreeCommands(ctx, treeHistory);
+  registerCompaction(ctx, treeHistory);
 
   const handle = mountAshi(ctx);
   stopFrontend = handle.stop;

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -17,6 +17,7 @@ import { mountAshi } from "./frontend.js";
 import { TreeHistoryAdapter } from "./tree-history.js";
 import { registerTreeCommands } from "./commands.js";
 import { registerCompaction } from "./compaction.js";
+import { registerSessionRestore, restoreSnapshot } from "./session-restore.js";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -98,11 +99,13 @@ async function main(): Promise<void> {
 
   registerTreeCommands(ctx, treeHistory);
   registerCompaction(ctx, treeHistory);
+  registerSessionRestore(ctx, treeHistory);
 
   const handle = mountAshi(ctx);
   stopFrontend = handle.stop;
 
   await core.activateBackend(config.backend ?? getSettings().defaultBackend);
+  restoreSnapshot(ctx, treeHistory);
 
   process.on("SIGTERM", cleanup);
   process.on("SIGHUP", cleanup);

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -14,6 +14,10 @@ import { getSettings } from "agent-sh/settings";
 import type { AgentShellConfig } from "agent-sh/types";
 
 import { mountAshi } from "./frontend.js";
+import { TreeHistoryAdapter } from "./tree-history.js";
+import { registerTreeCommands } from "./commands.js";
+import * as os from "node:os";
+import * as path from "node:path";
 
 function parseArgs(argv: string[]): AgentShellConfig & { extensions?: string[] } {
   let model: string | undefined;
@@ -53,7 +57,10 @@ async function main(): Promise<void> {
     process.stderr.write("ashi requires a TTY for interactive rendering.\n");
     process.exit(1);
   }
-  const core = createCore(config);
+  // Separate dir so the tree doesn't share state with the shell's linear ~/.agent-sh/history.
+  const ashiDir = path.join(os.homedir(), ".agent-sh", "extensions", "ashi");
+  const treeHistory = new TreeHistoryAdapter(ashiDir);
+  const core = createCore({ ...config, history: treeHistory });
 
   // Built by frontend.ts; declared up here so cleanup can reach it.
   let stopFrontend: (() => void) | null = null;
@@ -86,6 +93,8 @@ async function main(): Promise<void> {
     process.stderr.write("ashi: no agent backend registered. Set OPENAI_API_KEY or OPENROUTER_API_KEY, or configure ~/.agent-sh/settings.json.\n");
     process.exit(1);
   }
+
+  registerTreeCommands(ctx, treeHistory);
 
   const handle = mountAshi(ctx);
   stopFrontend = handle.stop;

--- a/examples/extensions/ashi/src/commands.ts
+++ b/examples/extensions/ashi/src/commands.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "agent-sh/types";
-import type { NuclearEntry } from "agent-sh/core";
+import { type NuclearEntry, formatNuclearLine } from "agent-sh/core";
 import type { TreeHistoryAdapter } from "./tree-history.js";
 
 export function registerTreeCommands(
@@ -36,10 +36,7 @@ export function registerTreeCommands(
       bus.emit("ui:error", { message: `fork: no entry at seq ${seq}` });
       return;
     }
-    try { tree.setLeaf(seq); } catch (e) {
-      bus.emit("ui:error", { message: `fork: ${(e as Error).message}` });
-      return;
-    }
+    tree.setLeaf(seq);
     bus.emit("ui:info", {
       message: `fork: next turn parents from #${seq}. (Caveat: the agent's in-context messages don't rewind — only the on-disk parent pointer changes.)`,
     });
@@ -51,7 +48,7 @@ export function registerTreeCommands(
       bus.emit("ui:info", { message: "branch: empty" });
       return;
     }
-    const lines = branch.map((e) => `#${e.seq} ${e.sum}`);
+    const lines = branch.map(formatNuclearLine);
     bus.emit("ui:info", { message: `branch (${branch.length} entries):\n${lines.join("\n")}` });
   });
 }

--- a/examples/extensions/ashi/src/commands.ts
+++ b/examples/extensions/ashi/src/commands.ts
@@ -37,9 +37,13 @@ export function registerTreeCommands(
       return;
     }
     tree.setLeaf(seq);
-    bus.emit("ui:info", {
-      message: `fork: next turn parents from #${seq}. (Caveat: the agent's in-context messages don't rewind — only the on-disk parent pointer changes.)`,
-    });
+    const snapshot = tree.loadSnapshot(seq);
+    if (snapshot && snapshot.length > 0) {
+      ctx.call("conversation:replace-messages", snapshot);
+      bus.emit("ui:info", { message: `fork: restored ${snapshot.length} messages from snapshot @ #${seq}` });
+    } else {
+      bus.emit("ui:info", { message: `fork: next turn parents from #${seq} (no snapshot — agent context not rewound)` });
+    }
   });
 
   ctx.registerCommand("branch", "Show the active branch (root → leaf)", async () => {

--- a/examples/extensions/ashi/src/commands.ts
+++ b/examples/extensions/ashi/src/commands.ts
@@ -1,0 +1,71 @@
+import type { ExtensionContext } from "agent-sh/types";
+import type { NuclearEntry } from "agent-sh/core";
+import type { TreeHistoryAdapter } from "./tree-history.js";
+
+export function registerTreeCommands(
+  ctx: ExtensionContext,
+  tree: TreeHistoryAdapter,
+): void {
+  const { bus } = ctx;
+
+  ctx.registerCommand("tree", "Show the history tree (active branch + sibling counts)", async () => {
+    const all = await tree.getTree();
+    if (all.length === 0) {
+      bus.emit("ui:info", { message: "tree: empty" });
+      return;
+    }
+    const activeLeaf = tree.getActiveLeaf();
+    const branchSeqs = new Set((await tree.getBranch(activeLeaf)).map((e) => e.seq));
+    const childCount = new Map<number, number>();
+    for (const e of all) {
+      if (e.parentSeq == null) continue;
+      childCount.set(e.parentSeq, (childCount.get(e.parentSeq) ?? 0) + 1);
+    }
+    const lines = all.map((e) => formatRow(e, branchSeqs, childCount, activeLeaf));
+    bus.emit("ui:info", { message: `tree (active leaf #${activeLeaf}):\n${lines.join("\n")}` });
+  });
+
+  ctx.registerCommand("fork", "Fork the next turn from a specific seq: /fork <seq>", async (args) => {
+    const trimmed = args.trim();
+    const seq = trimmed === "" ? 0 : parseInt(trimmed, 10);
+    if (Number.isNaN(seq)) {
+      bus.emit("ui:error", { message: "fork: expected a numeric seq" });
+      return;
+    }
+    if (seq !== 0 && !(await tree.findBySeq(seq))) {
+      bus.emit("ui:error", { message: `fork: no entry at seq ${seq}` });
+      return;
+    }
+    try { tree.setLeaf(seq); } catch (e) {
+      bus.emit("ui:error", { message: `fork: ${(e as Error).message}` });
+      return;
+    }
+    bus.emit("ui:info", {
+      message: `fork: next turn parents from #${seq}. (Caveat: the agent's in-context messages don't rewind — only the on-disk parent pointer changes.)`,
+    });
+  });
+
+  ctx.registerCommand("branch", "Show the active branch (root → leaf)", async () => {
+    const branch = await tree.getBranch(tree.getActiveLeaf());
+    if (branch.length === 0) {
+      bus.emit("ui:info", { message: "branch: empty" });
+      return;
+    }
+    const lines = branch.map((e) => `#${e.seq} ${e.sum}`);
+    bus.emit("ui:info", { message: `branch (${branch.length} entries):\n${lines.join("\n")}` });
+  });
+}
+
+function formatRow(
+  e: NuclearEntry,
+  branchSeqs: Set<number>,
+  childCount: Map<number, number>,
+  activeLeaf: number,
+): string {
+  const onBranch = branchSeqs.has(e.seq);
+  const marker = e.seq === activeLeaf ? "●" : onBranch ? "│" : " ";
+  const kids = childCount.get(e.seq) ?? 0;
+  const fork = kids > 1 ? ` (${kids} branches)` : "";
+  const parent = e.parentSeq != null ? ` ← #${e.parentSeq}` : "";
+  return `${marker} #${e.seq} ${e.sum}${parent}${fork}`;
+}

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -66,7 +66,7 @@ export function registerCompaction(ctx: ExtensionContext, tree: TreeHistoryAdapt
       summary = await ctx.llm.ask({
         system: SUMMARY_PROMPT,
         query: buildQuery(older, prevSummary),
-        maxTokens: 4096,
+        maxTokens: 16384,
         reasoningEffort: "low",
       });
     } catch (e) {

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "agent-sh/types";
-import { type NuclearEntry, formatNuclearLine } from "agent-sh/core";
+import { type NuclearEntry } from "agent-sh/core";
 import type { TreeHistoryAdapter } from "./tree-history.js";
 
 const KEEP_RECENT_TOKEN_BUDGET = 20_000;
@@ -44,19 +44,6 @@ interface AgentMessage {
 }
 
 export function registerCompaction(ctx: ExtensionContext, tree: TreeHistoryAdapter): void {
-  ctx.advise("conversation:format-prior-history", (_next: unknown, entries: NuclearEntry[]) => {
-    if (!entries || entries.length === 0) return null;
-    const parts: string[] = ["[Prior session history]"];
-    for (const e of entries) {
-      if (e.kind === "compaction" && e.body) {
-        parts.push(`\n--- Compaction at #${e.seq} ---\n${e.body}\n--- End compaction ---\n`);
-      } else {
-        parts.push(formatNuclearLine(e));
-      }
-    }
-    return parts.join("\n");
-  });
-
   ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
     if (!ctx.llm.available) return next(opts);
 

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -1,0 +1,176 @@
+import type { ExtensionContext } from "agent-sh/types";
+import type { NuclearEntry } from "agent-sh/core";
+import type { TreeHistoryAdapter } from "./tree-history.js";
+
+/** Pi-style LLM-driven compaction.
+ *
+ *  Advises `conversation:compact` to summarize older messages into a
+ *  structured block and append the summary as a `compaction` NuclearEntry
+ *  in the tree — instead of agent-sh's default "replace evicted turns with
+ *  pre-computed nuclear one-liners" path. On auto-trigger, the kernel
+ *  still decides *when* to compact; we replace *how*.
+ *
+ *  v0 scope: live compaction only. Restart fidelity (reloading the
+ *  [summary, kept messages] shape from disk) is deferred — current tree
+ *  storage doesn't persist raw AgentMessages per entry.
+ */
+const KEEP_RECENT_TOKEN_BUDGET = 20_000;
+const APPROX_TOKENS_PER_CHAR = 0.25;
+
+const SUMMARY_PROMPT = `You are compacting a coding-agent conversation so the agent can continue with limited context.
+
+Produce a Markdown summary using EXACTLY this structure:
+
+## Goal
+[What the user is trying to accomplish, one or two sentences]
+
+## Constraints & Preferences
+- [Bulleted user requirements / preferences expressed so far]
+
+## Progress
+### Done
+- [x] [Completed work]
+
+### In Progress
+- [ ] [Active work and current sub-goal]
+
+### Blocked
+- [Issues, or "None"]
+
+## Key Decisions
+- **[Decision]**: [Rationale]
+
+## Next Steps
+1. [What should happen next]
+
+## Critical Context
+- [Specific paths, names, identifiers, or data the agent must remember]
+
+Be concrete. Quote file paths, function names, error strings verbatim when relevant. Do not invent details that aren't in the conversation.`;
+
+interface AgentMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: unknown;
+  tool_calls?: Array<{ function?: { name: string; arguments: string } }>;
+}
+
+export function registerCompaction(ctx: ExtensionContext, tree: TreeHistoryAdapter): void {
+  ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
+    if (!ctx.llm.available) return next(opts);
+
+    const messages = ctx.call("conversation:get-messages") as AgentMessage[] | undefined;
+    if (!messages || messages.length < 6) return next(opts);
+
+    const cutIdx = findCutPoint(messages, KEEP_RECENT_TOKEN_BUDGET);
+    if (cutIdx < 2) return next(opts);
+
+    const older = messages.slice(0, cutIdx);
+    const kept = messages.slice(cutIdx);
+
+    const branch = await tree.getBranch(tree.getActiveLeaf());
+    const prevSummary = [...branch].reverse().find((e) => e.kind === "compaction")?.body;
+
+    const tokensBefore = (ctx.call("conversation:estimate-prompt-tokens") as number) ?? 0;
+
+    let summary: string;
+    try {
+      summary = await ctx.llm.ask({
+        system: SUMMARY_PROMPT,
+        query: buildQuery(older, prevSummary),
+        maxTokens: 4096,
+        reasoningEffort: "low",
+      });
+    } catch (e) {
+      ctx.bus.emit("ui:error", { message: `compaction: LLM failed (${(e as Error).message}); falling back to two-tier-pin` });
+      return next(opts);
+    }
+
+    const summaryMessage: AgentMessage = {
+      role: "user",
+      content: `[Compacted conversation summary]\n${summary.trim()}`,
+    };
+    ctx.call("conversation:replace-messages", [summaryMessage, ...kept]);
+
+    const seq = ctx.call("conversation:allocate-seq") as number;
+    const entry: NuclearEntry = {
+      seq,
+      ts: Date.now(),
+      iid: ctx.instanceId,
+      kind: "compaction",
+      sum: `compacted ${older.length} messages (${tokensBefore} → ~${estimateTokens(summary)} tokens)`,
+      body: summary,
+    };
+    ctx.call("history:append", [entry]);
+
+    const tokensAfter = (ctx.call("conversation:estimate-prompt-tokens") as number) ?? 0;
+    ctx.bus.emit("ui:info", { message: `compacted ${older.length} messages: ${tokensBefore} → ${tokensAfter} tokens` });
+
+    return { before: tokensBefore, after: tokensAfter, evictedCount: older.length };
+  });
+}
+
+/** Find the index such that messages[cutIdx..] is ≤ tokenBudget tokens
+ *  AND messages[cutIdx] is a safe cut point (not a tool result; not in
+ *  the middle of an assistant→tool call/result group). Walks backwards
+ *  from the end. */
+function findCutPoint(messages: AgentMessage[], tokenBudget: number): number {
+  let acc = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    acc += estimateMessageTokens(messages[i]!);
+    if (acc >= tokenBudget) {
+      let cut = i;
+      while (cut < messages.length && !isSafeCutPoint(messages, cut)) cut++;
+      return cut;
+    }
+  }
+  return 0;
+}
+
+function isSafeCutPoint(messages: AgentMessage[], idx: number): boolean {
+  const m = messages[idx];
+  if (!m) return true;
+  if (m.role === "tool") return false;
+  if (m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0) return false;
+  return true;
+}
+
+function estimateMessageTokens(m: AgentMessage): number {
+  let chars = 0;
+  if (typeof m.content === "string") chars += m.content.length;
+  if (m.tool_calls) for (const tc of m.tool_calls) chars += (tc.function?.arguments?.length ?? 0);
+  return Math.ceil(chars * APPROX_TOKENS_PER_CHAR) + 20;
+}
+
+function estimateTokens(s: string): number {
+  return Math.ceil(s.length * APPROX_TOKENS_PER_CHAR);
+}
+
+/** Pi-style conversation serialization. Tool results truncated to 2000
+ *  chars; keeps role labels so the model doesn't try to continue the
+ *  conversation. */
+function buildQuery(messages: AgentMessage[], prevSummary?: string): string {
+  const lines: string[] = [];
+  if (prevSummary) lines.push("Previous compaction summary (continue iteratively):\n", prevSummary, "\n---\n");
+  lines.push("Conversation to summarize:");
+  for (const m of messages) {
+    const text = typeof m.content === "string" ? m.content : "";
+    if (m.role === "user") lines.push(`[User]: ${text}`);
+    else if (m.role === "assistant") {
+      if (text) lines.push(`[Assistant]: ${text}`);
+      if (m.tool_calls) {
+        for (const tc of m.tool_calls) {
+          const args = tc.function?.arguments ?? "";
+          lines.push(`[Assistant tool call]: ${tc.function?.name ?? "?"}(${truncate(args, 400)})`);
+        }
+      }
+    } else if (m.role === "tool") {
+      lines.push(`[Tool result]: ${truncate(text, 2000)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + `\n[…truncated ${s.length - max} chars…]`;
+}

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "agent-sh/types";
-import type { NuclearEntry } from "agent-sh/core";
+import { type NuclearEntry, formatNuclearLine } from "agent-sh/core";
 import type { TreeHistoryAdapter } from "./tree-history.js";
 
 const KEEP_RECENT_TOKEN_BUDGET = 20_000;
@@ -44,6 +44,19 @@ interface AgentMessage {
 }
 
 export function registerCompaction(ctx: ExtensionContext, tree: TreeHistoryAdapter): void {
+  ctx.advise("conversation:format-prior-history", (_next: unknown, entries: NuclearEntry[]) => {
+    if (!entries || entries.length === 0) return null;
+    const parts: string[] = ["[Prior session history]"];
+    for (const e of entries) {
+      if (e.kind === "compaction" && e.body) {
+        parts.push(`\n--- Compaction at #${e.seq} ---\n${e.body}\n--- End compaction ---\n`);
+      } else {
+        parts.push(formatNuclearLine(e));
+      }
+    }
+    return parts.join("\n");
+  });
+
   ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
     if (!ctx.llm.available) return next(opts);
 

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -2,19 +2,8 @@ import type { ExtensionContext } from "agent-sh/types";
 import type { NuclearEntry } from "agent-sh/core";
 import type { TreeHistoryAdapter } from "./tree-history.js";
 
-/** Pi-style LLM-driven compaction.
- *
- *  Advises `conversation:compact` to summarize older messages into a
- *  structured block and append the summary as a `compaction` NuclearEntry
- *  in the tree — instead of agent-sh's default "replace evicted turns with
- *  pre-computed nuclear one-liners" path. On auto-trigger, the kernel
- *  still decides *when* to compact; we replace *how*.
- *
- *  v0 scope: live compaction only. Restart fidelity (reloading the
- *  [summary, kept messages] shape from disk) is deferred — current tree
- *  storage doesn't persist raw AgentMessages per entry.
- */
 const KEEP_RECENT_TOKEN_BUDGET = 20_000;
+// Matches agent-sh ConversationState.estimateTokens (chars/4).
 const APPROX_TOKENS_PER_CHAR = 0.25;
 
 const SUMMARY_PROMPT = `You are compacting a coding-agent conversation so the agent can continue with limited context.
@@ -109,10 +98,6 @@ export function registerCompaction(ctx: ExtensionContext, tree: TreeHistoryAdapt
   });
 }
 
-/** Find the index such that messages[cutIdx..] is ≤ tokenBudget tokens
- *  AND messages[cutIdx] is a safe cut point (not a tool result; not in
- *  the middle of an assistant→tool call/result group). Walks backwards
- *  from the end. */
 function findCutPoint(messages: AgentMessage[], tokenBudget: number): number {
   let acc = 0;
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -130,8 +115,7 @@ function isSafeCutPoint(messages: AgentMessage[], idx: number): boolean {
   const m = messages[idx];
   if (!m) return true;
   if (m.role === "tool") return false;
-  if (m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0) return false;
-  return true;
+  return !(m.role === "assistant" && m.tool_calls?.length);
 }
 
 function estimateMessageTokens(m: AgentMessage): number {
@@ -145,9 +129,8 @@ function estimateTokens(s: string): number {
   return Math.ceil(s.length * APPROX_TOKENS_PER_CHAR);
 }
 
-/** Pi-style conversation serialization. Tool results truncated to 2000
- *  chars; keeps role labels so the model doesn't try to continue the
- *  conversation. */
+// Role labels prevent the model from treating the serialized text as a
+// conversation to continue. Tool results capped at 2000 chars (pi convention).
 function buildQuery(messages: AgentMessage[], prevSummary?: string): string {
   const lines: string[] = [];
   if (prevSummary) lines.push("Previous compaction summary (continue iteratively):\n", prevSummary, "\n---\n");

--- a/examples/extensions/ashi/src/session-restore.ts
+++ b/examples/extensions/ashi/src/session-restore.ts
@@ -1,0 +1,34 @@
+import type { ExtensionContext } from "agent-sh/types";
+import { type NuclearEntry, formatNuclearLine } from "agent-sh/core";
+import type { TreeHistoryAdapter } from "./tree-history.js";
+
+export function registerSessionRestore(ctx: ExtensionContext, tree: TreeHistoryAdapter): void {
+  ctx.advise("conversation:format-prior-history", (_next: unknown, entries: NuclearEntry[]) => {
+    if (tree.hasSnapshot(tree.getActiveLeaf())) return null;
+    if (!entries || entries.length === 0) return null;
+    const parts: string[] = ["[Prior session history]"];
+    for (const e of entries) {
+      if (e.kind === "compaction" && e.body) {
+        parts.push(`\n--- Compaction at #${e.seq} ---\n${e.body}\n--- End compaction ---\n`);
+      } else {
+        parts.push(formatNuclearLine(e));
+      }
+    }
+    return parts.join("\n");
+  });
+
+  ctx.bus.on("agent:processing-done", () => {
+    const messages = ctx.call("conversation:get-messages") as unknown[] | undefined;
+    if (!messages) return;
+    tree.saveSnapshot(tree.getActiveLeaf(), messages);
+  });
+}
+
+export function restoreSnapshot(ctx: ExtensionContext, tree: TreeHistoryAdapter): boolean {
+  const leaf = tree.getActiveLeaf();
+  const snapshot = tree.loadSnapshot(leaf);
+  if (!snapshot || snapshot.length === 0) return false;
+  ctx.call("conversation:replace-messages", snapshot);
+  ctx.bus.emit("ui:info", { message: `restored ${snapshot.length} messages from snapshot @ #${leaf}` });
+  return true;
+}

--- a/examples/extensions/ashi/src/tree-history.ts
+++ b/examples/extensions/ashi/src/tree-history.ts
@@ -1,0 +1,123 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import {
+  type HistoryAdapter,
+  type NuclearEntry,
+} from "agent-sh/core";
+
+/** Tree-shaped on-disk history. Each entry carries a parentSeq pointing at
+ *  its parent in the tree; sibling branches from the same parent stay on
+ *  disk so the user can /fork between them. readRecent returns only the
+ *  currently active branch (root → activeLeaf) so the agent prompt isn't
+ *  contaminated with content from sibling threads. */
+export class TreeHistoryAdapter implements HistoryAdapter {
+  private entriesPath: string;
+  private leafPath: string;
+  private entries = new Map<number, NuclearEntry>();
+  private activeLeaf = 0;
+
+  constructor(dir: string) {
+    this.entriesPath = path.join(dir, "tree.jsonl");
+    this.leafPath = path.join(dir, "active-leaf");
+    fs.mkdirSync(dir, { recursive: true });
+    this.loadFromDisk();
+  }
+
+  private loadFromDisk(): void {
+    try {
+      const raw = fs.readFileSync(this.entriesPath, "utf-8");
+      for (const line of raw.split("\n")) {
+        if (!line) continue;
+        try {
+          const e = JSON.parse(line) as NuclearEntry;
+          if (typeof e.seq === "number") this.entries.set(e.seq, e);
+        } catch { /* skip malformed line */ }
+      }
+    } catch { /* fresh file */ }
+    try {
+      this.activeLeaf = parseInt(fs.readFileSync(this.leafPath, "utf-8").trim(), 10) || 0;
+    } catch { this.activeLeaf = this.highestSeq(); }
+  }
+
+  private highestSeq(): number {
+    let max = 0;
+    for (const seq of this.entries.keys()) if (seq > max) max = seq;
+    return max;
+  }
+
+  private persistLeaf(): void {
+    fs.writeFileSync(this.leafPath, String(this.activeLeaf));
+  }
+
+  async append(batch: NuclearEntry[]): Promise<void> {
+    if (batch.length === 0) return;
+    let parent = this.activeLeaf;
+    const lines: string[] = [];
+    for (const e of batch) {
+      if (e.parentSeq == null) e.parentSeq = parent;
+      this.entries.set(e.seq, e);
+      lines.push(JSON.stringify(e));
+      parent = e.seq;
+    }
+    this.activeLeaf = parent;
+    await fsp.appendFile(this.entriesPath, lines.join("\n") + "\n");
+    this.persistLeaf();
+  }
+
+  async readRecent(maxEntries?: number): Promise<NuclearEntry[]> {
+    const branch = this.walkBranch(this.activeLeaf);
+    return maxEntries ? branch.slice(-maxEntries) : branch;
+  }
+
+  async search(query: string): Promise<{ entry: NuclearEntry; line: string }[]> {
+    if (!query.trim()) return [];
+    const needle = query.toLowerCase();
+    const hits: { entry: NuclearEntry; line: string }[] = [];
+    for (const e of [...this.entries.values()].sort((a, b) => b.seq - a.seq)) {
+      const haystack = `${e.sum}\n${e.body ?? ""}`.toLowerCase();
+      if (haystack.includes(needle)) {
+        hits.push({ entry: e, line: `#${e.seq} ${e.sum}` });
+      }
+    }
+    return hits;
+  }
+
+  async findBySeq(seq: number): Promise<NuclearEntry | null> {
+    return this.entries.get(seq) ?? null;
+  }
+
+  async getBranch(leafSeq: number): Promise<NuclearEntry[]> {
+    return this.walkBranch(leafSeq);
+  }
+
+  async getTree(): Promise<NuclearEntry[]> {
+    return [...this.entries.values()].sort((a, b) => a.seq - b.seq);
+  }
+
+  setLeaf(seq: number): void {
+    if (!this.entries.has(seq) && seq !== 0) {
+      throw new Error(`Unknown seq: ${seq}`);
+    }
+    this.activeLeaf = seq;
+    this.persistLeaf();
+  }
+
+  getActiveLeaf(): number { return this.activeLeaf; }
+
+  /** Walk parent pointers from leaf to root, returning oldest-first. */
+  private walkBranch(leaf: number): NuclearEntry[] {
+    const out: NuclearEntry[] = [];
+    const seen = new Set<number>();
+    let cur: number | undefined = leaf;
+    while (cur && cur !== 0 && !seen.has(cur)) {
+      seen.add(cur);
+      const e = this.entries.get(cur);
+      if (!e) break;
+      out.push(e);
+      cur = e.parentSeq;
+    }
+    return out.reverse();
+  }
+}
+

--- a/examples/extensions/ashi/src/tree-history.ts
+++ b/examples/extensions/ashi/src/tree-history.ts
@@ -11,14 +11,37 @@ import {
 export class TreeHistoryAdapter implements HistoryAdapter {
   private entriesPath: string;
   private leafPath: string;
+  private snapshotsDir: string;
   private entries = new Map<number, NuclearEntry>();
   private activeLeaf = 0;
 
   constructor(dir: string) {
     this.entriesPath = path.join(dir, "tree.jsonl");
     this.leafPath = path.join(dir, "active-leaf");
+    this.snapshotsDir = path.join(dir, "snapshots");
     fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(this.snapshotsDir, { recursive: true });
     this.loadFromDisk();
+  }
+
+  saveSnapshot(leaf: number, messages: unknown[]): void {
+    if (leaf === 0 || messages.length === 0) return;
+    fs.writeFileSync(path.join(this.snapshotsDir, `${leaf}.json`), JSON.stringify(messages));
+  }
+
+  loadSnapshot(leaf: number): unknown[] | null {
+    if (leaf === 0) return null;
+    try {
+      const raw = fs.readFileSync(path.join(this.snapshotsDir, `${leaf}.json`), "utf-8");
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : null;
+    } catch { return null; }
+  }
+
+  hasSnapshot(leaf: number): boolean {
+    if (leaf === 0) return false;
+    try { fs.statSync(path.join(this.snapshotsDir, `${leaf}.json`)); return true; }
+    catch { return false; }
   }
 
   private loadFromDisk(): void {

--- a/examples/extensions/ashi/src/tree-history.ts
+++ b/examples/extensions/ashi/src/tree-history.ts
@@ -4,13 +4,10 @@ import * as path from "node:path";
 import {
   type HistoryAdapter,
   type NuclearEntry,
+  compileSearchRegex,
+  matchEntry,
 } from "agent-sh/core";
 
-/** Tree-shaped on-disk history. Each entry carries a parentSeq pointing at
- *  its parent in the tree; sibling branches from the same parent stay on
- *  disk so the user can /fork between them. readRecent returns only the
- *  currently active branch (root → activeLeaf) so the agent prompt isn't
- *  contaminated with content from sibling threads. */
 export class TreeHistoryAdapter implements HistoryAdapter {
   private entriesPath: string;
   private leafPath: string;
@@ -72,13 +69,11 @@ export class TreeHistoryAdapter implements HistoryAdapter {
 
   async search(query: string): Promise<{ entry: NuclearEntry; line: string }[]> {
     if (!query.trim()) return [];
-    const needle = query.toLowerCase();
+    const re = compileSearchRegex(query);
     const hits: { entry: NuclearEntry; line: string }[] = [];
     for (const e of [...this.entries.values()].sort((a, b) => b.seq - a.seq)) {
-      const haystack = `${e.sum}\n${e.body ?? ""}`.toLowerCase();
-      if (haystack.includes(needle)) {
-        hits.push({ entry: e, line: `#${e.seq} ${e.sum}` });
-      }
+      const m = matchEntry(e, re);
+      if (m) hits.push(m);
     }
     return hits;
   }
@@ -105,7 +100,6 @@ export class TreeHistoryAdapter implements HistoryAdapter {
 
   getActiveLeaf(): number { return this.activeLeaf; }
 
-  /** Walk parent pointers from leaf to root, returning oldest-first. */
   private walkBranch(leaf: number): NuclearEntry[] {
     const out: NuclearEntry[] = [];
     const seen = new Set<number>();
@@ -120,4 +114,3 @@ export class TreeHistoryAdapter implements HistoryAdapter {
     return out.reverse();
   }
 }
-

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1000,6 +1000,13 @@ export class AgentLoop implements AgentBackend {
     h.define("history:search", async (query: string) => this.history.search(query));
     h.define("history:find-by-seq", async (seq: number) => this.history.findBySeq(seq));
     h.define("history:read-recent", async (max?: number) => this.history.readRecent(max));
+    h.define("history:get-branch", async (leafSeq: number) =>
+      this.history.getBranch ? this.history.getBranch(leafSeq) : this.history.readRecent());
+    h.define("history:get-tree", async () =>
+      this.history.getTree ? this.history.getTree() : this.history.readRecent());
+    h.define("history:set-leaf", (seq: number) => {
+      this.history.setLeaf?.(seq);
+    });
 
     // Prior-session preamble renderer. Default: flat chronological list.
     h.define("conversation:format-prior-history", (entries: NuclearEntry[]) => {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -975,6 +975,7 @@ export class AgentLoop implements AgentBackend {
     h.define("conversation:nucleate-tool",
       (toolName: string, args: Record<string, unknown>, content: string, isError: boolean, iid: string, seq: number) =>
         nucleate(isError ? "error" : "tool", toolName, args, content, isError, iid, seq));
+    h.define("conversation:allocate-seq", () => this.conversation.allocateSeq());
 
     // Read-only views into the nuclear state, for compact strategies
     // and introspect that read without replacing.

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -405,6 +405,12 @@ export class ConversationState {
     this.handlers.call("history:append", entries);
   }
 
+  /** Bump and return the global sequence counter. For extensions that
+   *  synthesize their own NuclearEntries (e.g. ashi's compaction summaries). */
+  allocateSeq(): number {
+    return this.nextSeq++;
+  }
+
   // ── Token estimation ──────────────────────────────────────────
 
   updateApiTokenCount(promptTokens: number): void {

--- a/src/agent/conversation-state.ts
+++ b/src/agent/conversation-state.ts
@@ -406,7 +406,8 @@ export class ConversationState {
   }
 
   /** Bump and return the global sequence counter. For extensions that
-   *  synthesize their own NuclearEntries (e.g. ashi's compaction summaries). */
+   *  synthesize their own NuclearEntries (e.g. compaction summaries that
+   *  should land in the same sequence space as kernel-produced entries). */
   allocateSeq(): number {
     return this.nextSeq++;
   }

--- a/src/agent/history-file.ts
+++ b/src/agent/history-file.ts
@@ -27,6 +27,12 @@ export interface HistoryAdapter {
   readRecent(maxEntries?: number): Promise<NuclearEntry[]>;
   search(query: string): Promise<{ entry: NuclearEntry; line: string }[]>;
   findBySeq(seq: number): Promise<NuclearEntry | null>;
+  /** Walk parent pointers from a leaf back to the root. Tree-aware adapters only. */
+  getBranch?(leafSeq: number): Promise<NuclearEntry[]>;
+  /** Return every entry, including sibling branches. Tree-aware adapters only. */
+  getTree?(): Promise<NuclearEntry[]>;
+  /** Move the active leaf for the next append. Tree-aware adapters only. */
+  setLeaf?(seq: number): void;
 }
 
 export class InMemoryHistory implements HistoryAdapter {

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -35,6 +35,13 @@ export interface NuclearEntry {
    * survives into summaries. Displayed as `{why}` in formatNuclearLine.
    */
   why?: string;
+  /**
+   * Optional parent pointer for tree-shaped history. The default
+   * HistoryFile adapter ignores this and treats the file as linear;
+   * tree-aware adapters (see examples/extensions/ashi) use it to
+   * branch on /fork and walk a single path on resume.
+   */
+  parentSeq?: number;
 }
 
 /**

--- a/src/agent/nuclear-form.ts
+++ b/src/agent/nuclear-form.ts
@@ -38,8 +38,8 @@ export interface NuclearEntry {
   /**
    * Optional parent pointer for tree-shaped history. The default
    * HistoryFile adapter ignores this and treats the file as linear;
-   * tree-aware adapters (see examples/extensions/ashi) use it to
-   * branch on /fork and walk a single path on resume.
+   * tree-aware HistoryAdapter implementations use it to fork and to
+   * walk a single path on resume.
    */
   parentSeq?: number;
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -41,6 +41,7 @@ export { runSubagent, type SubagentOptions } from "./agent/subagent.js";
 export { LlmClient } from "./utils/llm-client.js";
 export { HistoryFile, InMemoryHistory, NoopHistory, type HistoryAdapter } from "./agent/history-file.js";
 export type { NuclearEntry } from "./agent/nuclear-form.js";
+export { compileSearchRegex, matchEntry, formatNuclearLine } from "./agent/nuclear-form.js";
 
 export interface AgentShellCore {
   bus: EventBus;


### PR DESCRIPTION
## Summary

Ashi (an ash-backend / pi-tui-frontend example extension) gains three pi-style features end-to-end, demonstrating that agent-sh's kernel really is frontend-agnostic. Total kernel-side change is ~15 LOC; everything else (~700 LOC) lives in the ashi extension.

### Kernel changes (additive, generic)

- `NuclearEntry.parentSeq?: number` — schema field for tree-shaped history. Default `HistoryFile` ignores it.
- `HistoryAdapter.getBranch?` / `getTree?` / `setLeaf?` — optional capability methods. Default adapter doesn't implement.
- Handler `conversation:allocate-seq` — lets extensions synthesize `NuclearEntry`s that share the kernel's global seq counter.
- `core.ts` re-exports `compileSearchRegex`, `matchEntry`, `formatNuclearLine` so extensions get kernel-consistent search and display semantics.

Zero mention of ashi in kernel code.

### Ashi extension

**Tree history (`tree-history.ts`):** JSONL store keyed by per-cwd slug (`~/.agent-sh/extensions/ashi/history/<cwd-slug>/tree.jsonl`), in-memory parent-pointer index, active-leaf cursor. Sibling branches stay on disk. `readRecent` walks active branch only so the preamble isn't contaminated. `search`/`findBySeq` scan the whole tree.

**Slash commands (`commands.ts`):** `/tree` (full tree with parent pointers + fork counts), `/branch` (active root→leaf via `formatNuclearLine`), `/fork <seq>`.

**LLM compaction (`compaction.ts`):** Advises `conversation:compact` to replace agent-sh's default deterministic two-tier-pin with pi's LLM-driven approach. Walks back to a safe cut point (~20K kept, never cut at tool results or in the middle of a tool call group), serializes the older span with pi's role labels, asks the LLM for a structured summary (Goal / Constraints / Progress / Decisions / Next Steps / Critical Context), and splices live messages to `[summary, ...kept]`. The summary lands in the tree as a `compaction` `NuclearEntry` parented at the pre-compaction leaf. Iterative: each new summary references the previous one. Falls through to the default eviction on LLM failure or too-short conversations. `maxTokens: 16384` so reasoning models don't exhaust the cap on thinking.

**Session restore (`session-restore.ts`):** After every turn, snapshots the live message array to `snapshots/<leaf-seq>.json`. On startup, `restoreSnapshot` loads the snapshot for the active leaf and calls `conversation:replace-messages` — the agent resumes with the exact same context, including post-compaction `[summary, ...kept]`. `/fork <seq>` now also rewinds: snapshot at target seq is loaded into live messages. Forks to leaves predating snapshotting fall through to degraded mode (parent pointer changes, context stays). `format-prior-history` advisor suppresses the kernel preamble when a snapshot is available (snapshot covers everything); falls back to compaction-aware rendering otherwise.

## What pi has that this still doesn't

- `BranchSummaryEntry`: pi summarizes the *leaving* branch on `/tree` navigation and injects it at the navigation point. Skipped here; `/fork` just rewinds via snapshot.
- Pi's tree UI overlay (this PR uses chat-line `/tree` output).
- Pi's session-tree compaction settings UI.

These are scope for follow-ups.

## Test plan

- [x] Unit-tested tree adapter: linear chains, mid-branch fork divergence, reload picks up active leaf, walks the right branch.
- [x] Unit-tested snapshot save/load: persisted to disk, restored byte-for-byte on a fresh adapter instance, retrievable at older leaves, returns null at unsnapshotted leaves.
- [x] `npm run build` clean at repo root and in `examples/extensions/ashi/`.
- [x] `ashi --help` boots without crashing.
- [x] `/simplify` review pass: agents identified reuse opportunities and narration comments; addressed where it shrunk code.
- [ ] Run `ashi` interactively: do a few turns, `/tree`, `/fork <seq>` (verify context rewinds), trigger compaction with a long session, restart, confirm full conversation restores.