### PR TITLE
Bridge protocol tests via module-level SDK stubbing, plus opencode/claude-code smoke

### DIFF
--- a/tests/bridges/claude-code-bridge.test.ts
+++ b/tests/bridges/claude-code-bridge.test.ts
@@ -1,0 +1,256 @@
+import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+import * as path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createCore } from "../../src/core/index.js";
+import type { AppConfig } from "../../src/shell/host-types.js";
+
+register(new URL("../fixtures/claude-sdk-mock-loader.mjs", import.meta.url));
+
+const stubModule = await import(
+  new URL("../fixtures/claude-sdk-stub.mjs", import.meta.url).href
+) as {
+  __reset(): void;
+  __queryCalls(): Array<{ prompt: string; options: Record<string, unknown> }>;
+  __pushMessage(msg: unknown): void;
+  __endQuery(): void;
+  __wasInterrupted(): boolean;
+};
+
+const BRIDGE_URL = pathToFileURL(path.resolve("examples/extensions/claude-code-bridge/index.ts")).href;
+
+interface LoadedBridge {
+  core: ReturnType<typeof createCore>;
+  bus: ReturnType<typeof createCore>["bus"];
+}
+
+const microtask = () => new Promise<void>((r) => setImmediate(r));
+async function flush(n = 8): Promise<void> {
+  for (let i = 0; i < n; i++) await microtask();
+}
+
+async function loadBridge(): Promise<LoadedBridge> {
+  stubModule.__reset();
+  const core = createCore({} as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  const activate = (mod.default ?? mod.activate) as (c: typeof ctx) => void;
+  activate(ctx);
+  await core.activateBackend("claude-code");
+  return { core, bus: core.bus };
+}
+
+function collect<T>(bus: LoadedBridge["bus"], event: string): T[] {
+  const buf: T[] = [];
+  bus.on(event as any, (e: T) => buf.push(e));
+  return buf;
+}
+
+test("claude-code-bridge registers backend 'claude-code' after activate", async () => {
+  const { bus } = await loadBridge();
+  const { names, active } = bus.emitPipe("config:get-backends", { names: [] as string[], active: null });
+  assert.ok(names.includes("claude-code"), `expected backend "claude-code" in ${names.join(", ")}`);
+  assert.equal(active, "claude-code");
+});
+
+test("claude-code-bridge emits agent:info after boot", async () => {
+  const infos: Array<{ name: string; version?: string }> = [];
+  const core = createCore({} as AppConfig);
+  core.bus.on("agent:info", (info) => { infos.push(info); });
+  const ctx = core.extensionContext({ quit: () => {} });
+  stubModule.__reset();
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  (mod.default ?? mod.activate)(ctx);
+  await core.activateBackend("claude-code");
+
+  assert.equal(infos.length, 1);
+  assert.equal(infos[0]!.name, "claude-code");
+  assert.equal(infos[0]!.version, "1.0");
+});
+
+test("agent:submit calls query() with the user prompt and standard options", async () => {
+  const { bus } = await loadBridge();
+  bus.emit("agent:submit", { query: "do the thing" });
+  await flush();
+
+  const calls = stubModule.__queryCalls();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.prompt, "do the thing");
+  const opts = calls[0]!.options as { allowedTools: string[]; permissionMode: string; includePartialMessages: boolean };
+  assert.deepEqual(opts.allowedTools, ["Read", "Edit", "Write", "Bash", "Glob", "Grep"]);
+  assert.equal(opts.permissionMode, "acceptEdits");
+  assert.equal(opts.includePartialMessages, true);
+});
+
+test("text_delta stream events flow to agent:response-chunk", async () => {
+  const { bus } = await loadBridge();
+  const chunks = collect<{ blocks: Array<{ type: string; text: string }> }>(bus, "agent:response-chunk");
+
+  bus.emit("agent:submit", { query: "hello" });
+  await flush();
+
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "hello" },
+    },
+  });
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: " world" },
+    },
+  });
+  stubModule.__endQuery();
+  await flush();
+
+  const text = chunks.flatMap((c) => c.blocks.map((b) => b.text)).join("");
+  assert.equal(text, "hello world");
+});
+
+test("thinking_delta stream events flow to agent:thinking-chunk", async () => {
+  const { bus } = await loadBridge();
+  const thinks = collect<{ text: string }>(bus, "agent:thinking-chunk");
+
+  bus.emit("agent:submit", { query: "ponder" });
+  await flush();
+
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "considering" },
+    },
+  });
+  stubModule.__endQuery();
+  await flush();
+
+  assert.deepEqual(thinks.map((t) => t.text), ["considering"]);
+});
+
+test("tool_use streamed via content_block_* events flows to agent:tool-started", async () => {
+  const { bus } = await loadBridge();
+  const started = collect<{ title: string; toolCallId: string; kind: string }>(bus, "agent:tool-started");
+
+  bus.emit("agent:submit", { query: "list files" });
+  await flush();
+
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "tool-1", name: "Bash" },
+    },
+  });
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: "{\"command\":\"ls\"}" },
+    },
+  });
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: { type: "content_block_stop", index: 0 },
+  });
+  stubModule.__endQuery();
+  await flush();
+
+  assert.equal(started.length, 1);
+  assert.equal(started[0]!.title, "Bash");
+  assert.equal(started[0]!.toolCallId, "tool-1");
+  assert.equal(started[0]!.kind, "execute");
+});
+
+test("tool_result user message flows to agent:tool-completed", async () => {
+  const { bus } = await loadBridge();
+  const completed = collect<{ toolCallId: string; exitCode: number }>(bus, "agent:tool-completed");
+
+  bus.emit("agent:submit", { query: "run ls" });
+  await flush();
+
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "tool-1", name: "Bash" },
+    },
+  });
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: "{\"command\":\"ls\"}" },
+    },
+  });
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: { type: "content_block_stop", index: 0 },
+  });
+  stubModule.__pushMessage({
+    type: "user",
+    message: {
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          is_error: false,
+          content: "file1.txt\nfile2.txt\n",
+        },
+      ],
+    },
+  });
+  stubModule.__endQuery();
+  await flush();
+
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0]!.toolCallId, "tool-1");
+  assert.equal(completed[0]!.exitCode, 0);
+});
+
+test("agent:cancel-request calls .interrupt() on the active query", async () => {
+  const { bus } = await loadBridge();
+  bus.emit("agent:submit", { query: "long task" });
+  await flush();
+  assert.equal(stubModule.__wasInterrupted(), false);
+
+  bus.emit("agent:cancel-request" as any, {});
+  await flush();
+
+  assert.equal(stubModule.__wasInterrupted(), true);
+});
+
+test("iterator end fires agent:response-done with accumulated text", async () => {
+  const { bus } = await loadBridge();
+  const dones = collect<{ response: string }>(bus, "agent:response-done");
+  const procDones = collect<unknown>(bus, "agent:processing-done");
+
+  bus.emit("agent:submit", { query: "say hi" });
+  await flush();
+
+  stubModule.__pushMessage({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "hi there" },
+    },
+  });
+  stubModule.__endQuery();
+  await flush();
+
+  assert.equal(dones.length, 1);
+  assert.equal(dones[0]!.response, "hi there");
+  assert.equal(procDones.length, 1);
+});

--- a/tests/bridges/opencode-bridge.test.ts
+++ b/tests/bridges/opencode-bridge.test.ts
@@ -1,0 +1,209 @@
+import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+import * as path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createCore } from "../../src/core/index.js";
+import type { AppConfig } from "../../src/shell/host-types.js";
+
+register(new URL("../fixtures/opencode-sdk-mock-loader.mjs", import.meta.url));
+
+const stubModule = await import(
+  new URL("../fixtures/opencode-sdk-stub.mjs", import.meta.url).href
+) as {
+  __reset(): void;
+  __emitEvent(event: unknown): void;
+  __sessionId(): string;
+  __promptCalls(): Array<{ sessionID: string; directory: string; parts: unknown[] }>;
+  __abortCalls(): Array<{ sessionID: string; directory: string }>;
+  __permissionReplies(): Array<{ requestID: string; reply: string }>;
+};
+
+const BRIDGE_URL = pathToFileURL(path.resolve("examples/extensions/opencode-bridge/index.ts")).href;
+
+interface LoadedBridge {
+  core: ReturnType<typeof createCore>;
+  bus: ReturnType<typeof createCore>["bus"];
+}
+
+async function loadBridge(): Promise<LoadedBridge> {
+  stubModule.__reset();
+  const core = createCore({} as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  (ctx as { shell?: unknown }).shell = {
+    compositor: { surface: () => null },
+  };
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  const activate = (mod.default ?? mod.activate) as (c: typeof ctx) => void;
+  activate(ctx);
+  await core.activateBackend("opencode");
+  // consumeEvents is void inside start(); flush so the for-await registers.
+  await flush();
+  return { core, bus: core.bus };
+}
+
+function collect<T>(bus: LoadedBridge["bus"], event: string): T[] {
+  const buf: T[] = [];
+  bus.on(event as any, (e: T) => buf.push(e));
+  return buf;
+}
+
+const microtask = () => new Promise<void>((r) => setImmediate(r));
+
+async function flush(n = 8): Promise<void> {
+  for (let i = 0; i < n; i++) await microtask();
+}
+
+test("opencode-bridge registers backend 'opencode' after activate", async () => {
+  const { bus } = await loadBridge();
+  const { names, active } = bus.emitPipe("config:get-backends", { names: [] as string[], active: null });
+  assert.ok(names.includes("opencode"), `expected backend "opencode" in ${names.join(", ")}`);
+  assert.equal(active, "opencode");
+});
+
+test("opencode-bridge emits agent:info after boot", async () => {
+  const infos: Array<{ name: string; version?: string }> = [];
+  const core = createCore({} as AppConfig);
+  core.bus.on("agent:info", (info) => { infos.push(info); });
+  const ctx = core.extensionContext({ quit: () => {} });
+  (ctx as { shell?: unknown }).shell = { compositor: { surface: () => null } };
+  stubModule.__reset();
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  (mod.default ?? mod.activate)(ctx);
+  await core.activateBackend("opencode");
+
+  assert.equal(infos.length, 1);
+  assert.equal(infos[0]!.name, "opencode");
+});
+
+test("agent:submit forwards the query to client.session.prompt", async () => {
+  const { bus } = await loadBridge();
+  bus.emit("agent:submit", { query: "hello opencode" });
+  await flush();
+
+  const calls = stubModule.__promptCalls();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionID, stubModule.__sessionId());
+  const parts = calls[0]!.parts as Array<{ type: string; text: string }>;
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0]!.type, "text");
+  assert.equal(parts[0]!.text, "hello opencode");
+});
+
+test("message.part.delta with text kind flows to agent:response-chunk", async () => {
+  const { bus } = await loadBridge();
+  const chunks = collect<{ blocks: Array<{ type: string; text: string }> }>(bus, "agent:response-chunk");
+
+  stubModule.__emitEvent({
+    type: "message.part.updated",
+    properties: { part: { id: "p1", type: "text" } },
+  });
+  stubModule.__emitEvent({
+    type: "message.part.delta",
+    properties: { partID: "p1", delta: "hello" },
+  });
+  stubModule.__emitEvent({
+    type: "message.part.delta",
+    properties: { partID: "p1", delta: " world" },
+  });
+  await flush();
+
+  const text = chunks.flatMap((c) => c.blocks.map((b) => b.text)).join("");
+  assert.equal(text, "hello world");
+});
+
+test("message.part.delta with reasoning kind flows to agent:thinking-chunk", async () => {
+  const { bus } = await loadBridge();
+  const thinks = collect<{ text: string }>(bus, "agent:thinking-chunk");
+
+  stubModule.__emitEvent({
+    type: "message.part.updated",
+    properties: { part: { id: "r1", type: "reasoning" } },
+  });
+  stubModule.__emitEvent({
+    type: "message.part.delta",
+    properties: { partID: "r1", delta: "let me think" },
+  });
+  await flush();
+
+  assert.deepEqual(thinks.map((t) => t.text), ["let me think"]);
+});
+
+test("tool part updates flow to agent:tool-started + agent:tool-completed", async () => {
+  const { bus } = await loadBridge();
+  const started = collect<{ title: string; toolCallId: string; kind: string }>(bus, "agent:tool-started");
+  const completed = collect<{ toolCallId: string; exitCode: number; kind: string }>(bus, "agent:tool-completed");
+
+  stubModule.__emitEvent({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "t1",
+        type: "tool",
+        callID: "call-1",
+        tool: "bash",
+        state: { status: "running", input: { command: "ls" } },
+      },
+    },
+  });
+  stubModule.__emitEvent({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "t1",
+        type: "tool",
+        callID: "call-1",
+        tool: "bash",
+        state: { status: "completed", input: { command: "ls" }, output: "file.txt\n" },
+      },
+    },
+  });
+  await flush();
+
+  assert.equal(started.length, 1);
+  assert.equal(started[0]!.title, "bash");
+  assert.equal(started[0]!.toolCallId, "call-1");
+  assert.equal(started[0]!.kind, "execute");
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0]!.toolCallId, "call-1");
+  assert.equal(completed[0]!.exitCode, 0);
+});
+
+test("session.error flows to agent:error", async () => {
+  const { bus } = await loadBridge();
+  const errors = collect<{ message: string }>(bus, "agent:error");
+
+  stubModule.__emitEvent({
+    type: "session.error",
+    properties: { error: { message: "boom" } },
+  });
+  await flush();
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0]!.message, "boom");
+});
+
+test("agent:cancel-request triggers client.session.abort", async () => {
+  const { bus } = await loadBridge();
+  const before = stubModule.__abortCalls().length;
+  bus.emit("agent:cancel-request" as any, {});
+  await flush();
+  const after = stubModule.__abortCalls();
+  assert.equal(after.length, before + 1);
+  assert.equal(after[before]!.sessionID, stubModule.__sessionId());
+});
+
+test("permission.asked is auto-approved via client.permission.reply", async () => {
+  const { bus: _ } = await loadBridge();
+  stubModule.__emitEvent({
+    type: "permission.asked",
+    properties: { id: "req-42" },
+  });
+  await flush();
+
+  const replies = stubModule.__permissionReplies();
+  assert.equal(replies.length, 1);
+  assert.equal(replies[0]!.requestID, "req-42");
+  assert.equal(replies[0]!.reply, "once");
+});

--- a/tests/bridges/pi-bridge.test.ts
+++ b/tests/bridges/pi-bridge.test.ts
@@ -1,0 +1,158 @@
+import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+import * as path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createCore } from "../../src/core/index.js";
+import type { AppConfig } from "../../src/shell/host-types.js";
+
+register(new URL("../fixtures/pi-sdk-mock-loader.mjs", import.meta.url));
+
+const stubModule = await import(
+  new URL("../fixtures/pi-sdk-stub.mjs", import.meta.url).href
+) as {
+  __reset(): void;
+  __emit(event: unknown): void;
+  __promptCalls(): string[];
+  __abortCalls(): number[];
+};
+
+const BRIDGE_URL = pathToFileURL(path.resolve("examples/extensions/pi-bridge/index.ts")).href;
+
+interface LoadedBridge {
+  core: ReturnType<typeof createCore>;
+  bus: ReturnType<typeof createCore>["bus"];
+}
+
+async function loadBridge(): Promise<LoadedBridge> {
+  stubModule.__reset();
+  const core = createCore({} as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  const activate = (mod.default ?? mod.activate) as (c: typeof ctx) => void;
+  activate(ctx);
+  await core.activateBackend("pi");
+  return { core, bus: core.bus };
+}
+
+function collect<T>(bus: LoadedBridge["bus"], event: string): T[] {
+  const buf: T[] = [];
+  bus.on(event as any, (e: T) => buf.push(e));
+  return buf;
+}
+
+test("pi-bridge registers backend 'pi' after activate", async () => {
+  const { bus } = await loadBridge();
+  const { names, active } = bus.emitPipe("config:get-backends", { names: [] as string[], active: null });
+  assert.ok(names.includes("pi"), `expected backend "pi" in ${names.join(", ")}`);
+  assert.equal(active, "pi");
+});
+
+test("pi-bridge surfaces model info via agent:info after boot", async () => {
+  const infos: Array<{ name: string; model?: string }> = [];
+  const core = createCore({} as AppConfig);
+  core.bus.on("agent:info", (info) => { infos.push(info); });
+  const ctx = core.extensionContext({ quit: () => {} });
+  stubModule.__reset();
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  (mod.default ?? mod.activate)(ctx);
+  await core.activateBackend("pi");
+
+  assert.equal(infos.length, 1);
+  assert.equal(infos[0]!.name, "pi");
+  assert.equal(infos[0]!.model, "stub/stub-model");
+});
+
+test("agent:submit forwards the query to session.prompt", async () => {
+  const { bus } = await loadBridge();
+  bus.emit("agent:submit", { query: "hello pi" });
+  await new Promise((r) => setImmediate(r));
+  const calls = stubModule.__promptCalls();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0], "hello pi");
+});
+
+test("text_delta events flow to agent:response-chunk", async () => {
+  const { bus } = await loadBridge();
+  const chunks = collect<{ blocks: Array<{ type: string; text: string }> }>(bus, "agent:response-chunk");
+
+  stubModule.__emit({ type: "agent_start" });
+  stubModule.__emit({
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: "hello" },
+  });
+  stubModule.__emit({
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: " world" },
+  });
+
+  const text = chunks.flatMap((c) => c.blocks.map((b) => b.text)).join("");
+  assert.equal(text, "hello world");
+});
+
+test("thinking_delta events flow to agent:thinking-chunk", async () => {
+  const { bus } = await loadBridge();
+  const thinks = collect<{ text: string }>(bus, "agent:thinking-chunk");
+
+  stubModule.__emit({ type: "agent_start" });
+  stubModule.__emit({
+    type: "message_update",
+    assistantMessageEvent: { type: "thinking_delta", delta: "let me think" },
+  });
+
+  assert.deepEqual(thinks.map((t) => t.text), ["let me think"]);
+});
+
+test("tool_execution_start/end flow to agent:tool-started + agent:tool-completed", async () => {
+  const { bus } = await loadBridge();
+  const started = collect<{ title: string; toolCallId: string; kind: string }>(bus, "agent:tool-started");
+  const completed = collect<{ toolCallId: string; exitCode: number; kind: string }>(bus, "agent:tool-completed");
+
+  stubModule.__emit({
+    type: "tool_execution_start",
+    toolCallId: "call-1",
+    toolName: "bash",
+    args: { cmd: "ls" },
+  });
+  stubModule.__emit({
+    type: "tool_execution_end",
+    toolCallId: "call-1",
+    toolName: "bash",
+    isError: false,
+    result: { ok: true },
+  });
+
+  assert.equal(started.length, 1);
+  assert.equal(started[0]!.title, "bash");
+  assert.equal(started[0]!.toolCallId, "call-1");
+  assert.equal(started[0]!.kind, "execute");
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0]!.toolCallId, "call-1");
+  assert.equal(completed[0]!.exitCode, 0);
+});
+
+test("agent_end fires agent:response-done and agent:processing-done", async () => {
+  const { bus } = await loadBridge();
+  const dones = collect<{ response: string }>(bus, "agent:response-done");
+  const procs = collect<unknown>(bus, "agent:processing-done");
+
+  stubModule.__emit({ type: "agent_start" });
+  stubModule.__emit({
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: "ok." },
+  });
+  stubModule.__emit({ type: "agent_end" });
+
+  assert.equal(dones.length, 1);
+  assert.equal(dones[0]!.response, "ok.");
+  assert.equal(procs.length, 1);
+});
+
+test("agent:cancel-request triggers session.abort", async () => {
+  const { bus } = await loadBridge();
+  const before = stubModule.__abortCalls().length;
+  bus.emit("agent:cancel-request" as any, {});
+  await new Promise((r) => setImmediate(r));
+  assert.equal(stubModule.__abortCalls().length, before + 1);
+});

--- a/tests/cli/bridges.test.ts
+++ b/tests/cli/bridges.test.ts
@@ -79,25 +79,29 @@ function stripAnsi(s: string): string {
   return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
 }
 
-test("pi-bridge installs and the CLI reaches the banner under --backend pi", { timeout: 120000 }, async () => {
-  const home = freshHome();
-  try {
-    const inst = await runOnce(["install", "pi-bridge"], home, 90000);
-    assert.equal(inst.code, 0, `install failed:\nstdout: ${inst.stdout}\nstderr: ${inst.stderr}`);
+const BRIDGES: Array<{ ext: string; backend: string }> = [
+  { ext: "pi-bridge", backend: "pi" },
+  { ext: "opencode-bridge", backend: "opencode" },
+  { ext: "claude-code-bridge", backend: "claude-code" },
+];
 
-    const launch = await runUntilBanner(["--backend", "pi"], home, 30000);
-    const cleanStdout = stripAnsi(launch.stdout);
-    const cleanStderr = stripAnsi(launch.stderr);
+for (const { ext, backend } of BRIDGES) {
+  test(`${ext} installs and the CLI reaches the banner under --backend ${backend}`, { timeout: 120000 }, async () => {
+    const home = freshHome();
+    try {
+      const inst = await runOnce(["install", ext], home, 90000);
+      assert.equal(inst.code, 0, `install failed:\nstdout: ${inst.stdout}\nstderr: ${inst.stderr}`);
 
-    assert.match(cleanStdout, /Backend:\s+pi/, `banner missing.\nstdout: ${cleanStdout}\nstderr: ${cleanStderr}`);
+      const launch = await runUntilBanner(["--backend", backend], home, 30000);
+      const cleanStdout = stripAnsi(launch.stdout);
+      const cleanStderr = stripAnsi(launch.stderr);
 
-    // Kernel-level smoke: no module-resolution or syntax errors from loading
-    // the extension. We don't assert anything about pi's own auth state —
-    // pi-bridge surfaces that via ui:error, which is its contract, not ours.
-    assert.doesNotMatch(cleanStderr, /Cannot find module/i, cleanStderr);
-    assert.doesNotMatch(cleanStderr, /SyntaxError/, cleanStderr);
-    assert.doesNotMatch(cleanStderr, /UnhandledPromiseRejection/, cleanStderr);
-  } finally {
-    rmSync(home, { recursive: true, force: true });
-  }
-});
+      assert.match(cleanStdout, new RegExp(`Backend:\\s+${backend}`), `banner missing.\nstdout: ${cleanStdout}\nstderr: ${cleanStderr}`);
+      assert.doesNotMatch(cleanStderr, /Cannot find module/i, cleanStderr);
+      assert.doesNotMatch(cleanStderr, /SyntaxError/, cleanStderr);
+      assert.doesNotMatch(cleanStderr, /UnhandledPromiseRejection/, cleanStderr);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/fixtures/claude-sdk-mock-loader.mjs
+++ b/tests/fixtures/claude-sdk-mock-loader.mjs
@@ -1,0 +1,18 @@
+const STUB_URL = new URL("./claude-sdk-stub.mjs", import.meta.url).href;
+const REPO_ROOT = new URL("../../", import.meta.url);
+
+// agent-sh/utils/* → dist/utils/* (no node_modules/agent-sh in-process).
+const AGENT_SH_MAP = {
+  "agent-sh/utils/diff": "dist/utils/diff.js",
+};
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "@anthropic-ai/claude-agent-sdk") {
+    return { url: STUB_URL, format: "module", shortCircuit: true };
+  }
+  const mapped = AGENT_SH_MAP[specifier];
+  if (mapped) {
+    return { url: new URL(mapped, REPO_ROOT).href, format: "module", shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/tests/fixtures/claude-sdk-stub.mjs
+++ b/tests/fixtures/claude-sdk-stub.mjs
@@ -1,0 +1,76 @@
+// Loader at claude-sdk-mock-loader.mjs reroutes `@anthropic-ai/claude-agent-sdk`
+// here so the bridge and tests share this module instance.
+
+const queryCalls = [];
+let activeIterator = null;
+
+class QueryIterator {
+  constructor() {
+    this.queue = [];
+    this.resolvers = [];
+    this.done = false;
+    this.interrupted = false;
+  }
+
+  push(message) {
+    if (this.done) return;
+    if (this.resolvers.length > 0) {
+      this.resolvers.shift()({ value: message, done: false });
+    } else {
+      this.queue.push(message);
+    }
+  }
+
+  close() {
+    this.done = true;
+    while (this.resolvers.length > 0) {
+      this.resolvers.shift()({ value: undefined, done: true });
+    }
+  }
+
+  interrupt() {
+    this.interrupted = true;
+    this.close();
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+
+  next() {
+    if (this.queue.length > 0) {
+      return Promise.resolve({ value: this.queue.shift(), done: false });
+    }
+    if (this.done) {
+      return Promise.resolve({ value: undefined, done: true });
+    }
+    return new Promise((resolve) => this.resolvers.push(resolve));
+  }
+}
+
+export function __reset() {
+  queryCalls.length = 0;
+  activeIterator = null;
+}
+
+export function __queryCalls() {
+  return queryCalls.slice();
+}
+
+export function __pushMessage(msg) {
+  if (activeIterator) activeIterator.push(msg);
+}
+
+export function __endQuery() {
+  if (activeIterator) activeIterator.close();
+}
+
+export function __wasInterrupted() {
+  return activeIterator?.interrupted ?? false;
+}
+
+export function query(opts) {
+  queryCalls.push(opts);
+  activeIterator = new QueryIterator();
+  return activeIterator;
+}

--- a/tests/fixtures/opencode-sdk-mock-loader.mjs
+++ b/tests/fixtures/opencode-sdk-mock-loader.mjs
@@ -1,0 +1,20 @@
+const STUB_URL = new URL("./opencode-sdk-stub.mjs", import.meta.url).href;
+const REPO_ROOT = new URL("../../", import.meta.url);
+
+// agent-sh/utils/* → dist/utils/* (no node_modules/agent-sh in-process).
+const AGENT_SH_MAP = {
+  "agent-sh/utils/diff": "dist/utils/diff.js",
+  "agent-sh/utils/tool-interactive": "dist/utils/tool-interactive.js",
+  "agent-sh/utils/palette": "dist/utils/palette.js",
+};
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "@opencode-ai/sdk/v2") {
+    return { url: STUB_URL, format: "module", shortCircuit: true };
+  }
+  const mapped = AGENT_SH_MAP[specifier];
+  if (mapped) {
+    return { url: new URL(mapped, REPO_ROOT).href, format: "module", shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/tests/fixtures/opencode-sdk-stub.mjs
+++ b/tests/fixtures/opencode-sdk-stub.mjs
@@ -1,0 +1,112 @@
+// Loader at opencode-sdk-mock-loader.mjs reroutes `@opencode-ai/sdk/v2`
+// here so the bridge and tests share this module instance.
+
+const STUB_SESSION_ID = "stub-session-id";
+
+class EventStream {
+  constructor() {
+    this.queue = [];
+    this.resolvers = [];
+    this.closed = false;
+  }
+
+  push(event) {
+    if (this.closed) return;
+    if (this.resolvers.length > 0) {
+      const resolve = this.resolvers.shift();
+      resolve({ value: event, done: false });
+    } else {
+      this.queue.push(event);
+    }
+  }
+
+  close() {
+    this.closed = true;
+    while (this.resolvers.length > 0) {
+      const resolve = this.resolvers.shift();
+      resolve({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => {
+        if (this.queue.length > 0) {
+          return Promise.resolve({ value: this.queue.shift(), done: false });
+        }
+        if (this.closed) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise((resolve) => this.resolvers.push(resolve));
+      },
+    };
+  }
+}
+
+// Don't close old streams on reset: closing wakes orphan bridges from prior
+// tests, which then re-subscribe and steal events from the current test.
+let activeStream = null;
+const promptCalls = [];
+const abortCalls = [];
+const questionReplies = [];
+const permissionReplies = [];
+
+export function __reset() {
+  activeStream = null;
+  promptCalls.length = 0;
+  abortCalls.length = 0;
+  questionReplies.length = 0;
+  permissionReplies.length = 0;
+}
+
+export function __emitEvent(event) {
+  if (!activeStream) return;
+  if (event && typeof event === "object" && event.properties && !("sessionID" in event.properties)) {
+    event.properties.sessionID = STUB_SESSION_ID;
+  }
+  activeStream.push(event);
+}
+
+export function __sessionId() {
+  return STUB_SESSION_ID;
+}
+
+export function __promptCalls() { return promptCalls.slice(); }
+export function __abortCalls() { return abortCalls.slice(); }
+export function __questionReplies() { return questionReplies.slice(); }
+export function __permissionReplies() { return permissionReplies.slice(); }
+
+const client = {
+  event: {
+    subscribe: async () => {
+      activeStream = new EventStream();
+      return { stream: activeStream };
+    },
+  },
+  session: {
+    create: async ({ directory }) => ({ data: { id: STUB_SESSION_ID, directory } }),
+    prompt: async ({ sessionID, directory, parts }) => {
+      promptCalls.push({ sessionID, directory, parts });
+      return { data: { parts: [] } };
+    },
+    abort: async ({ sessionID, directory }) => {
+      abortCalls.push({ sessionID, directory });
+    },
+  },
+  question: {
+    reply: async (args) => { questionReplies.push(args); },
+    reject: async (args) => { questionReplies.push({ ...args, rejected: true }); },
+  },
+  permission: {
+    reply: async (args) => { permissionReplies.push(args); },
+  },
+};
+
+const server = {
+  url: "http://stub.local",
+  close() {},
+};
+
+export async function createOpencode() {
+  return { client, server };
+}

--- a/tests/fixtures/pi-sdk-mock-loader.mjs
+++ b/tests/fixtures/pi-sdk-mock-loader.mjs
@@ -1,0 +1,8 @@
+const STUB_URL = new URL("./pi-sdk-stub.mjs", import.meta.url).href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "@mariozechner/pi-coding-agent") {
+    return { url: STUB_URL, format: "module", shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/tests/fixtures/pi-sdk-stub.mjs
+++ b/tests/fixtures/pi-sdk-stub.mjs
@@ -1,0 +1,76 @@
+// Loader at pi-sdk-mock-loader.mjs reroutes `@mariozechner/pi-coding-agent`
+// here so the bridge and tests share this module instance.
+
+let capturedSubscriber = null;
+let queuedEvents = [];
+const promptCalls = [];
+const abortCalls = [];
+
+export function __reset() {
+  capturedSubscriber = null;
+  queuedEvents = [];
+  promptCalls.length = 0;
+  abortCalls.length = 0;
+}
+
+export function __emit(event) {
+  if (capturedSubscriber) {
+    capturedSubscriber(event);
+  } else {
+    queuedEvents.push(event);
+  }
+}
+
+export function __promptCalls() {
+  return promptCalls.slice();
+}
+
+export function __abortCalls() {
+  return abortCalls.slice();
+}
+
+const fakeSession = {
+  subscribe(fn) {
+    capturedSubscriber = fn;
+    while (queuedEvents.length > 0) fn(queuedEvents.shift());
+  },
+  async prompt(text) {
+    promptCalls.push(text);
+  },
+  async abort() {
+    abortCalls.push(Date.now());
+  },
+  async compact() {},
+  getContextUsage() {
+    return { tokens: 0, contextWindow: 100_000 };
+  },
+  model: { provider: "stub", id: "stub-model" },
+};
+
+const fakeRuntime = {
+  session: fakeSession,
+  async newSession() {},
+};
+
+export class SessionManager {
+  static inMemory() {
+    return new SessionManager();
+  }
+}
+
+export async function createAgentSessionServices() {
+  return {
+    modelRegistry: {
+      getAvailable: () => [{ id: "stub-model", provider: "stub" }],
+    },
+  };
+}
+
+export async function createAgentSessionFromServices() {
+  return { session: fakeSession };
+}
+
+export async function createAgentSessionRuntime(createRuntime, opts) {
+  await createRuntime({ ...opts, sessionManager: opts.sessionManager });
+  return fakeRuntime;
+}


### PR DESCRIPTION
## Summary

Two layers of bridge coverage, complementary to the existing pi-bridge smoke test.

**Protocol tests (in-process, mocked SDKs)** — `tests/bridges/*`

For each of `pi`, `opencode`, `claude-code`, a Node loader hook (registered via `node:module` `register()`) reroutes the bridge's SDK import to a stub module so the bridge and tests share the same module instance. The bridge sees a fake session/iterator whose callback or stream the test drives directly; scripted events flow through the bridge into the bus, and the test asserts on the bus output. No subprocess, no install, no network.

| Bridge | SDK stubbed | Cases |
|---|---|---|
| pi | `@mariozechner/pi-coding-agent` | 8 — register, agent:info, submit→prompt, text_delta, thinking_delta, tool start/end, agent_end, cancel-request→abort |
| opencode | `@opencode-ai/sdk/v2` | 9 — register, agent:info, submit→prompt, text/reasoning deltas via part-routing, tool part.updated, session.error, cancel-request→abort, permission.asked auto-reply |
| claude-code | `@anthropic-ai/claude-agent-sdk` | 9 — register, agent:info, query() options shape, text_delta, thinking_delta, streamed tool_use, tool_result→tool-completed, cancel-request→interrupt, response-done |

Two opencode/claude-code wrinkles vs pi worth flagging in review:
- opencode delivers events via an async iterable returned from `client.event.subscribe()`, not a callback. The stub uses an `EventStream` class with a queue + pending-resolver pattern. `__reset` deliberately does *not* close prior streams — closing wakes orphan bridges from earlier tests, which then re-subscribe and steal events from the current test. Leaving them parked on a never-resolving `next()` keeps them inert.
- opencode and claude-code bridges runtime-import from `agent-sh/utils/*` (where pi-bridge only type-imports). The loader maps those specifiers to `dist/utils/*.js` per the package.json exports map.

**Bridge install+launch smoke matrix** — `tests/cli/bridges.test.ts`

Parameterized the existing pi-bridge smoke test over `(pi-bridge, opencode-bridge, claude-code-bridge)`. Each test goes through the real `runInstall` path (`npm install` + `npm run build` inside the target) and launches the CLI with `--backend <name>`, asserting the banner appears and no kernel-level module/syntax/unhandled-rejection errors hit stderr. Catches install pipeline and CLI activation regressions that the in-process protocol tests deliberately bypass.

## Counts
- Before: 33 tests
- After: 61 tests (+28: 26 protocol + 2 smoke for opencode/claude-code)

## Test plan
- [x] `npm test` locally → 61/61 pass.
- [x] Tightened the cancel-test assertion after confirming pi-bridge's actual wiring (`bus.on("agent:cancel-request", onCancel)` → `session.abort()`); no false positives.
- [x] `npx tsc --noEmit` clean.
- [x] CI green on this PR.