### PR TITLE
Add agent-sh auth subcommand for managing provider API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ See [Bring your own agent](#bring-your-own-agent) below for full details and the
 
 `ash` is agent-sh's own lightweight agent. It works with any OpenAI-compatible API — pick one of the zero-config paths below, no settings file needed. agent-sh auto-activates a built-in provider when it sees a known key.
 
+**Quickest path** — store a key once via the auth subcommand:
+
+```bash
+agent-sh auth login          # picks a provider interactively
+agent-sh                     # launches with the saved key
+```
+
+Keys are written to `~/.agent-sh/keys.json` (chmod 0600). Resolution order is `settings.json` → `keys.json` → env var, so an env var or settings entry will still win when present. `auth login` also accepts any provider you declare under `providers` in `settings.json` — useful for custom OpenAI-compatible endpoints where the URL is committable but the key shouldn't be.
+
+Or export the env var directly:
+
 **Hosted models via OpenRouter** (300+ models, one key):
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,29 @@ agent-sh install <name>         # install a bundled extension (e.g. agent-sh ins
 agent-sh install ./path/to/ext  # install from a local path
 agent-sh uninstall <name>       # remove an installed extension
 agent-sh list                   # show extensions discovered from ~/.agent-sh/extensions/ and settings.json
+agent-sh auth login [provider]  # store an API key (openai | openrouter | deepseek | any provider declared in settings.json)
+agent-sh auth logout <provider> # remove a stored key
+agent-sh auth list              # show configured providers and their key source
+```
+
+Keys stored via `auth` live in `~/.agent-sh/keys.json` (chmod 0600). Resolution order when launching is `settings.json` → `keys.json` → env var, so explicit configuration always wins over the auth store.
+
+Any provider you declare under `providers` in `settings.json` is also accepted by `auth login <id>`. This lets you keep custom endpoints in version control (id, baseURL, model list) while the key stays in `keys.json` out of the committable file:
+
+```json
+{
+  "providers": {
+    "my-llama": {
+      "baseURL": "http://localhost:8000/v1",
+      "defaultModel": "llama-3.1-70b",
+      "models": ["llama-3.1-70b"]
+    }
+  }
+}
+```
+
+```bash
+agent-sh auth login my-llama   # prompts for the key, saves to keys.json
 ```
 
 `install` accepts a bundled-extension name (see `agent-sh install` with no argument for the list), a `file:`/`./`/absolute path, or — once implemented — `npm:<pkg>` and `github:<user>/<repo>` specs.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,6 +66,8 @@ Any provider you declare under `providers` in `settings.json` is also accepted b
 agent-sh auth login my-llama   # prompts for the key, saves to keys.json
 ```
 
+`auth login <id>` also accepts ids it doesn't recognize (with a warning). This lets extensions that register their own provider at runtime tell users to run `agent-sh auth login <their-id>` — the key sits in `keys.json` until the extension loads and claims it. Such entries appear in `auth list` tagged `unattached`.
+
 `install` accepts a bundled-extension name (see `agent-sh install` with no argument for the list), a `file:`/`./`/absolute path, or — once implemented — `npm:<pkg>` and `github:<user>/<repo>` specs.
 
 ## Updating

--- a/src/auth/cli.ts
+++ b/src/auth/cli.ts
@@ -1,0 +1,228 @@
+import * as readline from "node:readline";
+import { palette as p } from "../utils/palette.js";
+import {
+  KNOWN_PROVIDERS,
+  KEYS_PATH,
+  loadKeysFile,
+  saveKeysFile,
+  resolveApiKey,
+  listAllProviders,
+  findProvider as findProviderById,
+  type ProviderAuthInfo,
+} from "./keys.js";
+
+export async function runAuth(args: string[]): Promise<void> {
+  const sub = args[0];
+  if (!sub || sub === "--help" || sub === "-h") {
+    printHelp();
+    return;
+  }
+  if (sub === "login") {
+    await runLogin(args[1]);
+    return;
+  }
+  if (sub === "logout") {
+    runLogout(args[1]);
+    return;
+  }
+  if (sub === "list" || sub === "ls" || sub === "status") {
+    runList();
+    return;
+  }
+  console.error(`agent-sh auth: unknown subcommand "${sub}"`);
+  printHelp();
+  process.exit(1);
+}
+
+function printHelp(): void {
+  const builtins = KNOWN_PROVIDERS.map((p) => p.id).join(" | ");
+  console.log(
+    `agent-sh auth — manage API keys for providers\n\n` +
+    `Usage:\n` +
+    `  agent-sh auth login [provider]   Store an API key (prompts if omitted)\n` +
+    `  agent-sh auth logout <provider>  Remove a stored key\n` +
+    `  agent-sh auth list               Show configured providers and key sources\n\n` +
+    `Built-in providers: ${builtins}\n` +
+    `Custom providers declared in settings.json are also accepted by id.\n\n` +
+    `Keys are stored in ${KEYS_PATH} (chmod 0600).\n` +
+    `Resolution order: settings.json > keys.json > env var.\n`,
+  );
+}
+
+async function runLogin(providerArg: string | undefined): Promise<void> {
+  const provider = providerArg
+    ? findProvider(providerArg)
+    : await pickProvider();
+  if (!provider) process.exit(1);
+
+  const key = await promptSecret(`Enter ${provider.label} API key: `);
+  const trimmed = key.trim();
+  if (!trimmed) {
+    console.error("agent-sh auth: empty key, nothing saved.");
+    process.exit(1);
+  }
+  if (/\s/.test(trimmed)) {
+    console.error("agent-sh auth: key contains whitespace; aborting.");
+    process.exit(1);
+  }
+
+  const keys = { ...loadKeysFile() };
+  keys[provider.id] = trimmed;
+  saveKeysFile(keys);
+
+  const resolved = resolveApiKey(provider.id);
+  console.log(`${p.success}✓${p.reset} Saved ${provider.label} key to ${KEYS_PATH}`);
+  if (resolved.source !== "keys-file") {
+    console.log(
+      `${p.warning}Note:${p.reset} an existing ${sourceLabel(resolved.source, provider)} entry ` +
+      `takes precedence; the stored key is shadowed until you remove it.`,
+    );
+  }
+}
+
+function runLogout(providerArg: string | undefined): void {
+  if (!providerArg) {
+    console.error("Usage: agent-sh auth logout <provider>");
+    process.exit(1);
+  }
+  const provider = findProvider(providerArg);
+  if (!provider) process.exit(1);
+
+  const keys = { ...loadKeysFile() };
+  if (!(provider.id in keys)) {
+    console.log(`agent-sh auth: no stored key for ${provider.label}.`);
+    return;
+  }
+  delete keys[provider.id];
+  saveKeysFile(keys);
+  console.log(`${p.success}✓${p.reset} Removed ${provider.label} key from ${KEYS_PATH}`);
+}
+
+function runList(): void {
+  const providers = listAllProviders();
+  console.log("Provider key status:\n");
+  const idWidth = Math.max(...providers.map((p) => p.id.length));
+  for (const info of providers) {
+    const resolved = resolveApiKey(info.id);
+    const padded = info.id.padEnd(idWidth);
+    const marker = info.custom ? `  ${p.dim}custom${p.reset}` : "";
+    if (resolved.key) {
+      console.log(`  ${p.success}●${p.reset} ${padded}  ${p.dim}(${sourceLabel(resolved.source, info)})${p.reset}${marker}`);
+    } else {
+      console.log(`  ${p.muted}○${p.reset} ${padded}  ${p.dim}(not configured)${p.reset}${marker}`);
+    }
+  }
+  const example = providers[0]!.id;
+  console.log(`\n${p.muted}Login with:${p.reset} agent-sh auth login <id>   ${p.dim}(e.g. agent-sh auth login ${example})${p.reset}`);
+}
+
+function findProvider(name: string): ProviderAuthInfo | null {
+  const found = findProviderById(name);
+  if (found) return found;
+  const known = listAllProviders().map((p) => p.id).join(", ");
+  console.error(`agent-sh auth: unknown provider "${name}". Known: ${known}`);
+  console.error(`(Declare custom providers under "providers" in settings.json — see \`agent-sh init\`.)`);
+  return null;
+}
+
+async function pickProvider(): Promise<ProviderAuthInfo | null> {
+  if (!process.stdin.isTTY) {
+    console.error("agent-sh auth: no provider specified and stdin is not a TTY.");
+    return null;
+  }
+  const providers = listAllProviders();
+  console.log("Select a provider:");
+  providers.forEach((info, i) => {
+    const resolved = resolveApiKey(info.id);
+    const tag = resolved.key
+      ? `${p.dim}(currently from ${sourceLabel(resolved.source, info)})${p.reset}`
+      : `${p.dim}(not configured)${p.reset}`;
+    const labelStr = info.custom ? `${p.dim}custom${p.reset}` : `${p.dim}${info.label}${p.reset}`;
+    console.log(`  ${i + 1}) ${info.id.padEnd(12)} ${labelStr}  ${tag}`);
+  });
+  const answer = await promptLine("Choice [1]: ");
+  const idx = answer.trim() === "" ? 0 : Number(answer.trim()) - 1;
+  if (!Number.isInteger(idx) || idx < 0 || idx >= providers.length) {
+    console.error("agent-sh auth: invalid selection.");
+    return null;
+  }
+  return providers[idx]!;
+}
+
+function promptLine(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+function promptSecret(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY) {
+      let buf = "";
+      process.stdin.setEncoding("utf-8");
+      process.stdin.on("data", (chunk: string) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl >= 0) {
+          process.stdin.pause();
+          resolve(buf.slice(0, nl).replace(/\r$/, ""));
+        }
+      });
+      return;
+    }
+
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+    const wasRaw = stdin.isRaw;
+    stdout.write(question);
+    stdin.resume();
+    stdin.setRawMode(true);
+    stdin.setEncoding("utf-8");
+
+    let buf = "";
+    const finish = (value: string | null): void => {
+      stdout.write("\n");
+      stdin.removeListener("data", onData);
+      stdin.setRawMode(wasRaw);
+      stdin.pause();
+      if (value === null) process.exit(130);
+      resolve(value);
+    };
+    const onData = (ch: string): void => {
+      for (const c of ch) {
+        if (c === "\n" || c === "\r" || c === "\x04") {
+          finish(buf);
+          return;
+        }
+        if (c === "\x03") {
+          finish(null);
+          return;
+        }
+        if (c === "\x7f" || c === "\b") {
+          if (buf.length > 0) {
+            buf = buf.slice(0, -1);
+            stdout.write("\b \b");
+          }
+          continue;
+        }
+        if (c < " ") continue;
+        buf += c;
+        stdout.write("*");
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+function sourceLabel(source: string, info?: ProviderAuthInfo): string {
+  switch (source) {
+    case "settings": return "settings.json";
+    case "keys-file": return "keys.json";
+    case "env": return info ? `$${info.envVar}` : "env var";
+    default: return source;
+  }
+}

--- a/src/auth/cli.ts
+++ b/src/auth/cli.ts
@@ -50,9 +50,24 @@ function printHelp(): void {
 }
 
 async function runLogin(providerArg: string | undefined): Promise<void> {
-  const provider = providerArg
-    ? findProvider(providerArg)
-    : await pickProvider();
+  let provider: ProviderAuthInfo | null;
+  if (providerArg) {
+    const id = providerArg.toLowerCase();
+    if (!/^[a-z0-9][a-z0-9_\-./:]*$/.test(id)) {
+      console.error(`agent-sh auth: invalid provider id "${providerArg}".`);
+      process.exit(1);
+    }
+    provider = findProviderById(id);
+    if (!provider) {
+      console.error(
+        `${p.warning}Note:${p.reset} no built-in or settings.json provider named "${id}". ` +
+        `Storing the key anyway — it will resolve once an extension or settings.json declares the provider.`,
+      );
+      provider = { id, label: id, unattached: true };
+    }
+  } else {
+    provider = await pickProvider();
+  }
   if (!provider) process.exit(1);
 
   const key = await promptSecret(`Enter ${provider.label} API key: `);
@@ -85,17 +100,15 @@ function runLogout(providerArg: string | undefined): void {
     console.error("Usage: agent-sh auth logout <provider>");
     process.exit(1);
   }
-  const provider = findProvider(providerArg);
-  if (!provider) process.exit(1);
-
+  const id = providerArg.toLowerCase();
   const keys = { ...loadKeysFile() };
-  if (!(provider.id in keys)) {
-    console.log(`agent-sh auth: no stored key for ${provider.label}.`);
+  if (!(id in keys)) {
+    console.log(`agent-sh auth: no stored key for ${id}.`);
     return;
   }
-  delete keys[provider.id];
+  delete keys[id];
   saveKeysFile(keys);
-  console.log(`${p.success}✓${p.reset} Removed ${provider.label} key from ${KEYS_PATH}`);
+  console.log(`${p.success}✓${p.reset} Removed ${id} key from ${KEYS_PATH}`);
 }
 
 function runList(): void {
@@ -105,7 +118,11 @@ function runList(): void {
   for (const info of providers) {
     const resolved = resolveApiKey(info.id);
     const padded = info.id.padEnd(idWidth);
-    const marker = info.custom ? `  ${p.dim}custom${p.reset}` : "";
+    const marker = info.custom
+      ? `  ${p.dim}custom${p.reset}`
+      : info.unattached
+      ? `  ${p.dim}unattached${p.reset}`
+      : "";
     if (resolved.key) {
       console.log(`  ${p.success}●${p.reset} ${padded}  ${p.dim}(${sourceLabel(resolved.source, info)})${p.reset}${marker}`);
     } else {
@@ -114,15 +131,6 @@ function runList(): void {
   }
   const example = providers[0]!.id;
   console.log(`\n${p.muted}Login with:${p.reset} agent-sh auth login <id>   ${p.dim}(e.g. agent-sh auth login ${example})${p.reset}`);
-}
-
-function findProvider(name: string): ProviderAuthInfo | null {
-  const found = findProviderById(name);
-  if (found) return found;
-  const known = listAllProviders().map((p) => p.id).join(", ");
-  console.error(`agent-sh auth: unknown provider "${name}". Known: ${known}`);
-  console.error(`(Declare custom providers under "providers" in settings.json — see \`agent-sh init\`.)`);
-  return null;
 }
 
 async function pickProvider(): Promise<ProviderAuthInfo | null> {
@@ -137,7 +145,11 @@ async function pickProvider(): Promise<ProviderAuthInfo | null> {
     const tag = resolved.key
       ? `${p.dim}(currently from ${sourceLabel(resolved.source, info)})${p.reset}`
       : `${p.dim}(not configured)${p.reset}`;
-    const labelStr = info.custom ? `${p.dim}custom${p.reset}` : `${p.dim}${info.label}${p.reset}`;
+    const labelStr = info.custom
+      ? `${p.dim}custom${p.reset}`
+      : info.unattached
+      ? `${p.dim}unattached${p.reset}`
+      : `${p.dim}${info.label}${p.reset}`;
     console.log(`  ${i + 1}) ${info.id.padEnd(12)} ${labelStr}  ${tag}`);
   });
   const answer = await promptLine("Choice [1]: ");

--- a/src/auth/keys.ts
+++ b/src/auth/keys.ts
@@ -1,0 +1,106 @@
+// Resolution order: settings.json → keys.json → env var.
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CONFIG_DIR, getSettings, expandEnvVars } from "../settings.js";
+
+export const KEYS_PATH = path.join(CONFIG_DIR, "keys.json");
+
+export interface ProviderAuthInfo {
+  id: string;
+  label: string;
+  /** Conventional env var. Absent for user-declared providers. */
+  envVar?: string;
+  /** True for entries declared in settings.json (vs. a built-in). */
+  custom?: boolean;
+}
+
+export const KNOWN_PROVIDERS: ProviderAuthInfo[] = [
+  { id: "openai",     label: "OpenAI",     envVar: "OPENAI_API_KEY" },
+  { id: "openrouter", label: "OpenRouter", envVar: "OPENROUTER_API_KEY" },
+  { id: "deepseek",   label: "DeepSeek",   envVar: "DEEPSEEK_API_KEY" },
+];
+
+/** Built-ins merged with user-declared providers from settings.json. */
+export function listAllProviders(): ProviderAuthInfo[] {
+  const out: ProviderAuthInfo[] = [...KNOWN_PROVIDERS];
+  const seen = new Set(out.map((p) => p.id));
+  const settingsProviders = getSettings().providers ?? {};
+  for (const id of Object.keys(settingsProviders)) {
+    if (seen.has(id)) continue;
+    out.push({ id, label: id, custom: true });
+    seen.add(id);
+  }
+  return out;
+}
+
+export function findProvider(id: string): ProviderAuthInfo | null {
+  return listAllProviders().find((p) => p.id === id.toLowerCase()) ?? null;
+}
+
+export type KeySource = "settings" | "keys-file" | "env" | "none";
+
+export interface ResolvedKey {
+  key: string | null;
+  source: KeySource;
+}
+
+type KeysFile = Record<string, string>;
+
+let cached: KeysFile | null = null;
+
+export function loadKeysFile(): KeysFile {
+  if (cached) return cached;
+  try {
+    const raw = fs.readFileSync(KEYS_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      cached = parsed as KeysFile;
+    } else {
+      cached = {};
+    }
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      console.error(`[agent-sh] Warning: invalid JSON in ${KEYS_PATH}: ${err.message}`);
+    }
+    cached = {};
+  }
+  return cached;
+}
+
+export function saveKeysFile(keys: KeysFile): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  const tmp = `${KEYS_PATH}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(keys, null, 2) + "\n", { mode: 0o600 });
+  fs.renameSync(tmp, KEYS_PATH);
+  try { fs.chmodSync(KEYS_PATH, 0o600); } catch { /* best effort */ }
+  cached = { ...keys };
+}
+
+export function reloadKeysFile(): void {
+  cached = null;
+}
+
+export function resolveApiKey(providerId: string): ResolvedKey {
+  const settingsKey = getSettings().providers?.[providerId]?.apiKey;
+  if (settingsKey) {
+    const expanded = expandEnvVars(settingsKey);
+    if (expanded) return { key: expanded, source: "settings" };
+  }
+
+  const fileKey = loadKeysFile()[providerId];
+  if (fileKey) return { key: fileKey, source: "keys-file" };
+
+  const info = KNOWN_PROVIDERS.find((p) => p.id === providerId);
+  if (info?.envVar) {
+    const envKey = process.env[info.envVar];
+    if (envKey) return { key: envKey, source: "env" };
+  }
+
+  return { key: null, source: "none" };
+}
+
+export function anyProviderConfigured(): boolean {
+  // openai-compatible activates on OPENAI_BASE_URL alone (keyless local servers).
+  if (process.env.OPENAI_BASE_URL) return true;
+  return listAllProviders().some((p) => resolveApiKey(p.id).key);
+}

--- a/src/auth/keys.ts
+++ b/src/auth/keys.ts
@@ -12,6 +12,9 @@ export interface ProviderAuthInfo {
   envVar?: string;
   /** True for entries declared in settings.json (vs. a built-in). */
   custom?: boolean;
+  /** True for ids only present in keys.json — likely owned by an extension
+   *  that registers a provider at runtime. */
+  unattached?: boolean;
 }
 
 export const KNOWN_PROVIDERS: ProviderAuthInfo[] = [
@@ -20,7 +23,8 @@ export const KNOWN_PROVIDERS: ProviderAuthInfo[] = [
   { id: "deepseek",   label: "DeepSeek",   envVar: "DEEPSEEK_API_KEY" },
 ];
 
-/** Built-ins merged with user-declared providers from settings.json. */
+/** Built-ins merged with settings-declared providers, plus any ids that only
+ *  appear in keys.json (likely registered by an extension at runtime). */
 export function listAllProviders(): ProviderAuthInfo[] {
   const out: ProviderAuthInfo[] = [...KNOWN_PROVIDERS];
   const seen = new Set(out.map((p) => p.id));
@@ -30,11 +34,23 @@ export function listAllProviders(): ProviderAuthInfo[] {
     out.push({ id, label: id, custom: true });
     seen.add(id);
   }
+  for (const id of Object.keys(loadKeysFile())) {
+    if (seen.has(id)) continue;
+    out.push({ id, label: id, unattached: true });
+    seen.add(id);
+  }
   return out;
 }
 
+/** Resolve an id against known + settings entries only. Returns null for
+ *  unattached or unknown ids — callers decide whether to accept them. */
 export function findProvider(id: string): ProviderAuthInfo | null {
-  return listAllProviders().find((p) => p.id === id.toLowerCase()) ?? null;
+  const lower = id.toLowerCase();
+  const known = KNOWN_PROVIDERS.find((p) => p.id === lower);
+  if (known) return known;
+  const settings = getSettings().providers ?? {};
+  if (lower in settings) return { id: lower, label: lower, custom: true };
+  return null;
 }
 
 export type KeySource = "settings" | "keys-file" | "env" | "none";

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -10,23 +10,24 @@
  * specially from `src/index.ts` rather than through this manifest.
  */
 import type { ExtensionContext } from "../types.js";
+import { resolveApiKey } from "../auth/keys.js";
 
 type ActivateFn = (ctx: ExtensionContext) => void;
 
 export const BUILTIN_EXTENSIONS: Array<{
   name: string;
   // When present and false, the module isn't imported — keeps provider
-  // built-ins dormant unless their env var is set.
+  // built-ins dormant unless a key is configured.
   when?: () => boolean;
   load: () => Promise<ActivateFn>;
 }> = [
   { name: "shell-context",   load: () => import("./shell-context.js").then(m => m.default) },
   { name: "agent-backend",    load: () => import("./agent-backend.js").then(m => m.default) },
   { name: "openrouter",
-    when: () => !!process.env.OPENROUTER_API_KEY,
+    when: () => !!resolveApiKey("openrouter").key,
     load: () => import("./providers/openrouter.js").then(m => m.default) },
   { name: "openai",
-    when: () => !!process.env.OPENAI_API_KEY && !process.env.OPENAI_BASE_URL,
+    when: () => !!resolveApiKey("openai").key && !process.env.OPENAI_BASE_URL,
     load: () => import("./providers/openai.js").then(m => m.default) },
   { name: "openai-compatible",
     when: () => !!process.env.OPENAI_BASE_URL,

--- a/src/extensions/providers/deepseek.ts
+++ b/src/extensions/providers/deepseek.ts
@@ -5,6 +5,7 @@
  * is opt-in alongside any settings.json entry.
  */
 import type { ExtensionContext } from "../../types.js";
+import { resolveApiKey } from "../../auth/keys.js";
 
 const BASE_URL = "https://api.deepseek.com";
 const DEFAULT_MODELS = [
@@ -21,7 +22,7 @@ function buildReasoningParams(level: string, _model?: string): Record<string, un
 export default function activate(ctx: ExtensionContext): void {
   ctx.providers.configure("deepseek", { reasoningParams: buildReasoningParams });
 
-  const apiKey = process.env.DEEPSEEK_API_KEY;
+  const apiKey = resolveApiKey("deepseek").key;
   if (!apiKey) return;
   ctx.bus.emit("provider:register", {
     id: "deepseek",

--- a/src/extensions/providers/openai.ts
+++ b/src/extensions/providers/openai.ts
@@ -4,6 +4,7 @@
  * floors at "minimal"; gpt-5.1+ accepts "none" as documented full off.
  */
 import type { ExtensionContext } from "../../types.js";
+import { resolveApiKey } from "../../auth/keys.js";
 
 const CLOUD_MODELS = [
   { id: "gpt-5", reasoning: true },
@@ -29,7 +30,7 @@ function buildReasoningParams(level: string, model?: string): Record<string, unk
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey = resolveApiKey("openai").key;
   if (!apiKey) return;
   if (process.env.OPENAI_BASE_URL) return; // openai-compatible handles this
 

--- a/src/extensions/providers/openrouter.ts
+++ b/src/extensions/providers/openrouter.ts
@@ -5,6 +5,7 @@
  */
 import type { ExtensionContext } from "../../types.js";
 import { getSettings } from "../../settings.js";
+import { resolveApiKey } from "../../auth/keys.js";
 
 const BASE_URL = "https://openrouter.ai/api/v1";
 
@@ -31,7 +32,7 @@ interface OpenRouterModel {
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const apiKey = process.env.OPENROUTER_API_KEY;
+  const apiKey = resolveApiKey("openrouter").key;
   if (!apiKey) return;
 
   ctx.providers.configure("openrouter", { reasoningParams: buildReasoningParams });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { loadExtensions } from "./extension-loader.js";
 import { getSettings } from "./settings.js";
 import { runInit } from "./init.js";
 import { runInstall, runUninstall, runList, suggestBridgeFor } from "./install.js";
+import { runAuth } from "./auth/cli.js";
+import { anyProviderConfigured } from "./auth/keys.js";
 import { PACKAGE_VERSION } from "./utils/package-version.js";
 import { clearOpost } from "./utils/tty.js";
 import type { AgentShellConfig } from "./types.js";
@@ -118,6 +120,9 @@ Usage: agent-sh [options]
        agent-sh install <spec> [--force]  Install an extension (bundled name, file:, npm:, github:)
        agent-sh uninstall <name>          Remove an installed extension
        agent-sh list                      List installed extensions
+       agent-sh auth login [provider]     Store an API key for a built-in provider
+       agent-sh auth logout <provider>    Remove a stored key
+       agent-sh auth list                 Show configured providers
 
 Provider Profiles:
   --provider <name>   Use a provider from ~/.agent-sh/settings.json
@@ -180,6 +185,10 @@ async function main(): Promise<void> {
     runList();
     return;
   }
+  if (rawArgs[0] === "auth") {
+    await runAuth(rawArgs.slice(1));
+    return;
+  }
 
   if (process.env.AGENT_SH) {
     console.error("agent-sh: already running inside an agent-sh session (nested sessions are not supported).");
@@ -215,6 +224,16 @@ async function main(): Promise<void> {
     }
   } catch {
     // Ignore errors, we already have process.env as fallback
+  }
+
+  if (!config.apiKey && !config.provider && !anyProviderConfigured()) {
+    console.error(
+      "\nagent-sh: no LLM provider configured.\n\n" +
+      "  Run `agent-sh auth login` to store an API key, or\n" +
+      "  export OPENAI_API_KEY / OPENROUTER_API_KEY / DEEPSEEK_API_KEY, or\n" +
+      "  run `agent-sh init` for a settings.json template.\n",
+    );
+    process.exit(1);
   }
 
   // ── Core (frontend-agnostic) ──────────────────────────────────


### PR DESCRIPTION
## Summary

- New `agent-sh auth login | logout | list` subcommands. Keys are stored in `~/.agent-sh/keys.json` (chmod 0600). Resolution order on launch is `settings.json` → `keys.json` → env var, so existing setups keep working unchanged.
- `auth login <id>` accepts the three built-ins (`openai`, `openrouter`, `deepseek`) **and** any provider declared under `providers` in `settings.json` — useful for custom OpenAI-compatible endpoints where the baseURL is committable but the key shouldn't be.
- First-run hint: when nothing is configured (no flags, no settings.json provider with a key, no keys.json entry, no known env var, no `OPENAI_BASE_URL`), agent-sh now prints a one-liner pointing at `auth login` instead of letting the boot reach the more confusing "no backend available" error after extension load.
- Built-in provider modules (`openai`, `openrouter`, `deepseek`) now read keys via `resolveApiKey()` instead of `process.env` directly, picking up the new sources transparently. `deepseek`'s reasoning-shape hook still installs unconditionally so other providers can borrow it via `reasoningShape: "deepseek"`.

## Test plan

- [x] `auth login <id>` prompts (with masking on TTY) and writes a 0600 `keys.json`
- [x] `auth list` shows id + source: `(settings.json)`, `(keys.json)`, `($ENV_VAR)`, or `(not configured)`
- [x] `auth login` with no arg shows interactive picker covering built-ins + settings-declared providers
- [x] `auth logout <id>` removes a stored key; reports cleanly when none was stored
- [x] Settings-declared custom provider (`my-llama` with `baseURL` + models) accepted by `auth login`; truly unknown ids rejected with a hint
- [x] Precedence: settings.json beats keys.json beats env var
- [x] First-run hint fires only when nothing is configured; skipped when `OPENAI_BASE_URL` set, when `--api-key` passed, when `--provider` passed, or when any settings/keys/env source resolves a key
- [x] No regression: existing `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `DEEPSEEK_API_KEY` workflows boot as before
- [x] `tsc` build clean