### PR TITLE
Add ashi management subcommands and expose CLI entrypoints

### DIFF
--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
-    "agent-sh": "^0.13.0",
+    "agent-sh": "^0.13.1",
     "chalk": "^5.5.0",
     "cli-highlight": "^2.1.11"
   },

--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
-    "agent-sh": "^0.12.27",
+    "agent-sh": "^0.13.0",
     "chalk": "^5.5.0",
     "cli-highlight": "^2.1.11"
   },

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -54,8 +54,58 @@ function parseArgs(argv: string[]): AppConfig & { extensions?: string[] } {
   return { shell: "/bin/sh", model, apiKey, baseURL, provider, backend, extensions };
 }
 
+const MANAGEMENT_HELP = `ashi — ash backend, pi-tui frontend
+
+Management:
+  ashi install <name> [--force]   Install an extension
+  ashi uninstall <name>           Remove an installed extension
+  ashi list                       List installed extensions
+  ashi auth login [provider]      Store an API key
+  ashi auth logout <provider>     Remove a stored key
+  ashi auth list                  Show configured providers
+  ashi init [--force]             Scaffold ~/.agent-sh/ (settings, AGENTS.md)
+
+Launch (default):
+  ashi [--provider <name>] [--model <id>] [--api-key <key>] [--base-url <url>]
+       [--backend <name>] [-e <ext>[,<ext>...]]
+
+Reads ~/.agent-sh/settings.json for providers and defaults.`;
+
 async function main(): Promise<void> {
-  const config = parseArgs(process.argv.slice(2));
+  const rawArgs = process.argv.slice(2);
+  const sub = rawArgs[0];
+  const rest = rawArgs.slice(1);
+
+  if (sub === "install" || sub === "uninstall" || sub === "list") {
+    const { runInstall, runUninstall, runList } = await import("agent-sh/cli/install");
+    if (sub === "install") await runInstall(rest[0] ?? "", { force: rest.includes("--force") });
+    else if (sub === "uninstall") await runUninstall(rest[0] ?? "");
+    else runList();
+    process.exit(0);
+  }
+  if (sub === "auth") {
+    const { runAuth } = await import("agent-sh/cli/auth");
+    await runAuth(rest);
+    process.exit(0);
+  }
+  if (sub === "init") {
+    const { runInit } = await import("agent-sh/cli/init");
+    runInit({ force: rest.includes("--force") });
+    process.exit(0);
+  }
+  if (sub === "--help" || sub === "-h") {
+    process.stdout.write(MANAGEMENT_HELP + "\n");
+    process.exit(0);
+  }
+  if (sub && !sub.startsWith("-")) {
+    process.stderr.write(`ashi: unknown subcommand "${sub}".\n`);
+    process.stderr.write("Available: install, uninstall, list, auth, init\n");
+    process.stderr.write("Run `ashi --help` for details.\n");
+    process.exit(1);
+  }
+
+  // ── Pi-tui frontend
+  const config = parseArgs(rawArgs);
 
   if (!process.stdin.isTTY) {
     process.stderr.write("ashi requires a TTY for interactive rendering.\n");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sh",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A shell-first terminal where AI is one keystroke away",
   "type": "module",
   "main": "dist/core/index.js",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,18 @@
     "./executor": {
       "types": "./dist/utils/executor.d.ts",
       "default": "./dist/utils/executor.js"
+    },
+    "./cli/install": {
+      "types": "./dist/cli/install.d.ts",
+      "default": "./dist/cli/install.js"
+    },
+    "./cli/init": {
+      "types": "./dist/cli/init.d.ts",
+      "default": "./dist/cli/init.js"
+    },
+    "./cli/auth": {
+      "types": "./dist/cli/auth/cli.d.ts",
+      "default": "./dist/cli/auth/cli.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

ashi was previously TUI-only — managing extensions, keys, or scaffolding required dropping back to `agent-sh`. This adds first-class subcommands that delegate to agent-sh's existing CLI code:

- `ashi install <name> [--force]` / `uninstall <name>` / `list`
- `ashi auth [login|logout|list] …`
- `ashi init [--force]`

`ashi <unknown>` errors with a usage hint; `ashi` with no subcommand keeps the existing pi-tui frontend launch behavior.

Implementation:
- `package.json` now exports `./cli/install`, `./cli/init`, `./cli/auth` so downstream packages (ashi, future bridges) can import the dispatchers directly instead of shelling out.
- `examples/extensions/ashi/src/cli.ts` dispatches on `argv[0]` before falling through to `parseArgs` + frontend mount. Lazy-imports the CLI modules so the TUI path doesn't pay the cost.
- `examples/extensions/ashi/package.json` bumps `agent-sh` to `^0.13.0` where the new exports live.

## Test plan

- [ ] `ashi --help` shows the management commands plus the launch usage.
- [ ] `ashi install some-package` installs into `~/.agent-sh/extensions/`.
- [ ] `ashi auth list` prints the same provider table as `agent-sh auth list`.
- [ ] `ashi init` scaffolds settings + `AGENTS.md` and refuses without `--force` if files exist.
- [ ] `ashi` with no args still mounts the pi-tui frontend.
- [ ] `ashi bogus` errors with the available-subcommands hint, exit 1.