### PR TITLE
Fix ashi Ctrl-T double-fire; add shift+tab thinking cycle

### DIFF
--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -161,6 +161,12 @@ export function mountAshi(
   const refreshBranch = (): void => {
     statusFooter.update({ branch: currentGitBranch(cwd) });
   };
+  const refreshThinking = (): void => {
+    const { level, supported } = bus.emitPipe("config:get-thinking", {
+      level: "off", levels: [] as string[], supported: true,
+    });
+    statusFooter.update({ thinking: supported ? level : undefined });
+  };
 
   tui.addChild(chat);
   tui.addChild(footerSlot);
@@ -556,6 +562,12 @@ export function mountAshi(
       provider: info.provider,
       contextWindow: info.contextWindow,
     });
+    refreshThinking();
+    tui.requestRender();
+  });
+
+  bus.on("config:changed", () => {
+    refreshThinking();
     tui.requestRender();
   });
 
@@ -679,6 +691,16 @@ export function mountAshi(
     }
     if (matchesKey(data, "ctrl+t")) {
       toggleThinking();
+      return { consume: true };
+    }
+    if (matchesKey(data, "shift+tab")) {
+      const { level, levels, supported } = bus.emitPipe("config:get-thinking", {
+        level: "off", levels: [] as string[], supported: true,
+      });
+      if (supported && levels.length > 0) {
+        const next = levels[(levels.indexOf(level) + 1) % levels.length];
+        bus.emit("config:set-thinking", { level: next });
+      }
       return { consume: true };
     }
     if (matchesKey(data, "ctrl+o")) {

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -11,6 +11,8 @@ import {
   type SelectItem,
   getImageDimensions,
   matchesKey,
+  isKeyRelease,
+  isKeyRepeat,
 } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
 import { editorTheme, selectListTheme, theme } from "./theme.js";
@@ -658,11 +660,11 @@ export function mountAshi(
       }
     };
     walk(chat);
-    bus.emit("ui:info", { message: `thinking: ${hideThinking ? "hidden" : "visible"}` });
     tui.requestRender();
   };
 
   tui.addInputListener((data) => {
+    if (isKeyRelease(data) || isKeyRepeat(data)) return;
     if (matchesKey(data, "escape") && processing) {
       bus.emit("agent:cancel-request", {});
       return { consume: true };

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -10,6 +10,7 @@ interface StatusFields {
   leaf?: number;
   tokens?: number;
   compactions?: number;
+  thinking?: string;
 }
 
 export class StatusFooter extends Container {
@@ -28,12 +29,13 @@ export class StatusFooter extends Container {
   }
 
   private repaint(): void {
-    const { model, provider, contextWindow, cwd, branch, leaf, tokens, compactions } = this.fields;
+    const { model, provider, contextWindow, cwd, branch, leaf, tokens, compactions, thinking } = this.fields;
     const sep = theme.fg("dim", " | ");
     const parts: string[] = [];
     if (model) {
       const tail = provider ? theme.fg("muted", `@${provider}`) : "";
-      parts.push(`${theme.fg("accent", model)}${tail ? " " + tail : ""}`);
+      const think = thinking ? theme.fg("muted", ` • ${thinking}`) : "";
+      parts.push(`${theme.fg("accent", model)}${tail ? " " + tail : ""}${think}`);
     } else if (provider) {
       parts.push(theme.fg("muted", `@${provider}`));
     }

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -34,7 +34,7 @@ export class StatusFooter extends Container {
     const parts: string[] = [];
     if (model) {
       const tail = provider ? theme.fg("muted", `@${provider}`) : "";
-      const think = thinking ? theme.fg("muted", ` • ${thinking}`) : "";
+      const think = thinking ? theme.fg("muted", ` [${thinking}]`) : "";
       parts.push(`${theme.fg("accent", model)}${tail ? " " + tail : ""}${think}`);
     } else if (provider) {
       parts.push(theme.fg("muted", `@${provider}`));

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -391,7 +391,6 @@ export default function activate(ctx: ExtensionContext): void {
         return;
       }
       session.setThinkingLevel(level);
-      bus.emit("ui:info", { message: `Thinking: ${level}` });
       bus.emit("config:changed", {});
     };
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -352,7 +352,6 @@ export class AgentLoop implements AgentBackend {
         return;
       }
       this.thinkingLevel = level;
-      this.bus.emit("ui:info", { message: `Thinking: ${level}` });
       this.bus.emit("config:changed", {});
     });
     onPipe("config:get-thinking", () => {


### PR DESCRIPTION
## Summary

- **Kitty key-release fix.** pi-tui enables Kitty keyboard protocol flag 2 (report event types), so terminals that negotiate the protocol emit a CSI-u press *and* release for one Ctrl-T. `matchesKey()` matches both shapes, doubling every bound key. Filter `isKeyRelease(data) || isKeyRepeat(data)` at the top of ashi's input listener. Also drops the `thinking: hidden / visible` toast that made the doubling visible.
- **Shift+Tab cycles thinking level.** Mirrors pi-coding-agent's `app.thinking.cycle` keybinding. Wraps through whatever levels the active backend exposes via `config:get-thinking`.
- **Footer shows the current thinking level** as `[level]` beside the model when the model supports reasoning.
- **Drop the `Thinking: <level>` success toast** from both `config:set-thinking` handlers (ash backend + pi-bridge). Footer + `/thinking` (no args) already surface the level; errors still toast.

## Test plan

- [ ] On a Kitty-protocol terminal (Ghostty / WezTerm / Kitty), press Ctrl-T inside ashi — thinking blocks collapse/expand on each press, no flicker.
- [ ] Press Shift+Tab — footer cycles through `off → low → medium → high → off` (or pi's wider range under pi-bridge), no toast line in chat.
- [ ] `/thinking` with no args still prints the current level and options.
- [ ] `/thinking <invalid>` and `/thinking high` on a non-reasoning model still emit error toasts.