### PR TITLE
Normalize lone LF to CRLF in StdoutSurface

### DIFF
--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -372,7 +372,7 @@ export class Shell implements InputContext {
     this.bus.onPipeAsync("shell:exec-request", async (payload) => {
       const visible = this.acquireUnmute("exec-request");
       this.skipNextLine();
-      process.stdout.write("\n");
+      process.stdout.write("\r\n");
       this.bus.emit("shell:agent-exec-start", {});
 
       try {

--- a/src/utils/compositor.ts
+++ b/src/utils/compositor.ts
@@ -71,7 +71,8 @@ export const nullSurface: RenderSurface = {
 export class StdoutSurface implements RenderSurface {
   write(text: string): void {
     if (process.stdout.writable) {
-      try { process.stdout.write(text); } catch { /* ignore */ }
+      // OPOST is cleared on the TTY; add CR to lone \n so we don't staircase.
+      try { process.stdout.write(text.replace(/(?<!\r)\n/g, "\r\n")); } catch { /* ignore */ }
     }
   }
   writeLine(line: string): void {


### PR DESCRIPTION
## Summary

Since b5260c3 cleared \`OPOST\` on the controlling TTY (so TUIs over ssh render correctly), the kernel no longer rewrites \`\\n\` → \`\\r\\n\` on output. PTY-forwarded shell output is unaffected — the inner PTY runs its own OPOST — but agent-sh-generated content written through \`StdoutSurface\` (banners, markdown response lines, status hints) staircased across the screen.

This routes the CR fix through the one chokepoint that owns the stdout bridge:

- \`src/utils/compositor.ts\` — \`StdoutSurface.write\` replaces any \`\\n\` not preceded by \`\\r\` with \`\\r\\n\` before writing.
- \`src/shell/shell.ts\` — the single bare-\`\\n\` write at the agent-exec-request boundary that bypasses \`StdoutSurface\` is updated to \`\\r\\n\` directly.

## Verification

- \`npm run build\` clean.
- Manually verified the staircase disappears in agent responses under both zsh and fish.