### PR TITLE
Add AgentShMessage with meta field stripped before LLM serialization

### DIFF
--- a/src/utils/llm-client.ts
+++ b/src/utils/llm-client.ts
@@ -15,6 +15,16 @@ import type {
 
 export type { ChatCompletionMessageParam, ChatCompletionTool };
 
+export type AgentShMessage = ChatCompletionMessageParam & {
+  meta?: Record<string, unknown>;
+};
+
+function stripMeta(m: ChatCompletionMessageParam): ChatCompletionMessageParam {
+  if (!("meta" in m)) return m;
+  const { meta: _meta, ...rest } = m as ChatCompletionMessageParam & { meta?: unknown };
+  return rest as ChatCompletionMessageParam;
+}
+
 export interface LlmClientConfig {
   apiKey: string;
   baseURL?: string;
@@ -61,7 +71,7 @@ export class LlmClient {
     const body = {
       ...rest,
       model: model ?? this.model,
-      messages,
+      messages: messages.map(stripMeta),
       tools: tools?.length ? tools : undefined,
       max_tokens: max_tokens ?? 65536,
       stream: true as const,
@@ -75,7 +85,7 @@ export class LlmClient {
     const body = {
       ...rest,
       model: model ?? this.model,
-      messages,
+      messages: messages.map(stripMeta),
       max_tokens: max_tokens ?? 1024,
     };
     const response = await this.client.chat.completions.create(body as ChatCompletionCreateParamsNonStreaming);


### PR DESCRIPTION
## Summary

- New exported type `AgentShMessage = ChatCompletionMessageParam & { meta?: Record<string, unknown> }`
- `stripMeta` runs at the LLM API boundary (`stream`, `complete`) so the `meta` field never reaches the provider
- Gives extensions a single, typed place to attach caller-internal metadata (provenance, tracing, tree-history linkage) without:
  - leaking to strict providers (DeepSeek 400s on unknown fields the SDK doesn't filter for them)
  - field-name collisions between extensions (no \`_id\` vs \`_treeEntryId\` bikeshedding)
  - relying on the incidental \"agent-sh happens to preserve unknown fields\" behavior

## Motivation

asHub is building tree-shaped conversation history that needs to maintain an index→tree-entry mapping across \`bridge.compact({kind: \"replace\"})\` calls. The mapping has to survive agent-sh's normalization safeguards (\`dropOrphanToolMessages\`, \`stubDanglingToolCalls\`, \`normalizeReasoningConsistency\`).

Today the only path is to attach an unknown field and hope agent-sh preserves it. That works incidentally — all three safeguards happen to use \`result.push(msg)\` or \`{...m, ...}\` spread patterns. But:

- It's not part of any documented contract
- A future safeguard that uses \`{role, content, tool_calls}\` explicit-listing would silently strip the field
- Some providers may 400 on unknown fields reaching the API

A \`meta\` dict with a single explicit strip rule fixes all three: structurally unambiguous, type-declared, and verifiable in code review (\"does the strip step exist?\").

## Scope

- No runtime behavior change for existing code (no current path uses \`meta\`).
- One new exported type.
- ~10 lines total.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: run agent-sh CLI, send a turn, verify no regression in LLM responses