### PR TITLE
ashi: queue user input during processing

### DIFF
--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -175,6 +175,7 @@ export function mountAshi(
 
   const chat = new Container();
   const footerSlot = new Container();
+  const queueSlot = new Container();
   const editor = new Editor(tui, editorTheme(), { paddingX: 1 });
   editor.setAutocompleteProvider(new BusAutocompleteProvider(bus));
   editor.onSubmit = (text) => {
@@ -186,6 +187,12 @@ export function mountAshi(
       const name = sp === -1 ? query : query.slice(0, sp);
       const args = sp === -1 ? "" : query.slice(sp + 1).trim();
       bus.emit("command:execute", { name, args });
+      return;
+    }
+    if (processing) {
+      queuedQueries.push(query);
+      renderQueueSlot();
+      tui.requestRender();
       return;
     }
     bus.emit("agent:submit", { query });
@@ -211,6 +218,7 @@ export function mountAshi(
 
   tui.addChild(chat);
   tui.addChild(footerSlot);
+  tui.addChild(queueSlot);
   tui.addChild(editor);
   tui.addChild(statusFooter);
   tui.setFocus(editor);
@@ -227,6 +235,16 @@ export function mountAshi(
   let lastToolResult: ToolResultView | null = null;
   let loader: Loader | null = null;
   let processing = false;
+  const queuedQueries: string[] = [];
+
+  const renderQueueSlot = (): void => {
+    queueSlot.clear();
+    for (const q of queuedQueries) {
+      const oneLine = q.replace(/\s+/g, " ");
+      const preview = oneLine.length > 80 ? oneLine.slice(0, 77) + "…" : oneLine;
+      queueSlot.addChild(new InfoLine(`↳ queued: ${preview}`));
+    }
+  };
   let hideThinking = true;
 
   const renderState = (): { state: Record<string, unknown>; invalidate: () => void } => ({
@@ -552,6 +570,11 @@ export function mountAshi(
     chat.addChild(new Spacer(1));
     refreshFooterStats();
     refreshBranch();
+    const next = queuedQueries.shift();
+    if (next !== undefined) {
+      renderQueueSlot();
+      bus.emit("agent:submit", { query: next });
+    }
     tui.requestRender();
   });
 
@@ -709,6 +732,13 @@ export function mountAshi(
     if (isKeyRelease(data) || isKeyRepeat(data)) return;
     if (matchesKey(data, "escape") && processing) {
       bus.emit("agent:cancel-request", {});
+      return { consume: true };
+    }
+    if (matchesKey(data, "up") && queuedQueries.length > 0 && editor.getText().length === 0) {
+      const last = queuedQueries.pop()!;
+      renderQueueSlot();
+      editor.setText(last);
+      tui.requestRender();
       return { consume: true };
     }
     if (matchesKey(data, "ctrl+c")) {


### PR DESCRIPTION
## Summary
- Submitting a message while the agent is mid-turn now queues it instead of preempting. The new message no longer cancels the in-flight turn, and the stale \`(cancelled)\` marker that used to land below the new user line is gone.
- Queued messages appear in a new sticky \`queueSlot\` between the loader and the editor, rendered as muted \`↳ queued: <preview>\` lines.
- Drain on \`agent:processing-done\` — which fires after both natural completion and Escape-cancel — so "queue then Escape to pick up" works for free.
- Up arrow on an empty composer pops the most recently queued message back for editing. Clear the editor and press Up again to step through older entries; not pressing Enter discards it.
- Slash commands still pass through immediately.

## Test plan
- [ ] Submit a long-running prompt, type a follow-up mid-turn and press Enter — confirm \`↳ queued: …\` appears above the input and the active turn keeps streaming.
- [ ] Let the first turn finish — queued message starts on its own.
- [ ] Submit, queue, Escape mid-turn — queued message picks up after the cancel marker.
- [ ] Queue three messages, verify FIFO drain order.
- [ ] On empty editor, press Up — most recent queued message pops into the editor; clear and Up again pops the next.
- [ ] Up with a non-empty editor or empty queue still moves the cursor as before.