### PR TITLE
Expose render hooks for ashi chat entries

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -126,6 +126,39 @@ autocomplete, session search/rename/delete inside the `/resume` picker, theme se
 image rendering. Each can be added by writing a pi-tui Component and subscribing to the
 corresponding bus event.
 
+## Extension surface
+
+Other extensions can override how chat entries render without forking ashi.
+Four hooks are exposed via `ctx.define` (defaults) + `ctx.advise` (override):
+
+| Hook | Args | Returns |
+|---|---|---|
+| `ashi:render-user-message` | `{ text, state, invalidate }` | `Component` |
+| `ashi:render-assistant` | `{ text, state, invalidate }` | `Component` |
+| `ashi:render-thinking` | `{ text, hidden, state, invalidate }` | `Component` |
+| `ashi:render-tool-execution` | `{ toolCallId, name, title, kind, displayDetail, rawInput, state, invalidate }` | `ToolExecutionView` |
+
+`state` is a per-call mutable bag; `invalidate()` requests a re-render.
+
+`ToolExecutionView` extends `Component` with `appendOutput(chunk)`, `setBody(lines)`,
+`complete(exitCode, summary)` — ashi mutates the returned view as the tool progresses,
+so custom renderers must satisfy this contract (or replace the entire tool render
+including completion handling).
+
+Example: override how `edit_file` results render.
+
+```ts
+export default function activate(ctx) {
+  ctx.advise("ashi:render-tool-execution", (next, args) => {
+    if (args.kind !== "write") return next(args);
+    return new MyPrettyEditView(args);  // must implement ToolExecutionView
+  });
+}
+```
+
+For non-render concerns (commands, settings, tools, providers) use the standard
+agent-sh extension API.
+
 ## Development
 
 To iterate on ashi from inside this repo:

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -19,6 +19,7 @@ import { registerForkCommands } from "./commands.js";
 import { registerSessionCommands } from "./session-commands.js";
 import { registerCompaction } from "./compaction.js";
 import { registerCapture } from "./capture.js";
+import { registerRenderDefaults } from "./hooks.js";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -96,6 +97,7 @@ async function main(): Promise<void> {
 
   const capture = registerCapture(ctx, getStore);
   registerCompaction(ctx, getStore, capture);
+  registerRenderDefaults(ctx);
 
   ctx.advise("conversation:format-prior-history", () => null);
   ctx.advise("system-prompt:build", (base) => `${base}\n\n<cwd>${process.cwd()}</cwd>`);

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -6,6 +6,7 @@ import {
   Loader,
   SelectList,
   Spacer,
+  type Component,
   type SelectItem,
   matchesKey,
 } from "@earendil-works/pi-tui";
@@ -16,9 +17,8 @@ import {
   ErrorLine,
   InfoLine,
   ThinkingBlock,
-  ToolExecution,
-  UserMessage,
 } from "./components.js";
+import type { ToolExecutionView } from "./hooks.js";
 import { BusAutocompleteProvider } from "./autocomplete.js";
 import { StatusFooter } from "./status-footer.js";
 import type { MultiSessionStore } from "./multi-session-store.js";
@@ -134,14 +134,40 @@ export function mountAshi(
 
   let activeAssistant: AssistantMessage | null = null;
   let activeThinking: ThinkingBlock | null = null;
-  const activeTools = new Map<string, ToolExecution>();
+  const activeTools = new Map<string, ToolExecutionView>();
   let loader: Loader | null = null;
   let processing = false;
   let hideThinking = false;
 
+  const renderState = (): { state: Record<string, unknown>; invalidate: () => void } => ({
+    state: {},
+    invalidate: () => tui.requestRender(),
+  });
+
+  const renderUserMessage = (text: string): Component =>
+    ctx.call("ashi:render-user-message", { text, ...renderState() }) as Component;
+
+  const renderAssistantLive = (): AssistantMessage =>
+    ctx.call("ashi:render-assistant", { text: "", ...renderState() }) as AssistantMessage;
+
+  const renderAssistantFinal = (text: string): Component =>
+    ctx.call("ashi:render-assistant", { text, ...renderState() }) as Component;
+
+  const renderThinkingLive = (): ThinkingBlock =>
+    ctx.call("ashi:render-thinking", { text: "", hidden: hideThinking, ...renderState() }) as ThinkingBlock;
+
+  const renderThinkingFinal = (text: string): Component =>
+    ctx.call("ashi:render-thinking", { text, hidden: hideThinking, ...renderState() }) as Component;
+
+  const renderToolExecution = (args: {
+    toolCallId: string; name: string; title: string;
+    kind?: string; displayDetail?: string; rawInput?: unknown;
+  }): ToolExecutionView =>
+    ctx.call("ashi:render-tool-execution", { ...args, ...renderState() }) as ToolExecutionView;
+
   const ensureAssistant = (): AssistantMessage => {
     if (!activeAssistant) {
-      activeAssistant = new AssistantMessage();
+      activeAssistant = renderAssistantLive();
       chat.addChild(activeAssistant);
     }
     return activeAssistant;
@@ -156,8 +182,7 @@ export function mountAshi(
 
   const ensureThinking = (): ThinkingBlock => {
     if (!activeThinking) {
-      activeThinking = new ThinkingBlock();
-      activeThinking.setHidden(hideThinking);
+      activeThinking = renderThinkingLive();
       chat.addChild(activeThinking);
     }
     return activeThinking;
@@ -175,7 +200,7 @@ export function mountAshi(
     loader = null;
   };
 
-  const replayEntry = (entry: SessionEntry, toolMap: Map<string, ToolExecution>): void => {
+  const replayEntry = (entry: SessionEntry, toolMap: Map<string, ToolExecutionView>): void => {
     if (entry.type === "session") return;
     if (entry.type === "compaction") {
       chat.addChild(new InfoLine(`▼ compacted (firstKept=${entry.firstKeptId.slice(0, 6)}, ${entry.tokensBefore} tokens)`));
@@ -185,28 +210,25 @@ export function mountAshi(
     if (m.role === "user") {
       const text = typeof m.content === "string" ? m.content : "";
       if (text.startsWith("[Compacted conversation summary]")) return;
-      chat.addChild(new UserMessage(text));
+      chat.addChild(renderUserMessage(text));
     } else if (m.role === "assistant") {
       const reasoning = readReasoning(m);
       if (reasoning) {
-        const tb = new ThinkingBlock();
-        tb.appendText(reasoning);
-        tb.finalize();
-        tb.setHidden(hideThinking);
-        chat.addChild(tb);
+        chat.addChild(renderThinkingFinal(reasoning));
       }
       const text = typeof m.content === "string" ? m.content : "";
       if (text) {
-        const msg = new AssistantMessage();
-        msg.appendText(text);
-        msg.finalize();
-        chat.addChild(msg);
+        chat.addChild(renderAssistantFinal(text));
       }
       if (m.tool_calls) {
         for (const tc of m.tool_calls) {
           const id = tc.id ?? "";
           const name = tc.function?.name ?? "tool";
-          const exec = new ToolExecution(name, undefined, detailFromArgs(tc.function?.arguments));
+          const exec = renderToolExecution({
+            toolCallId: id, name, title: name, kind: undefined,
+            displayDetail: detailFromArgs(tc.function?.arguments),
+            rawInput: tc.function?.arguments,
+          });
           chat.addChild(exec);
           if (id) toolMap.set(id, exec);
         }
@@ -231,14 +253,14 @@ export function mountAshi(
     activeTools.clear();
     chat.clear();
     const branch = getStore().current().getBranch();
-    const toolMap = new Map<string, ToolExecution>();
+    const toolMap = new Map<string, ToolExecutionView>();
     for (const e of branch) replayEntry(e, toolMap);
     tui.requestRender();
   };
 
   // ── Bus wiring ───────────────────────────────────────────────
   bus.on("agent:query", ({ query }) => {
-    chat.addChild(new UserMessage(query));
+    chat.addChild(renderUserMessage(query));
     activeAssistant = null;
     tui.requestRender();
   });
@@ -276,7 +298,10 @@ export function mountAshi(
     const detail = e.displayDetail || detailFromArgs(
       typeof e.rawInput === "string" ? e.rawInput : JSON.stringify(e.rawInput ?? {})
     );
-    const tool = new ToolExecution(title, e.kind, detail);
+    const tool = renderToolExecution({
+      toolCallId: id, name: title, title, kind: e.kind,
+      displayDetail: detail, rawInput: e.rawInput,
+    });
     activeTools.set(id, tool);
     chat.addChild(tool);
     tui.requestRender();

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -1,0 +1,64 @@
+import type { Component } from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "agent-sh/types";
+import { AssistantMessage, ThinkingBlock, ToolExecution, UserMessage } from "./components.js";
+
+export interface RenderState {
+  state: Record<string, unknown>;
+  invalidate: () => void;
+}
+
+export interface UserMessageArgs extends RenderState { text: string }
+
+export interface AssistantArgs extends RenderState { text: string }
+
+export interface ThinkingArgs extends RenderState { text: string; hidden: boolean }
+
+export interface ToolExecutionArgs extends RenderState {
+  toolCallId: string;
+  name: string;
+  title: string;
+  kind?: string;
+  displayDetail?: string;
+  rawInput?: unknown;
+}
+
+/** ToolExecutionView is the contract a tool-execution renderer must satisfy.
+ *  ashi mutates the returned component as the tool progresses; custom
+ *  renderers must accept these mutations or override them at the bus level. */
+export interface ToolExecutionView extends Component {
+  appendOutput(chunk: string): void;
+  setBody(lines: string[]): void;
+  complete(exitCode: number | null, summary?: string): void;
+}
+
+/** Register the default render-* handlers. Extensions advise these names
+ *  via ctx.advise to override or wrap. ashi's frontend.ts only ever calls
+ *  ctx.call("ashi:render-*", args), never instantiates components directly. */
+export function registerRenderDefaults(ctx: ExtensionContext): void {
+  ctx.define("ashi:render-user-message", (args: UserMessageArgs): Component => {
+    return new UserMessage(args.text);
+  });
+
+  ctx.define("ashi:render-assistant", (args: AssistantArgs): Component => {
+    const msg = new AssistantMessage();
+    if (args.text) {
+      msg.appendText(args.text);
+      msg.finalize();
+    }
+    return msg;
+  });
+
+  ctx.define("ashi:render-thinking", (args: ThinkingArgs): Component => {
+    const tb = new ThinkingBlock();
+    if (args.text) {
+      tb.appendText(args.text);
+      tb.finalize();
+    }
+    tb.setHidden(args.hidden);
+    return tb;
+  });
+
+  ctx.define("ashi:render-tool-execution", (args: ToolExecutionArgs): ToolExecutionView => {
+    return new ToolExecution(args.title, args.kind, args.displayDetail);
+  });
+}


### PR DESCRIPTION
## Summary

Adds four named render hooks to ashi so third-party extensions can override how chat entries display without forking ashi or owning tools. Uses agent-sh's `ctx.define` (defaults) + `ctx.advise` (override) pattern — the same around-advice surface the kernel already exposes.

Motivation: a pi-tool-display-style display extension should be able to live as a separate package and compose cleanly with ashi. Today, ashi constructs its components directly in `frontend.ts`, so there's no seam for an extension to plug into.

## Hooks

| Hook | Args | Returns |
|---|---|---|
| `ashi:render-user-message` | `{ text, state, invalidate }` | `Component` |
| `ashi:render-assistant` | `{ text, state, invalidate }` | `Component` |
| `ashi:render-thinking` | `{ text, hidden, state, invalidate }` | `Component` |
| `ashi:render-tool-execution` | `{ toolCallId, name, title, kind, displayDetail, rawInput, state, invalidate }` | `ToolExecutionView` |

- `state` is a per-call mutable bag for renderer-owned state (expand/collapse, streaming progress).
- `invalidate()` requests a re-render — lets extensions implement stateful renderers without polling.

## ToolExecutionView contract

`ToolExecutionView` extends `Component` with `appendOutput(chunk)`, `setBody(lines)`, `complete(exitCode, summary)`. ashi mutates the returned view as the tool progresses, so custom tool-execution renderers must satisfy this contract (or override the entire lifecycle by also handling later mutations themselves).

## Why define+advise, not pipe-based

The render case is \"compute one Component, optionally override\" — that's function-call semantics, which around-advice models naturally:

```ts
ctx.advise(\"ashi:render-tool-execution\", (next, args) => {
  if (args.kind !== \"write\") return next(args);   // explicit delegate
  return new MyEditView(args);                       // override
});
```

Around-advice gives us:
- Default always defined (no `null` sentinel and `??` fallback).
- Override semantics explicit (call `next` or don't).
- Stronger typing (single return value, no \"maybe-set\" output field).
- Multiple advisors stack naturally; each chooses whether to invoke the next.

`bus.emitPipe` is the right primitive for *transform-payload* cases (e.g. `query-context:build` where each subscriber appends). For *replace-or-delegate*, `define`/`advise` is cleaner.

## What this enables (without further work)

A separate \"pretty-tool-display\" extension can:
- Override `ashi:render-tool-execution` to return a custom view per tool kind.
- Override `ashi:render-user-message` for alternative user-bubble styles.
- Override `ashi:render-thinking` for custom labels.

Without conflict with other display extensions or with ashi's defaults.

## What this does not enable

- **Per-component focus & keyboard routing** (e.g. Ctrl+O to expand a specific tool's output). That's an ashi infrastructure gap — needs a chat-focus primitive that doesn't exist yet. Independent work.
- **Streaming-aware override of the live assistant/thinking components.** The default hooks return classes whose internals (`appendText`, `finalize`) ashi calls as chunks arrive. Custom renderers can implement the same shape, but the contract is implicit. If this becomes a real use case, we can promote it to an explicit interface.

## Files

- `examples/extensions/ashi/src/hooks.ts` — new, declares args + view contract, registers defaults.
- `examples/extensions/ashi/src/cli.ts` — wires `registerRenderDefaults(ctx)`.
- `examples/extensions/ashi/src/frontend.ts` — all chat-entry constructions route through `ctx.call`.
- `examples/extensions/ashi/README.md` — documents the surface with a sample advisor.

## Test plan

- [x] `npm run build` clean at repo root and in `examples/extensions/ashi/`.
- [ ] Smoke: run ashi, verify user / assistant / thinking / tool rendering looks the same as before (defaults intact).
- [ ] Smoke: write a no-op advisor for each hook and confirm it's invoked.