### PR TITLE
Clear OPOST after setRawMode so TUIs over ssh render correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { getSettings } from "./settings.js";
 import { runInit } from "./init.js";
 import { runInstall, runUninstall, runList, suggestBridgeFor } from "./install.js";
 import { PACKAGE_VERSION } from "./utils/package-version.js";
+import { clearOpost } from "./utils/tty.js";
 import type { AgentShellConfig } from "./types.js";
 
 /**
@@ -369,6 +370,7 @@ async function main(): Promise<void> {
     if (process.stdin.isTTY) {
       try {
         process.stdin.setRawMode(true);
+        clearOpost();
       } catch {
         // May fail if stdin is not a TTY
       }

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -5,6 +5,7 @@ import type { EventBus } from "../event-bus.js";
 import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
 import { getSettings } from "../settings.js";
+import { clearOpost } from "../utils/tty.js";
 import {
   pickStrategy,
   FALLBACK_STRATEGY,
@@ -126,6 +127,8 @@ export class Shell implements InputContext {
         // Ignore - will be set up later in index.ts
       }
     }
+
+    clearOpost();
 
     this.bus = opts.bus;
     this.handlers = opts.handlers;

--- a/src/utils/tty.ts
+++ b/src/utils/tty.ts
@@ -1,0 +1,14 @@
+import { execSync } from "child_process";
+
+/**
+ * libuv's setRawMode(true) keeps OPOST on, so the kernel rewrites \n to
+ * \r\n. TUIs over ssh (e.g. emacs -nw) emit relative moves like "\n\n\n\b\b"
+ * assuming a raw path — with OPOST on, \n snaps the cursor to col 0 and
+ * subsequent text lands in the wrong column. Call after every setRawMode(true).
+ */
+export function clearOpost(): void {
+  if (!process.stdin.isTTY) return;
+  try {
+    execSync("stty -opost", { stdio: "inherit" });
+  } catch { /* best effort */ }
+}


### PR DESCRIPTION
## Summary

- libuv's `setRawMode(true)` keeps `OPOST` on, so the kernel rewrites `\n` to `\r\n` on the local terminal. Inside agent-sh, that means the TTY emacs (over ssh) is rendering into has a different output mode than the one ssh itself would set when launched from a normal shell — ssh clears `OPOST` outright in its raw-mode setup.
- Emacs `-nw` over ssh emits relative cursor moves like `\n\n\n\b\b` on the assumption that the entire output path is raw. With `OPOST` on, each `\n` snaps the cursor to column 0 and the backspaces become no-ops; subsequent text (e.g. lazy-highlight overlays on wrap-continuation rows) lands in the wrong column. The artifact is visible as stale characters in the line-number gutter and survives incremental redraws — `M-x redraw-display` clears it, since a full repaint sends absolute cursor positions.
- Match ssh's behavior by running `stty -opost` on the controlling TTY after every `setRawMode(true)`: once after the Shell constructor's setRawMode dance (which temporarily un-raws stdin around `pty.spawn`, then re-raws and thereby restores `OPOST`), and once in the `SIGCONT` handler after suspend/resume.

## Test plan

- [x] Reproduce in `emacs -nw` over ssh inside agent-sh with a symbol-highlight mode active; observe the gutter artifact on wrap-continuation rows.
- [x] Apply the patch, rebuild, repeat — artifact gone.
- [x] Verify `stty -a` reports `-opost` while inside agent-sh after the Shell constructor runs.
- [ ] Smoke-test a non-TUI session (running `ls`, `cat`, normal shell prompt) to confirm nothing visibly changed.
- [ ] `Ctrl-Z` / `fg` an inner program (e.g. `less`) to confirm the `SIGCONT` path keeps `OPOST` cleared on resume.