### PR TITLE
ashi: diff box polish, replay rendering, kernel quality-of-life

### DIFF
--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -11,7 +11,7 @@
  * In agent-shell (Emacs):
  *   (setq agent-shell-agentsh-acp-command '("agent-sh-acp"))
  */
-import { createCore, type AgentShellCore } from "agent-sh";
+import { createCore, NoopHistory, type AgentShellCore } from "agent-sh";
 import { loadExtensions } from "agent-sh/extension-loader";
 import { loadBuiltinExtensions } from "agent-sh/extensions";
 import { activateAgent } from "agent-sh/agent";
@@ -483,6 +483,7 @@ async function handleSessionNew(id: number | string, params: Record<string, unkn
     core = createCore({
       model: cliArgs.model,
       provider: cliArgs.provider,
+      history: new NoopHistory(),
     });
     wireEvents(core);
 

--- a/examples/extensions/ashi/src/capture.ts
+++ b/examples/extensions/ashi/src/capture.ts
@@ -15,11 +15,27 @@ export function registerCapture(
   getStore: () => MultiSessionStore,
 ): Capture {
   let liveEntryIds: (string | null)[] = [];
+  const diffMeta = new Map<string, { diff: unknown; filePath: string }>();
+
+  ctx.bus.on("agent:tool-completed", (e) => {
+    const id = e.toolCallId;
+    const body = e.resultDisplay?.body;
+    if (id && body?.kind === "diff") {
+      diffMeta.set(id, { diff: body.diff, filePath: body.filePath });
+    }
+  });
+
+  const enrich = (m: AgentMessage): AgentMessage => {
+    if (m.role !== "tool" || !m.tool_call_id) return m;
+    const meta = diffMeta.get(m.tool_call_id);
+    if (!meta) return m;
+    return { ...m, meta: { ...m.meta, diff: meta.diff, filePath: meta.filePath } };
+  };
 
   const flush = async (): Promise<void> => {
     const messages = ctx.call("conversation:get-messages") as AgentMessage[] | undefined;
     if (!messages || messages.length <= liveEntryIds.length) return;
-    const newMessages = messages.slice(liveEntryIds.length);
+    const newMessages = messages.slice(liveEntryIds.length).map(enrich);
     const newIds = await getStore().current().appendMessages(newMessages);
     liveEntryIds = [...liveEntryIds, ...newIds];
   };

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -190,7 +190,7 @@ function lineCountHint(buffer: string, exitCode: number | null | undefined): str
   return `${arrow}${theme.fg("muted", label)}`;
 }
 
-const GROUP_ICONS: Record<string, string> = { read: "◆", search: "⌕" };
+export const GROUP_ICONS: Record<string, string> = { read: "◆", search: "⌕" };
 
 interface GroupChild {
   name: string;

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -98,7 +98,8 @@ export class ToolResultBody extends Container {
   private outputText: Text;
   private bodyText: Text;
   private outputBuffer = "";
-  private diffLines: string[] = [];
+  private diffRenderer: ((width: number) => string[]) | null = null;
+  private lastDiffWidth = -1;
   private mode: ToolResultMode;
   private previewLines: number;
   private finalized = false;
@@ -120,8 +121,9 @@ export class ToolResultBody extends Container {
     this.repaint();
   }
 
-  setDiff(lines: string[]): void {
-    this.diffLines = lines;
+  setDiffRenderer(fn: (width: number) => string[]): void {
+    this.diffRenderer = fn;
+    this.lastDiffWidth = -1;
     this.repaint();
   }
 
@@ -136,12 +138,23 @@ export class ToolResultBody extends Container {
     this.repaint();
   }
 
+  override render(width: number): string[] {
+    if (this.diffRenderer && width !== this.lastDiffWidth) {
+      this.lastDiffWidth = width;
+      const showDiff = this.expanded || this.mode === "preview";
+      this.bodyText.setText(showDiff ? this.diffRenderer(width).join("\n") : "");
+    }
+    return super.render(width);
+  }
+
   private repaint(): void {
-    // Hide the framed diff in hidden/summary modes — the stats already live
-    // on the call line so showing it again is noise.
-    const hasDiff = this.diffLines.length > 0;
+    const hasDiff = this.diffRenderer !== null;
     const showDiff = hasDiff && (this.expanded || this.mode === "preview");
-    this.bodyText.setText(showDiff ? this.diffLines.join("\n") : "");
+    if (showDiff && this.lastDiffWidth >= 0 && this.diffRenderer) {
+      this.bodyText.setText(this.diffRenderer(this.lastDiffWidth).join("\n"));
+    } else if (!showDiff) {
+      this.bodyText.setText("");
+    }
 
     // When a diff exists, the textual output ("Edited /path (+12 -3)") just
     // restates the call line — suppress its line-count hint to keep edits quiet.

--- a/examples/extensions/ashi/src/default-renderers.ts
+++ b/examples/extensions/ashi/src/default-renderers.ts
@@ -10,6 +10,10 @@ const TOOL_ICON: Record<string, string> = {
   ls: GROUP_ICONS.read!,
   grep: GROUP_ICONS.search!,
   glob: GROUP_ICONS.search!,
+  edit: "✎",
+  edit_file: "✎",
+  write: "✎",
+  write_file: "✎",
 };
 
 function iconPrefix(name: string): string {
@@ -136,7 +140,7 @@ function lsLabel(args: ToolCallArgs): string {
 function pathOnlyLabel(name: string, args: ToolCallArgs): string {
   const r = parseRaw(args.rawInput);
   const path = str(r.file_path) ?? str(r.path);
-  return `${bold(name)} ${accent(path ? relativize(path) : "…")}`;
+  return `${iconPrefix(name)}${bold(name)} ${accent(path ? relativize(path) : "…")}`;
 }
 
 function genericLabel(args: ToolCallArgs): string {

--- a/examples/extensions/ashi/src/default-renderers.ts
+++ b/examples/extensions/ashi/src/default-renderers.ts
@@ -1,7 +1,21 @@
 import { Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
 import { theme } from "./theme.js";
+import { GROUP_ICONS } from "./components.js";
 import type { ToolCallArgs, ToolCallView } from "./hooks.js";
+
+const TOOL_ICON: Record<string, string> = {
+  read_file: GROUP_ICONS.read!,
+  read: GROUP_ICONS.read!,
+  ls: GROUP_ICONS.read!,
+  grep: GROUP_ICONS.search!,
+  glob: GROUP_ICONS.search!,
+};
+
+function iconPrefix(name: string): string {
+  const icon = TOOL_ICON[name];
+  return icon ? `${theme.fg("warning", icon)} ` : "";
+}
 
 interface StatusOpts { exitCode: number | null; elapsedMs: number; summary?: string }
 
@@ -92,7 +106,7 @@ function readLabel(args: ToolCallArgs): string {
     const to = limit !== undefined ? from + limit - 1 : undefined;
     range = theme.fg("warning", to ? `:${from}-${to}` : `:${from}`);
   }
-  return `${bold("read")} ${accent(path ? relativize(path) : "…")}${range}`;
+  return `${iconPrefix("read")}${bold("read")} ${accent(path ? relativize(path) : "…")}${range}`;
 }
 
 function grepLabel(args: ToolCallArgs): string {
@@ -103,20 +117,20 @@ function grepLabel(args: ToolCallArgs): string {
   const limit = num(r.limit);
   const extras = [glob ? `(${glob})` : "", limit !== undefined ? `limit ${limit}` : ""].filter(Boolean).join(" ");
   const tail = extras ? muted(` ${extras}`) : "";
-  return `${bold("grep")} ${accent(`/${pattern}/`)} ${muted(`in ${scope}`)}${tail}`;
+  return `${iconPrefix("grep")}${bold("grep")} ${accent(`/${pattern}/`)} ${muted(`in ${scope}`)}${tail}`;
 }
 
 function globLabel(args: ToolCallArgs): string {
   const r = parseRaw(args.rawInput);
   const pattern = str(r.pattern) ?? "…";
   const scope = relativize(str(r.path) ?? ".");
-  return `${bold("glob")} ${accent(pattern)} ${muted(`in ${scope}`)}`;
+  return `${iconPrefix("glob")}${bold("glob")} ${accent(pattern)} ${muted(`in ${scope}`)}`;
 }
 
 function lsLabel(args: ToolCallArgs): string {
   const r = parseRaw(args.rawInput);
   const p = str(r.path) ?? ".";
-  return `${bold("ls")} ${accent(relativize(p))}`;
+  return `${iconPrefix("ls")}${bold("ls")} ${accent(relativize(p))}`;
 }
 
 function pathOnlyLabel(name: string, args: ToolCallArgs): string {

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -495,7 +495,7 @@ export function mountAshi(
         const diffLines = renderDiff(diff, {
           width: contentW,
           filePath: body.filePath,
-          trueColor: true,
+          trueColor: false,
           maxLines: 30,
         });
         const inner = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -503,23 +503,23 @@ export function mountAshi(
     if (body?.kind === "diff") {
       const diff = body.diff as DiffStats & Parameters<typeof renderDiff>[0];
       if (!diff.isIdentical) {
-        const termW = process.stdout.columns ?? 80;
-        const boxW = Math.max(40, termW);
-        const contentW = Math.max(20, boxW - 4);
-        const inner = diff.isNewFile
-          ? renderNewFilePreview(diff, 30)
-          : ((): string[] => {
-              const lines = renderDiff(diff, {
-                width: contentW, filePath: body.filePath, trueColor: true, maxLines: 30,
-              });
-              return lines.length > 1 ? ["", ...lines.slice(1), ""] : lines;
-            })();
-        const framed = renderBoxFrame(inner, {
-          width: boxW,
-          style: "rounded",
-          title: diffFrameTitle(body.filePath, diff),
+        pair.result.setDiffRenderer((width) => {
+          const boxW = Math.max(40, width);
+          const contentW = Math.max(20, boxW - 4);
+          const inner = diff.isNewFile
+            ? renderNewFilePreview(diff, 30)
+            : ((): string[] => {
+                const lines = renderDiff(diff, {
+                  width: contentW, filePath: body.filePath, trueColor: true, maxLines: 30, mode: "unified",
+                });
+                return lines.length > 1 ? ["", ...lines.slice(1), ""] : lines;
+              })();
+          return renderBoxFrame(inner, {
+            width: boxW,
+            style: "rounded",
+            title: diffFrameTitle(body.filePath, diff),
+          });
         });
-        pair.result.setDiff(framed);
       }
     }
     pair.call.setStatus({ exitCode: e.exitCode, elapsedMs: Date.now() - pair.startedAt, summary });

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -45,6 +45,29 @@ import { renderBoxFrame } from "agent-sh/utils/box-frame.js";
 
 interface DiffStats { added: number; removed: number; isNewFile: boolean; isIdentical: boolean }
 
+function buildDiffRenderer(
+  diff: DiffStats & Parameters<typeof renderDiff>[0],
+  filePath: string,
+): (width: number) => string[] {
+  return (width) => {
+    const boxW = Math.max(40, width);
+    const contentW = Math.max(20, boxW - 4);
+    const inner = diff.isNewFile
+      ? renderNewFilePreview(diff, 30)
+      : ((): string[] => {
+          const lines = renderDiff(diff, {
+            width: contentW, filePath, trueColor: true, maxLines: 30, mode: "unified",
+          });
+          return lines.length > 1 ? ["", ...lines.slice(1), ""] : lines;
+        })();
+    return renderBoxFrame(inner, {
+      width: boxW,
+      style: "rounded",
+      title: diffFrameTitle(filePath, diff),
+    });
+  };
+}
+
 function renderNewFilePreview(
   diff: { hunks?: { lines: { type: string; text: string }[] }[] },
   maxLines: number,
@@ -350,6 +373,13 @@ export function mountAshi(
       if (found.kind === "group") {
         found.group.recordCompletion(id, 0, summary);
       } else {
+        const meta = m.meta as { diff?: unknown; filePath?: string } | undefined;
+        if (meta?.diff && typeof meta.filePath === "string") {
+          const diff = meta.diff as DiffStats & Parameters<typeof renderDiff>[0];
+          if (!diff.isIdentical) {
+            found.pair.result.setDiffRenderer(buildDiffRenderer(diff, meta.filePath));
+          }
+        }
         found.pair.result.finalize({ exitCode: 0, summary });
         found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0, summary });
       }
@@ -503,23 +533,7 @@ export function mountAshi(
     if (body?.kind === "diff") {
       const diff = body.diff as DiffStats & Parameters<typeof renderDiff>[0];
       if (!diff.isIdentical) {
-        pair.result.setDiffRenderer((width) => {
-          const boxW = Math.max(40, width);
-          const contentW = Math.max(20, boxW - 4);
-          const inner = diff.isNewFile
-            ? renderNewFilePreview(diff, 30)
-            : ((): string[] => {
-                const lines = renderDiff(diff, {
-                  width: contentW, filePath: body.filePath, trueColor: true, maxLines: 30, mode: "unified",
-                });
-                return lines.length > 1 ? ["", ...lines.slice(1), ""] : lines;
-              })();
-          return renderBoxFrame(inner, {
-            width: boxW,
-            style: "rounded",
-            title: diffFrameTitle(body.filePath, diff),
-          });
-        });
+        pair.result.setDiffRenderer(buildDiffRenderer(diff, body.filePath));
       }
     }
     pair.call.setStatus({ exitCode: e.exitCode, elapsedMs: Date.now() - pair.startedAt, summary });

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -45,6 +45,22 @@ import { renderBoxFrame } from "agent-sh/utils/box-frame.js";
 
 interface DiffStats { added: number; removed: number; isNewFile: boolean; isIdentical: boolean }
 
+function renderNewFilePreview(
+  diff: { hunks?: { lines: { type: string; text: string }[] }[] },
+  maxLines: number,
+): string[] {
+  const lines = diff.hunks?.[0]?.lines.filter((l) => l.type === "added") ?? [];
+  const shown = lines.slice(0, maxLines);
+  const overflow = lines.length - shown.length;
+  const noW = String(shown.length).length || 1;
+  const body = shown.map((l, i) => {
+    const no = String(i + 1).padStart(noW);
+    return `${theme.fg("muted", `${no} │`)} ${l.text}`;
+  });
+  if (overflow > 0) body.push(theme.fg("muted", `… ${overflow} more lines`));
+  return ["", ...body, ""];
+}
+
 function diffFrameTitle(filePath: string, diff: DiffStats): string {
   const stats = diff.isNewFile
     ? theme.fg("success", `+${diff.added}`)
@@ -490,13 +506,14 @@ export function mountAshi(
         const termW = process.stdout.columns ?? 80;
         const boxW = Math.max(40, termW);
         const contentW = Math.max(20, boxW - 4);
-        const diffLines = renderDiff(diff, {
-          width: contentW,
-          filePath: body.filePath,
-          trueColor: false,
-          maxLines: 30,
-        });
-        const inner = diffLines.length > 1 ? ["", ...diffLines.slice(1), ""] : diffLines;
+        const inner = diff.isNewFile
+          ? renderNewFilePreview(diff, 30)
+          : ((): string[] => {
+              const lines = renderDiff(diff, {
+                width: contentW, filePath: body.filePath, trueColor: true, maxLines: 30,
+              });
+              return lines.length > 1 ? ["", ...lines.slice(1), ""] : lines;
+            })();
         const framed = renderBoxFrame(inner, {
           width: boxW,
           style: "rounded",

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -484,7 +484,6 @@ export function mountAshi(
     }
     const pair = entry.pair;
     const body = e.resultDisplay?.body;
-    const ok = e.exitCode === null || e.exitCode === 0;
     if (body?.kind === "diff") {
       const diff = body.diff as DiffStats & Parameters<typeof renderDiff>[0];
       if (!diff.isIdentical) {
@@ -502,7 +501,6 @@ export function mountAshi(
           width: boxW,
           style: "rounded",
           title: diffFrameTitle(body.filePath, diff),
-          bgColor: theme.bgCode(ok ? "toolSuccessBg" : "toolErrorBg"),
         });
         pair.result.setDiff(framed);
       }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -334,7 +334,6 @@ export function mountAshi(
       if (found.kind === "group") {
         found.group.recordCompletion(id, 0, summary);
       } else {
-        if (text) found.pair.result.appendChunk(text);
         found.pair.result.finalize({ exitCode: 0, summary });
         found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0, summary });
       }

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -45,11 +45,13 @@ export interface ToolCallView extends Component {
 }
 
 /** Mutated by ashi as output streams in and when the tool completes.
- *  setDiff is optional behavior — renderers may no-op if they don't show diffs.
- *  toggleExpanded flips the view's internal expansion state (Ctrl+O). */
+ *  setDiffRenderer is optional behavior — renderers may no-op if they don't
+ *  show diffs. The renderer is called on each terminal-width change so diffs
+ *  reflow on resize. toggleExpanded flips the view's internal expansion state
+ *  (Ctrl+O). */
 export interface ToolResultView extends Component {
   appendChunk(chunk: string): void;
-  setDiff(lines: string[]): void;
+  setDiffRenderer(fn: (width: number) => string[]): void;
   finalize(opts: { exitCode: number | null; summary?: string }): void;
   toggleExpanded(): void;
 }

--- a/examples/extensions/ashi/src/session-store.ts
+++ b/examples/extensions/ashi/src/session-store.ts
@@ -14,6 +14,7 @@ export interface AgentMessage {
   tool_calls?: ToolCall[];
   tool_call_id?: string;
   name?: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface SessionHeaderEntry {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1169,14 +1169,15 @@ export class AgentLoop implements AgentBackend {
 
       responseText = await this.executeLoop(signal);
     } catch (e) {
-      if (signal.aborted && signal.reason !== "silent") {
-        this.bus.emit("agent:cancelled", {});
-      } else if (!signal.aborted) {
+      if (!signal.aborted) {
         if (e instanceof Error) console.error("[agent-sh] query failed:\n" + e.stack);
         const msg = this.formatError(e);
         this.bus.emit("agent:error", { message: msg });
       }
     } finally {
+      if (signal.aborted && signal.reason !== "silent") {
+        this.bus.emit("agent:cancelled", {});
+      }
       // Ensure any buffered text in the stream transform pipeline gets
       // flushed as a complete line before response-done closes the box.
       if (responseText && !responseText.endsWith("\n")) {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -134,7 +134,7 @@ export class AgentLoop implements AgentBackend {
   private bus: EventBus;
   private llmClient: LlmClient;
   private handlers: HandlerFunctions;
-  private thinkingLevel = "off";
+  private thinkingLevel: string = getSettings().thinkingLevel ?? "off";
   private compositor: Compositor | null = null;
   private toolProtocol: ToolProtocol;
   private instanceId: string;
@@ -352,6 +352,7 @@ export class AgentLoop implements AgentBackend {
         return;
       }
       this.thinkingLevel = level;
+      updateSettings({ thinkingLevel: level });
       this.bus.emit("config:changed", {});
     });
     onPipe("config:get-thinking", () => {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -160,9 +160,6 @@ function normalizeBin(pkg: PackageJson): Record<string, string> {
 
 function maybeNpmBuild(target: string, pkg: PackageJson): void {
   if (!pkg.scripts?.build) return;
-  const binPaths = Object.values(normalizeBin(pkg)).map((p) => path.join(target, p));
-  if (binPaths.length === 0) return;
-  if (binPaths.every((p) => fs.existsSync(p))) return;
   console.log(`Running npm run build in ${target}...`);
   const result = spawnSync("npm", ["run", "build"], { cwd: target, stdio: "inherit" });
   if (result.status !== 0) {

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -62,6 +62,8 @@ export interface Settings {
   defaultProvider?: string;
   /** Preferred agent backend (extension name, e.g. "pi", "claude-code"). */
   defaultBackend?: string;
+  /** Default thinking/reasoning effort level for new sessions ("off"|"low"|"medium"|"high"). */
+  thinkingLevel?: string;
 
   // ── Shell output spill ────────────────────────────────────
   /** Shell output lines before spill-to-tempfile kicks in. */
@@ -149,6 +151,7 @@ const DEFAULTS: Required<Settings> = {
   providers: {},
   defaultProvider: undefined as unknown as string,
   defaultBackend: "ash",
+  thinkingLevel: undefined as unknown as string,
   toolMode: "api" as "api" | "deferred" | "deferred-lookup" | "inline",
   coreTools: [],
   shellTruncateThreshold: 20,

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -369,14 +369,14 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
       }
 
       if (useTrueColor) {
-        out.push(padToWidth(`${p.errorBg}${p.error}- ${no} │ ${preserveBg(removedText, p.errorBg)}${p.reset}`, textWidth));
+        out.push(padToWidth(`${p.errorBg}${p.error}- ${no} │ ${preserveBg(removedText, p.errorBg)}`, textWidth) + p.reset);
       } else {
         out.push(`${p.error}- ${no} │ ${removedText}${p.reset}`);
       }
 
       if (addedText !== null && addedNo !== null) {
         if (useTrueColor) {
-          out.push(padToWidth(`${p.successBg}${p.success}+ ${addedNo} │ ${preserveBg(addedText, p.successBg)}${p.reset}`, textWidth));
+          out.push(padToWidth(`${p.successBg}${p.success}+ ${addedNo} │ ${preserveBg(addedText, p.successBg)}`, textWidth) + p.reset);
         } else {
           out.push(`${p.success}+ ${addedNo} │ ${addedText}${p.reset}`);
         }
@@ -389,7 +389,7 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
       const raw = truncateText(line.text, lineTextW);
       const text = lang ? highlightLine(raw, lang) : raw;
       if (useTrueColor) {
-        out.push(padToWidth(`${p.successBg}${p.success}+ ${no} │ ${preserveBg(text, p.successBg)}${p.reset}`, textWidth));
+        out.push(padToWidth(`${p.successBg}${p.success}+ ${no} │ ${preserveBg(text, p.successBg)}`, textWidth) + p.reset);
       } else {
         out.push(`${p.success}+ ${no} │ ${text}${p.reset}`);
       }
@@ -477,8 +477,8 @@ function renderSplitHunk(hunk: DiffHunk, layout: SplitLayout): string[] {
     } else if (row.left.type === "removed") {
       if (useTrueColor) {
         leftCol = padToWidth(
-          `${p.errorBg}${p.error}${leftNo} │ ${preserveBg(leftText, p.errorBg)}${p.reset}`, colWidth,
-        );
+          `${p.errorBg}${p.error}${leftNo} │ ${preserveBg(leftText, p.errorBg)}`, colWidth,
+        ) + p.reset;
       } else {
         leftCol = padToWidth(`${p.error}${leftNo} │ ${leftText}${p.reset}`, colWidth);
       }
@@ -491,8 +491,8 @@ function renderSplitHunk(hunk: DiffHunk, layout: SplitLayout): string[] {
     } else if (row.right.type === "added") {
       if (useTrueColor) {
         rightCol = padToWidth(
-          `${p.successBg}${p.success}${rightNo} │ ${preserveBg(rightText, p.successBg)}${p.reset}`, colWidth,
-        );
+          `${p.successBg}${p.success}${rightNo} │ ${preserveBg(rightText, p.successBg)}`, colWidth,
+        ) + p.reset;
       } else {
         rightCol = padToWidth(`${p.success}${rightNo} │ ${rightText}${p.reset}`, colWidth);
       }


### PR DESCRIPTION
## Summary

A loose grouping of polish and fix work that grew out of cleaning up ashi's tool-call rendering. Each commit stands on its own.

**ashi UI**
- Pencil icon prefix on `edit`/`write` tool lines (matches the `◆`/`⌕` group-header style for read/search).
- New files render as a line-numbered preview instead of a side-by-side diff with an empty left column.
- Diff box drops the saturated `toolSuccessBg`/`toolErrorBg` row fill — the call line's ✓/✗ + `+N -M` already convey status.
- `mode: "unified"` forced so the split layout never kicks in.
- Resumed sessions no longer dump the full tool-result text into the result body; the call-line summary suffices, matching live behavior.

**ashi architecture**
- `ToolResultBody` stores a width-aware renderer instead of pre-baked diff lines, so the diff box reflows on terminal resize like every other pi-tui component.
- Diff metadata (`diff` + `filePath`) is now persisted as `meta` on saved tool messages, so resumed sessions re-render the diff box. (Pre-existing session logs lack meta and degrade gracefully to the bare call line.)

**Kernel**
- `Extend diff row background fill to full column width` — `padToWidth` was appending plain spaces after the trailing reset, so the row tint cut off at the text end. Same fix benefits the ash shell.
- `Persist thinking level across sessions` — `config:set-thinking` now writes through `updateSettings`, mirroring the `/model` pattern. Each running session stays independent; only fresh boots inherit.
- `Emit agent:cancelled in finally instead of catch` — `executeLoop` can exit normally on abort (inter-iteration / inter-chunk checks return rather than throw), so the cancelled signal sometimes never fired.
- `install: always run npm build when package defines one` — the bin-exists short-circuit skipped `npm run build` on reinstall when a stale `dist/` had been copied from source, masking local-dev changes.

## Test plan
- [x] Rebuild ashi (`agent-sh install --force ashi` or `npm run build` in the install dir).
- [x] Resize the terminal during a session — diff boxes should redraw rather than fragmenting at the old width.
- [x] `write_file` a new file → expect a clean line-numbered preview.
- [x] `edit_file` an existing file → expect unified diff with row backgrounds extending to the right edge.
- [x] Shift-tab through thinking levels, restart ashi, confirm the level was preserved.
- [x] Start a fresh session that touches edit/write tools, resume it, verify the diff box re-renders.
- [x] `agent-sh install --force <bundled-extension>` triggers a rebuild even when dist already exists.