### PR TITLE
Reset DECCKM, app-keypad, cursor-blink on overlay teardown

### DIFF
--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -1099,12 +1099,17 @@ export class FloatingPanel {
     this.surface.write("\x1b[?1049l");
 
     if (!this.usedAltScreen) {
-      // Program exited mid-overlay; its reset bytes were eaten by
-      // stdout-hold. Reset modes serialize() doesn't track or the
-      // host stays in vim's modifyOtherKeys mode.
+      // Alt-screen TUI exited mid-overlay; its reset bytes were eaten
+      // by stdout-hold. Re-emit the modes commonly set by full-screen
+      // programs (vim, neovim, emacs -nw, less, htop, tmux, ssh→TUI):
+      // modifyOtherKeys, kitty kbd, bracketed paste, focus reporting,
+      // mouse, DECCKM cursor-key mode, application keypad, cursor
+      // blink. Without this, arrow keys / keypad digits / cursor state
+      // misbehave at the post-overlay shell prompt.
       this.surface.write(
         "\x1b[>4;0m\x1b[<u\x1b[?2004l\x1b[?1004l" +
-        "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+        "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" +
+        "\x1b[?1l\x1b>\x1b[?12l",
       );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #124. The post-TUI-exit reset list in \`teardownScreen()\` compensates for mode bytes the alt-screen program emitted while \`stdoutHold\` was swallowing the PTY stream. #124 covered \`modifyOtherKeys\`, kitty kbd pop, bracketed paste, focus reporting, and the mouse modes. Three modes commonly set by full-screen TUIs were still leaking:

| Mode | Code | Set by | Symptom if left on |
|---|---|---|---|
| DECCKM (cursor-key mode) | \`CSI ?1l\` | vim, less, neovim, more | arrow keys report as SS3 (\`\\eOA\`) instead of CSI (\`\\e[A\`); shell bindings for arrow keys don't match |
| Application keypad | \`ESC >\` | vim, less, more | numeric keypad keys send escape sequences instead of digits |
| Cursor blink | \`CSI ?12l\` | vim (mostly) | unexpectedly blinking cursor at the post-overlay shell prompt |

These get eaten by \`stdoutHold\` the same way the modes already in #124's list do. The fix applies to any alt-screen program — vim, neovim, emacs -nw, less, htop, tmux, ssh→remote-TUI — not just vim.

## Evidence

Localized via the env-gated tracer on \`debug/fish-vim-exit\`. With \`AGENT_SH_TRACE_OVERLAY=1\`, vim's exit chunk (after \`terminal_keys\` injects \`\\e:q!\\r\`) shows:

\`\`\`
pty-out: ESC[?1004l ESC[?2004l ESC[?1l ESC> ESC[?1049l ESC[?25h ESC[>4;m
pty-out:gate {"muted":true,"hard":1,"soft":0,"unmute":1,"echoSkip":0}
\`\`\`

All bytes swallowed. The subsequent \`teardown:write-mode-resets\` only contained the #124 set, leaving \`?1\`, \`=\`, and \`?12\` still active on the host terminal.

## Why these aren't fish-specific

Same mode-leak class applies to \`emacs -nw\`, \`tmux\`, \`less\`, etc. The fix is shell-agnostic and lives in \`floating-panel.ts\`, not in any shell strategy.

## Intentionally not added

\`?2026\` (synchronized update), \`?2031\` (color scheme detection), \`CSI=Nu\` (kitty kbd set-flags) — these are modes the user's *shell* (fish 4, modern neovim-as-companion) wants enabled. Resetting would fight the shell, which re-asserts them on every prompt redraw anyway.

## Verification

- \`npm run build\` clean.
- The instrumentation that surfaced this is parked on \`debug/fish-vim-exit\` for future runs.