### PR TITLE
Remove permission system; gating moves to tool advisors

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -143,9 +143,7 @@ LLM response
   ├─ Text only → done, emit response
   └─ Tool calls → for each tool call:
        ├─ Look up tool in registry
-       ├─ Permission check (if tool.requiresPermission)
-       │    └─ Emits permission:request async pipe → extensions decide
-       ├─ Execute tool → get result (content + exitCode)
+       ├─ Execute via the `tool:<name>` handler chain (advisors can wrap)
        ├─ Emit tool events (tool-started, tool-output-chunk, tool-completed)
        ├─ Add tool result to conversation
        └─ After all tools: call LLM again with updated conversation
@@ -155,23 +153,12 @@ The loop continues until the LLM returns a response with no tool calls. There's 
 
 ### Permission gating
 
-Some tools require permission before executing. The agent emits a `permission:request` event through the async pipe, and extensions can approve or deny:
-
-```typescript
-const result = await bus.emitPipeAsync("permission:request", {
-  kind: "tool-call",
-  title: toolName,
-  metadata: { args },
-  decision: { outcome: "approved" },  // default: auto-approve (yolo mode)
-});
-if (result.decision.outcome !== "approved") {
-  // return "Permission denied" as tool result — LLM sees this and adapts
-}
-```
-
-In yolo mode (the default), everything is auto-approved. Load the `interactive-prompts` extension to add confirmation prompts.
-
-Tools that require permission: **bash**, **write_file**, **edit_file** (anything that executes code or modifies files).
+The kernel has no opinion on permission. By default every tool runs (yolo
+mode). Gating extensions register tool advisors via `ctx.adviseTool(name, ...)`
+to interpose a confirmation prompt, audit log, or policy check before calling
+`next(args, onChunk, ctx)`. See `examples/extensions/interactive-prompts.ts`
+for a reference implementation that gates `bash`, `pwsh`, `write_file`, and
+`edit_file`.
 
 ## Built-in Tools
 
@@ -185,17 +172,17 @@ Extensions can add tools that cross the shell↔agent boundary via `shell:exec-r
 
 ### All tools
 
-| Tool | Purpose | Permission | Modifies files |
-|---|---|---|---|
-| `bash` | Run commands in isolated subprocess | Yes | Yes |
-| `read_file` | Read file contents (line-numbered, with offset/limit) | No | No |
-| `write_file` | Create or overwrite a file | Yes | Yes |
-| `edit_file` | Find-and-replace in a file (old_text → new_text) | Yes | Yes |
-| `grep` | Search file contents with regex (via ripgrep) | No | No |
-| `glob` | Find files by name pattern | No | No |
-| `ls` | List directory contents (with timestamps and sizes) | No | No |
-| `list_skills` | List available skills (name, description, path) | No | No |
-| `conversation_recall` | Browse/search/expand evicted turns from the in-session archive and `~/.agent-sh/history` | No | No |
+| Tool | Purpose | Side effects |
+|---|---|---|
+| `bash` | Run commands in isolated subprocess | Yes |
+| `read_file` | Read file contents (line-numbered, with offset/limit) | No |
+| `write_file` | Create or overwrite a file | Yes |
+| `edit_file` | Find-and-replace in a file (old_text → new_text) | Yes |
+| `grep` | Search file contents with regex (via ripgrep) | No |
+| `glob` | Find files by name pattern | No |
+| `ls` | List directory contents (with timestamps and sizes) | No |
+| `list_skills` | List available skills (name, description, path) | No |
+| `conversation_recall` | Browse/search/expand evicted turns from the in-session archive and `~/.agent-sh/history` | No |
 
 **Common pattern**: all file-based tools resolve relative paths from the current working directory, looked up via the `cwd` handler (`ctx.call("cwd")`). The shell-context built-in advises this with the PTY-tracked cwd; without it, tools fall back to `process.cwd()`.
 
@@ -227,7 +214,7 @@ When the LLM requests multiple tool calls in a single response, the agent groups
 
 1. **Batch event** — before execution, the agent emits `agent:tool-batch` with tools grouped by kind (`read`, `search`, `execute`, etc.). The TUI uses this to render group headers with tree-style connectors.
 
-2. **Parallel execution** — read-only tools (no `requiresPermission`, no `modifiesFiles`) run in parallel via `Promise.all`. Permission-requiring tools run sequentially to avoid overlapping permission prompts.
+2. **Parallel execution** — side-effect-free tools (`modifiesFiles` unset) run in parallel via `Promise.all`. Side-effecting tools run sequentially.
 
 3. **Output truncation** — tool results over 16KB (~4K tokens) are head+tail truncated before being added to the conversation, preventing a single tool call from blowing through the context window.
 
@@ -298,8 +285,7 @@ interface ToolDefinition {
     onChunk?: (chunk: string) => void,    // optional streaming callback
   ): Promise<ToolResult>;
 
-  requiresPermission?: boolean;   // gate via permission:request
-  modifiesFiles?: boolean;        // triggers file watcher
+  modifiesFiles?: boolean;        // has side effects (skips caching + parallel execution)
   showOutput?: boolean;           // stream output to TUI (default: true)
 
   // Display hooks (all optional)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -158,19 +158,14 @@ bus.onPipe("autocomplete:request", (payload) => {
 
 ### `onPipeAsync` / `emitPipeAsync` — Async Transform Chain
 
-Same as `onPipe` but listeners can be async. Also notifies regular `on` listeners first (so UI can prepare before async work starts). Use this for transforms that need I/O — permission prompts, shell execution, network calls.
+Same as `onPipe` but listeners can be async. Also notifies regular `on` listeners first (so UI can prepare before async work starts). Use this for transforms that need I/O — shell execution, network calls, context-compaction handlers.
 
 ```typescript
-// Permission system: emit a request, wait for extensions to decide
-const result = await bus.emitPipeAsync("permission:request", {
-  kind: "tool-call", title: toolName, decision: { outcome: "approved" },
-});
-if (result.decision.outcome !== "approved") { /* denied */ }
-
-// Interactive extension: prompt the user asynchronously
-bus.onPipeAsync("permission:request", async (payload) => {
-  const answer = await promptUser(`Allow ${payload.title}?`);
-  return { ...payload, decision: { outcome: answer } };
+// Example: the shell-exec request pipe lets extensions intercept commands
+// the agent wants to run in the user's PTY.
+bus.onPipeAsync("shell:exec-request", async (payload) => {
+  const result = await runInPty(payload.command);
+  return { ...payload, output: result.output, exitCode: result.exitCode };
 });
 ```
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -35,10 +35,8 @@ core.bus.on("agent:response-chunk", ({ blocks }) => {
 });
 core.bus.on("agent:processing-done", () => console.log("\n[done]"));
 
-// Handle permissions (auto-approve, or wire to your own UI)
-core.bus.onPipeAsync("permission:request", async (p) => {
-  return { ...p, decision: { approved: true } };
-});
+// Tools run without confirmation by default; to gate them, register tool
+// advisors via ctx.adviseTool (see examples/extensions/interactive-prompts.ts).
 
 // Activate the backend, then send a query
 core.activateBackend();

--- a/examples/extensions/ash-acp-bridge/README.md
+++ b/examples/extensions/ash-acp-bridge/README.md
@@ -36,4 +36,7 @@ The adapter translates between ACP methods and agent-sh's event bus:
 - `session/new` → create core, set cwd
 - `session/prompt` → `agent:submit` event
 - `session/update` notifications ← `agent:response-chunk`, `agent:tool-started`, etc.
-- `session/request_permission` ↔ `permission:request` async pipe
+- Permission gating is not bridged — agent-sh runs tools without confirmation
+  unless a gating extension (e.g. interactive-prompts) is also loaded. To
+  surface ACP's `session/request_permission`, register tool advisors here
+  that call back into the ACP client.

--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -412,16 +412,6 @@ function wireEvents(core: AgentShellCore): void {
     }
   });
 
-  // Permission gating — auto-approve all tool calls.
-  // agent-sh's built-in tools handle their own safety; the ACP layer
-  // doesn't add a second permission gate. If you want to bridge
-  // permissions to agent-shell's UI, replace this with the
-  // requestPermission() flow.
-  bus.onPipeAsync("permission:request", async (payload) => {
-    payload.decision = { outcome: "approved" };
-    return payload;
-  });
-
   // Surface ui:error to stderr — extension load failures are otherwise silent.
   bus.on("ui:error", ({ message }) => {
     process.stderr.write(`[ash-acp-bridge] ${message}\n`);

--- a/examples/extensions/interactive-prompts.ts
+++ b/examples/extensions/interactive-prompts.ts
@@ -1,10 +1,9 @@
 /**
  * Interactive permission prompts extension.
  *
- * Adds permission gates for tool calls and file writes.
- * Without this extension, agent-sh runs in yolo mode (auto-approve).
- *
- * Uses the interactive UI primitive for compositor-aware, themed rendering.
+ * Gates the four built-in side-effect tools (bash, pwsh, write_file,
+ * edit_file) via tool advisors. Without this extension, agent-sh runs in
+ * yolo mode — tools execute without confirmation.
  *
  * Usage:
  *   agent-sh -e ./examples/extensions/interactive-prompts.ts
@@ -12,19 +11,22 @@
  *   # Or copy to ~/.agent-sh/extensions/ for permanent use:
  *   cp examples/extensions/interactive-prompts.ts ~/.agent-sh/extensions/
  */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { renderDiff } from "agent-sh/utils/diff-renderer.js";
 import { renderBoxFrame } from "agent-sh/utils/box-frame.js";
 import { palette as p } from "agent-sh/utils/palette.js";
+import { computeDiff, computeEditDiff, computeInputDiff, type DiffResult } from "agent-sh/utils/diff.js";
 import type { ExtensionContext } from "agent-sh/types";
 import type { ToolUI } from "agent-sh/agent/types.js";
+
+const GATED_TOOLS = ["bash", "pwsh", "write_file", "edit_file"] as const;
 
 export default function activate(ctx: ExtensionContext) {
   let autoApproveWrites = false;
 
-  // Advise the TUI diff renderer to add permission prompt framing.
-  // This replaces the default plain diff box with one that has a warning
-  // border and key hints, so only one diff box is shown (not two).
-  ctx.advise("tui:render-diff", (next, filePath: string, diff: any, width: number) => {
+  // Frame pre-execute diff previews as a permission prompt.
+  ctx.advise("tui:render-diff", (_next, filePath: string, diff: DiffResult, width: number) => {
     const boxW = Math.min(84, width);
     const contentW = boxW - 4;
     const MAX_DISPLAY = 25;
@@ -54,74 +56,91 @@ export default function activate(ctx: ExtensionContext) {
     });
   });
 
-  const { bus } = ctx;
+  for (const name of GATED_TOOLS) {
+    ctx.adviseTool(name, async (next, args, onChunk, toolCtx) => {
+      const ui = toolCtx?.ui;
+      if (!ui) return next(args, onChunk, toolCtx);
 
-  bus.onPipeAsync("permission:request", async (payload) => {
-    const ui = payload.ui as ToolUI | undefined;
-    if (!ui) return payload;
+      const isFileWrite = name === "write_file" || name === "edit_file";
+      let diffPreRendered = false;
 
-    switch (payload.kind) {
-      case "tool-call":
-        return handleToolCall(payload, ui);
-      case "file-write": {
-        if (autoApproveWrites) {
-          return { ...payload, decision: { outcome: "approved" } };
+      ctx.bus.emit("shell:stdout-show", {});
+      try {
+        if (isFileWrite) {
+          if (autoApproveWrites) {
+            // Skip prompt; tool's own post-execute diff renders as usual.
+            return next(args, onChunk, toolCtx);
+          }
+          await renderPreviewDiff(ctx, name, args);
+          diffPreRendered = true;
+
+          const answer = await promptWrite(ui);
+          if (answer === "reject") {
+            return { content: "Permission denied by user.", exitCode: 1, isError: true };
+          }
+          if (answer === "approve_all") autoApproveWrites = true;
+        } else {
+          const answer = await promptCommand(ui, name, args);
+          if (answer === "deny") {
+            return { content: "Permission denied by user.", exitCode: 1, isError: true };
+          }
         }
-        const result = await handleFileWrite(payload, ui);
-        if ((result.decision as any).autoApprove) {
-          autoApproveWrites = true;
-        }
-        return result;
+      } finally {
+        ctx.bus.emit("shell:stdout-hide", {});
       }
-      default:
-        return payload;
-    }
-  });
-}
 
-async function handleToolCall(payload: any, ui: ToolUI) {
-  const options = payload.metadata.options;
-
-  const answer = await ui.custom<"approve" | "approve_all" | "deny">({
-    render(width) {
-      const boxW = Math.min(84, width);
-      return renderBoxFrame(
-        [`${p.bold}⚠ ${payload.title}${p.reset}`],
-        {
-          width: boxW,
-          style: "rounded",
-          borderColor: p.warning,
-          title: "Permission required",
-          footer: [`  ${p.dim}[y]es / [n]o / [a]llow all${p.reset}`],
-        },
-      );
-    },
-    handleInput(data, done) {
-      const ch = data.toLowerCase();
-      if (ch === "y") done("approve");
-      else if (ch === "a") done("approve_all");
-      else if (ch === "n" || ch === "\x1b") done("deny");
-    },
-  });
-
-  if (answer === "approve" || answer === "approve_all") {
-    const kind = answer === "approve_all" ? "allow_always" : "allow_once";
-    const option = options?.find((o: any) => o.kind === kind)
-      ?? options?.find((o: any) => o.kind === "allow_once" || o.kind === "allow_always");
-    if (option) {
-      return { ...payload, decision: { outcome: "selected", optionId: option.optionId } };
-    }
-    return { ...payload, decision: { outcome: "approved" } };
+      const result = await next(args, onChunk, toolCtx);
+      if (diffPreRendered && result.display?.body?.kind === "diff") {
+        // Strip the redundant post-execute diff body since we already showed it.
+        return { ...result, display: { ...result.display, body: undefined } };
+      }
+      return result;
+    });
   }
-  return { ...payload, decision: { outcome: "cancelled" } };
 }
 
-async function handleFileWrite(payload: any, ui: ToolUI) {
-  const answer = await ui.custom<"approve" | "approve_all" | "reject">({
+async function renderPreviewDiff(
+  ctx: ExtensionContext,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<void> {
+  const rawPath = args.path;
+  if (typeof rawPath !== "string") return;
+  const absPath = path.resolve(process.cwd(), rawPath);
+
+  let diff: DiffResult | undefined;
+  if (toolName === "edit_file" && typeof args.old_text === "string" && typeof args.new_text === "string") {
+    const normalizedOld = (args.old_text as string).replace(/\r\n/g, "\n");
+    const normalizedNew = (args.new_text as string).replace(/\r\n/g, "\n");
+    try {
+      const oldFileContent = await fs.readFile(absPath, "utf-8");
+      diff = computeEditDiff(
+        oldFileContent, normalizedOld, normalizedNew,
+        args.replace_all === true,
+      );
+    } catch {
+      diff = computeInputDiff(normalizedOld, normalizedNew);
+    }
+  } else if (toolName === "write_file" && typeof args.content === "string") {
+    let oldContent: string | null = null;
+    try { oldContent = await fs.readFile(absPath, "utf-8"); } catch { /* new file */ }
+    diff = computeDiff(oldContent, args.content as string);
+  }
+  if (!diff || diff.isIdentical) return;
+
+  const cwd = process.cwd();
+  const home = process.env.HOME ?? "";
+  let displayPath = absPath;
+  if (absPath.startsWith(cwd + "/")) displayPath = absPath.slice(cwd.length + 1);
+  else if (home && absPath.startsWith(home + "/")) displayPath = "~/" + absPath.slice(home.length + 1);
+
+  ctx.call("tui:show-diff", displayPath, diff);
+}
+
+async function promptWrite(ui: ToolUI): Promise<"approve" | "approve_all" | "reject"> {
+  return ui.custom<"approve" | "approve_all" | "reject">({
     render(width) {
       const boxW = Math.min(84, width);
-      // Just show the prompt actions — the diff itself was already rendered
-      // by our advise on "tui:render-diff".
       return renderBoxFrame([], {
         width: boxW,
         style: "rounded",
@@ -136,12 +155,38 @@ async function handleFileWrite(payload: any, ui: ToolUI) {
       else if (ch === "n" || ch === "\x1b") done("reject");
     },
   });
+}
 
-  if (answer === "approve") {
-    return { ...payload, decision: { outcome: "approved" } };
-  }
-  if (answer === "approve_all") {
-    return { ...payload, decision: { outcome: "approved", autoApprove: true } };
-  }
-  return { ...payload, decision: { outcome: "cancelled" } };
+async function promptCommand(
+  ui: ToolUI,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<"approve" | "deny"> {
+  const command = typeof args.command === "string" ? args.command : "";
+  const description = typeof args.description === "string" ? args.description : "";
+  const title = description ? `${toolName}: ${description}` : toolName;
+  const body = command
+    ? `${p.bold}${title}${p.reset}\n${p.dim}${truncate(command, 200)}${p.reset}`
+    : `${p.bold}${title}${p.reset}`;
+  return ui.custom<"approve" | "deny">({
+    render(width) {
+      const boxW = Math.min(84, width);
+      return renderBoxFrame(body.split("\n"), {
+        width: boxW,
+        style: "rounded",
+        borderColor: p.warning,
+        title: "Permission required",
+        footer: [`  ${p.dim}[y]es / [n]o${p.reset}`],
+      });
+    },
+    handleInput(data, done) {
+      const ch = data.toLowerCase();
+      if (ch === "y") done("approve");
+      else if (ch === "n" || ch === "\x1b") done("deny");
+    },
+  });
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
 }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -16,11 +16,7 @@ import type { AgentMode } from "../core/types.js";
 import type { LlmClient } from "../utils/llm-client.js";
 import type { HandlerFunctions } from "../utils/handler-registry.js";
 import { setMaxListeners } from "node:events";
-import * as fs from "node:fs/promises";
-import * as fsSync from "node:fs";
 import * as path from "node:path";
-import * as os from "node:os";
-import { computeDiff, computeEditDiff, computeInputDiff } from "../utils/diff.js";
 import type { AgentBackend, SkillView, ToolDefinition, ToolExecutionContext } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { normalizeToolArgs } from "./normalize-args.js";
@@ -1087,74 +1083,6 @@ export class AgentLoop implements AgentBackend {
       }
 
       const display = tool.getDisplayInfo?.(args) ?? { kind: "execute" as const };
-      let diffShown = false;
-
-      // Permission gating
-      if (tool.requiresPermission) {
-        let permKind = "tool-call";
-        let permTitle = typeof args.description === "string"
-          ? `${name}: ${args.description}`
-          : name;
-        let metadata: Record<string, unknown> = { args };
-
-        // For file-modifying tools, pre-compute diff for display
-        if (tool.modifiesFiles && typeof args.path === "string") {
-          try {
-            const absPath = path.resolve(process.cwd(), args.path as string);
-            let diff: ReturnType<typeof computeDiff> | undefined;
-
-            if (typeof args.old_text === "string" && typeof args.new_text === "string") {
-              // edit_file — read the file so line numbers are real (not relative to the edit region)
-              const normalizedOld = (args.old_text as string).replace(/\r\n/g, "\n");
-              const normalizedNew = (args.new_text as string).replace(/\r\n/g, "\n");
-              try {
-                const oldFileContent = await fs.readFile(absPath, "utf-8");
-                diff = computeEditDiff(
-                  oldFileContent, normalizedOld, normalizedNew,
-                  args.replace_all === true,
-                );
-              } catch {
-                // File doesn't exist yet — fall back to input-only diff
-                diff = computeInputDiff(normalizedOld, normalizedNew);
-              }
-            } else if (typeof args.content === "string") {
-              // write_file — still need to read the old file for comparison
-              let oldContent: string | null = null;
-              try { oldContent = await fs.readFile(absPath, "utf-8"); } catch { /* new file */ }
-              if (oldContent !== null) {
-                diff = computeDiff(oldContent, args.content as string);
-              }
-            }
-
-            if (diff && !diff.isIdentical) {
-              permKind = "file-write";
-              // Shorten path for display
-              const cwd = process.cwd();
-              const home = process.env.HOME ?? os.homedir();
-              let displayPath = absPath;
-              if (absPath.startsWith(cwd + "/")) displayPath = absPath.slice(cwd.length + 1);
-              else if (home && absPath.startsWith(home + "/")) displayPath = "~/" + absPath.slice(home.length + 1);
-              permTitle = displayPath;
-              metadata = { args, diff };
-              diffShown = true;
-            }
-          } catch { /* fall back to generic permission */ }
-        }
-
-        const ui = this.compositor
-          ? createToolUI(this.bus, this.compositor.surface("agent"))
-          : undefined;
-        const perm = await this.bus.emitPipeAsync("permission:request", {
-          kind: permKind,
-          title: permTitle,
-          metadata,
-          ui,
-          decision: { outcome: "approved" },
-        });
-        if ((perm.decision as { outcome: string }).outcome !== "approved") {
-          return { content: "Permission denied by user.", exitCode: 1, isError: true };
-        }
-      }
 
       // Emit tool-started for TUI
       const label = tool.displayName ?? name;
@@ -1168,10 +1096,7 @@ export class AgentLoop implements AgentBackend {
       this.bus.emit("agent:tool-call", { tool: name, args });
 
       // Execute — use ctx.onChunk so advisors can wrap the streaming callback.
-      // Suppress streaming output if diff was already shown.
-      const onChunk = (tool.showOutput !== false && !diffShown)
-        ? ctx.onChunk
-        : undefined;
+      const onChunk = tool.showOutput !== false ? ctx.onChunk : undefined;
       const toolCtx: ToolExecutionContext = { signal };
       if (this.compositor) {
         toolCtx.ui = createToolUI(this.bus, this.compositor.surface("agent"));
@@ -1406,7 +1331,7 @@ export class AgentLoop implements AgentBackend {
         args = normalizeToolArgs(args, tool.input_schema);
 
         // ── Round-scoped cache for cacheable read-only tools ──
-        const cacheable = !tool.modifiesFiles && !tool.requiresPermission && tool.showOutput !== true;
+        const cacheable = !tool.modifiesFiles && tool.showOutput !== true;
         const cacheKey = cacheable ? `${tc.name}:${JSON.stringify(args)}` : null;
         if (cacheKey) {
           const cached = roundCache.get(cacheKey);
@@ -1486,12 +1411,11 @@ export class AgentLoop implements AgentBackend {
         collectedResults.push(finalResult);
       };
 
-      // Partition into parallel-safe (read-only) and sequential (needs permission)
       const parallel: PendingToolCall[] = [];
       const sequential: PendingToolCall[] = [];
       for (const tc of toolCalls) {
         const tool = this.toolRegistry.get(tc.name);
-        if (tool && !tool.requiresPermission && !tool.modifiesFiles) {
+        if (tool && !tool.modifiesFiles) {
           parallel.push(tc);
         } else {
           sequential.push(tc);

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -37,7 +37,6 @@ export function createBashTool(opts: {
 
     showOutput: true,
     modifiesFiles: true,
-    requiresPermission: true,
 
     getDisplayInfo: (args) => ({
       kind: "execute",

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -73,7 +73,6 @@ export function createEditFileTool(getCwd: () => string): ToolDefinition {
 
     showOutput: true,
     modifiesFiles: true,
-    requiresPermission: true,
 
     getDisplayInfo: (args) => ({
       kind: "write",

--- a/src/agent/tools/pwsh.ts
+++ b/src/agent/tools/pwsh.ts
@@ -67,7 +67,6 @@ export function createPwshTool(opts: {
 
     showOutput: true,
     modifiesFiles: true,
-    requiresPermission: true,
 
     getDisplayInfo: () => ({
       kind: "execute",

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -27,7 +27,6 @@ export function createWriteFileTool(getCwd: () => string): ToolDefinition {
 
     showOutput: true,
     modifiesFiles: true,
-    requiresPermission: true,
 
     getDisplayInfo: (args) => ({
       kind: "write",

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -106,9 +106,6 @@ export interface ToolDefinition {
    *  body on eviction (like the builtin read_file/grep/ls). Default: false. */
   readOnly?: boolean;
 
-  /** Whether to gate execution via permission:request (default: false). */
-  requiresPermission?: boolean;
-
   /** Derive display metadata (icon kind, file paths) for the TUI. */
   getDisplayInfo?: (args: Record<string, unknown>) => ToolDisplayInfo;
 

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -153,18 +153,6 @@ export interface ShellEvents {
   "tool:interactive-start": Record<string, never>;
   "tool:interactive-end": Record<string, never>;
 
-  // Permission request (async pipe — core emits with safe default, extensions override)
-  // Generic: `kind` discriminates the scenario, `metadata` carries context,
-  // `decision` carries the response. Extensions check `kind` and handle accordingly.
-  "permission:request": {
-    kind: string;
-    title: string;
-    metadata: Record<string, unknown>;
-    /** Interactive UI capability — available when the built-in agent is active. */
-    ui?: unknown;
-    decision: Record<string, unknown>;
-  };
-
   // Slash command registration (extensions → slash-commands)
   "command:register": {
     name: string;

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -355,20 +355,6 @@ export class Shell implements InputContext {
       this.handlers.call("shell:on-processing-done");
     });
 
-    // Permission UI is briefly visible during the prompt; an unmute scope
-    // overrides whatever mute is currently held, then releases cleanly.
-    // Doesn't touch agent-turn state, so suppressed handlers can't leak.
-    let permissionVisible: ShellScope | null = null;
-    this.bus.on("permission:request", () => {
-      permissionVisible?.release();
-      permissionVisible = this.acquireUnmute("permission-ui");
-    });
-    this.bus.onPipeAsync("permission:request", async (payload) => {
-      permissionVisible?.release();
-      permissionVisible = null;
-      return payload;
-    });
-
     this.bus.onPipeAsync("shell:exec-request", async (payload) => {
       const visible = this.acquireUnmute("exec-request");
       this.skipNextLine();

--- a/src/shell/tui-renderer.ts
+++ b/src/shell/tui-renderer.ts
@@ -104,11 +104,6 @@ interface RenderState {
   isThinking: boolean;
   showThinkingText: boolean;
   thinkingPending: boolean;
-
-  /** Tool calls whose diff was already shown via permission preview —
-   *  suppress the duplicate diff body on tool-completed. */
-  previewedDiffPending: boolean;
-  previewedDiffToolIds: Set<string>;
 }
 
 function createRenderState(): RenderState {
@@ -140,8 +135,6 @@ function createRenderState(): RenderState {
     isThinking: false,
     showThinkingText: false,
     thinkingPending: false,
-    previewedDiffPending: false,
-    previewedDiffToolIds: new Set(),
   };
 }
 
@@ -366,10 +359,6 @@ export default function activate(ctx: ExtensionContext): void {
     s.currentToolKind = e.kind;
     s.toolStartTime = Date.now();
     s.orphanContHeaderKind = undefined;
-    if (s.previewedDiffPending && e.toolCallId) {
-      s.previewedDiffToolIds.add(e.toolCallId);
-    }
-    s.previewedDiffPending = false;
 
     if (e.title === "user_shell") {
       finalizeToolGroup();
@@ -437,13 +426,7 @@ export default function activate(ctx: ExtensionContext): void {
     s.toolExitCode = e.exitCode;
     if (e.exitCode !== 0) s.toolGroupAllOk = false;
 
-    let resultDisplay = e.resultDisplay;
-    if (e.toolCallId && s.previewedDiffToolIds.has(e.toolCallId)) {
-      s.previewedDiffToolIds.delete(e.toolCallId);
-      if (resultDisplay?.body?.kind === "diff") {
-        resultDisplay = { ...resultDisplay, body: undefined };
-      }
-    }
+    const resultDisplay = e.resultDisplay;
 
     if (s.toolGroupKind) {
       // Grouped tool — track success/failure and summaries, show aggregate on ⎿ line.
@@ -500,45 +483,6 @@ export default function activate(ctx: ExtensionContext): void {
     s.renderer!.writeLine(`${p.error}Error: ${e.message}${p.reset}`);
     s.renderer!.writeLine("");
     drain();
-  });
-
-  bus.on("permission:request", (e) => {
-    if (!shouldRender()) return;
-    stopCurrentSpinner();
-    flushCommandOutput();
-    if (s.renderer) {
-      s.renderer.flush();
-      drain();
-    }
-    // Diff rendering is handled in the async pipe below so it can yield
-    // to the event loop between hunks (keeping the spinner responsive).
-  });
-
-  // Async pipe: render diffs via the tui:render-diff handler (extensions can
-  // advise to customize).  Runs after the sync `on` handler above (which
-  // flushes state) and before shell.ts's pipe (which pauses stdout).
-  bus.onPipeAsync("permission:request", async (e) => {
-    if (!shouldRender()) return e;
-
-    if (e.kind === "file-write" && e.metadata?.diff) {
-      showCollapsedThinking();
-      const lines = ctx.call("tui:render-diff", e.title, e.metadata.diff as DiffResult, cappedW()) as string[];
-      if (lines.length > 0) {
-        if (!s.renderer) startAgentResponse();
-        contentGap("diff");
-        for (const line of lines) s.renderer!.writeLine(line);
-        drain();
-      }
-      // The diff box IS the visual representation of the upcoming tool call.
-      // Mark lastContentKind as "tool" so the tool call line that follows
-      // doesn't inject an extra gap between the diff box and the checkmark.
-      s.lastContentKind = "tool";
-      s.previewedDiffPending = true;
-    }
-    // Don't endAgentResponse() here — permission requests that aren't
-    // file-write diffs are handled inline (auto-approved or by extensions).
-    // Closing the response prematurely causes double separator borders.
-    return e;
   });
 
   bus.on("input:keypress", (e) => {
@@ -753,6 +697,22 @@ export default function activate(ctx: ExtensionContext): void {
    */
   define("tui:render-diff", (filePath: string, diff: DiffResult, width: number): string[] => {
     return renderDiffBody(diff, filePath, width);
+  });
+
+  /** Display a diff inline above the agent response (e.g. for pre-execute
+   *  preview from a gating advisor). Formats via `tui:render-diff` so
+   *  advisors can theme it. */
+  define("tui:show-diff", (filePath: string, diff: DiffResult): void => {
+    if (!shouldRender()) return;
+    stopCurrentSpinner();
+    showCollapsedThinking();
+    const lines = ctx.call("tui:render-diff", filePath, diff, cappedW()) as string[];
+    if (lines.length === 0) return;
+    if (!s.renderer) startAgentResponse();
+    contentGap("diff");
+    for (const line of lines) s.renderer!.writeLine(line);
+    drain();
+    s.lastContentKind = "tool";
   });
 
   /** Render a diff as framed box lines (pure — no TUI state side effects). */


### PR DESCRIPTION
## Summary

The kernel no longer ships a permission gate. Permission becomes
entirely an extension concern, handled via the existing `ctx.adviseTool`
surface.

- Deleted `permission:request` event from the bus schema.
- Deleted `requiresPermission` from `ToolDefinition`.
- Removed the 65-line permission block in `agent-loop.ts`; caching and
  parallel-partitioning now key off `modifiesFiles` alone (which is
  already set on all four side-effect tools).
- Removed `permission:request` hooks in `shell.ts` (mute coordination)
  and `tui-renderer.ts` (pre-execute diff render, `previewedDiffPending`
  machinery).
- Added `tui:show-diff` handler so a gating advisor can render a diff
  inline above the agent response (used by interactive-prompts).
- `examples/extensions/interactive-prompts.ts` rewritten as four
  name-keyed tool advisors (`bash`, `pwsh`, `write_file`, `edit_file`).
  It coordinates with the agent-turn mute via `shell:stdout-show` /
  `shell:stdout-hide` events.
- `ash-acp-bridge` drops its no-op auto-approve hook; auto-approve is
  the new default behavior.

Net `-130` lines across 15 files.

## Why

The earlier event-driven `permission:request` async pipe predated the
richer `ctx.adviseTool` / `ctx.define` / `ctx.call` surface. Tool
advisors already compose, can sync-reject, and let an extension wrap a
tool without owning it — everything the permission event did, with
better composition. The pipe also baked specific UX concepts
(`kind: "tool-call" | "file-write"`, mutable `decision` payload, default
auto-approve) into the kernel. Now extensions own all of that.

## Behavior change

Without `interactive-prompts` loaded, agent-sh runs in yolo mode (the
same default as before). With `interactive-prompts` loaded, the four
built-in destructive tools prompt before executing. Anyone shipping
a new gateable tool either writes its own advisor or adds the name to
interactive-prompts' list (`GATED_TOOLS`).

## Downstream

Consumers of the deleted event need to migrate:

- `asHub` bridges `permission:request` to its web UI — separate PR
  needed to register a tool advisor that proxies to ACP's
  `requestPermission`.
- User extensions in `~/.agent-sh/extensions/` (web-renderer, the
  installed ash-acp-bridge, superash's user-defined tools that set
  `requiresPermission: true`) will silently no-op. Safe but worth
  cleaning up.

## Test plan

- [ ] Without interactive-prompts: `write_file` / `edit_file` runs
      silently and the diff renders post-execute via the normal
      tool-completed path.
- [ ] Without interactive-prompts: `bash` / `pwsh` runs silently.
- [ ] With interactive-prompts: write/edit prompts pre-execute with
      diff preview; y/n/a behaviors match prior UX.
- [ ] With interactive-prompts: bash/pwsh prompt with command preview.
- [ ] Parallel batch of read-only tools still parallelizes; mixed batch
      with write/edit/bash still serializes.
- [ ] Read cache invalidation on write_file still fires.