### PR TITLE
Fix LlmClient race when a stub mode is replaced via config:add-modes

### DIFF
--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -446,10 +446,13 @@ function getModelsPayload(): Record<string, unknown> | undefined {
   if (!core) return undefined;
   const info = core.bus.emitPipe("config:get-models", { models: [], active: null });
   if (!info.models.length) return undefined;
+  const idFor = (m: { model: string; provider: string }) =>
+    m.provider ? `${m.model}@${m.provider}` : m.model;
+  const current = info.active ?? info.models[0]!;
   return {
-    currentModelId: info.active?.model ?? info.models[0]?.model,
+    currentModelId: idFor(current),
     availableModels: info.models.map((m) => ({
-      modelId: m.model,
+      modelId: idFor(m),
       name: m.provider ? `${m.provider}/${m.model}` : m.model,
       description: m.provider ? `Provider: ${m.provider}` : "",
     })),

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -222,7 +222,13 @@ export class AgentLoop implements AgentBackend {
         const newIdx = this.modes.findIndex(
           (m) => m.model === prev.model && m.provider === prev.provider,
         );
-        if (newIdx !== -1) this.currentModeIndex = newIdx;
+        if (newIdx !== -1) {
+          this.currentModeIndex = newIdx;
+          const next = this.modes[newIdx]!;
+          if (next.providerConfig && next.providerConfig !== prev.providerConfig) {
+            this.llmClient.reconfigure({ ...next.providerConfig, model: next.model });
+          }
+        }
       }
       if (activePreserved && prev) {
         this.bus.emit("ui:info", {


### PR DESCRIPTION
## Summary

When the active provider's catalog hasn't returned by `core:extensions-loaded`, agentBackend prepends a *stub* mode whose `providerConfig.apiKey` comes from `effectiveApiKey`. If `config.apiKey` was set (e.g. an env var that doesn't match the user's `defaultProvider`), the stub carries the wrong credential.

When the provider's real catalog arrives later, `config:add-modes` fires. The agent-loop handler drops the stub, inserts the real entries, and slides `currentModeIndex` to the new matching mode — but never re-reconfigured the `LlmClient`. The stale stub credential lived on the wire and 401'd the first request.

The existing late-registration reconcile path in agentBackend doesn't catch this because of its `llmClient.model !== pendingModel` guard, which is true exactly when the user has the model persisted in settings (the common case).

This fix re-reconfigures the LlmClient whenever the active mode's `providerConfig` changes during a `config:add-modes` update.

Concrete repro: env has `OPENROUTER_API_KEY` set, `settings.defaultProvider = "ollama-cloud"`, `ollama-cloud` catalog fetch happens to return after `core:extensions-loaded`. Result: the OpenRouter key is sent to `ollama.com/v1/chat/completions`, which returns 401. Hit rate depends on network/scheduling, so the bug hides intermittently.

## Test plan

- [ ] Run with `OPENROUTER_API_KEY` exported + `defaultProvider: ollama-cloud` + ollama-cloud configured in `keys.json` — confirm no 401 on first turn.
- [ ] Verify `/model deepseek-v4-pro@ollama-cloud` still works (the existing config:switch-model path is unchanged).
- [ ] Verify subsequent turns work after a catalog refresh.