### PR TITLE
ashi: publishable package + tool display revamp

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -128,12 +128,15 @@ This is a spike, not a clone of pi's full UI. The MVP renders:
 - Multi-session tree history with `/resume` and `/fork` pickers
 - LLM compaction with summaries that survive across `/resume`
 - Loader, errors, info messages
+- Inline images via the `image` ContentBlock and the `render:image` handler — the
+  bundled `latex-images` extension works against ashi without modification
+  (terminal must support iTerm2 or Kitty graphics)
 
 Out of scope for v0: branch summaries on `/fork` navigation (pi has this), `/clone`
 (duplicate active branch into a new session), permission dialogs, diff renderer, file-path
-autocomplete, session search/rename/delete inside the `/resume` picker, theme selector,
-image rendering. Each can be added by writing a pi-tui Component and subscribing to the
-corresponding bus event.
+autocomplete, session search/rename/delete inside the `/resume` picker, theme selector.
+Each can be added by writing a pi-tui Component and subscribing to the corresponding
+bus event.
 
 ## Extension surface
 

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -136,35 +136,82 @@ corresponding bus event.
 ## Extension surface
 
 Other extensions can override how chat entries render without forking ashi.
-Four hooks are exposed via `ctx.define` (defaults) + `ctx.advise` (override):
+Hooks are exposed via `ctx.define` (defaults) + `ctx.advise` (override).
+
+### Chat hooks
 
 | Hook | Args | Returns |
 |---|---|---|
 | `ashi:render-user-message` | `{ text, state, invalidate }` | `Component` |
 | `ashi:render-assistant` | `{ text, state, invalidate }` | `Component` |
 | `ashi:render-thinking` | `{ text, hidden, state, invalidate }` | `Component` |
-| `ashi:render-tool-execution` | `{ toolCallId, name, title, kind, displayDetail, rawInput, state, invalidate }` | `ToolExecutionView` |
+
+### Tool hooks (per-tool)
+
+Tool rendering is split into a call line (the input header) and a result body
+(streaming output + final state). Each side is dispatched by tool name with a
+`:default` fallback:
+
+| Hook | Args | Returns |
+|---|---|---|
+| `ashi:render-tool-call:{name}` | `{ toolCallId, name, title, kind, displayDetail, rawInput, state, invalidate }` | `ToolCallView` |
+| `ashi:render-tool-call:default` | (same) | `ToolCallView` |
+| `ashi:render-tool-result:{name}` | `{ toolCallId, name, kind, rawInput, mode, previewLines, state, invalidate }` | `ToolResultView` |
+| `ashi:render-tool-result:default` | (same) | `ToolResultView` |
 
 `state` is a per-call mutable bag; `invalidate()` requests a re-render.
 
-`ToolExecutionView` extends `Component` with `appendOutput(chunk)`, `setBody(lines)`,
-`complete(exitCode, summary)` — ashi mutates the returned view as the tool progresses,
-so custom renderers must satisfy this contract (or replace the entire tool render
-including completion handling).
+- `ToolCallView` extends `Component` with `setStatus({ exitCode, elapsedMs, summary })` — called once on completion.
+- `ToolResultView` extends `Component` with `appendChunk(chunk)`, `setDiff(lines)`, and `finalize({ exitCode, summary })` — ashi mutates the result view as output streams in.
 
-Example: override how `edit_file` results render.
+`mode` and `previewLines` on result args come from `ashi.display.{name}` config
+(see below) so renderers can honor the user's compactness preference without
+re-implementing the resolution logic.
+
+Example: override how `bash` calls render.
 
 ```ts
 export default function activate(ctx) {
-  ctx.advise("ashi:render-tool-execution", (next, args) => {
-    if (args.kind !== "write") return next(args);
-    return new MyPrettyEditView(args);  // must implement ToolExecutionView
+  ctx.advise("ashi:render-tool-call:bash", (next, args) => {
+    return new MyFancyBashLine(args);  // must implement ToolCallView
   });
 }
 ```
 
 For non-render concerns (commands, settings, tools, providers) use the standard
 agent-sh extension API.
+
+## Display configuration
+
+Per-tool compactness lives under `ashi.display` in `~/.agent-sh/settings.json`:
+
+```json
+{
+  "ashi": {
+    "display": {
+      "default": { "result": "preview", "previewLines": 8 },
+      "read":    { "result": "hidden" },
+      "ls":      { "result": "hidden" },
+      "grep":    { "result": "summary" },
+      "bash":    { "result": "preview", "previewLines": 12 },
+      "edit":    { "result": "preview" },
+      "write":   { "result": "preview" }
+    }
+  }
+}
+```
+
+`result` modes:
+
+- `"hidden"` — call line only; suppress the output body.
+- `"summary"` — collapsed: a line count after the tool completes (e.g. `↳ 42 lines`).
+  Bash-style streaming previews degrade to a 2-line tail until completion.
+- `"preview"` — last `previewLines` lines of output (default 8).
+
+Each tool inherits from `default` and is overridden by its own block. Unknown
+tool names fall through to `default`. Built-in defaults aim for compactness
+(`read`/`ls` hidden, `grep` summarized) — override under `default` to widen
+everything, or under a specific tool to tune one.
 
 ## Development
 

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -49,6 +49,8 @@ Match pi-coding-agent's convention:
 Esc      Cancel active turn
 Ctrl+C   Clear editor
 Ctrl+D   Quit (when editor is empty)
+Ctrl+T   Toggle thinking-block visibility
+Ctrl+O   Expand/collapse the most recent tool result
 ```
 
 ## Sessions
@@ -162,7 +164,7 @@ Tool rendering is split into a call line (the input header) and a result body
 `state` is a per-call mutable bag; `invalidate()` requests a re-render.
 
 - `ToolCallView` extends `Component` with `setStatus({ exitCode, elapsedMs, summary })` — called once on completion.
-- `ToolResultView` extends `Component` with `appendChunk(chunk)`, `setDiff(lines)`, and `finalize({ exitCode, summary })` — ashi mutates the result view as output streams in.
+- `ToolResultView` extends `Component` with `appendChunk(chunk)`, `setDiff(lines)`, `finalize({ exitCode, summary })`, and `toggleExpanded()` — ashi mutates the result view as output streams in and when the user hits `Ctrl+O`.
 
 `mode` and `previewLines` on result args come from `ashi.display.{name}` config
 (see below) so renderers can honor the user's compactness preference without
@@ -203,10 +205,12 @@ Per-tool compactness lives under `ashi.display` in `~/.agent-sh/settings.json`:
 
 `result` modes:
 
-- `"hidden"` — call line only; suppress the output body.
-- `"summary"` — collapsed: a line count after the tool completes (e.g. `↳ 42 lines`).
-  Bash-style streaming previews degrade to a 2-line tail until completion.
-- `"preview"` — last `previewLines` lines of output (default 8).
+- `"hidden"` — call line only while streaming; line count (`↳ 42 lines`) after completion.
+- `"summary"` — 2-line tail while streaming; line count after completion.
+- `"preview"` — last `previewLines` lines of output (default 8), with a `... (N more lines)` hint when content overflows.
+
+Hit `Ctrl+O` to expand the most recent tool result inline — shows the full
+buffer regardless of mode. Press again to collapse back.
 
 Each tool inherits from `default` and is overridden by its own block. Unknown
 tool names fall through to `default`. Built-in defaults aim for compactness

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -23,6 +23,9 @@ ashi
 Reads `~/.agent-sh/settings.json` for providers and defaults, same as `agent-sh` itself. The
 quickest path is exporting `OPENROUTER_API_KEY` or `OPENAI_API_KEY` and running `ashi`.
 
+See the agent-sh [Usage Guide](https://github.com/guanyilun/agent-sh/blob/main/docs/usage.md)
+for the full `settings.json` schema, provider profiles, and model selection details.
+
 CLI flags mirror `agent-sh`:
 
 ```
@@ -33,6 +36,10 @@ CLI flags mirror `agent-sh`:
 --backend <name>     Agent backend (default: ash)
 -e, --extensions     Extra extensions to load (comma-separated)
 ```
+
+Extensions loaded via `-e` follow the standard agent-sh extension contract — see
+[Extensions](https://github.com/guanyilun/agent-sh/blob/main/docs/extensions.md) for the
+`ExtensionContext` API, event bus, content transforms, and custom backends.
 
 ## Keybindings
 
@@ -161,14 +168,24 @@ agent-sh extension API.
 
 ## Development
 
-To iterate on ashi from inside this repo:
+`@guanyilun/ashi` depends on the published `agent-sh` package. To iterate against
+the parent checkout instead, use `npm link`:
 
 ```bash
+# one-time: register the local agent-sh checkout
+cd /path/to/agent-sh
+npm run build
+npm link
+
+# in ashi, point its agent-sh dependency at the linked checkout
 cd examples/extensions/ashi
 npm install
+npm link agent-sh
+
 npm run dev      # tsx-driven, no compile step
 # or: npm run build && node dist/cli.js
 ```
 
-`file:../../..` in `package.json` wires `agent-sh` to the parent checkout — run
-`npm run build` at the repo root first if you haven't already.
+Rebuild agent-sh (`npm run build` at the repo root) whenever you change the
+kernel — the link picks up `dist/` directly. To go back to the published
+version, run `npm unlink agent-sh && npm install` inside `examples/extensions/ashi`.

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -209,8 +209,13 @@ Per-tool compactness lives under `ashi.display` in `~/.agent-sh/settings.json`:
 - `"summary"` — 2-line tail while streaming; line count after completion.
 - `"preview"` — last `previewLines` lines of output (default 8), with a `... (N more lines)` hint when content overflows.
 
+For `edit_file` / `write_file`, the diff frame is treated as the output and
+follows the same gating: shown for `preview`, hidden for `hidden`/`summary`
+(the call line already carries `+12 -3` stats). The line-count hint is
+suppressed for diff-producing tools so edits stay quiet.
+
 Hit `Ctrl+O` to expand the most recent tool result inline — shows the full
-buffer regardless of mode. Press again to collapse back.
+output buffer and the full diff regardless of mode. Press again to collapse.
 
 Each tool inherits from `default` and is overridden by its own block. Unknown
 tool names fall through to `default`. Built-in defaults aim for compactness

--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-sh-ashi",
+  "name": "@guanyilun/ashi",
   "version": "0.1.0",
   "description": "Ash with a pi-tui frontend — agent-sh's kernel without the shell, rendered through pi's TUI library",
   "type": "module",
@@ -7,20 +7,54 @@
   "bin": {
     "ashi": "dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "dev": "tsx src/cli.ts",
-    "build": "tsc",
-    "start": "node dist/cli.js"
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc",
+    "start": "node dist/cli.js",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "agent-sh",
+    "ashi",
+    "ash",
+    "pi-tui",
+    "tui",
+    "agent",
+    "ai",
+    "llm",
+    "cli"
+  ],
+  "author": "Yilun Guan",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guanyilun/agent-sh.git",
+    "directory": "examples/extensions/ashi"
+  },
+  "homepage": "https://github.com/guanyilun/agent-sh/tree/main/examples/extensions/ashi",
+  "bugs": {
+    "url": "https://github.com/guanyilun/agent-sh/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
-    "agent-sh": "file:../../..",
+    "agent-sh": "^0.12.27",
     "chalk": "^5.5.0",
-    "cli-highlight": "^2.1.11",
-    "tsx": "^4.20.0"
+    "cli-highlight": "^2.1.11"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tsx": "^4.20.0",
     "typescript": "^5.7.0"
   }
 }

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -20,6 +20,7 @@ import { registerSessionCommands } from "./session-commands.js";
 import { registerCompaction } from "./compaction.js";
 import { registerCapture } from "./capture.js";
 import { registerRenderDefaults } from "./hooks.js";
+import { registerDefaultToolRenderers } from "./default-renderers.js";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -98,6 +99,7 @@ async function main(): Promise<void> {
   const capture = registerCapture(ctx, getStore);
   registerCompaction(ctx, getStore, capture);
   registerRenderDefaults(ctx);
+  registerDefaultToolRenderers(ctx);
 
   ctx.advise("conversation:format-prior-history", () => null);
   ctx.advise("system-prompt:build", (base) => `${base}\n\n<cwd>${process.cwd()}</cwd>`);

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -142,8 +142,8 @@ export class ToolResultBody extends Container {
   }
 
   private repaint(): void {
-    // Diff body shows for mode=preview or when expanded; otherwise the diff
-    // stats already live on the call line so the framed view is redundant.
+    // Hide the framed diff in hidden/summary modes — the stats already live
+    // on the call line so showing it again is noise.
     const hasDiff = this.diffLines.length > 0;
     const showDiff = hasDiff && (this.expanded || this.mode === "preview");
     this.bodyText.setText(showDiff ? this.diffLines.join("\n") : "");
@@ -169,7 +169,7 @@ export class ToolResultBody extends Container {
     }
     if (this.mode === "summary") {
       if (!this.finalized) {
-        // While streaming, summary mode shows a brief tail; on finalize, switch to a line count.
+        // Brief tail while streaming; collapses to a line count on finalize.
         const tail = this.outputBuffer.split("\n").slice(-2).join("\n");
         this.outputText.setText(theme.fg("muted", tail));
         return;
@@ -274,8 +274,8 @@ export class ToolGroup extends Container {
 
   finalize(): void {
     const collapsed = this.addedCount - this.renderedCount;
-    // No overflow ⇒ no aggregate; close the tree by swapping the last
-    // visible child's ├ for a └.
+    // No overflow ⇒ no aggregate; close the tree by promoting the last
+    // visible child's ├ to a └.
     if (collapsed === 0) {
       this.aggregateText.setText("");
       const last = [...this.visibleChildren.values()].pop();
@@ -303,8 +303,8 @@ export class ToolGroup extends Container {
       tail = ` ${mark}${sum}`;
     }
     const connector = isLast ? "└" : "├";
-    // Only show the tool name when it diverges from the kind header — for
-    // a pure read_file batch under "◆ read", the per-child "read" is noise.
+    // Tool name omitted when it duplicates the kind header (e.g. read_file
+    // children under "◆ read").
     const namePart = child.name !== this.kind
       ? `${theme.bold(theme.fg("toolTitle", child.name))} `
       : "";

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -250,21 +250,29 @@ function fmtElapsed(ms: number): string {
 
 const GROUP_ICONS: Record<string, string> = { read: "◆", search: "⌕" };
 
-/** A batch of parallel same-kind tool calls. Renders one header + child
- *  branch lines + a single aggregate completion. Mirrors the ash renderer's
- *  grouping (read_file/ls grouped under "read"; grep/glob under "search"). */
+interface GroupChild {
+  detail: string;
+  text: Text;
+  status?: { exitCode: number | null; summary?: string };
+}
+
+/** A batch of parallel same-kind tool calls. Renders one header, per-call
+ *  child branch lines that each carry their own summary on completion, and
+ *  a final aggregate. Mirrors ash's grouping (read_file/ls → "read";
+ *  grep/glob → "search"). */
 export class ToolGroup extends Container {
   private headerText: Text;
   private childContainer: Container;
   private aggregateText: Text;
   private kind: string;
+  private total: number;
   private maxVisible: number;
-  private count = 0;
+  private visibleChildren = new Map<string, GroupChild>();
+  private hiddenSummaries: string[] = [];
+  private addedCount = 0;
   private renderedCount = 0;
   private completedCount = 0;
-  private total = 0;
   private allOk = true;
-  private summaries: string[] = [];
 
   constructor(kind: string, total: number, maxVisible = 5) {
     super();
@@ -281,35 +289,64 @@ export class ToolGroup extends Container {
     this.repaintHeader();
   }
 
-  addCall(detail: string): void {
-    this.count++;
-    if (this.renderedCount < this.maxVisible) {
-      const text = detail || "…";
-      this.childContainer.addChild(
-        new Text(`${theme.fg("muted", "├")} ${theme.fg("muted", text)}`, 1, 0),
-      );
+  addCall(toolCallId: string, detail: string): void {
+    this.addedCount++;
+    if (this.renderedCount < this.maxVisible && toolCallId) {
+      const text = new Text("", 1, 0);
+      const child: GroupChild = { detail: detail || "…", text };
+      this.visibleChildren.set(toolCallId, child);
+      this.childContainer.addChild(text);
       this.renderedCount++;
+      this.repaintChild(child);
     }
   }
 
-  recordCompletion(exitCode: number | null, summary?: string): void {
+  recordCompletion(toolCallId: string, exitCode: number | null, summary?: string): void {
     this.completedCount++;
     if (exitCode !== null && exitCode !== 0) this.allOk = false;
-    if (summary) this.summaries.push(summary);
+    const child = this.visibleChildren.get(toolCallId);
+    if (child) {
+      child.status = { exitCode, summary };
+      this.repaintChild(child);
+    } else if (summary) {
+      this.hiddenSummaries.push(summary);
+    }
     if (this.completedCount >= this.total) this.finalize();
   }
 
   finalize(): void {
+    const collapsed = this.addedCount - this.renderedCount;
+    // No overflow ⇒ no aggregate; close the tree by swapping the last
+    // visible child's ├ for a └.
+    if (collapsed === 0) {
+      this.aggregateText.setText("");
+      const last = [...this.visibleChildren.values()].pop();
+      if (last) this.repaintChild(last, true);
+      return;
+    }
     const mark = this.allOk ? theme.fg("success", "✓") : theme.fg("error", "✗");
-    const collapsed = this.count - this.renderedCount;
-    const more = collapsed > 0 ? `${theme.fg("muted", `+${collapsed} more`)} ` : "";
-    const sumText = this.summaries.length > 0
-      ? ` ${theme.fg("muted", this.summaries.join(", "))}`
+    const more = theme.fg("muted", `+${collapsed} more`);
+    const sumText = this.hiddenSummaries.length > 0
+      ? ` ${theme.fg("muted", this.hiddenSummaries.join(", "))}`
       : "";
-    this.aggregateText.setText(`${theme.fg("muted", "└")} ${more}${mark}${sumText}`);
+    this.aggregateText.setText(`${theme.fg("muted", "└")} ${more} ${mark}${sumText}`);
   }
 
   isComplete(): boolean { return this.completedCount >= this.total; }
+
+  private repaintChild(child: GroupChild, isLast = false): void {
+    let tail: string;
+    if (!child.status) {
+      tail = ` ${theme.fg("muted", "…")}`;
+    } else {
+      const ok = child.status.exitCode === null || child.status.exitCode === 0;
+      const mark = ok ? theme.fg("success", "✓") : theme.fg("error", "✗");
+      const sum = child.status.summary ? ` ${theme.fg("muted", child.status.summary)}` : "";
+      tail = ` ${mark}${sum}`;
+    }
+    const connector = isLast ? "└" : "├";
+    child.text.setText(`${theme.fg("muted", connector)} ${theme.fg("muted", child.detail)} ${tail}`);
+  }
 
   private repaintHeader(): void {
     const icon = GROUP_ICONS[this.kind] ?? "▶";

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -5,7 +5,7 @@ import {
   Spacer,
   Text,
 } from "@earendil-works/pi-tui";
-import { iconFor, markdownTheme, theme } from "./theme.js";
+import { markdownTheme, theme } from "./theme.js";
 import type { ToolResultMode } from "./display-config.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -96,53 +96,6 @@ export class ThinkingBlock extends Container {
       });
       this.addChild(this.md);
     }
-  }
-}
-
-export class ToolCallLine extends Container {
-  private line: Text;
-  private title: string;
-  private detail?: string;
-  private kind?: string;
-  private startedAt: number;
-  private exitCode: number | null | undefined;
-  private elapsedMs?: number;
-  private summary?: string;
-
-  constructor(title: string, kind?: string, detail?: string) {
-    super();
-    this.title = title;
-    this.kind = kind;
-    this.detail = detail;
-    this.startedAt = Date.now();
-    this.line = new Text("", 1, 0);
-    this.addChild(new Spacer(1));
-    this.addChild(this.line);
-    this.repaint();
-  }
-
-  setStatus(opts: { exitCode: number | null; elapsedMs: number; summary?: string }): void {
-    this.exitCode = opts.exitCode;
-    this.elapsedMs = opts.elapsedMs;
-    this.summary = opts.summary;
-    this.repaint();
-  }
-
-  private repaint(): void {
-    const icon = iconFor(this.kind);
-    const head = theme.bold(theme.fg("toolTitle", `${icon} ${this.title}`));
-    const detail = this.detail ? ` ${theme.fg("muted", this.detail)}` : "";
-    let tail: string;
-    if (this.exitCode !== undefined) {
-      const ok = this.exitCode === null || this.exitCode === 0;
-      const mark = ok ? theme.fg("success", "✓") : theme.fg("error", "✗");
-      const elapsed = this.elapsedMs !== undefined ? ` ${theme.fg("muted", fmtElapsed(this.elapsedMs))}` : "";
-      const sum = this.summary ? ` ${theme.fg("muted", this.summary)}` : "";
-      tail = `  ${mark}${elapsed}${sum}`;
-    } else {
-      tail = `  ${theme.fg("muted", "…")}`;
-    }
-    this.line.setText(`${head}${detail}${tail}`);
   }
 }
 
@@ -240,12 +193,6 @@ function lineCountHint(buffer: string, exitCode: number | null | undefined): str
   const ok = exitCode === null || exitCode === 0;
   const arrow = ok ? theme.fg("muted", "↳ ") : theme.fg("error", "↳ ");
   return `${arrow}${theme.fg("muted", label)}`;
-}
-
-function fmtElapsed(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 10_000) return `${(ms / 1000).toFixed(2)}s`;
-  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 const GROUP_ICONS: Record<string, string> = { read: "◆", search: "⌕" };

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -248,6 +248,75 @@ function fmtElapsed(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+const GROUP_ICONS: Record<string, string> = { read: "◆", search: "⌕" };
+
+/** A batch of parallel same-kind tool calls. Renders one header + child
+ *  branch lines + a single aggregate completion. Mirrors the ash renderer's
+ *  grouping (read_file/ls grouped under "read"; grep/glob under "search"). */
+export class ToolGroup extends Container {
+  private headerText: Text;
+  private childContainer: Container;
+  private aggregateText: Text;
+  private kind: string;
+  private maxVisible: number;
+  private count = 0;
+  private renderedCount = 0;
+  private completedCount = 0;
+  private total = 0;
+  private allOk = true;
+  private summaries: string[] = [];
+
+  constructor(kind: string, total: number, maxVisible = 5) {
+    super();
+    this.kind = kind;
+    this.total = total;
+    this.maxVisible = maxVisible;
+    this.headerText = new Text("", 1, 0);
+    this.childContainer = new Container();
+    this.aggregateText = new Text("", 1, 0);
+    this.addChild(new Spacer(1));
+    this.addChild(this.headerText);
+    this.addChild(this.childContainer);
+    this.addChild(this.aggregateText);
+    this.repaintHeader();
+  }
+
+  addCall(detail: string): void {
+    this.count++;
+    if (this.renderedCount < this.maxVisible) {
+      const text = detail || "…";
+      this.childContainer.addChild(
+        new Text(`${theme.fg("muted", "├")} ${theme.fg("muted", text)}`, 1, 0),
+      );
+      this.renderedCount++;
+    }
+  }
+
+  recordCompletion(exitCode: number | null, summary?: string): void {
+    this.completedCount++;
+    if (exitCode !== null && exitCode !== 0) this.allOk = false;
+    if (summary) this.summaries.push(summary);
+    if (this.completedCount >= this.total) this.finalize();
+  }
+
+  finalize(): void {
+    const mark = this.allOk ? theme.fg("success", "✓") : theme.fg("error", "✗");
+    const collapsed = this.count - this.renderedCount;
+    const more = collapsed > 0 ? `${theme.fg("muted", `+${collapsed} more`)} ` : "";
+    const sumText = this.summaries.length > 0
+      ? ` ${theme.fg("muted", this.summaries.join(", "))}`
+      : "";
+    this.aggregateText.setText(`${theme.fg("muted", "└")} ${more}${mark}${sumText}`);
+  }
+
+  isComplete(): boolean { return this.completedCount >= this.total; }
+
+  private repaintHeader(): void {
+    const icon = GROUP_ICONS[this.kind] ?? "▶";
+    this.headerText.setText(`${theme.fg("warning", icon)} ${theme.bold(theme.fg("toolTitle", this.kind))}`);
+  }
+}
+
 export class ErrorLine extends Container {
   constructor(message: string) {
     super();

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -150,6 +150,7 @@ export class ToolResultBody extends Container {
   private outputText: Text;
   private bodyText: Text;
   private outputBuffer = "";
+  private diffLines: string[] = [];
   private mode: ToolResultMode;
   private previewLines: number;
   private finalized = false;
@@ -172,7 +173,8 @@ export class ToolResultBody extends Container {
   }
 
   setDiff(lines: string[]): void {
-    this.bodyText.setText(lines.join("\n"));
+    this.diffLines = lines;
+    this.repaint();
   }
 
   finalize(opts: { exitCode: number | null; summary?: string }): void {
@@ -187,11 +189,22 @@ export class ToolResultBody extends Container {
   }
 
   private repaint(): void {
+    // Diff body shows for mode=preview or when expanded; otherwise the diff
+    // stats already live on the call line so the framed view is redundant.
+    const hasDiff = this.diffLines.length > 0;
+    const showDiff = hasDiff && (this.expanded || this.mode === "preview");
+    this.bodyText.setText(showDiff ? this.diffLines.join("\n") : "");
+
+    // When a diff exists, the textual output ("Edited /path (+12 -3)") just
+    // restates the call line — suppress its line-count hint to keep edits quiet.
+    if (hasDiff && !this.expanded) {
+      this.outputText.setText("");
+      return;
+    }
     if (!this.outputBuffer) {
       this.outputText.setText("");
       return;
     }
-    // Expanded view bypasses collapse: full output regardless of mode.
     if (this.expanded) {
       this.outputText.setText(theme.fg("toolOutput", this.outputBuffer));
       return;

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -251,9 +251,20 @@ function fmtElapsed(ms: number): string {
 const GROUP_ICONS: Record<string, string> = { read: "◆", search: "⌕" };
 
 interface GroupChild {
+  name: string;
   detail: string;
   text: Text;
   status?: { exitCode: number | null; summary?: string };
+}
+
+const SHORT_TOOL_NAMES: Record<string, string> = {
+  read_file: "read",
+  edit_file: "edit",
+  write_file: "write",
+};
+
+function shortToolName(name: string): string {
+  return SHORT_TOOL_NAMES[name] ?? name;
 }
 
 /** A batch of parallel same-kind tool calls. Renders one header, per-call
@@ -289,11 +300,11 @@ export class ToolGroup extends Container {
     this.repaintHeader();
   }
 
-  addCall(toolCallId: string, detail: string): void {
+  addCall(toolCallId: string, name: string, detail: string): void {
     this.addedCount++;
     if (this.renderedCount < this.maxVisible && toolCallId) {
       const text = new Text("", 1, 0);
-      const child: GroupChild = { detail: detail || "…", text };
+      const child: GroupChild = { name: shortToolName(name), detail: detail || "…", text };
       this.visibleChildren.set(toolCallId, child);
       this.childContainer.addChild(text);
       this.renderedCount++;
@@ -345,7 +356,12 @@ export class ToolGroup extends Container {
       tail = ` ${mark}${sum}`;
     }
     const connector = isLast ? "└" : "├";
-    child.text.setText(`${theme.fg("muted", connector)} ${theme.fg("muted", child.detail)} ${tail}`);
+    // Only show the tool name when it diverges from the kind header — for
+    // a pure read_file batch under "◆ read", the per-child "read" is noise.
+    const namePart = child.name !== this.kind
+      ? `${theme.bold(theme.fg("toolTitle", child.name))} `
+      : "";
+    child.text.setText(`${theme.fg("muted", connector)} ${namePart}${theme.fg("muted", child.detail)} ${tail}`);
   }
 
   private repaintHeader(): void {

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -153,6 +153,7 @@ export class ToolResultBody extends Container {
   private mode: ToolResultMode;
   private previewLines: number;
   private finalized = false;
+  private expanded = false;
   private exitCode: number | null | undefined;
 
   constructor(mode: ToolResultMode, previewLines: number) {
@@ -180,13 +181,24 @@ export class ToolResultBody extends Container {
     this.repaint();
   }
 
+  toggleExpanded(): void {
+    this.expanded = !this.expanded;
+    this.repaint();
+  }
+
   private repaint(): void {
-    if (this.mode === "hidden") {
+    if (!this.outputBuffer) {
       this.outputText.setText("");
       return;
     }
-    if (!this.outputBuffer) {
-      this.outputText.setText("");
+    // Expanded view bypasses collapse: full output regardless of mode.
+    if (this.expanded) {
+      this.outputText.setText(theme.fg("toolOutput", this.outputBuffer));
+      return;
+    }
+    if (this.mode === "hidden") {
+      if (!this.finalized) { this.outputText.setText(""); return; }
+      this.outputText.setText(lineCountHint(this.outputBuffer, this.exitCode));
       return;
     }
     if (this.mode === "summary") {
@@ -196,16 +208,25 @@ export class ToolResultBody extends Container {
         this.outputText.setText(theme.fg("muted", tail));
         return;
       }
-      const lines = this.outputBuffer.split("\n").filter((l) => l.length > 0);
-      const label = lines.length === 1 ? "1 line" : `${lines.length} lines`;
-      const ok = this.exitCode === null || this.exitCode === 0;
-      const prefix = ok ? theme.fg("muted", "↳ ") : theme.fg("error", "↳ ");
-      this.outputText.setText(`${prefix}${theme.fg("muted", label)}`);
+      this.outputText.setText(lineCountHint(this.outputBuffer, this.exitCode));
       return;
     }
-    const trimmed = this.outputBuffer.split("\n").slice(-this.previewLines).join("\n");
-    this.outputText.setText(theme.fg("toolOutput", trimmed));
+    const lines = this.outputBuffer.split("\n");
+    const trimmed = lines.slice(-this.previewLines).join("\n");
+    const remaining = Math.max(0, lines.length - this.previewLines);
+    const overflow = remaining > 0
+      ? `\n${theme.fg("muted", `... (${remaining} more ${remaining === 1 ? "line" : "lines"})`)}`
+      : "";
+    this.outputText.setText(`${theme.fg("toolOutput", trimmed)}${overflow}`);
   }
+}
+
+function lineCountHint(buffer: string, exitCode: number | null | undefined): string {
+  const lines = buffer.split("\n").filter((l) => l.length > 0);
+  const label = lines.length === 1 ? "1 line" : `${lines.length} lines`;
+  const ok = exitCode === null || exitCode === 0;
+  const arrow = ok ? theme.fg("muted", "↳ ") : theme.fg("error", "↳ ");
+  return `${arrow}${theme.fg("muted", label)}`;
 }
 
 function fmtElapsed(ms: number): string {

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -1,13 +1,12 @@
 import {
-  Box,
   Container,
   Markdown,
   type MarkdownTheme,
   Spacer,
   Text,
-  type Component,
 } from "@earendil-works/pi-tui";
 import { iconFor, markdownTheme, theme } from "./theme.js";
+import type { ToolResultMode } from "./display-config.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
@@ -33,8 +32,6 @@ export class UserMessage extends Container {
   }
 }
 
-/** paddingY=0 so the Markdown sits flush against the following tool box,
- *  matching pi's vertical rhythm. */
 export class AssistantMessage extends Container {
   private md: Markdown;
   private buffer = "";
@@ -102,11 +99,8 @@ export class ThinkingBlock extends Container {
   }
 }
 
-export class ToolExecution extends Container {
-  private box: Box;
-  private header: Text;
-  private outputText: Text;
-  private outputBuffer = "";
+export class ToolCallLine extends Container {
+  private line: Text;
   private title: string;
   private detail?: string;
   private kind?: string;
@@ -115,65 +109,102 @@ export class ToolExecution extends Container {
   private elapsedMs?: number;
   private summary?: string;
 
-  private bodyText: Text;
-
   constructor(title: string, kind?: string, detail?: string) {
     super();
     this.title = title;
     this.kind = kind;
     this.detail = detail;
     this.startedAt = Date.now();
-    this.box = new Box(1, 1, (t) => theme.bg("toolPendingBg", t));
-    this.header = new Text("", 0, 0);
-    this.bodyText = new Text("", 0, 0);
-    this.outputText = new Text("", 0, 0);
-    this.box.addChild(this.header);
-    this.box.addChild(this.outputText);
+    this.line = new Text("", 1, 0);
     this.addChild(new Spacer(1));
-    this.addChild(this.box);
-    this.addChild(this.bodyText);
+    this.addChild(this.line);
     this.repaint();
   }
 
-  setBody(lines: string[]): void {
-    this.bodyText.setText(lines.join("\n"));
-  }
-
-  appendOutput(chunk: string): void {
-    this.outputBuffer += chunk;
-    this.repaint();
-  }
-
-  complete(exitCode: number | null, summary?: string): void {
-    this.exitCode = exitCode;
-    this.elapsedMs = Date.now() - this.startedAt;
-    this.summary = summary;
-    const ok = exitCode === null || exitCode === 0;
-    this.box.setBgFn((t) => theme.bg(ok ? "toolSuccessBg" : "toolErrorBg", t));
+  setStatus(opts: { exitCode: number | null; elapsedMs: number; summary?: string }): void {
+    this.exitCode = opts.exitCode;
+    this.elapsedMs = opts.elapsedMs;
+    this.summary = opts.summary;
     this.repaint();
   }
 
   private repaint(): void {
     const icon = iconFor(this.kind);
-    const titlePart = theme.bold(theme.fg("toolTitle", `${icon} ${this.title}`));
-    const detailPart = this.detail ? ` ${theme.fg("muted", this.detail)}` : "";
-    let tailPart = "";
+    const head = theme.bold(theme.fg("toolTitle", `${icon} ${this.title}`));
+    const detail = this.detail ? ` ${theme.fg("muted", this.detail)}` : "";
+    let tail: string;
     if (this.exitCode !== undefined) {
       const ok = this.exitCode === null || this.exitCode === 0;
       const mark = ok ? theme.fg("success", "✓") : theme.fg("error", "✗");
       const elapsed = this.elapsedMs !== undefined ? ` ${theme.fg("muted", fmtElapsed(this.elapsedMs))}` : "";
       const sum = this.summary ? ` ${theme.fg("muted", this.summary)}` : "";
-      tailPart = `   ${mark}${elapsed}${sum}`;
+      tail = `  ${mark}${elapsed}${sum}`;
     } else {
-      tailPart = `   ${theme.fg("muted", "…")}`;
+      tail = `  ${theme.fg("muted", "…")}`;
     }
-    this.header.setText(`${titlePart}${detailPart}\n${tailPart}`);
-    if (this.outputBuffer) {
-      const trimmed = this.outputBuffer.split("\n").slice(-8).join("\n");
-      this.outputText.setText(theme.fg("toolOutput", trimmed));
-    } else {
+    this.line.setText(`${head}${detail}${tail}`);
+  }
+}
+
+export class ToolResultBody extends Container {
+  private outputText: Text;
+  private bodyText: Text;
+  private outputBuffer = "";
+  private mode: ToolResultMode;
+  private previewLines: number;
+  private finalized = false;
+  private exitCode: number | null | undefined;
+
+  constructor(mode: ToolResultMode, previewLines: number) {
+    super();
+    this.mode = mode;
+    this.previewLines = previewLines;
+    this.outputText = new Text("", 1, 0);
+    this.bodyText = new Text("", 0, 0);
+    this.addChild(this.outputText);
+    this.addChild(this.bodyText);
+  }
+
+  appendChunk(chunk: string): void {
+    this.outputBuffer += chunk;
+    this.repaint();
+  }
+
+  setDiff(lines: string[]): void {
+    this.bodyText.setText(lines.join("\n"));
+  }
+
+  finalize(opts: { exitCode: number | null; summary?: string }): void {
+    this.finalized = true;
+    this.exitCode = opts.exitCode;
+    this.repaint();
+  }
+
+  private repaint(): void {
+    if (this.mode === "hidden") {
       this.outputText.setText("");
+      return;
     }
+    if (!this.outputBuffer) {
+      this.outputText.setText("");
+      return;
+    }
+    if (this.mode === "summary") {
+      if (!this.finalized) {
+        // While streaming, summary mode shows a brief tail; on finalize, switch to a line count.
+        const tail = this.outputBuffer.split("\n").slice(-2).join("\n");
+        this.outputText.setText(theme.fg("muted", tail));
+        return;
+      }
+      const lines = this.outputBuffer.split("\n").filter((l) => l.length > 0);
+      const label = lines.length === 1 ? "1 line" : `${lines.length} lines`;
+      const ok = this.exitCode === null || this.exitCode === 0;
+      const prefix = ok ? theme.fg("muted", "↳ ") : theme.fg("error", "↳ ");
+      this.outputText.setText(`${prefix}${theme.fg("muted", label)}`);
+      return;
+    }
+    const trimmed = this.outputBuffer.split("\n").slice(-this.previewLines).join("\n");
+    this.outputText.setText(theme.fg("toolOutput", trimmed));
   }
 }
 

--- a/examples/extensions/ashi/src/default-renderers.ts
+++ b/examples/extensions/ashi/src/default-renderers.ts
@@ -149,8 +149,5 @@ export function registerDefaultToolRenderers(ctx: ExtensionContext): void {
   define("write_file", (args) => new LabeledCallLine(() => pathOnlyLabel("write", args)));
   define("write", (args) => new LabeledCallLine(() => pathOnlyLabel("write", args)));
 
-  // Fallback for unknown tools: name + displayDetail, no icon, no boxing.
-  ctx.advise("ashi:render-tool-call:default", (_next, args: ToolCallArgs) => {
-    return new LabeledCallLine(() => genericLabel(args));
-  });
+  define("default", (args) => new LabeledCallLine(() => genericLabel(args)));
 }

--- a/examples/extensions/ashi/src/default-renderers.ts
+++ b/examples/extensions/ashi/src/default-renderers.ts
@@ -1,0 +1,156 @@
+import { Container, Spacer, Text } from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "agent-sh/types";
+import { theme } from "./theme.js";
+import type { ToolCallArgs, ToolCallView } from "./hooks.js";
+
+interface StatusOpts { exitCode: number | null; elapsedMs: number; summary?: string }
+
+function fmtElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 10_000) return `${(ms / 1000).toFixed(2)}s`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const totalSeconds = Math.floor(ms / 1000);
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}m ${s}s`;
+}
+
+function parseRaw(raw: unknown): Record<string, unknown> {
+  if (typeof raw === "string") {
+    try { return JSON.parse(raw) as Record<string, unknown>; } catch { return {}; }
+  }
+  if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+  return {};
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function relativize(fp: string): string {
+  const home = process.env.HOME;
+  const cwd = process.cwd();
+  if (fp.startsWith(`${cwd}/`)) return fp.slice(cwd.length + 1);
+  if (home && fp.startsWith(`${home}/`)) return `~/${fp.slice(home.length + 1)}`;
+  return fp;
+}
+
+function statusSuffix(opts?: StatusOpts): string {
+  if (!opts) return `  ${theme.fg("muted", "…")}`;
+  const ok = opts.exitCode === null || opts.exitCode === 0;
+  const mark = ok ? theme.fg("success", "✓") : theme.fg("error", "✗");
+  const elapsed = opts.elapsedMs > 0 ? ` ${theme.fg("muted", fmtElapsed(opts.elapsedMs))}` : "";
+  const sum = opts.summary ? ` ${theme.fg("muted", opts.summary)}` : "";
+  return `  ${mark}${elapsed}${sum}`;
+}
+
+/** Renders a one-line tool call header from a label producer. The label is
+ *  recomputed on setStatus so the trailing status mark updates in place. */
+class LabeledCallLine extends Container implements ToolCallView {
+  private line: Text;
+  private status?: StatusOpts;
+  constructor(private label: () => string) {
+    super();
+    this.line = new Text("", 1, 0);
+    this.addChild(new Spacer(1));
+    this.addChild(this.line);
+    this.repaint();
+  }
+  setStatus(opts: StatusOpts): void {
+    this.status = opts;
+    this.repaint();
+  }
+  private repaint(): void {
+    this.line.setText(`${this.label()}${statusSuffix(this.status)}`);
+  }
+}
+
+const bold = (t: string): string => theme.bold(theme.fg("toolTitle", t));
+const accent = (t: string): string => theme.fg("accent", t);
+const muted = (t: string): string => theme.fg("muted", t);
+
+function bashLabel(args: ToolCallArgs): string {
+  const r = parseRaw(args.rawInput);
+  const command = str(r.command) ?? "…";
+  const timeout = num(r.timeout);
+  const to = timeout ? muted(` (timeout ${timeout}s)`) : "";
+  return `${bold("$")} ${accent(command)}${to}`;
+}
+
+function readLabel(args: ToolCallArgs): string {
+  const r = parseRaw(args.rawInput);
+  const path = str(r.file_path) ?? str(r.path);
+  const offset = num(r.offset);
+  const limit = num(r.limit);
+  let range = "";
+  if (offset !== undefined || limit !== undefined) {
+    const from = offset ?? 1;
+    const to = limit !== undefined ? from + limit - 1 : undefined;
+    range = theme.fg("warning", to ? `:${from}-${to}` : `:${from}`);
+  }
+  return `${bold("read")} ${accent(path ? relativize(path) : "…")}${range}`;
+}
+
+function grepLabel(args: ToolCallArgs): string {
+  const r = parseRaw(args.rawInput);
+  const pattern = str(r.pattern) ?? "…";
+  const scope = relativize(str(r.path) ?? ".");
+  const glob = str(r.glob);
+  const limit = num(r.limit);
+  const extras = [glob ? `(${glob})` : "", limit !== undefined ? `limit ${limit}` : ""].filter(Boolean).join(" ");
+  const tail = extras ? muted(` ${extras}`) : "";
+  return `${bold("grep")} ${accent(`/${pattern}/`)} ${muted(`in ${scope}`)}${tail}`;
+}
+
+function globLabel(args: ToolCallArgs): string {
+  const r = parseRaw(args.rawInput);
+  const pattern = str(r.pattern) ?? "…";
+  const scope = relativize(str(r.path) ?? ".");
+  return `${bold("glob")} ${accent(pattern)} ${muted(`in ${scope}`)}`;
+}
+
+function lsLabel(args: ToolCallArgs): string {
+  const r = parseRaw(args.rawInput);
+  const p = str(r.path) ?? ".";
+  return `${bold("ls")} ${accent(relativize(p))}`;
+}
+
+function pathOnlyLabel(name: string, args: ToolCallArgs): string {
+  const r = parseRaw(args.rawInput);
+  const path = str(r.file_path) ?? str(r.path);
+  return `${bold(name)} ${accent(path ? relativize(path) : "…")}`;
+}
+
+function genericLabel(args: ToolCallArgs): string {
+  const detail = args.displayDetail ? ` ${muted(args.displayDetail)}` : "";
+  return `${bold(args.title)}${detail}`;
+}
+
+export function registerDefaultToolRenderers(ctx: ExtensionContext): void {
+  const define = (name: string, fn: (args: ToolCallArgs) => ToolCallView): void => {
+    ctx.define(`ashi:render-tool-call:${name}`, fn);
+  };
+
+  define("bash", (args) => new LabeledCallLine(() => bashLabel(args)));
+
+  define("read_file", (args) => new LabeledCallLine(() => readLabel(args)));
+  define("read", (args) => new LabeledCallLine(() => readLabel(args)));
+
+  define("grep", (args) => new LabeledCallLine(() => grepLabel(args)));
+  define("glob", (args) => new LabeledCallLine(() => globLabel(args)));
+  define("ls", (args) => new LabeledCallLine(() => lsLabel(args)));
+
+  define("edit_file", (args) => new LabeledCallLine(() => pathOnlyLabel("edit", args)));
+  define("edit", (args) => new LabeledCallLine(() => pathOnlyLabel("edit", args)));
+  define("write_file", (args) => new LabeledCallLine(() => pathOnlyLabel("write", args)));
+  define("write", (args) => new LabeledCallLine(() => pathOnlyLabel("write", args)));
+
+  // Fallback for unknown tools: name + displayDetail, no icon, no boxing.
+  ctx.advise("ashi:render-tool-call:default", (_next, args: ToolCallArgs) => {
+    return new LabeledCallLine(() => genericLabel(args));
+  });
+}

--- a/examples/extensions/ashi/src/display-config.ts
+++ b/examples/extensions/ashi/src/display-config.ts
@@ -1,0 +1,62 @@
+import { getExtensionSettings } from "agent-sh/settings";
+
+export type ToolResultMode = "hidden" | "summary" | "preview";
+
+export interface ToolEntryConfig {
+  result: ToolResultMode;
+  previewLines: number;
+}
+
+export interface ToolDisplayConfig {
+  default: ToolEntryConfig;
+  [toolName: string]: ToolEntryConfig;
+}
+
+const DEFAULT_ENTRY: ToolEntryConfig = { result: "preview", previewLines: 8 };
+
+const BUILTIN_OVERRIDES: Record<string, Partial<ToolEntryConfig>> = {
+  read: { result: "hidden" },
+  ls: { result: "hidden" },
+  grep: { result: "summary" },
+  find: { result: "summary" },
+  glob: { result: "summary" },
+  bash: { result: "preview", previewLines: 12 },
+  edit: { result: "preview" },
+  edit_file: { result: "preview" },
+  write: { result: "preview" },
+  write_file: { result: "preview" },
+};
+
+interface AshiSettings extends Record<string, unknown> {
+  display?: Record<string, Partial<ToolEntryConfig>>;
+}
+
+function mergeEntry(base: ToolEntryConfig, patch?: Partial<ToolEntryConfig>): ToolEntryConfig {
+  if (!patch) return { ...base };
+  return {
+    result: patch.result ?? base.result,
+    previewLines: patch.previewLines ?? base.previewLines,
+  };
+}
+
+export function loadToolDisplayConfig(): ToolDisplayConfig {
+  const ashi = getExtensionSettings<AshiSettings>("ashi", {});
+  const userDisplay = ashi.display ?? {};
+  const userDefault = mergeEntry(DEFAULT_ENTRY, userDisplay.default);
+  const config: ToolDisplayConfig = { default: userDefault };
+  const names = new Set([
+    ...Object.keys(BUILTIN_OVERRIDES),
+    ...Object.keys(userDisplay).filter((k) => k !== "default"),
+  ]);
+  for (const name of names) {
+    config[name] = mergeEntry(
+      mergeEntry(userDefault, BUILTIN_OVERRIDES[name]),
+      userDisplay[name],
+    );
+  }
+  return config;
+}
+
+export function entryFor(config: ToolDisplayConfig, name: string): ToolEntryConfig {
+  return config[name] ?? config.default;
+}

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -138,6 +138,7 @@ export function mountAshi(
   let activeAssistant: AssistantMessage | null = null;
   let activeThinking: ThinkingBlock | null = null;
   const activeTools = new Map<string, ToolPair>();
+  let lastToolResult: ToolResultView | null = null;
   let loader: Loader | null = null;
   let processing = false;
   let hideThinking = false;
@@ -245,6 +246,7 @@ export function mountAshi(
           chat.addChild(pair.call);
           chat.addChild(pair.result);
           if (id) toolMap.set(id, pair);
+          lastToolResult = pair.result;
         }
       }
     } else if (m.role === "tool") {
@@ -266,6 +268,7 @@ export function mountAshi(
     activeAssistant = null;
     activeThinking = null;
     activeTools.clear();
+    lastToolResult = null;
     chat.clear();
     const branch = getStore().current().getBranch();
     const toolMap = new Map<string, ToolPair>();
@@ -320,6 +323,7 @@ export function mountAshi(
     activeTools.set(id, pair);
     chat.addChild(pair.call);
     chat.addChild(pair.result);
+    lastToolResult = pair.result;
     tui.requestRender();
   });
 
@@ -542,6 +546,13 @@ export function mountAshi(
     }
     if (matchesKey(data, "ctrl+t")) {
       toggleThinking();
+      return { consume: true };
+    }
+    if (matchesKey(data, "ctrl+o")) {
+      if (lastToolResult) {
+        lastToolResult.toggleExpanded();
+        tui.requestRender();
+      }
       return { consume: true };
     }
     return undefined;

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -263,7 +263,8 @@ export function mountAshi(
               for (let k = i; k < j; k++) {
                 const c = calls[k]!;
                 const cid = c.id ?? "";
-                group.addCall(cid, detailFromArgs(c.function?.arguments));
+                const cname = c.function?.name ?? "tool";
+                group.addCall(cid, cname, detailFromArgs(c.function?.arguments));
                 if (cid) toolMap.set(cid, { kind: "group", group });
               }
               i = j;
@@ -373,7 +374,7 @@ export function mountAshi(
         batchEntry!.group = new ToolGroup(kind, batchEntry!.total);
         chat.addChild(batchEntry!.group);
       }
-      batchEntry!.group.addCall(id, detail);
+      batchEntry!.group.addCall(id, title, detail);
       activeTools.set(id, { kind: "group", group: batchEntry!.group });
       // Grouped tools have no individual result body — Ctrl+O wouldn't have
       // anything to expand, so leave lastToolResult pointing at the prior tool.

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -519,12 +519,7 @@ export function mountAshi(
     tui.requestRender();
   });
 
-  let bootBannerShown = false;
   bus.on("agent:info", (info) => {
-    if (!bootBannerShown) {
-      chat.addChild(new InfoLine(`${info.name}${info.model ? ` · ${info.model}` : ""}`));
-      bootBannerShown = true;
-    }
     statusFooter.update({
       model: info.model,
       provider: info.provider,

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -17,9 +17,16 @@ import {
   ErrorLine,
   InfoLine,
   ThinkingBlock,
+  ToolGroup,
 } from "./components.js";
 import type { ToolCallView, ToolResultView } from "./hooks.js";
 import { createToolHookResolver } from "./hooks.js";
+
+const GROUPABLE_KINDS = new Set(["read", "search"]);
+const TOOL_KIND: Record<string, string> = {
+  read_file: "read", ls: "read",
+  grep: "search", glob: "search",
+};
 import { BusAutocompleteProvider } from "./autocomplete.js";
 import { StatusFooter } from "./status-footer.js";
 import type { MultiSessionStore } from "./multi-session-store.js";
@@ -134,10 +141,14 @@ export function mountAshi(
   tui.setFocus(editor);
 
   interface ToolPair { call: ToolCallView; result: ToolResultView; startedAt: number }
+  type LiveToolEntry = { kind: "pair"; pair: ToolPair } | { kind: "group"; group: ToolGroup };
 
   let activeAssistant: AssistantMessage | null = null;
   let activeThinking: ThinkingBlock | null = null;
-  const activeTools = new Map<string, ToolPair>();
+  const activeTools = new Map<string, LiveToolEntry>();
+  /** Per-batch state from agent:tool-batch — the group is created lazily on
+   *  the first member's tool-started so the chat insertion order is correct. */
+  const batchGroups = new Map<string, { total: number; group: ToolGroup | null }>();
   let lastToolResult: ToolResultView | null = null;
   let loader: Loader | null = null;
   let processing = false;
@@ -214,7 +225,9 @@ export function mountAshi(
     loader = null;
   };
 
-  const replayEntry = (entry: SessionEntry, toolMap: Map<string, ToolPair>): void => {
+  type ReplayEntry = { kind: "pair"; pair: ToolPair } | { kind: "group"; group: ToolGroup };
+
+  const replayEntry = (entry: SessionEntry, toolMap: Map<string, ReplayEntry>): void => {
     if (entry.type === "session") return;
     if (entry.type === "compaction") {
       chat.addChild(new InfoLine(`▼ compacted (firstKept=${entry.firstKeptId.slice(0, 6)}, ${entry.tokensBefore} tokens)`));
@@ -235,7 +248,29 @@ export function mountAshi(
         chat.addChild(renderAssistantFinal(text));
       }
       if (m.tool_calls) {
-        for (const tc of m.tool_calls) {
+        const calls = m.tool_calls;
+        let i = 0;
+        while (i < calls.length) {
+          const startName = calls[i]!.function?.name ?? "";
+          const startKind = TOOL_KIND[startName];
+          if (startKind && GROUPABLE_KINDS.has(startKind)) {
+            let j = i;
+            while (j < calls.length && TOOL_KIND[calls[j]!.function?.name ?? ""] === startKind) j++;
+            const runLen = j - i;
+            if (runLen > 1) {
+              const group = new ToolGroup(startKind, runLen);
+              chat.addChild(group);
+              for (let k = i; k < j; k++) {
+                const c = calls[k]!;
+                const cid = c.id ?? "";
+                group.addCall(detailFromArgs(c.function?.arguments));
+                if (cid) toolMap.set(cid, { kind: "group", group });
+              }
+              i = j;
+              continue;
+            }
+          }
+          const tc = calls[i]!;
           const id = tc.id ?? "";
           const name = tc.function?.name ?? "tool";
           const pair = renderToolPair({
@@ -245,22 +280,27 @@ export function mountAshi(
           });
           chat.addChild(pair.call);
           chat.addChild(pair.result);
-          if (id) toolMap.set(id, pair);
+          if (id) toolMap.set(id, { kind: "pair", pair });
           lastToolResult = pair.result;
+          i++;
         }
       }
     } else if (m.role === "tool") {
       const id = m.tool_call_id ?? "";
       const text = typeof m.content === "string" ? m.content : "";
-      const pair = id ? toolMap.get(id) : undefined;
-      if (pair) {
-        if (text) pair.result.appendChunk(text);
-        pair.result.finalize({ exitCode: 0 });
-        pair.call.setStatus({ exitCode: 0, elapsedMs: 0 });
-        if (id) toolMap.delete(id);
-      } else {
+      const found = id ? toolMap.get(id) : undefined;
+      if (!found) {
         chat.addChild(new InfoLine(`tool result (no matching call): ${text.slice(0, 80)}`));
+        return;
       }
+      if (found.kind === "group") {
+        found.group.recordCompletion(0);
+      } else {
+        if (text) found.pair.result.appendChunk(text);
+        found.pair.result.finalize({ exitCode: 0 });
+        found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0 });
+      }
+      if (id) toolMap.delete(id);
     }
   };
 
@@ -268,10 +308,11 @@ export function mountAshi(
     activeAssistant = null;
     activeThinking = null;
     activeTools.clear();
+    batchGroups.clear();
     lastToolResult = null;
     chat.clear();
     const branch = getStore().current().getBranch();
-    const toolMap = new Map<string, ToolPair>();
+    const toolMap = new Map<string, ReplayEntry>();
     for (const e of branch) replayEntry(e, toolMap);
     tui.requestRender();
   };
@@ -305,6 +346,13 @@ export function mountAshi(
     tui.requestRender();
   });
 
+  bus.on("agent:tool-batch", (e) => {
+    batchGroups.clear();
+    for (const g of e.groups) {
+      batchGroups.set(g.kind, { total: g.tools.length, group: null });
+    }
+  });
+
   bus.on("agent:tool-started", (e) => {
     finalizeThinking();
     if (activeAssistant) {
@@ -316,11 +364,28 @@ export function mountAshi(
     const detail = e.displayDetail || detailFromArgs(
       typeof e.rawInput === "string" ? e.rawInput : JSON.stringify(e.rawInput ?? {})
     );
+
+    const kind = e.kind ?? "";
+    const batchEntry = batchGroups.get(kind);
+    const shouldGroup = !!batchEntry && batchEntry.total > 1 && GROUPABLE_KINDS.has(kind);
+    if (shouldGroup) {
+      if (!batchEntry!.group) {
+        batchEntry!.group = new ToolGroup(kind, batchEntry!.total);
+        chat.addChild(batchEntry!.group);
+      }
+      batchEntry!.group.addCall(detail);
+      activeTools.set(id, { kind: "group", group: batchEntry!.group });
+      // Grouped tools have no individual result body — Ctrl+O wouldn't have
+      // anything to expand, so leave lastToolResult pointing at the prior tool.
+      tui.requestRender();
+      return;
+    }
+
     const pair = renderToolPair({
       toolCallId: id, name: title, title, kind: e.kind,
       displayDetail: detail, rawInput: e.rawInput,
     });
-    activeTools.set(id, pair);
+    activeTools.set(id, { kind: "pair", pair });
     chat.addChild(pair.call);
     chat.addChild(pair.result);
     lastToolResult = pair.result;
@@ -328,18 +393,29 @@ export function mountAshi(
   });
 
   bus.on("agent:tool-output-chunk", ({ chunk }) => {
-    if (activeTools.size === 0) return;
-    const last = [...activeTools.values()].pop();
-    last?.result.appendChunk(chunk);
-    tui.requestRender();
+    // Stream output only into pair-shaped tools; grouped tools have no body.
+    for (const entry of [...activeTools.values()].reverse()) {
+      if (entry.kind === "pair") {
+        entry.pair.result.appendChunk(chunk);
+        tui.requestRender();
+        return;
+      }
+    }
   });
 
   bus.on("agent:tool-completed", (e) => {
     const id = e.toolCallId;
     if (!id) return;
-    const pair = activeTools.get(id);
-    if (!pair) return;
+    const entry = activeTools.get(id);
+    if (!entry) return;
     const summary = e.resultDisplay?.summary;
+    if (entry.kind === "group") {
+      entry.group.recordCompletion(e.exitCode, summary);
+      activeTools.delete(id);
+      tui.requestRender();
+      return;
+    }
+    const pair = entry.pair;
     const body = e.resultDisplay?.body;
     const ok = e.exitCode === null || e.exitCode === 0;
     if (body?.kind === "diff") {

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -79,6 +79,30 @@ function detailFromArgs(argsJson: string | undefined): string {
   return "";
 }
 
+/** Recompute the per-tool summary from a saved tool result message. We don't
+ *  persist resultDisplay, so /resume would otherwise lose "16 entries" / "117
+ *  lines" etc. Mirrors agent-sh's formatResult logic for the common tools. */
+function inferSummary(toolName: string, content: unknown): string | undefined {
+  if (typeof content !== "string" || content.length === 0) return undefined;
+  const lines = content.split("\n").filter((l) => l.length > 0);
+  switch (toolName) {
+    case "ls":
+      if (content === "(empty directory)") return "0 entries";
+      return `${lines.length} entries`;
+    case "glob":
+      if (content === "No files matched.") return "0 files";
+      return `${lines.length} files`;
+    case "grep":
+      if (content === "No matches found.") return "0 matches";
+      return `${lines.length} lines`;
+    case "read_file":
+      if (content.startsWith("File unchanged")) return "cached";
+      return `${lines.length} lines`;
+    default:
+      return undefined;
+  }
+}
+
 function relativize(fp: string): string {
   const home = process.env.HOME;
   const cwd = process.cwd();
@@ -225,7 +249,9 @@ export function mountAshi(
     loader = null;
   };
 
-  type ReplayEntry = { kind: "pair"; pair: ToolPair } | { kind: "group"; group: ToolGroup };
+  type ReplayEntry =
+    | { kind: "pair"; pair: ToolPair; name: string }
+    | { kind: "group"; group: ToolGroup; name: string };
 
   const replayEntry = (entry: SessionEntry, toolMap: Map<string, ReplayEntry>): void => {
     if (entry.type === "session") return;
@@ -265,7 +291,7 @@ export function mountAshi(
                 const cid = c.id ?? "";
                 const cname = c.function?.name ?? "tool";
                 group.addCall(cid, cname, detailFromArgs(c.function?.arguments));
-                if (cid) toolMap.set(cid, { kind: "group", group });
+                if (cid) toolMap.set(cid, { kind: "group", group, name: cname });
               }
               i = j;
               continue;
@@ -281,7 +307,7 @@ export function mountAshi(
           });
           chat.addChild(pair.call);
           chat.addChild(pair.result);
-          if (id) toolMap.set(id, { kind: "pair", pair });
+          if (id) toolMap.set(id, { kind: "pair", pair, name });
           lastToolResult = pair.result;
           i++;
         }
@@ -294,12 +320,13 @@ export function mountAshi(
         chat.addChild(new InfoLine(`tool result (no matching call): ${text.slice(0, 80)}`));
         return;
       }
+      const summary = inferSummary(found.name, text);
       if (found.kind === "group") {
-        found.group.recordCompletion(id, 0);
+        found.group.recordCompletion(id, 0, summary);
       } else {
         if (text) found.pair.result.appendChunk(text);
-        found.pair.result.finalize({ exitCode: 0 });
-        found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0 });
+        found.pair.result.finalize({ exitCode: 0, summary });
+        found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0, summary });
       }
       if (id) toolMap.delete(id);
     }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -18,7 +18,8 @@ import {
   InfoLine,
   ThinkingBlock,
 } from "./components.js";
-import type { ToolExecutionView } from "./hooks.js";
+import type { ToolCallView, ToolResultView } from "./hooks.js";
+import { createToolHookResolver } from "./hooks.js";
 import { BusAutocompleteProvider } from "./autocomplete.js";
 import { StatusFooter } from "./status-footer.js";
 import type { MultiSessionStore } from "./multi-session-store.js";
@@ -132,9 +133,11 @@ export function mountAshi(
   tui.addChild(statusFooter);
   tui.setFocus(editor);
 
+  interface ToolPair { call: ToolCallView; result: ToolResultView; startedAt: number }
+
   let activeAssistant: AssistantMessage | null = null;
   let activeThinking: ThinkingBlock | null = null;
-  const activeTools = new Map<string, ToolExecutionView>();
+  const activeTools = new Map<string, ToolPair>();
   let loader: Loader | null = null;
   let processing = false;
   let hideThinking = false;
@@ -143,6 +146,8 @@ export function mountAshi(
     state: {},
     invalidate: () => tui.requestRender(),
   });
+
+  const tools = createToolHookResolver(ctx, renderState);
 
   const renderUserMessage = (text: string): Component =>
     ctx.call("ashi:render-user-message", { text, ...renderState() }) as Component;
@@ -159,11 +164,19 @@ export function mountAshi(
   const renderThinkingFinal = (text: string): Component =>
     ctx.call("ashi:render-thinking", { text, hidden: hideThinking, ...renderState() }) as Component;
 
-  const renderToolExecution = (args: {
+  const renderToolPair = (args: {
     toolCallId: string; name: string; title: string;
     kind?: string; displayDetail?: string; rawInput?: unknown;
-  }): ToolExecutionView =>
-    ctx.call("ashi:render-tool-execution", { ...args, ...renderState() }) as ToolExecutionView;
+  }): ToolPair => {
+    const call = tools.call(args);
+    const result = tools.result({
+      toolCallId: args.toolCallId,
+      name: args.name,
+      kind: args.kind,
+      rawInput: args.rawInput,
+    });
+    return { call, result, startedAt: Date.now() };
+  };
 
   const ensureAssistant = (): AssistantMessage => {
     if (!activeAssistant) {
@@ -200,7 +213,7 @@ export function mountAshi(
     loader = null;
   };
 
-  const replayEntry = (entry: SessionEntry, toolMap: Map<string, ToolExecutionView>): void => {
+  const replayEntry = (entry: SessionEntry, toolMap: Map<string, ToolPair>): void => {
     if (entry.type === "session") return;
     if (entry.type === "compaction") {
       chat.addChild(new InfoLine(`▼ compacted (firstKept=${entry.firstKeptId.slice(0, 6)}, ${entry.tokensBefore} tokens)`));
@@ -224,22 +237,24 @@ export function mountAshi(
         for (const tc of m.tool_calls) {
           const id = tc.id ?? "";
           const name = tc.function?.name ?? "tool";
-          const exec = renderToolExecution({
+          const pair = renderToolPair({
             toolCallId: id, name, title: name, kind: undefined,
             displayDetail: detailFromArgs(tc.function?.arguments),
             rawInput: tc.function?.arguments,
           });
-          chat.addChild(exec);
-          if (id) toolMap.set(id, exec);
+          chat.addChild(pair.call);
+          chat.addChild(pair.result);
+          if (id) toolMap.set(id, pair);
         }
       }
     } else if (m.role === "tool") {
       const id = m.tool_call_id ?? "";
       const text = typeof m.content === "string" ? m.content : "";
-      const exec = id ? toolMap.get(id) : undefined;
-      if (exec) {
-        if (text) exec.appendOutput(text);
-        exec.complete(0, undefined);
+      const pair = id ? toolMap.get(id) : undefined;
+      if (pair) {
+        if (text) pair.result.appendChunk(text);
+        pair.result.finalize({ exitCode: 0 });
+        pair.call.setStatus({ exitCode: 0, elapsedMs: 0 });
         if (id) toolMap.delete(id);
       } else {
         chat.addChild(new InfoLine(`tool result (no matching call): ${text.slice(0, 80)}`));
@@ -253,7 +268,7 @@ export function mountAshi(
     activeTools.clear();
     chat.clear();
     const branch = getStore().current().getBranch();
-    const toolMap = new Map<string, ToolExecutionView>();
+    const toolMap = new Map<string, ToolPair>();
     for (const e of branch) replayEntry(e, toolMap);
     tui.requestRender();
   };
@@ -298,27 +313,28 @@ export function mountAshi(
     const detail = e.displayDetail || detailFromArgs(
       typeof e.rawInput === "string" ? e.rawInput : JSON.stringify(e.rawInput ?? {})
     );
-    const tool = renderToolExecution({
+    const pair = renderToolPair({
       toolCallId: id, name: title, title, kind: e.kind,
       displayDetail: detail, rawInput: e.rawInput,
     });
-    activeTools.set(id, tool);
-    chat.addChild(tool);
+    activeTools.set(id, pair);
+    chat.addChild(pair.call);
+    chat.addChild(pair.result);
     tui.requestRender();
   });
 
   bus.on("agent:tool-output-chunk", ({ chunk }) => {
     if (activeTools.size === 0) return;
     const last = [...activeTools.values()].pop();
-    last?.appendOutput(chunk);
+    last?.result.appendChunk(chunk);
     tui.requestRender();
   });
 
   bus.on("agent:tool-completed", (e) => {
     const id = e.toolCallId;
     if (!id) return;
-    const tool = activeTools.get(id);
-    if (!tool) return;
+    const pair = activeTools.get(id);
+    if (!pair) return;
     const summary = e.resultDisplay?.summary;
     const body = e.resultDisplay?.body;
     const ok = e.exitCode === null || e.exitCode === 0;
@@ -341,10 +357,11 @@ export function mountAshi(
           title: diffFrameTitle(body.filePath, diff),
           bgColor: theme.bgCode(ok ? "toolSuccessBg" : "toolErrorBg"),
         });
-        tool.setBody(framed);
+        pair.result.setDiff(framed);
       }
     }
-    tool.complete(e.exitCode, summary);
+    pair.call.setStatus({ exitCode: e.exitCode, elapsedMs: Date.now() - pair.startedAt, summary });
+    pair.result.finalize({ exitCode: e.exitCode, summary });
     activeTools.delete(id);
     tui.requestRender();
   });

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -263,7 +263,7 @@ export function mountAshi(
               for (let k = i; k < j; k++) {
                 const c = calls[k]!;
                 const cid = c.id ?? "";
-                group.addCall(detailFromArgs(c.function?.arguments));
+                group.addCall(cid, detailFromArgs(c.function?.arguments));
                 if (cid) toolMap.set(cid, { kind: "group", group });
               }
               i = j;
@@ -294,7 +294,7 @@ export function mountAshi(
         return;
       }
       if (found.kind === "group") {
-        found.group.recordCompletion(0);
+        found.group.recordCompletion(id, 0);
       } else {
         if (text) found.pair.result.appendChunk(text);
         found.pair.result.finalize({ exitCode: 0 });
@@ -373,7 +373,7 @@ export function mountAshi(
         batchEntry!.group = new ToolGroup(kind, batchEntry!.total);
         chat.addChild(batchEntry!.group);
       }
-      batchEntry!.group.addCall(detail);
+      batchEntry!.group.addCall(id, detail);
       activeTools.set(id, { kind: "group", group: batchEntry!.group });
       // Grouped tools have no individual result body — Ctrl+O wouldn't have
       // anything to expand, so leave lastToolResult pointing at the prior tool.
@@ -410,7 +410,7 @@ export function mountAshi(
     if (!entry) return;
     const summary = e.resultDisplay?.summary;
     if (entry.kind === "group") {
-      entry.group.recordCompletion(e.exitCode, summary);
+      entry.group.recordCompletion(id, e.exitCode, summary);
       activeTools.delete(id);
       tui.requestRender();
       return;

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -3,11 +3,13 @@ import {
   ProcessTerminal,
   Container,
   Editor,
+  Image,
   Loader,
   SelectList,
   Spacer,
   type Component,
   type SelectItem,
+  getImageDimensions,
   matchesKey,
 } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
@@ -361,12 +363,41 @@ export function mountAshi(
     tui.requestRender();
   });
 
+  const imageComponentFromPng = (data: Buffer): Image | null => {
+    const base64 = data.toString("base64");
+    const dims = getImageDimensions(base64, "image/png");
+    if (!dims) return null;
+    return new Image(
+      base64, "image/png",
+      { fallbackColor: (t) => theme.fg("muted", t) },
+      { maxWidthCells: 60, maxHeightCells: 20 },
+      dims,
+    );
+  };
+
+  /** Drop the live assistant message so the image lands as its own block,
+   *  then subsequent text starts a fresh markdown context below it. */
+  const appendImage = (data: Buffer): void => {
+    const img = imageComponentFromPng(data);
+    if (!img) return;
+    if (activeAssistant) { activeAssistant.finalize(); activeAssistant = null; }
+    chat.addChild(img);
+  };
+
+  // `render:image` is the seam latex-images and similar extensions call after
+  // generating a PNG (e.g. from ```latex code blocks). agent-sh's bundled
+  // tui-renderer defines it, but ashi disables that renderer, so we own it.
+  ctx.define("render:image", (data: Buffer) => {
+    appendImage(data);
+    tui.requestRender();
+  });
+
   bus.on("agent:response-chunk", ({ blocks }) => {
     finalizeThinking();
-    const msg = ensureAssistant();
     for (const b of blocks) {
-      if (b.type === "text") msg.appendText(b.text);
-      else if (b.type === "code-block") msg.appendCodeBlock(b.language, b.code);
+      if (b.type === "text") ensureAssistant().appendText(b.text);
+      else if (b.type === "code-block") ensureAssistant().appendCodeBlock(b.language, b.code);
+      else if (b.type === "image") appendImage(b.data);
     }
     tui.requestRender();
   });

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -342,6 +342,9 @@ export function mountAshi(
     const branch = getStore().current().getBranch();
     const toolMap = new Map<string, ReplayEntry>();
     for (const e of branch) replayEntry(e, toolMap);
+    // Match the trailing gap that processing-done adds in live turns, so the
+    // editor doesn't sit flush against the last replayed response.
+    chat.addChild(new Spacer(1));
     tui.requestRender();
   };
 

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -384,9 +384,8 @@ export function mountAshi(
     chat.addChild(img);
   };
 
-  // `render:image` is the seam latex-images and similar extensions call after
-  // generating a PNG (e.g. from ```latex code blocks). agent-sh's bundled
-  // tui-renderer defines it, but ashi disables that renderer, so we own it.
+  // tui-renderer normally owns render:image, but ashi disables it; provide
+  // our own so latex-images and friends reach the chat.
   ctx.define("render:image", (data: Buffer) => {
     appendImage(data);
     tui.requestRender();
@@ -455,7 +454,6 @@ export function mountAshi(
   });
 
   bus.on("agent:tool-output-chunk", ({ chunk }) => {
-    // Stream output only into pair-shaped tools; grouped tools have no body.
     for (const entry of [...activeTools.values()].reverse()) {
       if (entry.kind === "pair") {
         entry.pair.result.appendChunk(chunk);

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -3,7 +3,6 @@ import type { ExtensionContext } from "agent-sh/types";
 import {
   AssistantMessage,
   ThinkingBlock,
-  ToolCallLine,
   ToolResultBody,
   UserMessage,
 } from "./components.js";
@@ -83,10 +82,6 @@ export function registerRenderDefaults(ctx: ExtensionContext): void {
     }
     tb.setHidden(args.hidden);
     return tb;
-  });
-
-  ctx.define(`${CALL_PREFIX}default`, (args: ToolCallArgs): ToolCallView => {
-    return new ToolCallLine(args.title, args.kind, args.displayDetail);
   });
 
   ctx.define(`${RESULT_PREFIX}default`, (args: ToolResultArgs): ToolResultView => {

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -46,11 +46,13 @@ export interface ToolCallView extends Component {
 }
 
 /** Mutated by ashi as output streams in and when the tool completes.
- *  setDiff is optional behavior — renderers may no-op if they don't show diffs. */
+ *  setDiff is optional behavior — renderers may no-op if they don't show diffs.
+ *  toggleExpanded flips the view's internal expansion state (Ctrl+O). */
 export interface ToolResultView extends Component {
   appendChunk(chunk: string): void;
   setDiff(lines: string[]): void;
   finalize(opts: { exitCode: number | null; summary?: string }): void;
+  toggleExpanded(): void;
 }
 
 const CALL_PREFIX = "ashi:render-tool-call:";

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -59,7 +59,7 @@ const RESULT_PREFIX = "ashi:render-tool-result:";
 
 /** Register the default render-* handlers. Per-tool overrides are advised by
  *  name (e.g. `ashi:render-tool-call:bash`); unknown tools fall back to
- *  `:default`. ashi's frontend never instantiates components directly. */
+ *  `:default`. */
 export function registerRenderDefaults(ctx: ExtensionContext): void {
   ctx.define("ashi:render-user-message", (args: UserMessageArgs): Component => {
     return new UserMessage(args.text);
@@ -95,9 +95,9 @@ export interface ToolHookResolver {
   modeFor: (name: string) => { mode: ToolResultMode; previewLines: number };
 }
 
-/** Build a resolver bound to the current ctx + display config. Caches the
- *  handler-name list lazily; callers can call `refresh()` after extensions
- *  register new tool-specific renderers. */
+/** Resolves :{name} → :default for tool render hooks and looks up each tool's
+ *  display mode from ashi.display. Cache the registered-handler set; callers
+ *  can `refresh()` after extensions register new tool-specific renderers. */
 export function createToolHookResolver(
   ctx: ExtensionContext,
   renderState: () => RenderState,

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -1,6 +1,13 @@
 import type { Component } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
-import { AssistantMessage, ThinkingBlock, ToolExecution, UserMessage } from "./components.js";
+import {
+  AssistantMessage,
+  ThinkingBlock,
+  ToolCallLine,
+  ToolResultBody,
+  UserMessage,
+} from "./components.js";
+import { entryFor, loadToolDisplayConfig, type ToolResultMode } from "./display-config.js";
 
 export interface RenderState {
   state: Record<string, unknown>;
@@ -13,7 +20,7 @@ export interface AssistantArgs extends RenderState { text: string }
 
 export interface ThinkingArgs extends RenderState { text: string; hidden: boolean }
 
-export interface ToolExecutionArgs extends RenderState {
+export interface ToolCallArgs extends RenderState {
   toolCallId: string;
   name: string;
   title: string;
@@ -22,18 +29,36 @@ export interface ToolExecutionArgs extends RenderState {
   rawInput?: unknown;
 }
 
-/** ToolExecutionView is the contract a tool-execution renderer must satisfy.
- *  ashi mutates the returned component as the tool progresses; custom
- *  renderers must accept these mutations or override them at the bus level. */
-export interface ToolExecutionView extends Component {
-  appendOutput(chunk: string): void;
-  setBody(lines: string[]): void;
-  complete(exitCode: number | null, summary?: string): void;
+export interface ToolResultArgs extends RenderState {
+  toolCallId: string;
+  name: string;
+  kind?: string;
+  rawInput?: unknown;
+  /** Resolved from ashi.display.{name} (or .default) in settings.json. */
+  mode: ToolResultMode;
+  previewLines: number;
 }
 
-/** Register the default render-* handlers. Extensions advise these names
- *  via ctx.advise to override or wrap. ashi's frontend.ts only ever calls
- *  ctx.call("ashi:render-*", args), never instantiates components directly. */
+/** Mutated by ashi when the tool completes. Renderers may ignore setStatus
+ *  if they encode status differently (e.g. a sigil in the call line). */
+export interface ToolCallView extends Component {
+  setStatus(opts: { exitCode: number | null; elapsedMs: number; summary?: string }): void;
+}
+
+/** Mutated by ashi as output streams in and when the tool completes.
+ *  setDiff is optional behavior — renderers may no-op if they don't show diffs. */
+export interface ToolResultView extends Component {
+  appendChunk(chunk: string): void;
+  setDiff(lines: string[]): void;
+  finalize(opts: { exitCode: number | null; summary?: string }): void;
+}
+
+const CALL_PREFIX = "ashi:render-tool-call:";
+const RESULT_PREFIX = "ashi:render-tool-result:";
+
+/** Register the default render-* handlers. Per-tool overrides are advised by
+ *  name (e.g. `ashi:render-tool-call:bash`); unknown tools fall back to
+ *  `:default`. ashi's frontend never instantiates components directly. */
 export function registerRenderDefaults(ctx: ExtensionContext): void {
   ctx.define("ashi:render-user-message", (args: UserMessageArgs): Component => {
     return new UserMessage(args.text);
@@ -58,7 +83,57 @@ export function registerRenderDefaults(ctx: ExtensionContext): void {
     return tb;
   });
 
-  ctx.define("ashi:render-tool-execution", (args: ToolExecutionArgs): ToolExecutionView => {
-    return new ToolExecution(args.title, args.kind, args.displayDetail);
+  ctx.define(`${CALL_PREFIX}default`, (args: ToolCallArgs): ToolCallView => {
+    return new ToolCallLine(args.title, args.kind, args.displayDetail);
   });
+
+  ctx.define(`${RESULT_PREFIX}default`, (args: ToolResultArgs): ToolResultView => {
+    return new ToolResultBody(args.mode, args.previewLines);
+  });
+}
+
+export interface ToolHookResolver {
+  call: (args: Omit<ToolCallArgs, "state" | "invalidate"> & Partial<RenderState>) => ToolCallView;
+  result: (args: Omit<ToolResultArgs, "mode" | "previewLines" | "state" | "invalidate"> & Partial<RenderState>) => ToolResultView;
+  modeFor: (name: string) => { mode: ToolResultMode; previewLines: number };
+}
+
+/** Build a resolver bound to the current ctx + display config. Caches the
+ *  handler-name list lazily; callers can call `refresh()` after extensions
+ *  register new tool-specific renderers. */
+export function createToolHookResolver(
+  ctx: ExtensionContext,
+  renderState: () => RenderState,
+): ToolHookResolver & { refresh: () => void } {
+  const config = loadToolDisplayConfig();
+  let registered = new Set(ctx.list());
+
+  const pick = (prefix: string, name: string): string => {
+    const specific = `${prefix}${name}`;
+    return registered.has(specific) ? specific : `${prefix}default`;
+  };
+
+  return {
+    refresh(): void {
+      registered = new Set(ctx.list());
+    },
+    modeFor(name: string) {
+      const e = entryFor(config, name);
+      return { mode: e.result, previewLines: e.previewLines };
+    },
+    call(args) {
+      const handler = pick(CALL_PREFIX, args.name);
+      return ctx.call(handler, { ...renderState(), ...args }) as ToolCallView;
+    },
+    result(args) {
+      const { mode, previewLines } = this.modeFor(args.name);
+      const handler = pick(RESULT_PREFIX, args.name);
+      return ctx.call(handler, {
+        ...renderState(),
+        ...args,
+        mode,
+        previewLines,
+      }) as ToolResultView;
+    },
+  };
 }

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -28,19 +28,25 @@ export class StatusFooter extends Container {
   }
 
   private repaint(): void {
-    const parts: string[] = [];
     const { model, provider, contextWindow, cwd, branch, leaf, tokens, compactions } = this.fields;
-    if (model) parts.push(model);
-    if (provider) parts.push(provider);
-    if (cwd) parts.push(shortenCwd(cwd));
-    if (branch) parts.push(branch);
-    if (leaf != null && leaf > 0) parts.push(`#${leaf}`);
-    if (tokens != null) {
-      parts.push(contextWindow ? `${fmtTokens(tokens)}/${fmtTokens(contextWindow)}` : fmtTokens(tokens));
+    const sep = theme.fg("dim", " | ");
+    const parts: string[] = [];
+    if (model) {
+      const tail = provider ? theme.fg("muted", `@${provider}`) : "";
+      parts.push(`${theme.fg("accent", model)}${tail ? " " + tail : ""}`);
+    } else if (provider) {
+      parts.push(theme.fg("muted", `@${provider}`));
     }
-    if (compactions && compactions > 0) parts.push(`${compactions} compaction${compactions === 1 ? "" : "s"}`);
-    const line = parts.length === 0 ? "" : theme.fg("muted", parts.join("  ·  "));
-    this.text.setText(line);
+    if (cwd) parts.push(theme.fg("muted", shortenCwd(cwd)));
+    if (branch) parts.push(theme.fg("muted", `⎇ ${branch}`));
+    if (leaf != null && leaf > 0) parts.push(theme.fg("muted", `#${leaf}`));
+    if (tokens != null) {
+      const tokStr = contextWindow ? `${fmtTokens(tokens)}/${fmtTokens(contextWindow)}` : fmtTokens(tokens);
+      const pct = contextWindow ? ` ${theme.fg("dim", `${Math.round((tokens / contextWindow) * 100)}%`)}` : "";
+      parts.push(`${theme.fg("muted", tokStr)}${pct}`);
+    }
+    if (compactions && compactions > 0) parts.push(theme.fg("muted", `⊟ ${compactions}`));
+    this.text.setText(parts.length === 0 ? "" : parts.join(sep));
   }
 }
 

--- a/examples/extensions/ashi/src/theme.ts
+++ b/examples/extensions/ashi/src/theme.ts
@@ -149,20 +149,3 @@ export function editorTheme(): EditorTheme {
   };
 }
 
-/** Kind icon table — kept in sync with agent-sh/src/utils/tool-display.ts KIND_ICONS. */
-export const KIND_ICONS: Record<string, string> = {
-  read: "◆",
-  edit: "✎",
-  write: "✎",
-  delete: "✕",
-  move: "↗",
-  search: "⌕",
-  execute: "▶",
-  think: "◇",
-  fetch: "↓",
-  switch_mode: "⇄",
-};
-
-export function iconFor(kind?: string): string {
-  return kind ? (KIND_ICONS[kind] ?? "▶") : "▶";
-}


### PR DESCRIPTION
## Summary

Two related lines of work on the `ashi` extension:

**1. Publishable as a standalone npm package** (`@guanyilun/ashi`).
- Renames the package, pins `agent-sh: ^0.12.27` instead of `file:../../..`, adds `files`/`repository`/`publishConfig`/`prepublishOnly` metadata, moves `tsx` to devDeps, and gives `build` a clean step so stale `dist/` artifacts no longer ship.
- README documents `npm link agent-sh` for local dev against the parent checkout, plus cross-links to the agent-sh `docs/usage.md` and `docs/extensions.md`.
- `agent-sh install ashi` continues to work — the bundled-extension resolver keys off directory name, not `package.json` name.

**2. Tool display revamp.**
- **Split render hooks**: `ashi:render-tool-execution` → `ashi:render-tool-call:{name}` + `ashi:render-tool-result:{name}` with `:default` fallbacks. Per-tool overrides without intercepting the whole pipeline.
- **`ashi.display` config** in `~/.agent-sh/settings.json`: per-tool `result` mode (`hidden`/`summary`/`preview`) + `previewLines`. Built-in defaults aim for compactness (`read`/`ls` hidden, `grep`/`find`/`glob` summarized, `bash`/`edit`/`write` previewed).
- **Opencode-style call lines**: `$ ls -la`, `read foo.ts:1-100`, `grep /pattern/ in src`, etc. — single line per call, no boxed two-line header.
- **`Ctrl+O`** expands the most recent tool result inline (full output + full diff regardless of mode); collapsed views show discoverable hints (`↳ 42 lines`, `... (N more lines)`).
- **Diff frame gating**: edits/writes honor the same display modes (no diff frame when `result: \"hidden\"`/`\"summary\"`; the call line already carries `+12 -3` stats).
- **Batch grouping** like ash's tui-renderer: parallel same-kind calls (read/search) collapse into one `◆ read` / `⌕ search` header with `├ <tool> <detail>  ✓ <summary>` child lines, swapping the last `├` to `└` to close. Overflow beyond 5 children collapses into `└ +N more ✓ ...`. The tool name on each child only renders when it diverges from the group's kind (so a pure read_file batch reads `├ foo.ts ✓ 5 lines`, while a mixed batch shows `├ ls src ✓ 16 entries`).
- **Replay heuristic**: `/resume` recomputes per-call summaries from saved content (`16 entries`/`117 lines`/etc.) since `resultDisplay` isn't persisted; bash/edit/write summaries remain absent on replay (depend on side-effects not captured in content).
- **Trailing spacer**: `rebuildChat` adds the same gap `agent:processing-done` does, so the editor no longer sits flush against the last replayed response.

## Test plan

- [ ] `agent-sh install ashi` clean install on a fresh `~/.agent-sh/`
- [ ] `npm link agent-sh` + `npm run dev` from `examples/extensions/ashi/` against the parent checkout
- [ ] Tool batch with 3+ reads renders as a single `◆ read` group
- [ ] Mixed read_file + ls batch shows the tool name on the ls children only
- [ ] `Ctrl+O` toggles the most recent tool result; works on both live tools and the last replayed tool after `/resume`
- [ ] Setting `ashi.display.edit.result: \"hidden\"` suppresses the diff frame; expanding restores it
- [ ] `/resume` shows `16 entries` / `117 lines` for ls/read_file etc.; the trailing gap before the editor is present