### PR TITLE
Handle mid-stream cancel cleanly in the agent loop

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1259,12 +1259,15 @@ export class AgentLoop implements AgentBackend {
 
       fullResponseText += text;
 
-      // Record the assistant message via protocol
-      this.toolProtocol.recordAssistant(this.conversation, text, toolCalls, extras);
-      this.bus.emit("conversation:message-appended", {
-        role: "assistant",
-        content: text,
-      });
+      if (text || toolCalls.length > 0) {
+        this.toolProtocol.recordAssistant(this.conversation, text, toolCalls, extras);
+        this.bus.emit("conversation:message-appended", {
+          role: "assistant",
+          content: text,
+        });
+      }
+
+      if (signal.aborted) break;
 
       // No tool calls → agent is done
       if (toolCalls.length === 0) {
@@ -1716,6 +1719,7 @@ export class AgentLoop implements AgentBackend {
 
     const stream = await this.llmClient.stream({ ...requestParams, signal });
 
+    try {
     for await (const chunk of stream) {
       if (signal.aborted) break;
       this.bus.emit("llm:chunk", { chunk });
@@ -1794,6 +1798,10 @@ export class AgentLoop implements AgentBackend {
           }
         }
       }
+    }
+    } catch (e) {
+      // On abort, fall through with whatever was accumulated so far.
+      if (!signal.aborted) throw e;
     }
 
     // Flush any buffered content from the stream filter


### PR DESCRIPTION
## Summary
Three rough edges hit when the user cancels during a streaming turn:

1. **`AbortError` bubbled out of the streaming loop.** The OpenAI SDK's async iterator throws once the abort controller fires; that exception was uncaught. Wrap the `for await` in a try/catch that re-throws only when `!signal.aborted`, so genuine errors still propagate but cancel-driven aborts fall through to the post-stream cleanup (filter flush, etc.) with whatever content streamed in before the cancel.

2. **Tools executed after cancel.** The inner stream `for await` already exits on `signal.aborted`, but control fell through to `recordAssistant(...)` and then into the next outer iteration — which executes any tool calls the model emitted before the cancel landed. Add `if (signal.aborted) break;` after the record so the loop exits instead of issuing tool calls the user explicitly cancelled.

3. **Empty assistant turn recorded.** If the stream aborted before any chunk arrived, `recordAssistant(...)` was still called with empty content and no tool calls, leaving a blank assistant entry in history. Guard the append behind `text || toolCalls.length > 0`.

## Test plan
- [ ] Start a long-running turn, press cancel mid-stream — no `AbortError` surfaces; partial content is preserved.
- [ ] Cancel during a turn where the model has started emitting a tool call — the tool does **not** execute after cancel.
- [ ] Cancel before any chunk arrives — no empty assistant entry appears in history.
- [ ] Genuine stream errors (network failure, 5xx, etc.) still propagate normally.