### PR TITLE
Add fish shell strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ npm run build      # produces dist/
 npm link           # exposes `agent-sh` globally
 ```
 
-Requires Node.js 18+. Currently supports **bash** and **zsh**; other shells (fish, nushell, etc.) are not yet wired up.
+Requires Node.js 18+. Supports **bash**, **zsh**, and **fish**; other shells (nushell, etc.) are not yet wired up.
 
-**Windows:** the interactive shell layer is bash/zsh-only. Run agent-sh inside **WSL** for the full experience. Native Windows (cmd.exe / PowerShell) is not supported as the host shell, though headless / library / ACP-bridge usage may work — file an issue if you hit a gap.
+**Windows:** the interactive shell layer is bash/zsh/fish-only. Run agent-sh inside **WSL** for the full experience. Native Windows (cmd.exe / PowerShell) is not supported as the host shell, though headless / library / ACP-bridge usage may work — file an issue if you hit a gap.
 
 Tip — add a shell alias:
 

--- a/src/shell/strategies/fish.ts
+++ b/src/shell/strategies/fish.ts
@@ -1,0 +1,77 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
+
+const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" (hostname) "$PWD"';
+const TITLE_CMD =
+  'printf "\\e]0;⚡ agent-sh: %s\\a" (string replace -- "$HOME" "~" "$PWD")';
+
+export const fishStrategy: ShellStrategy = {
+  name: "fish",
+
+  matches(shellPath: string): boolean {
+    return path.basename(shellPath).includes("fish");
+  },
+
+  prepareSpawn(opts: PrepareSpawnOpts): ShellSpawnConfig {
+    const { tmpDirRoot, instanceTag, showIndicator } = opts;
+
+    // Layer hooks via `-C` so they run after the user's config — our wrapper
+    // around fish_prompt needs to see the user's final definition.
+    const tmpDir = fs.mkdtempSync(path.join(tmpDirRoot, "agent-sh-"));
+    const initPath = path.join(tmpDir, "init.fish");
+    const promptMarker = `printf "\\e]9999;${instanceTag};PROMPT\\a"`;
+
+    const lines = [
+      "# agent-sh hooks (invisible OSC sequences for cwd + prompt detection)",
+      "function __agent_sh_precmd --on-event fish_prompt",
+      `  ${OSC7_CMD}`,
+      `  ${promptMarker}`,
+      ...(showIndicator ? [`  ${TITLE_CMD}`] : []),
+      "end",
+      "",
+      "# Preexec hook: emit actual command text so agent-sh can track",
+      "# history-recalled and tab-completed commands accurately",
+      "function __agent_sh_preexec --on-event fish_preexec",
+      `  printf "\\e]9997;${instanceTag};%s\\a" "$argv"`,
+      "end",
+      "",
+      "# End-of-prompt marker: wrap fish_prompt so READY fires after render",
+      "if functions -q fish_prompt",
+      "  functions --copy fish_prompt __agent_sh_orig_fish_prompt",
+      "  function fish_prompt",
+      "    __agent_sh_orig_fish_prompt",
+      `    printf "\\e]9998;${instanceTag};READY\\a"`,
+      "  end",
+      "else",
+      "  function fish_prompt",
+      "    printf '%s> ' (prompt_pwd)",
+      `    printf "\\e]9998;${instanceTag};READY\\a"`,
+      "  end",
+      "end",
+      "",
+      "# Redraw binding. fish 4 silently drops \\e[N~ outside the F-key table,",
+      "# so we use CSI-u with a private-use codepoint (U+E028) instead.",
+      "bind \\e\\[57400u 'commandline -f repaint' 2>/dev/null",
+      "bind -M insert \\e\\[57400u 'commandline -f repaint' 2>/dev/null",
+      "bind -M default \\e\\[57400u 'commandline -f repaint' 2>/dev/null",
+    ];
+
+    fs.writeFileSync(initPath, lines.join("\n") + "\n");
+
+    return {
+      args: ["-l", "-i", "-C", `source ${initPath}`],
+      envOverrides: {},
+      tmpDir,
+    };
+  },
+
+  envCaptureCommand(): string {
+    // `fish -l` already sources config.fish + conf.d, so no explicit source.
+    return "env -0";
+  },
+
+  redrawEscape(): string {
+    return "\x1b[57400u";
+  },
+};

--- a/src/shell/strategies/index.ts
+++ b/src/shell/strategies/index.ts
@@ -1,10 +1,11 @@
 import { zshStrategy } from "./zsh.js";
 import { bashStrategy } from "./bash.js";
+import { fishStrategy } from "./fish.js";
 import type { ShellStrategy } from "./types.js";
 
 export type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
 
-const STRATEGIES: ShellStrategy[] = [zshStrategy, bashStrategy];
+const STRATEGIES: ShellStrategy[] = [zshStrategy, bashStrategy, fishStrategy];
 
 /** Strategy used when the requested shell isn't recognized. */
 export const FALLBACK_STRATEGY: ShellStrategy = bashStrategy;


### PR DESCRIPTION
## Summary

Completes the fish shell support that #132 set the stage for by extracting the \`ShellStrategy\` interface. New \`src/shell/strategies/fish.ts\` implements all four hooks against fish 4 and registers in the strategy table.

### Hook design

- **\`prepareSpawn\`** — spawns with \`-l -i -C 'source <tmp>/init.fish'\` so our hooks layer on after the user's config. The init script wires:
  - \`--on-event fish_prompt\` → OSC 7 cwd + OSC 9999 PROMPT (+ OSC 0 title)
  - \`--on-event fish_preexec\` → OSC 9997 command text from \`\$argv\`
  - wrapped \`fish_prompt\` → OSC 9998 READY after render (chains onto any user-defined \`fish_prompt\`)
- **\`envCaptureCommand\`** — just \`env -0\`; \`fish -l\` sources config.fish + conf.d already.
- **\`redrawEscape\`** — \`\\e[57400u\`. fish 4's input parser silently drops \`\\e[N~\` for \`N\` outside the known F-key table, so the zsh/bash \`\\e[9999~\` form is a no-op under fish. CSI-u with a U+E028 private-use codepoint dispatches reliably to a bound \`commandline -f repaint\` and re-fires \`fish_prompt\`.

### Verification

End-to-end against fish 4.7.1 through a real PTY (\`node-pty\`):

| Hook | Verified |
|---|---|
| envCaptureCommand | 76 env vars captured |
| OSC 7 cwd marker | fires on every prompt |
| OSC 9999 PROMPT marker | fires on \`fish_prompt\` event |
| OSC 9998 READY marker | fires after wrapped \`fish_prompt\` |
| OSC 9997 command text | fires on \`fish_preexec\` with \`\$argv\` |
| OSC 0 title indicator | fires when \`showIndicator\` is true |
| \`redrawEscape\` repaint | re-runs \`fish_prompt\` |

Also smoke-tested live: \`./dist/index.js --shell \$(which fish)\` — prompt detection, cwd tracking, command capture, and agent-turn redraw all working.

## Notes for reviewers

- Stacked on #156 (the CRLF normalization fix) because without it the staircase makes the live fish session unreadable. Once that lands, this can rebase onto main.