### PR TITLE
Add status footer to ashi

### DIFF
--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -101,7 +101,7 @@ async function main(): Promise<void> {
   registerCompaction(ctx, treeHistory);
   registerSessionRestore(ctx, treeHistory);
 
-  const handle = mountAshi(ctx);
+  const handle = mountAshi(ctx, treeHistory);
   stopFrontend = handle.stop;
 
   await core.activateBackend(config.backend ?? getSettings().defaultBackend);

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -88,8 +88,8 @@ export function mountAshi(ctx: ExtensionContext, tree: TreeHistoryAdapter): Ashi
 
   tui.addChild(chat);
   tui.addChild(footerSlot);
-  tui.addChild(statusFooter);
   tui.addChild(editor);
+  tui.addChild(statusFooter);
   tui.setFocus(editor);
 
   // ── Active render targets ────────────────────────────────────

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -16,6 +16,8 @@ import {
   UserMessage,
 } from "./components.js";
 import { BusAutocompleteProvider } from "./autocomplete.js";
+import { StatusFooter } from "./status-footer.js";
+import type { TreeHistoryAdapter } from "./tree-history.js";
 
 const fgAccent = (t: string): string => theme.fg("accent", t);
 const fgMuted = (t: string): string => theme.fg("muted", t);
@@ -53,7 +55,7 @@ export interface AshiHandle {
   stop: () => void;
 }
 
-export function mountAshi(ctx: ExtensionContext): AshiHandle {
+export function mountAshi(ctx: ExtensionContext, tree: TreeHistoryAdapter): AshiHandle {
   const { bus } = ctx;
   const terminal = new ProcessTerminal();
   const tui = new TUI(terminal);
@@ -76,8 +78,17 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
     bus.emit("agent:submit", { query });
   };
 
+  const statusFooter = new StatusFooter();
+  statusFooter.update({ cwd: ctx.call("cwd") as string });
+  let compactions = 0;
+  const refreshFooterStats = (): void => {
+    const tokens = ctx.call("conversation:estimate-prompt-tokens") as number | undefined;
+    statusFooter.update({ leaf: tree.getActiveLeaf(), tokens: tokens ?? 0 });
+  };
+
   tui.addChild(chat);
   tui.addChild(footerSlot);
+  tui.addChild(statusFooter);
   tui.addChild(editor);
   tui.setFocus(editor);
 
@@ -170,6 +181,7 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
     processing = false;
     stopLoader();
     if (activeAssistant) activeAssistant.finalize();
+    refreshFooterStats();
     tui.requestRender();
   });
 
@@ -199,8 +211,22 @@ export function mountAshi(ctx: ExtensionContext): AshiHandle {
 
   bus.on("agent:info", (info) => {
     chat.addChild(new InfoLine(`${info.name}${info.model ? ` · ${info.model}` : ""}`));
+    statusFooter.update({
+      model: info.model,
+      provider: info.provider,
+      contextWindow: info.contextWindow,
+    });
     tui.requestRender();
   });
+
+  bus.on("conversation:after-compact", () => {
+    compactions++;
+    statusFooter.update({ compactions });
+    refreshFooterStats();
+    tui.requestRender();
+  });
+
+  refreshFooterStats();
 
   // Match pi-coding-agent's keybindings:
   //   Esc    — cancel active turn (when autocomplete is closed, which the

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -1,0 +1,56 @@
+import { Container, Text } from "@earendil-works/pi-tui";
+import { theme } from "./theme.js";
+
+interface StatusFields {
+  model?: string;
+  provider?: string;
+  contextWindow?: number;
+  cwd?: string;
+  leaf?: number;
+  tokens?: number;
+  compactions?: number;
+}
+
+export class StatusFooter extends Container {
+  private text: Text;
+  private fields: StatusFields = {};
+
+  constructor() {
+    super();
+    this.text = new Text("", 1, 0);
+    this.addChild(this.text);
+  }
+
+  update(patch: Partial<StatusFields>): void {
+    this.fields = { ...this.fields, ...patch };
+    this.repaint();
+  }
+
+  private repaint(): void {
+    const parts: string[] = [];
+    const { model, provider, contextWindow, cwd, leaf, tokens, compactions } = this.fields;
+    if (model) parts.push(model);
+    if (provider) parts.push(provider);
+    if (cwd) parts.push(shortenCwd(cwd));
+    if (leaf != null && leaf > 0) parts.push(`#${leaf}`);
+    if (tokens != null) {
+      parts.push(contextWindow ? `${fmtTokens(tokens)}/${fmtTokens(contextWindow)}` : fmtTokens(tokens));
+    }
+    if (compactions && compactions > 0) parts.push(`${compactions} compaction${compactions === 1 ? "" : "s"}`);
+    const line = parts.length === 0 ? "" : theme.fg("muted", parts.join("  ·  "));
+    this.text.setText(line);
+  }
+}
+
+function shortenCwd(cwd: string): string {
+  const home = process.env.HOME;
+  if (home && cwd.startsWith(`${home}/`)) return `~/${cwd.slice(home.length + 1)}`;
+  if (home && cwd === home) return "~";
+  return cwd;
+}
+
+function fmtTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 100_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${Math.round(n / 1000)}k`;
+}


### PR DESCRIPTION
## Summary

Pi-style single-line status footer between the loader slot and editor:

```
gpt-4o · openrouter  ·  ~/work/project  ·  #42  ·  12.3k/200k  ·  2 compactions
```

Shows: model · provider · cwd · active leaf · tokens/contextWindow · compaction count.

## Wiring

- `agent:info` → model, provider, contextWindow
- `cwd` handler called once at mount
- `conversation:estimate-prompt-tokens` + `tree.getActiveLeaf()` on every `agent:processing-done` and `conversation:after-compact`
- Local counter for compactions

All sources are already-exposed kernel surfaces. **Zero kernel changes** — pure ashi-side.

## Test plan

- [x] `npm run build` clean.
- [ ] Run `ashi` interactively, confirm footer updates after turns / compactions / forks.