### PR TITLE
Fix autocomplete staircase + YAML block-scalar descriptions

### DIFF
--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -22,19 +22,52 @@ export interface Skill {
   baseDir: string;
 }
 
-/** Parse YAML frontmatter from a SKILL.md file. */
+/** Parse YAML frontmatter from a SKILL.md file. Supports inline scalars
+ *  and block scalars (`>`, `>-`, `|`, `|-`) for multi-line descriptions. */
 function parseFrontmatter(content: string): { meta: Record<string, string>; body: string } | null {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!match) return null;
 
   const meta: Record<string, string> = {};
-  for (const line of match[1].split("\n")) {
+  const lines = match[1].split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const indent = line.length - line.trimStart().length;
     const colon = line.indexOf(":");
-    if (colon > 0) {
-      const key = line.slice(0, colon).trim();
-      const value = line.slice(colon + 1).trim();
-      meta[key] = value;
+    if (colon <= 0 || indent > 0) { i++; continue; }
+    const key = line.slice(0, colon).trim();
+    const rawValue = line.slice(colon + 1).trim();
+    const blockStyle = rawValue.match(/^([>|])([+-]?)\s*$/);
+    if (!blockStyle) {
+      meta[key] = rawValue;
+      i++;
+      continue;
     }
+    const folded = blockStyle[1] === ">";
+    const chomp = blockStyle[2];
+    const body: string[] = [];
+    let blockIndent = -1;
+    let j = i + 1;
+    while (j < lines.length) {
+      const next = lines[j]!;
+      if (next.trim() === "") { body.push(""); j++; continue; }
+      const ind = next.length - next.trimStart().length;
+      if (blockIndent === -1) blockIndent = ind;
+      if (ind < blockIndent) break;
+      body.push(next.slice(blockIndent));
+      j++;
+    }
+    let end = body.length;
+    if (chomp !== "+") {
+      while (end > 0 && body[end - 1] === "") end--;
+      if (chomp !== "-" && end < body.length) end++;
+    }
+    const kept = body.slice(0, end);
+    meta[key] = folded
+      ? kept.join(" ").replace(/\s+/g, " ").trim()
+      : kept.join("\n");
+    i = j;
   }
 
   return { meta, body: match[2] };

--- a/src/shell/tui-input-view.ts
+++ b/src/shell/tui-input-view.ts
@@ -4,7 +4,7 @@
  * ANSI redraw. The controller drives it via a small VM shape.
  */
 
-import { visibleLen } from "../utils/ansi.js";
+import { visibleLen, truncateToWidth } from "../utils/ansi.js";
 import { palette as p } from "../utils/palette.js";
 import type { RenderSurface } from "../utils/compositor.js";
 import { StdoutSurface } from "../utils/compositor.js";
@@ -171,17 +171,28 @@ export class TuiInputView {
   drawAutocomplete(vm: AutocompleteVM): void {
     if (vm.items.length === 0) return;
     this.autoFrame(() => {
+      // Truncate descriptions so each row fits one physical line — a wrapped
+      // row makes autocompleteLines undercount, clearAutocomplete leaves a
+      // residual row, and the next drawPrompt redraws below the original
+      // prompt (staircase).
+      const termW = this.surface.columns;
       const lines: string[] = [];
       for (let i = 0; i < vm.items.length; i++) {
         const item = vm.items[i]!;
+        const nameW = Math.max(12, visibleLen(item.name));
+        const overhead = 5 + nameW;
+        const descBudget = Math.max(1, termW - overhead);
+        const desc = visibleLen(item.description) > descBudget
+          ? truncateToWidth(item.description, descBudget)
+          : item.description;
         const selected = i === vm.selected;
         if (selected) {
           lines.push(
-            `  \x1b[7m ${p.accent}${item.name.padEnd(12)}${p.reset}\x1b[7m ${item.description} ${p.reset}`
+            `  \x1b[7m ${p.accent}${item.name.padEnd(12)}${p.reset}\x1b[7m ${desc} ${p.reset}`
           );
         } else {
           lines.push(
-            `   ${p.muted}${item.name.padEnd(12)} ${item.description}${p.reset}`
+            `   ${p.muted}${item.name.padEnd(12)} ${desc}${p.reset}`
           );
         }
       }


### PR DESCRIPTION
## Summary

Two related autocomplete bugs surfaced while typing `/` in the agent
prompt — both visible in the same dropdown, both fixed here.

## Commits

1. **Truncate autocomplete row descriptions to terminal width.** Each
   row was emitted as a single logical line and counted as a single
   row in `autocompleteLines`. Long descriptions plus long names
   (`/skill:kb-manager` is 17 chars, the pad is 12) overflowed the
   terminal width, the terminal wrapped the row, and the cursor-up
   move after the dropdown undershot the prompt — leading to the
   "extra prompt line" staircase reported by users. Per-row budget
   now factors in actual name visible length, and descriptions are
   truncated with `…`.

2. **Parse YAML block scalars in SKILL.md frontmatter.** The naive
   `split(":")` parser treated `description: >-` as the literal
   value `>-` and dropped the indented continuation. Real-world
   SKILL.md files use folded block style for any non-trivial
   description, so they were showing up as just `/skill:foo >-` in
   the dropdown. Now handles `>`, `>-`, `>+`, `|`, `|-`, `|+`.

## Test plan

- [ ] Open agent prompt (`>`), type `/`. Dropdown shows the full
      slash-command + skill list with descriptions truncated to one
      row each, no staircase on subsequent keystrokes.
- [ ] Skills using `description: >-` (folded block style) show
      their actual description text rather than `>-`.
- [ ] Skills using inline `description: foo bar` keep rendering
      unchanged.