### PR TITLE
Interactive tree picker for /tree and /fork

### DIFF
--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -97,12 +97,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  registerTreeCommands(ctx, treeHistory);
   registerCompaction(ctx, treeHistory);
   registerSessionRestore(ctx, treeHistory);
 
   const handle = mountAshi(ctx, treeHistory);
   stopFrontend = handle.stop;
+  registerTreeCommands(ctx, treeHistory, handle.openTreePicker);
 
   await core.activateBackend(config.backend ?? getSettings().defaultBackend);
   restoreSnapshot(ctx, treeHistory);

--- a/examples/extensions/ashi/src/commands.ts
+++ b/examples/extensions/ashi/src/commands.ts
@@ -27,12 +27,16 @@ export function registerTreeCommands(
 
   ctx.registerCommand("fork", "Fork the next turn from a specific seq: /fork <seq>", async (args) => {
     const trimmed = args.trim();
-    const seq = trimmed === "" ? 0 : parseInt(trimmed, 10);
-    if (Number.isNaN(seq)) {
-      bus.emit("ui:error", { message: "fork: expected a numeric seq" });
+    if (trimmed === "") {
+      bus.emit("ui:error", { message: "fork: missing seq — usage: /fork <seq> (try /tree to list seqs)" });
       return;
     }
-    if (seq !== 0 && !(await tree.findBySeq(seq))) {
+    const seq = parseInt(trimmed, 10);
+    if (Number.isNaN(seq) || seq < 1) {
+      bus.emit("ui:error", { message: "fork: expected a positive numeric seq" });
+      return;
+    }
+    if (!(await tree.findBySeq(seq))) {
       bus.emit("ui:error", { message: `fork: no entry at seq ${seq}` });
       return;
     }

--- a/examples/extensions/ashi/src/commands.ts
+++ b/examples/extensions/ashi/src/commands.ts
@@ -1,34 +1,22 @@
 import type { ExtensionContext } from "agent-sh/types";
-import { type NuclearEntry, formatNuclearLine } from "agent-sh/core";
+import { formatNuclearLine } from "agent-sh/core";
 import type { TreeHistoryAdapter } from "./tree-history.js";
 
 export function registerTreeCommands(
   ctx: ExtensionContext,
   tree: TreeHistoryAdapter,
+  openTreePicker: () => Promise<void>,
 ): void {
   const { bus } = ctx;
 
-  ctx.registerCommand("tree", "Show the history tree (active branch + sibling counts)", async () => {
-    const all = await tree.getTree();
-    if (all.length === 0) {
-      bus.emit("ui:info", { message: "tree: empty" });
-      return;
-    }
-    const activeLeaf = tree.getActiveLeaf();
-    const branchSeqs = new Set((await tree.getBranch(activeLeaf)).map((e) => e.seq));
-    const childCount = new Map<number, number>();
-    for (const e of all) {
-      if (e.parentSeq == null) continue;
-      childCount.set(e.parentSeq, (childCount.get(e.parentSeq) ?? 0) + 1);
-    }
-    const lines = all.map((e) => formatRow(e, branchSeqs, childCount, activeLeaf));
-    bus.emit("ui:info", { message: `tree (active leaf #${activeLeaf}):\n${lines.join("\n")}` });
+  ctx.registerCommand("tree", "Open the history tree picker", async () => {
+    await openTreePicker();
   });
 
-  ctx.registerCommand("fork", "Fork the next turn from a specific seq: /fork <seq>", async (args) => {
+  ctx.registerCommand("fork", "Fork the next turn: /fork (interactive) or /fork <seq>", async (args) => {
     const trimmed = args.trim();
     if (trimmed === "") {
-      bus.emit("ui:error", { message: "fork: missing seq — usage: /fork <seq> (try /tree to list seqs)" });
+      await openTreePicker();
       return;
     }
     const seq = parseInt(trimmed, 10);
@@ -59,18 +47,4 @@ export function registerTreeCommands(
     const lines = branch.map(formatNuclearLine);
     bus.emit("ui:info", { message: `branch (${branch.length} entries):\n${lines.join("\n")}` });
   });
-}
-
-function formatRow(
-  e: NuclearEntry,
-  branchSeqs: Set<number>,
-  childCount: Map<number, number>,
-  activeLeaf: number,
-): string {
-  const onBranch = branchSeqs.has(e.seq);
-  const marker = e.seq === activeLeaf ? "●" : onBranch ? "│" : " ";
-  const kids = childCount.get(e.seq) ?? 0;
-  const fork = kids > 1 ? ` (${kids} branches)` : "";
-  const parent = e.parentSeq != null ? ` ← #${e.parentSeq}` : "";
-  return `${marker} #${e.seq} ${e.sum}${parent}${fork}`;
 }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -4,10 +4,12 @@ import {
   Container,
   Editor,
   Loader,
+  SelectList,
+  type SelectItem,
   matchesKey,
 } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
-import { editorTheme, theme } from "./theme.js";
+import { editorTheme, selectListTheme, theme } from "./theme.js";
 import {
   AssistantMessage,
   ErrorLine,
@@ -53,6 +55,7 @@ function detailFor(
 export interface AshiHandle {
   tui: TUI;
   stop: () => void;
+  openTreePicker: () => Promise<void>;
 }
 
 export function mountAshi(ctx: ExtensionContext, tree: TreeHistoryAdapter): AshiHandle {
@@ -252,10 +255,61 @@ export function mountAshi(ctx: ExtensionContext, tree: TreeHistoryAdapter): Ashi
     return undefined;
   });
 
+  let pickerOpen = false;
+  const openTreePicker = async (): Promise<void> => {
+    if (pickerOpen) return;
+    const entries = await tree.getTree();
+    if (entries.length === 0) {
+      bus.emit("ui:info", { message: "tree: empty" });
+      return;
+    }
+    const activeLeaf = tree.getActiveLeaf();
+    const branchSeqs = new Set((await tree.getBranch(activeLeaf)).map((e) => e.seq));
+    const items: SelectItem[] = entries.map((e) => ({
+      value: String(e.seq),
+      label: `${e.seq === activeLeaf ? "●" : branchSeqs.has(e.seq) ? "│" : " "} #${e.seq} ${e.sum}`,
+      description: e.parentSeq != null ? `← #${e.parentSeq}` : "root",
+    }));
+
+    const picker = new SelectList(items, 15, selectListTheme());
+    const activeIdx = items.findIndex((it) => it.value === String(activeLeaf));
+    if (activeIdx >= 0) picker.setSelectedIndex(activeIdx);
+
+    const close = (): void => {
+      pickerOpen = false;
+      footerSlot.removeChild(picker);
+      tui.setFocus(editor);
+      tui.requestRender();
+    };
+
+    picker.onSelect = (item) => {
+      const seq = parseInt(item.value, 10);
+      close();
+      if (seq === activeLeaf) return;
+      tree.setLeaf(seq);
+      const snapshot = tree.loadSnapshot(seq);
+      if (snapshot && snapshot.length > 0) {
+        ctx.call("conversation:replace-messages", snapshot);
+        bus.emit("ui:info", { message: `fork: restored ${snapshot.length} messages from snapshot @ #${seq}` });
+      } else {
+        bus.emit("ui:info", { message: `fork: next turn parents from #${seq} (no snapshot — agent context not rewound)` });
+      }
+      refreshFooterStats();
+      tui.requestRender();
+    };
+    picker.onCancel = close;
+
+    pickerOpen = true;
+    footerSlot.addChild(picker);
+    tui.setFocus(picker);
+    tui.requestRender();
+  };
+
   tui.start();
 
   return {
     tui,
     stop: () => { tui.stop(); },
+    openTreePicker,
   };
 }


### PR DESCRIPTION
## Summary

`/tree` now opens an interactive SelectList picker instead of dumping a text tree. Arrow keys navigate, Enter forks to the highlighted entry (with snapshot restoration if available), Esc cancels.

`/fork` with no argument also opens the picker. `/fork <seq>` stays direct for scripted use.

The picker pre-selects the current active leaf, marks entries by status:
- `●` active leaf
- `│` on the active branch
- `' '` sibling branches

Snapshot restore on fork still works the same way — switching to a leaf with a stored snapshot rewinds the agent context; switching to one without falls through to the degraded "parent pointer only" mode.

## Wiring

Picker lives in `footerSlot` (between chat and editor) so it pops up as a popover. `mountAshi` exposes `openTreePicker` on the handle; `registerTreeCommands` takes it as a third arg, since the slash-command handlers (in commands.ts) don't otherwise have access to the TUI.

## Test plan

- [x] `npm run build` clean.
- [ ] Run `ashi`, `/tree` opens picker, navigate, Enter forks, Esc cancels.
- [ ] `/fork` (no arg) opens the same picker.
- [ ] `/fork <seq>` still works directly.