### PR TITLE
Forward provider-specific extras through LlmClient

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -140,11 +140,12 @@ export default function agentBackend(ctx: ExtensionContext): void {
   const llmClient = new LlmClient({ apiKey: "not-configured", model: "not-configured" });
   ctx.define("llm:get-client", () => llmClient);
   ctx.define("llm:invoke", (messages: { role: string; content: string }[], opts?: { maxTokens?: number; model?: string; reasoningEffort?: string }) => {
+    const effort = opts?.reasoningEffort;
     return llmClient.complete({
       messages: messages as Parameters<typeof llmClient.complete>[0]["messages"],
       max_tokens: opts?.maxTokens,
       model: opts?.model,
-      reasoning_effort: opts?.reasoningEffort,
+      ...(effort && effort !== "off" ? { reasoning_effort: effort } : {}),
     });
   });
 

--- a/src/utils/llm-client.ts
+++ b/src/utils/llm-client.ts
@@ -6,7 +6,12 @@
  * (command suggestions, completions).
  */
 import OpenAI from "openai";
-import type { ChatCompletionMessageParam, ChatCompletionTool } from "openai/resources/chat/completions.js";
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionCreateParamsNonStreaming,
+} from "openai/resources/chat/completions.js";
 
 export type { ChatCompletionMessageParam, ChatCompletionTool };
 
@@ -51,59 +56,45 @@ export class LlmClient {
     this.model = newConfig.model;
   }
 
-  /**
-   * Create a streaming chat completion.
-   * Returns an async iterable of chunks.
-   */
-  stream(opts: {
-    messages: ChatCompletionMessageParam[];
-    tools?: ChatCompletionTool[];
-    model?: string;
-    max_tokens?: number;
-    /** Reasoning effort: "off" | "low" | "medium" | "high". Provider-dependent;
-     *  "off" matches agent-loop's thinkingLevel and omits the field. */
-    reasoning_effort?: string;
-    signal?: AbortSignal;
-  }) {
-    const sendEffort = opts.reasoning_effort && opts.reasoning_effort !== "off";
+  stream(opts: StreamOpts) {
+    const { signal, messages, tools, model, max_tokens, ...rest } = opts;
     const body = {
-      model: opts.model ?? this.model,
-      messages: opts.messages,
-      tools: opts.tools?.length ? opts.tools : undefined,
-      max_tokens: opts.max_tokens ?? 65536,
+      ...rest,
+      model: model ?? this.model,
+      messages,
+      tools: tools?.length ? tools : undefined,
+      max_tokens: max_tokens ?? 65536,
       stream: true as const,
       stream_options: { include_usage: true },
-      ...(sendEffort
-        ? { reasoning_effort: opts.reasoning_effort as "low" | "medium" | "high" }
-        : {}),
     };
-    return this.client.chat.completions.create(
-      body,
-      { signal: opts.signal },
-    );
+    return this.client.chat.completions.create(body as ChatCompletionCreateParamsStreaming, { signal });
   }
 
-  /**
-   * Single-shot completion (no streaming) — for fast-path features.
-   * Returns the text content of the first choice.
-   */
-  async complete(opts: {
-    messages: ChatCompletionMessageParam[];
-    model?: string;
-    max_tokens?: number;
-    /** Reasoning effort: "off" | "low" | "medium" | "high". Provider-dependent;
-     *  "off" matches agent-loop's thinkingLevel and omits the field. */
-    reasoning_effort?: string;
-  }): Promise<string> {
-    const sendEffort = opts.reasoning_effort && opts.reasoning_effort !== "off";
-    const response = await this.client.chat.completions.create({
-      model: opts.model ?? this.model,
-      messages: opts.messages,
-      max_tokens: opts.max_tokens ?? 1024,
-      ...(sendEffort
-        ? { reasoning_effort: opts.reasoning_effort as "low" | "medium" | "high" }
-        : {}),
-    });
+  async complete(opts: CompleteOpts): Promise<string> {
+    const { messages, model, max_tokens, ...rest } = opts;
+    const body = {
+      ...rest,
+      model: model ?? this.model,
+      messages,
+      max_tokens: max_tokens ?? 1024,
+    };
+    const response = await this.client.chat.completions.create(body as ChatCompletionCreateParamsNonStreaming);
     return response.choices[0]?.message?.content ?? "";
   }
 }
+
+/** Known fields are typed; extras are forwarded verbatim to the SDK so
+ *  provider hooks can ship non-standard params (thinking, reasoning, …). */
+export type StreamOpts = {
+  messages: ChatCompletionMessageParam[];
+  tools?: ChatCompletionTool[];
+  model?: string;
+  max_tokens?: number;
+  signal?: AbortSignal;
+} & Record<string, unknown>;
+
+export type CompleteOpts = {
+  messages: ChatCompletionMessageParam[];
+  model?: string;
+  max_tokens?: number;
+} & Record<string, unknown>;


### PR DESCRIPTION
## Summary

`LlmClient.stream`/`complete` built the SDK request body from a typed whitelist — `model`, `messages`, `tools`, `max_tokens`, `reasoning_effort`. Anything else on `opts` was silently dropped. So when a provider hook returned `thinking: { type: "disabled" }` (Z.AI, DeepSeek) or `reasoning: { effort: "none" }` (OpenRouter), the field was assembled into `agent-loop`'s `requestParams`, emitted to `llm:request` (so `wire-log` captured it), then thrown away by `LlmClient` before reaching the OpenAI SDK.

Discovered while debugging "Z.AI still streams reasoning_content despite `/thinking off`". Replaying the captured request body via curl bypasses `LlmClient` and shows the flag works upstream — the bug was on our side all along.

Fix:
- Both methods now forward arbitrary extras: known fields stay typed and apply defaults, anything else is spread into the body.
- `LlmClient` no longer special-cases `reasoning_effort === "off"`. The single external caller (`llm:invoke` handler in `src/agent/index.ts`) gets a small inline gate; `agent-loop` already filters via `reasoningParams()`.

## Test plan

- [ ] On Z.AI (`glm-5.1`) with `/thinking off`, confirm via wire-log that the request body still ships `thinking: { type: "disabled" }`, and that the response stream no longer contains `reasoning_content` deltas.
- [ ] On OpenRouter with a reasoning-capable model, confirm `reasoning: { effort: "none" }` reaches the upstream and is honored.
- [ ] Regression: standard OpenAI/Anthropic flows with `/thinking high` still produce reasoning as before.
- [ ] `llm:invoke` from an extension with `reasoningEffort: "off"` doesn't pass through the field (would 400 on OpenAI).