### PR TITLE
Open kernel surface for substrate-style extensions

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1312,9 +1312,11 @@ export class AgentLoop implements AgentBackend {
 
         const tool = this.toolRegistry.get(tc.name);
         if (!tool) {
+          const available = this.toolRegistry.all().map((t) => t.name).join(", ");
           collectedResults.push({
             callId: tc.id, toolName: tc.name,
-            content: `Unknown tool "${tc.name}"`, isError: true,
+            content: `Unknown tool "${tc.name}". Available tools: ${available}`,
+            isError: true,
           });
           return;
         }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1094,6 +1094,7 @@ export class AgentLoop implements AgentBackend {
         toolCallId: id,
         kind: display.kind, icon: display.icon, locations: display.locations, rawInput: args,
         displayDetail: tool.formatCall?.(args),
+        sourceLanguage: display.sourceLanguage,
         batchIndex: ctx.batchIndex, batchTotal: ctx.batchTotal,
       });
       this.bus.emit("agent:tool-call", { tool: name, args });
@@ -1345,6 +1346,7 @@ export class AgentLoop implements AgentBackend {
               toolCallId: tc.id,
               kind: display.kind, icon: display.icon, locations: display.locations, rawInput: args,
               displayDetail: tool.formatCall?.(args),
+              sourceLanguage: display.sourceLanguage,
               batchIndex, batchTotal: batchTotal > 1 ? batchTotal : undefined,
             });
             this.bus.emit("agent:tool-call", { tool: tc.name, args });

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1379,9 +1379,9 @@ export class AgentLoop implements AgentBackend {
             signal },
         );
 
-        // Truncate large outputs to avoid blowing context
+        // Truncate large outputs to avoid blowing context.
         let content = result.content;
-        const maxBytes = 16_384; // ~4k tokens
+        const maxBytes = tool.maxResultBytes ?? 16_384; // ~4k tokens
         if (content.length > maxBytes) {
           const headBytes = Math.floor(maxBytes * 0.6);
           const tailBytes = maxBytes - headBytes;

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -162,7 +162,10 @@ export class AgentLoop implements AgentBackend {
     this.currentModeIndex = config.initialModeIndex ?? 0;
 
     // Tool protocol — controls how tools are presented to the LLM
-    this.toolProtocol = createToolProtocol(getSettings().toolMode ?? "api");
+    this.toolProtocol = createToolProtocol(
+      getSettings().toolMode ?? "api",
+      getSettings().coreTools ?? [],
+    );
 
     // Register core tools
     this.registerCoreTools();

--- a/src/agent/providers/deepseek.ts
+++ b/src/agent/providers/deepseek.ts
@@ -9,8 +9,8 @@ import { resolveApiKey } from "../../cli/auth/keys.js";
 
 const BASE_URL = "https://api.deepseek.com";
 const DEFAULT_MODELS = [
-  { id: "deepseek-v4-flash", reasoning: true, echoReasoning: true },
-  { id: "deepseek-v4-pro", reasoning: true, echoReasoning: true },
+  { id: "deepseek-v4-flash", reasoning: true, echoReasoning: true, contextWindow: 1_000_000 },
+  { id: "deepseek-v4-pro", reasoning: true, echoReasoning: true, contextWindow: 1_000_000 },
 ];
 
 function buildReasoningParams(level: string, _model?: string): Record<string, unknown> {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -11,7 +11,7 @@ import { discoverProjectSkills, type Skill } from "./skills.js";
 export function formatSkillsBlock(skills: Skill[]): string {
   if (skills.length === 0) return "";
   return "# Available Skills\n\n"
-    + "Load a skill's full content with read_file on its file path when needed.\n\n"
+    + "Load a skill's full content from its file path with your file-reading tool when needed.\n\n"
     + skills.map(s => `- **${s.name}**: ${s.description}\n  Path: ${s.filePath}`).join("\n\n");
 }
 
@@ -112,19 +112,12 @@ agent-sh source and documentation live at ${CODE_DIR}. Read them when you need t
 - ${path.join(CODE_DIR, "src")} — kernel in src/core, default backend in src/agent, shell host in src/shell, built-in extensions in src/extensions
 - ${path.join(CODE_DIR, "examples/extensions")} — reference extensions to study or copy when adding functionality
 
-# Tool Decision Guide
-bash, read_file, grep, glob, ls, edit_file, write_file::
-Use these to investigate, search, read, and modify files. Output is returned
-to you for reasoning — the user doesn't see it directly.
+# Tools
 
-Extensions may register additional tools — follow their instructions.
-
-# Tool Usage Guidelines
-- Use read_file before editing a file you haven't seen
-- Prefer edit_file over write_file for modifying existing files
-- Use grep/glob to find files before reading them
-- Keep bash commands focused; avoid long-running blocking commands
-- Always check command exit codes for errors
+Use your registered tools to investigate, search, read, and modify files.
+Each tool's description tells you when and how to use it; follow that
+guidance rather than assuming a particular tool exists. Tool output is
+returned to you for reasoning — the user doesn't see it directly.
 
 # Context Envelopes
 - \`<query_context>\` (contains \`<cwd>\` always, and \`<shell_events>\` when there were user shell commands since the last turn): the user's situation when they sent this turn — \`<cwd>\` anchors where they are right now, \`<shell_events>\` grounds "fix this" / "what just happened" requests. Trust the most recent \`<cwd>\` over any cwd referenced in earlier history.

--- a/src/agent/tool-protocol.ts
+++ b/src/agent/tool-protocol.ts
@@ -714,11 +714,16 @@ const CORE_TOOLS = [
   "bash", "read_file", "write_file", "edit_file",
   "grep", "glob", "ls",
   "list_skills",
+  "conversation_recall",
 ];
 
-export function createToolProtocol(mode: "api" | "inline" | "deferred" | "deferred-lookup"): ToolProtocol {
+export function createToolProtocol(
+  mode: "api" | "inline" | "deferred" | "deferred-lookup",
+  extraCore: string[] = [],
+): ToolProtocol {
+  const core = extraCore.length === 0 ? CORE_TOOLS : [...CORE_TOOLS, ...extraCore];
   if (mode === "inline") return new InlineToolProtocol();
-  if (mode === "deferred") return new DeferredToolProtocol(CORE_TOOLS);
-  if (mode === "deferred-lookup") return new DeferredLookupProtocol(CORE_TOOLS);
+  if (mode === "deferred") return new DeferredToolProtocol(core);
+  if (mode === "deferred-lookup") return new DeferredLookupProtocol(core);
   return new ApiToolProtocol();
 }

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -13,6 +13,8 @@ export function createBashTool(opts: {
       "Execute a bash command in an isolated subprocess. Output is captured and returned. " +
       "Does not affect the user's shell state. " +
       "cwd is set to the working directory from the shell context. " +
+      "Keep commands focused; avoid long-running or blocking processes. " +
+      "Always check the returned exit code before treating output as success. " +
       "Do NOT use bash for file searching — use grep/glob instead. " +
       "Do NOT use bash for reading files — use read_file instead.",
     input_schema: {

--- a/src/agent/tools/read-file.ts
+++ b/src/agent/tools/read-file.ts
@@ -66,8 +66,10 @@ export function createReadFileTool(
       try {
         const stat = await fs.stat(absPath);
 
-        // Deduplication: if the file hasn't changed and same range, return stub
-        if (cache) {
+        // Deduplication: if the file hasn't changed and same range, return stub.
+        // bypass_cache lets in-process callers consume content as a value
+        // rather than a tool_result, where the dedup stub would be meaningless.
+        if (cache && !args.bypass_cache) {
           const prev = cache.get(absPath);
           if (
             prev &&
@@ -112,8 +114,9 @@ export function createReadFileTool(
           ? `\n[${lines.length - end} more lines, use offset=${end + 1} to continue]`
           : "";
 
-        // Update cache on successful read
-        if (cache) {
+        // Skip cache write for in-process callers — they shouldn't poison
+        // the LLM-facing dedup state.
+        if (cache && !args.bypass_cache) {
           cache.set(absPath, {
             mtimeMs: stat.mtimeMs,
             offset: reqOffset,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -123,4 +123,9 @@ export interface ToolDefinition {
    * Extensions can further override via bus.onPipe("agent:tool-completed", ...).
    */
   formatResult?: (args: Record<string, unknown>, result: ToolResult) => ToolResultDisplay;
+
+  /** Override the agent-loop's per-tool-result truncation cap (default 16 KB).
+   *  Use for tools that bundle multiple operations and legitimately produce
+   *  larger output (interpreter substrates etc.). */
+  maxResultBytes?: number;
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -44,6 +44,9 @@ export interface ToolDisplayInfo {
   /** Custom icon character for TUI display (e.g., "◆", "⌕"). When set, the TUI shows
    *  icon + detail only. When absent, the tool name is shown alongside the detail. */
   icon?: string;
+  /** highlight.js-style language identifier ("scheme", "python", …) for
+   *  renderers that syntax-highlight tool source. Omit for plain text. */
+  sourceLanguage?: string;
 }
 
 /** Interactive UI session — imperative control over rendering + input. */

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -132,6 +132,8 @@ export interface ShellEvents {
     rawInput?: unknown;
     /** Pre-formatted display detail from tool's formatCall(). */
     displayDetail?: string;
+    /** highlight.js-style identifier for syntax-highlighting `rawInput.source`. */
+    sourceLanguage?: string;
     batchIndex?: number;
     batchTotal?: number;
   };

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -104,6 +104,13 @@ export interface Settings {
    *   "inline" — tools described as text.
    */
   toolMode?: "api" | "deferred" | "deferred-lookup" | "inline";
+  /**
+   * Extra tool names treated as "core" in deferred / deferred-lookup mode —
+   * always sent with full schema instead of requiring an explicit load_tool
+   * call. Useful when an extension registers a substrate tool that should
+   * have first-class footing alongside the kernel built-ins.
+   */
+  coreTools?: string[];
   /** Additional directories to scan for skills (supports ~ expansion). */
   skillPaths?: string[];
   /**
@@ -143,6 +150,7 @@ const DEFAULTS: Required<Settings> = {
   defaultProvider: undefined as unknown as string,
   defaultBackend: "ash",
   toolMode: "api" as "api" | "deferred" | "deferred-lookup" | "inline",
+  coreTools: [],
   shellTruncateThreshold: 20,
   shellHeadLines: 10,
   shellTailLines: 10,

--- a/src/shell/tui-renderer.ts
+++ b/src/shell/tui-renderer.ts
@@ -770,6 +770,10 @@ export default function activate(ctx: ExtensionContext): void {
     const raw = extra.rawInput as Record<string, unknown> | undefined;
     if (!raw) return "";
     if (typeof raw.command === "string") return `$ ${raw.command}`;
+    if (typeof raw.source === "string") {
+      const firstLine = raw.source.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+      return firstLine.length > 80 ? firstLine.slice(0, 77) + "…" : firstLine;
+    }
     if (typeof raw.pattern === "string") return raw.pattern;
     if (typeof raw.path === "string") {
       const home = process.env.HOME;

--- a/src/utils/tool-display.ts
+++ b/src/utils/tool-display.ts
@@ -126,6 +126,9 @@ export function renderToolCall(
       if (raw && typeof raw === "object") {
         if (typeof raw.command === "string") {
           detail = `$ ${raw.command}`;
+        } else if (typeof raw.source === "string") {
+          const firstLine = raw.source.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+          detail = firstLine.length > 80 ? firstLine.slice(0, 77) + "…" : firstLine;
         } else if (typeof raw.pattern === "string") {
           // grep/glob — show the search pattern
           const target = typeof raw.path === "string" ? ` ${shortenPath(raw.path, cwd)}` : "";


### PR DESCRIPTION
## Summary

A handful of small, independently-useful additions to the kernel that
together let an extension expose a single substrate tool (e.g. a
language interpreter as the only tool the LLM sees) without the kernel
fighting it. Plus an unrelated DeepSeek context-window default fix
that surfaced during testing.

Each commit is self-contained — none of them is conditional on the
others, and any subset can be reverted in isolation.

## Commits

1. **Declare 1M context window for DeepSeek v4 models** — provider was
   declaring models without a context window, so auto-compact
   collapsed to the 60K fallback and the threshold landed at ~26K.
   DeepSeek's `/models` endpoint omits context size, so the value
   has to come from the provider definition.

2. **Allow extensions to declare additional core tools** — new
   `coreTools` setting threads through to `createToolProtocol`, so
   user config can extend the hardcoded core list without forking the
   kernel. Also adds `conversation_recall` (already kernel-registered)
   to the core set where it belongs.

3. **Allow tools to override the per-result truncation cap** — new
   `ToolDefinition.maxResultBytes`. The 16 KB ceiling fits
   single-purpose tools but truncates legitimately-large output from
   tools that bundle many sub-operations in one call.

4. **Carry source-language hint through to tool displays** — new
   `ToolDisplayInfo.sourceLanguage` + matching field on the
   `agent:tool-started` event payload. Tools that take source code as
   input (eval-style) tell renderers which highlight.js grammar to
   apply; renderers that don't recognize the identifier fall back to
   plain text. Adds a `raw.source` rendering branch alongside the
   existing `raw.command` / `raw.pattern` / `raw.path` ones.

5. **Add bypass_cache option to read_file for in-process callers** —
   the dedup stub points at a prior tool_result, which is meaningless
   for in-process consumers reading content as a value. Not exposed
   in `input_schema` since it's not for the LLM.

6. **Genericize system-prompt tool guidance** — the Tool Decision
   Guide / Tool Usage Guidelines sections hardcoded specific tool
   names. Replaced with a single Tools paragraph that defers to
   whatever tool descriptions are present. The bash-specific bullets
   migrate into the bash tool's own description.

7. **List available tools when the LLM calls an unknown one** —
   bare \"Unknown tool 'X'\" gave the model no path to self-correct
   when an extension had unregistered a kernel tool it expected from
   training-time familiarity.

## Test plan

- [ ] \`npx tsc --noEmit\` clean (verified after each commit during
      assembly)
- [ ] Smoke run with default config: bash / read_file / grep work as
      before
- [ ] Smoke run with \`coreTools: [\"scheme_eval\"]\` in settings.json:
      scheme_eval is sent with full schema under deferred-lookup mode
- [ ] DeepSeek auto-compact threshold now ~500K instead of ~26K