### PR TITLE
Consolidate agent:info emits in agent-loop

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -99,6 +99,7 @@ export class AgentLoop implements AgentBackend {
   private ctorListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
   private ctorPipeListeners: Array<{ event: string; fn: (...args: any[]) => any }> = [];
   private lastProjectSkillNames = new Set<string>();
+  private lastAgentInfo: { model?: string; provider?: string; contextWindow?: number } | null = null;
 
   // ── Session telemetry — behavioral self-awareness ──────────────
   // Every ash deserves to know what it's been doing. This tracks the
@@ -235,16 +236,7 @@ export class AgentLoop implements AgentBackend {
           message: `${prev.provider}:${prev.model} is not in the refreshed catalog — keeping it active until you /model to another.`,
         });
       }
-      const active = this.modes[this.currentModeIndex];
-      if (active && active.contextWindow !== prev?.contextWindow) {
-        this.bus.emit("agent:info", {
-          name: "ash",
-          version: PACKAGE_VERSION,
-          model: active.model,
-          provider: active.provider,
-          contextWindow: active.contextWindow,
-        });
-      }
+      this.emitAgentInfoIfChanged();
       this.bus.emit("config:changed", {});
     });
     // Fires before wire() too — agent-backend emits this from
@@ -260,6 +252,7 @@ export class AgentLoop implements AgentBackend {
       } else {
         this.llmClient.model = m.model;
       }
+      this.emitAgentInfoIfChanged();
       this.bus.emit("config:changed", {});
     });
     const getToolsPipe = () => ({ tools: this.getTools() });
@@ -320,7 +313,7 @@ export class AgentLoop implements AgentBackend {
         this.llmClient.model = m.model;
       }
       const label = m.provider ? `${m.provider}: ${m.model}` : m.model;
-      this.bus.emit("agent:info", { name: "ash", version: PACKAGE_VERSION, model: m.model, provider: m.provider, contextWindow: m.contextWindow });
+      this.emitAgentInfoIfChanged();
 
       // Persist as the new default — selection survives restart.
       // Safe even for dynamic providers: agent-backend defers mode
@@ -606,6 +599,23 @@ export class AgentLoop implements AgentBackend {
 
   private get currentMode(): AgentMode {
     return this.modes[this.currentModeIndex];
+  }
+
+  private emitAgentInfoIfChanged(): void {
+    const m = this.modes[this.currentModeIndex];
+    if (!m) return;
+    const prev = this.lastAgentInfo;
+    if (prev && prev.model === m.model && prev.provider === m.provider && prev.contextWindow === m.contextWindow) {
+      return;
+    }
+    this.lastAgentInfo = { model: m.model, provider: m.provider, contextWindow: m.contextWindow };
+    this.bus.emit("agent:info", {
+      name: "ash",
+      version: PACKAGE_VERSION,
+      model: m.model,
+      provider: m.provider,
+      contextWindow: m.contextWindow,
+    });
   }
 
   private get currentModel(): string {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -15,7 +15,6 @@ import { AgentLoop } from "./agent-loop.js";
 import { LlmClient } from "../utils/llm-client.js";
 import { createLlmFacade } from "../utils/llm-facade.js";
 import { resolveProvider, getProviderNames, getSettings, type ResolvedProvider } from "../core/settings.js";
-import { PACKAGE_VERSION } from "../utils/package-version.js";
 import { discoverSkills } from "./skills.js";
 import { resolveApiKey } from "../cli/auth/keys.js";
 import activateOpenrouter from "./providers/openrouter.js";
@@ -259,13 +258,6 @@ export default function agentBackend(ctx: ExtensionContext): void {
             });
           },
         });
-        bus.emit("agent:info", {
-          name: "ash",
-          version: PACKAGE_VERSION,
-          model: llmClient.model,
-          provider: modes[initialModeIndex]?.provider,
-          contextWindow: modes[initialModeIndex]?.contextWindow,
-        });
       },
     });
   });
@@ -366,10 +358,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
       };
     });
     bus.emit("config:set-modes", { modes: newModes });
-
-    bus.emit("agent:info", { name: "ash", version: PACKAGE_VERSION, model: switchModel, provider: name, contextWindow: p.contextWindow });
     bus.emit("ui:info", { message: `Switched to ${name} (${switchModel})` });
-    bus.emit("config:changed", {});
   });
 
   bus.onPipe("banner:collect", (e) => {


### PR DESCRIPTION
## Summary

- Fixes a race where `agent:info` was emitted from two sites within the ash backend with divergent views of "current mode", causing the tui-renderer's context-window display to clobber to the 60k default fallback (manifesting as `ctx: X/60k` regardless of the real model).
- Makes `AgentLoop` the sole `agent:info` emitter for the ash backend via a single `emitAgentInfoIfChanged()` helper that de-dupes by `(model, provider, contextWindow)`.
- Bridges (pi, claude-code, opencode) already own their own single emit, so the "one emitter per backend" rule is now uniform across backends.

## Root cause

`agent/index.ts`'s `start()` callback emitted `agent:info` reading `modes[initialModeIndex]?.contextWindow` from agent-backend's local `modes` array — a snapshot built at `core:extensions-loaded` time and never refreshed. Async catalog fetches (ollama, openrouter) update `agent-loop`'s `this.modes` later via `config:add-modes` events, leaving the snapshot stale. The CLI's 100ms `setTimeout` between `core:extensions-loaded` and `core.activateBackend()` reliably arranges for the catalog to arrive before `start()`, so `start()`'s stale emit clobbered the agent-loop's correct emit.

Introduced 2026-04-29 by `4eadd52` ("re-emit agent:info when add-modes refreshes active contextWindow"). That commit correctly fixed the opposite problem (openrouter catalog updates not reaching the UI) but created a second emitter that races with `start()`. Latent until then.

ashi happened to escape the bug because it has no 100ms delay before `activateBackend`, so its `start()` typically ran *before* the catalog landed and the agent-loop's later emit naturally won.

## Changes

- `src/agent/agent-loop.ts`: add `emitAgentInfoIfChanged()` and route the three internal emit sites (`config:set-modes`, `config:add-modes`, `config:switch-model`) through it.
- `src/agent/index.ts`: remove the `agent:info` emit from `start()` and from `config:switch-provider` (both redundant now — `config:set-modes` flows through agent-loop).

## Test plan

- [x] Verified before/after via a one-off bus tracer extension that subscribes to `agent:info`, `provider:register`, `config:add-modes`, `config:set-modes` and appends to `~/.agent-sh/ctx-trace.jsonl` with stack traces. Before: two `agent:info` emits, second one clobbers with `contextWindow: undefined`. After: one or two emits, all via `emitAgentInfoIfChanged`, final value is the model's real `contextWindow`.
- [x] `agent-sh` and `ashi` produce identical trace shapes against the same provider (`ollama-cloud` / `deepseek-v4-pro`).
- [x] `npm run build` clean.