### PR TITLE
Move executor.ts into src/utils/

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
       "default": "./dist/agent/nuclear-form.js"
     },
     "./executor": {
-      "types": "./dist/executor.d.ts",
-      "default": "./dist/executor.js"
+      "types": "./dist/utils/executor.d.ts",
+      "default": "./dist/utils/executor.js"
     }
   },
   "files": [

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -39,7 +39,7 @@ import { createToolProtocol, type ToolProtocol, type PendingToolCall as Protocol
 // Core tool factories
 import { createBashTool } from "./tools/bash.js";
 import { createPwshTool } from "./tools/pwsh.js";
-import { findBash } from "../executor.js";
+import { findBash } from "../utils/executor.js";
 import { createReadFileTool, type FileReadCache } from "./tools/read-file.js";
 import { createWriteFileTool } from "./tools/write-file.js";
 import { createEditFileTool } from "./tools/edit-file.js";

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -1,4 +1,4 @@
-import { executeCommand, killSession } from "../../executor.js";
+import { executeCommand, killSession } from "../../utils/executor.js";
 import type { EventBus } from "../../core/event-bus.js";
 import type { ToolDefinition } from "../types.js";
 

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { executeArgv } from "../../executor.js";
+import { executeArgv } from "../../utils/executor.js";
 import { resolveRgPath } from "../../utils/ripgrep-path.js";
 import type { ToolDefinition } from "../types.js";
 import { expandHome } from "./expand-home.js";

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -1,4 +1,4 @@
-import { executeArgv } from "../../executor.js";
+import { executeArgv } from "../../utils/executor.js";
 import { resolveRgPath } from "../../utils/ripgrep-path.js";
 import type { ToolDefinition } from "../types.js";
 import { expandHome } from "./expand-home.js";

--- a/src/agent/tools/pwsh.ts
+++ b/src/agent/tools/pwsh.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { executeArgv, killSession } from "../../executor.js";
+import { executeArgv, killSession } from "../../utils/executor.js";
 import type { EventBus } from "../../core/event-bus.js";
 import type { ToolDefinition } from "../types.js";
 

--- a/src/utils/executor.ts
+++ b/src/utils/executor.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { stripAnsi } from "./utils/ansi.js";
+import { stripAnsi } from "./ansi.js";
 
 // Node reports a missing cwd as `spawn <binary> ENOENT` — disambiguate.
 function explainSpawnError(err: NodeJS.ErrnoException, cwd: string): string {


### PR DESCRIPTION
## Summary
- `src/executor.ts` was the only top-level `.ts` file after the kernel/host tree split. Its exports (`findBash`, `executeCommand`, `executeArgv`, `killSession`, `ExecutorSession`) are generic subprocess primitives with no ash-specific shape, so it belongs in `src/utils/` alongside the other generic utilities.
- After this move, `src/` contains only the five subsystem directories: `core/`, `shell/`, `agent/`, `extensions/`, `cli/`, `utils/`.

## Public API
The `agent-sh/executor` import path is preserved — only the underlying `dist/` target changes (from `dist/executor.js` to `dist/utils/executor.js`). Consumers (ash tools, agent-loop, superash) unaffected.

## Test plan
- [x] `npm run build` clean
- [x] `dist/utils/executor.js` exposes the same four functions at runtime
- [ ] Manual: `ash` boots and a bash tool call still works end-to-end