### PR TITLE
Add xhigh thinking level for DeepSeek max tier

### DIFF
--- a/examples/extensions/ollama-cloud.ts
+++ b/examples/extensions/ollama-cloud.ts
@@ -12,7 +12,8 @@ const BASE_URL = `${HOST}/v1`;
 const ID = "ollama-cloud";
 
 function buildReasoningParams(level: string, _model?: string): Record<string, unknown> {
-  return { reasoning_effort: level === "off" ? "none" : level };
+  if (level === "off") return { reasoning_effort: "none" };
+  return { reasoning_effort: level === "xhigh" ? "high" : level };
 }
 
 async function fetchModels(apiKey: string) {

--- a/examples/extensions/ollama.ts
+++ b/examples/extensions/ollama.ts
@@ -38,7 +38,10 @@ export default function activate(ctx: ExtensionContext): void {
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 
   ctx.agent.providers.configure(id, {
-    reasoningParams: (level) => ({ reasoning_effort: level === "off" ? "none" : level }),
+    reasoningParams: (level) => {
+      if (level === "off") return { reasoning_effort: "none" };
+      return { reasoning_effort: level === "xhigh" ? "high" : level };
+    },
   });
 
   ctx.bus.emit("provider:register", { id, apiKey: sdkKey, baseURL, models: [] });

--- a/examples/extensions/zai-coding-plan.ts
+++ b/examples/extensions/zai-coding-plan.ts
@@ -19,7 +19,8 @@ const DEFAULT_MODELS = [
 
 function buildReasoningParams(level: string, _model?: string): Record<string, unknown> {
   if (level === "off") return { thinking: { type: "disabled" } };
-  return { thinking: { type: "enabled" }, reasoning_effort: level };
+  const effort = level === "xhigh" ? "high" : level;
+  return { thinking: { type: "enabled" }, reasoning_effort: effort };
 }
 
 export default function activate(ctx: AgentContext): void {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -129,7 +129,7 @@ export class AgentLoop implements AgentBackend {
   private lastErrorByTool = new Map<string, string>(); // tool → error summary
   private lastErrorByFile = new Map<string, string>(); // file path → error summary
 
-  private static readonly THINKING_LEVELS = ["off", "low", "medium", "high"];
+  private static readonly THINKING_LEVELS = ["off", "low", "medium", "high", "xhigh"];
 
   private bus: EventBus;
   private llmClient: LlmClient;
@@ -593,7 +593,8 @@ export class AgentLoop implements AgentBackend {
     if (mode.supportsReasoningEffort === false) return {};
     if (mode.buildReasoningParams) return mode.buildReasoningParams(this.thinkingLevel);
     if (this.thinkingLevel === "off") return {};
-    return { reasoning_effort: this.thinkingLevel };
+    const effort = this.thinkingLevel === "xhigh" ? "high" : this.thinkingLevel;
+    return { reasoning_effort: effort };
   }
 
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -31,7 +31,8 @@ function persistedModelFor(providerName: string | undefined): string | undefined
 type ModelCap = { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean };
 
 function defaultReasoningBuilder(level: string): Record<string, unknown> {
-  return level === "off" ? {} : { reasoning_effort: level };
+  if (level === "off") return {};
+  return { reasoning_effort: level === "xhigh" ? "high" : level };
 }
 
 function mergeCaps(
@@ -141,11 +142,12 @@ export default function agentBackend(ctx: ExtensionContext): void {
   ctx.define("llm:get-client", () => llmClient);
   ctx.define("llm:invoke", (messages: { role: string; content: string }[], opts?: { maxTokens?: number; model?: string; reasoningEffort?: string }) => {
     const effort = opts?.reasoningEffort;
+    const clampedEffort = effort === "xhigh" ? "high" : effort;
     return llmClient.complete({
       messages: messages as Parameters<typeof llmClient.complete>[0]["messages"],
       max_tokens: opts?.maxTokens,
       model: opts?.model,
-      ...(effort && effort !== "off" ? { reasoning_effort: effort } : {}),
+      ...(clampedEffort && clampedEffort !== "off" ? { reasoning_effort: clampedEffort } : {}),
     });
   });
 

--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -2,6 +2,8 @@
  * Cloud OpenAI (api.openai.com). reasoning_effort vocabulary diverges per
  * family: o-series has no off; gpt-5-codex floors at "low"; plain gpt-5
  * floors at "minimal"; gpt-5.1+ accepts "none" as documented full off.
+ * Top tier: only gpt-5.1-codex-max and gpt-5.[4-9]+ accept "xhigh"; others
+ * clamp to "high".
  */
 import type { AgentContext } from "../host-types.js";
 import { resolveApiKey } from "../../cli/auth/keys.js";
@@ -23,8 +25,16 @@ function offEffortFor(model: string): string | null {
   return null;
 }
 
+function supportsXhigh(model: string): boolean {
+  if (model.startsWith("gpt-5.1-codex-max")) return true;
+  return /^gpt-5\.[4-9]/.test(model);
+}
+
 function buildReasoningParams(level: string, model?: string): Record<string, unknown> {
-  if (level !== "off") return { reasoning_effort: level };
+  if (level !== "off") {
+    const effort = level === "xhigh" && !(model && supportsXhigh(model)) ? "high" : level;
+    return { reasoning_effort: effort };
+  }
   const off = model ? offEffortFor(model) : null;
   return off ? { reasoning_effort: off } : {};
 }


### PR DESCRIPTION
## Summary
- `THINKING_LEVELS` now includes `xhigh`, so `/thinking xhigh` is selectable.
- Native DeepSeek passes `xhigh` through — DeepSeek docs alias it to the `max` effort tier (otherwise unreachable from agent-sh).
- OpenAI built-in gates `xhigh` to families that actually accept it (`gpt-5.1-codex-max`, `gpt-5.[4-9]+`); older models clamp to `high`.
- OpenRouter passes `xhigh` through — OpenRouter docs say it maps the requested effort to the model's nearest supported level.
- Default fallback (`agent-loop.ts` `reasoningParams()`, `index.ts` `defaultReasoningBuilder`, `llm:invoke`) clamps `xhigh -> high` so providers without an explicit hook stay safe.
- Example provider extensions (`zai-coding-plan`, `ollama`, `ollama-cloud`) clamp `xhigh -> high` — their vocab tops at `high`.

## Background
DeepSeek's documented effort vocabulary is effectively `{high, max}` (with `low`/`medium` aliased to `high`, `xhigh` aliased to `max`). With levels capped at `high`, `/thinking high` could never reach DeepSeek's top tier — only a server-side classifier bump (per footnote 2 of the DeepSeek docs) would. Adding `xhigh` to the universal set lets users explicitly request that tier.

The same level also unlocks OpenAI's xhigh tier on `gpt-5.1-codex-max`, `gpt-5.4`, and `gpt-5.5` when those models are configured.

## Test plan
- [ ] `/thinking` autocomplete shows `xhigh`
- [ ] `/thinking xhigh` accepted; `config:get-thinking` returns `xhigh`
- [ ] Native DeepSeek request includes `reasoning_effort: "xhigh"` in the payload
- [ ] OpenAI request on `gpt-5` (or `o3`) sends `reasoning_effort: "high"` (clamped)
- [ ] OpenAI request on `gpt-5.4`/`gpt-5.1-codex-max` (if configured) sends `reasoning_effort: "xhigh"`
- [ ] OpenRouter request sends `reasoning: { effort: "xhigh" }` (server-side clamp does the rest)
- [ ] `/thinking off` still disables on DeepSeek (known silent no-op on thinking-native models — pre-existing)