### PR TITLE
Skip provider check when launching a non-ash backend

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -206,7 +206,8 @@ async function main(): Promise<void> {
     // Ignore errors, we already have process.env as fallback
   }
 
-  if (!config.apiKey && !config.provider && !anyProviderConfigured()) {
+  const selectedBackend = config.backend ?? getSettings().defaultBackend ?? "ash";
+  if (selectedBackend === "ash" && !config.apiKey && !config.provider && !anyProviderConfigured()) {
     console.error(
       "\nagent-sh: no LLM provider configured.\n\n" +
       "  Run `agent-sh auth login` to store an API key, or\n" +


### PR DESCRIPTION
## Summary
- The first-run "no LLM provider configured" hint introduced in 5470a48 (shipped in v0.13.0) fires unconditionally, so `agent-sh --backend pi` exits before extension load even though bridge backends own their own auth and don't need an agent-sh provider.
- Gate the check on the selected backend (`--backend` flag → `settings.defaultBackend` → `"ash"`). Bridge backends boot freely; ash users keep the original hint.

Fixes #178.

## Test plan
- [x] With all of `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `DEEPSEEK_API_KEY` / `OPENAI_BASE_URL` unset and no `~/.agent-sh/keys.json`: `agent-sh --backend pi` reaches the post-gate path (boots pi or prints the proper "backend not available" error) instead of exiting at the provider gate.
- [x] Regression: bare `agent-sh` (or any invocation that lands on ash) still prints `no LLM provider configured` when nothing is configured.
- [x] `npx tsc --noEmit` clean.