### PR TITLE
Add shell integration tests for bash, zsh, and fish

### DIFF
--- a/tests/shell/contract.test.ts
+++ b/tests/shell/contract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Strategy ↔ parser format-agreement tests.
+ *
+ * The bytes that each shell strategy makes the shell print MUST match the
+ * regexes that OutputParser uses. If someone changes the OSC number on one
+ * side but forgets the other, both unit-test suites still pass — but the
+ * integration is broken. These tests close that gap.
+ *
+ * Each test:
+ *   1. asks the strategy what it would emit (by simulating its printf format)
+ *   2. feeds the resulting bytes into a real OutputParser
+ *   3. asserts the parser fires the corresponding event
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventBus } from "../../src/core/event-bus.js";
+import { OutputParser } from "../../src/shell/output-parser.js";
+import { bashStrategy } from "../../src/shell/strategies/bash.js";
+import { zshStrategy } from "../../src/shell/strategies/zsh.js";
+import { fishStrategy } from "../../src/shell/strategies/fish.js";
+import type { ShellStrategy } from "../../src/shell/strategies/index.js";
+
+const STRATEGIES: ShellStrategy[] = [bashStrategy, zshStrategy, fishStrategy];
+
+const TAG_HEX = "abc12345";
+const INSTANCE_TAG = `id=${TAG_HEX}`;
+
+function collectEvents(bus: EventBus): Array<{ name: string; payload: unknown }> {
+  const events: Array<{ name: string; payload: unknown }> = [];
+  bus.onAny((name, payload) => events.push({ name, payload }));
+  return events;
+}
+
+/**
+ * What the shell's `printf` would actually emit when interpreting the
+ * escapes in the strategy's rc file. Mirrors the format the strategies
+ * use: \e]<num>;<instanceTag>;<body>\a
+ */
+function emit(num: number, body: string): string {
+  return `\x1b]${num};${INSTANCE_TAG};${body}\x07`;
+}
+
+for (const strategy of STRATEGIES) {
+  test(`${strategy.name}: OSC 9999 (PROMPT) format is what OutputParser expects`, () => {
+    const bus = new EventBus();
+    const events = collectEvents(bus);
+    const parser = new OutputParser(bus, "/start", INSTANCE_TAG);
+
+    // Simulate a fully-formed command cycle so command-done can fire.
+    parser.processData(emit(9997, "ls"));
+    parser.processData("ls\nfile1 file2\n");
+    parser.processData(emit(9999, "PROMPT"));
+
+    const done = events.find((e) => e.name === "shell:command-done");
+    assert.ok(done, `${strategy.name}: PROMPT marker did not trigger command-done`);
+  });
+
+  test(`${strategy.name}: OSC 9997 (PREEXEC) format is what OutputParser expects`, () => {
+    const bus = new EventBus();
+    const events = collectEvents(bus);
+    const parser = new OutputParser(bus, "/start", INSTANCE_TAG);
+
+    parser.processData(emit(9997, "make build"));
+
+    const start = events.find((e) => e.name === "shell:command-start") as
+      | { payload: { command: string } }
+      | undefined;
+    assert.ok(start, `${strategy.name}: PREEXEC marker did not trigger command-start`);
+    assert.equal(start!.payload.command, "make build");
+  });
+
+  test(`${strategy.name}: OSC 9998 (READY) format is what OutputParser expects`, () => {
+    const bus = new EventBus();
+    const parser = new OutputParser(bus, "/start", INSTANCE_TAG);
+
+    parser.processData(emit(9998, "READY"));
+    assert.equal(parser.isPromptReady(), true, `${strategy.name}: READY marker did not flip promptReady`);
+  });
+
+  test(`${strategy.name}: OSC 7 (cwd) format is what OutputParser expects`, () => {
+    const bus = new EventBus();
+    const events = collectEvents(bus);
+    const parser = new OutputParser(bus, "/start", INSTANCE_TAG);
+
+    // OSC 7 is shared across all three strategies — they all emit
+    // `\e]7;file://<host><path>\a`.
+    parser.processData("\x1b]7;file://host/work/dir\x07");
+    assert.equal(parser.getCwd(), "/work/dir");
+    const cwd = events.find((e) => e.name === "shell:cwd-change");
+    assert.deepEqual(cwd?.payload, { cwd: "/work/dir" });
+  });
+}
+
+// ── Nested-instance isolation ─────────────────────────────────────
+// Two agent-sh instances sharing the same PTY stream (e.g. ssh from
+// agent-sh into another host running agent-sh) must not cross-trigger
+// each other's command boundary detection.
+
+test("two parsers with distinct tags do not cross-trigger on each other's markers", () => {
+  const TAG_A = "id=aaaaaaaa";
+  const TAG_B = "id=bbbbbbbb";
+
+  const busA = new EventBus();
+  const busB = new EventBus();
+  const eventsA = collectEvents(busA);
+  const eventsB = collectEvents(busB);
+  const parserA = new OutputParser(busA, "/a", TAG_A);
+  const parserB = new OutputParser(busB, "/b", TAG_B);
+
+  // Merged stream delivered as separate chunks (matches real PTY behavior —
+  // each `data` callback typically carries one marker plus surrounding text).
+  const chunks = [
+    `\x1b]9997;${TAG_A};only-A-runs\x07`,         // A's PREEXEC
+    "output-line\n",
+    `\x1b]9999;${TAG_B};PROMPT\x07`,              // foreign — A must ignore, B must ignore (no lastCommand)
+    `\x1b]9998;${TAG_B};READY\x07`,               // foreign for A, own for B
+    `\x1b]9999;${TAG_A};PROMPT\x07`,              // own for A — finalizes, foreign for B
+  ];
+  for (const c of chunks) {
+    parserA.processData(c);
+    parserB.processData(c);
+  }
+
+  // Parser A: saw exactly one command-start (its own PREEXEC) and one
+  // command-done (its own PROMPT). The foreign markers between them did
+  // not split the command in half.
+  const aStarts = eventsA.filter((e) => e.name === "shell:command-start");
+  const aDones = eventsA.filter((e) => e.name === "shell:command-done");
+  assert.equal(aStarts.length, 1, "A: expected exactly one command-start");
+  assert.equal(aDones.length, 1, "A: expected exactly one command-done");
+  assert.equal((aStarts[0]!.payload as { command: string }).command, "only-A-runs");
+  assert.equal(parserA.isPromptReady(), false, "A: foreign READY must not flip its promptReady");
+
+  // Parser B: never saw a PREEXEC of its own, so no command-start, and
+  // no command-done (no lastCommand to finalize). It DID see its own
+  // PROMPT and READY — those just don't carry any pending command.
+  const bStarts = eventsB.filter((e) => e.name === "shell:command-start");
+  const bDones = eventsB.filter((e) => e.name === "shell:command-done");
+  assert.equal(bStarts.length, 0, "B: must not pick up A's PREEXEC");
+  assert.equal(bDones.length, 0, "B: must not pick up A's PROMPT");
+  assert.equal(parserB.isPromptReady(), true, "B: its own READY must flip promptReady");
+});

--- a/tests/shell/output-parser.test.ts
+++ b/tests/shell/output-parser.test.ts
@@ -1,0 +1,167 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventBus } from "../../src/core/event-bus.js";
+import { OutputParser } from "../../src/shell/output-parser.js";
+
+const OWN = "deadbeef";
+const FOREIGN = "cafebabe";
+
+function makeParser(): { parser: OutputParser; bus: EventBus; events: Array<{ name: string; payload: unknown }> } {
+  const bus = new EventBus();
+  const events: Array<{ name: string; payload: unknown }> = [];
+  bus.onAny((name, payload) => events.push({ name, payload }));
+  const parser = new OutputParser(bus, "/start/cwd", OWN);
+  return { parser, bus, events };
+}
+
+function osc(num: number, tag: string, body: string): string {
+  return `\x1b]${num};id=${tag};${body}\x07`;
+}
+
+// ── OSC 7 (cwd tracking) ─────────────────────────────────────────
+
+test("OSC 7 with a new path updates cwd and emits shell:cwd-change", () => {
+  const { parser, events } = makeParser();
+  parser.processData("\x1b]7;file://host/new/path\x07");
+  assert.equal(parser.getCwd(), "/new/path");
+  const cwd = events.find((e) => e.name === "shell:cwd-change");
+  assert.deepEqual(cwd?.payload, { cwd: "/new/path" });
+});
+
+test("OSC 7 with the same path does not re-emit shell:cwd-change", () => {
+  const { parser, events } = makeParser();
+  parser.processData("\x1b]7;file://host/start/cwd\x07");
+  assert.equal(events.filter((e) => e.name === "shell:cwd-change").length, 0);
+});
+
+test("OSC 7 decodes percent-encoded paths", () => {
+  const { parser, events } = makeParser();
+  parser.processData("\x1b]7;file://host/has%20space/dir\x07");
+  assert.equal(parser.getCwd(), "/has space/dir");
+  const cwd = events.find((e) => e.name === "shell:cwd-change");
+  assert.deepEqual(cwd?.payload, { cwd: "/has space/dir" });
+});
+
+// ── OSC 9997 (preexec / command-start) ──────────────────────────
+
+test("OSC 9997 with own tag emits shell:command-start with the carried command text", () => {
+  const { parser, events } = makeParser();
+  parser.processData(osc(9997, OWN, "ls -la"));
+  const start = events.find((e) => e.name === "shell:command-start");
+  assert.deepEqual(start?.payload, { command: "ls -la", cwd: "/start/cwd" });
+});
+
+test("OSC 9997 with own tag flips foreground-busy true exactly once", () => {
+  const { parser, events } = makeParser();
+  parser.processData(osc(9997, OWN, "ls"));
+  parser.processData(osc(9997, OWN, "pwd"));
+  const busy = events.filter((e) => e.name === "shell:foreground-busy");
+  assert.equal(busy.length, 1);
+  assert.deepEqual(busy[0]?.payload, { busy: true });
+});
+
+test("OSC 9997 with a foreign tag does not fire command-start or foreground-busy", () => {
+  const { parser, events } = makeParser();
+  parser.processData(osc(9997, FOREIGN, "nested-ls"));
+  assert.equal(events.filter((e) => e.name === "shell:command-start").length, 0);
+  assert.equal(events.filter((e) => e.name === "shell:foreground-busy").length, 0);
+});
+
+test("OSC 9997 is stripped from the captured output buffer so it never reaches command-done", () => {
+  const { parser, events } = makeParser();
+  parser.processData(`prefix${osc(9997, OWN, "ls")}body${osc(9999, OWN, "PROMPT")}`);
+  const done = events.find((e) => e.name === "shell:command-done") as { payload: { output: string } } | undefined;
+  assert.ok(done);
+  // Echoed-command stripping removes the first line ("ls"), leaving "body".
+  assert.equal(done!.payload.output.includes("\x1b]"), false);
+});
+
+// ── OSC 9999 (prompt marker / command-done) ─────────────────────
+
+test("OSC 9999 with own tag fires shell:command-done with stripped output and clears foreground-busy", () => {
+  const { parser, events } = makeParser();
+  parser.processData(osc(9997, OWN, "echo hello"));
+  parser.processData("hello\n");
+  parser.processData(osc(9999, OWN, "PROMPT"));
+
+  const done = events.find((e) => e.name === "shell:command-done") as
+    | { payload: { command: string; output: string; cwd: string; exitCode: number | null } }
+    | undefined;
+  assert.ok(done);
+  assert.equal(done!.payload.command, "echo hello");
+  assert.equal(done!.payload.output, "hello");
+  assert.equal(done!.payload.cwd, "/start/cwd");
+  assert.equal(done!.payload.exitCode, null);
+
+  const busyEvents = events.filter((e) => e.name === "shell:foreground-busy");
+  assert.equal((busyEvents.at(-1)?.payload as { busy: boolean }).busy, false);
+});
+
+test("OSC 9999 with a foreign tag does not fire command-done and keeps capturing into the buffer", () => {
+  const { parser, events } = makeParser();
+  parser.processData(osc(9997, OWN, "real-cmd"));
+  parser.processData(`some-output${osc(9999, FOREIGN, "PROMPT")}more-output`);
+  parser.processData(osc(9999, OWN, "PROMPT"));
+
+  const dones = events.filter((e) => e.name === "shell:command-done");
+  assert.equal(dones.length, 1, "exactly one command-done — from the own-tag prompt");
+  const payload = dones[0]!.payload as { output: string; command: string };
+  assert.equal(payload.command, "real-cmd");
+  assert.ok(payload.output.includes("more-output"));
+});
+
+test("OSC 9999 without a prior command does not emit command-done", () => {
+  const { parser, events } = makeParser();
+  parser.processData(osc(9999, OWN, "PROMPT"));
+  assert.equal(events.filter((e) => e.name === "shell:command-done").length, 0);
+});
+
+// ── OSC 9998 (prompt-ready) ─────────────────────────────────────
+
+test("OSC 9998 with own tag flips isPromptReady() to true", () => {
+  const { parser } = makeParser();
+  assert.equal(parser.isPromptReady(), false);
+  parser.processData(osc(9998, OWN, "READY"));
+  assert.equal(parser.isPromptReady(), true);
+});
+
+test("OSC 9998 with a foreign tag does NOT flip isPromptReady()", () => {
+  const { parser } = makeParser();
+  parser.processData(osc(9998, FOREIGN, "READY"));
+  assert.equal(parser.isPromptReady(), false);
+});
+
+test("OSC 9999 (own tag) resets promptReady — a new command is starting", () => {
+  const { parser } = makeParser();
+  parser.processData(osc(9998, OWN, "READY"));
+  assert.equal(parser.isPromptReady(), true);
+  parser.processData(osc(9999, OWN, "PROMPT"));
+  assert.equal(parser.isPromptReady(), false);
+});
+
+// ── onCommandEntered (the legacy line-buffer path) ──────────────
+
+test("onCommandEntered emits shell:command-start and flips foreground-busy true", () => {
+  const { parser, events } = makeParser();
+  parser.onCommandEntered("vim file", "/work");
+  const start = events.find((e) => e.name === "shell:command-start");
+  assert.deepEqual(start?.payload, { command: "vim file", cwd: "/work" });
+  const busy = events.find((e) => e.name === "shell:foreground-busy");
+  assert.deepEqual(busy?.payload, { busy: true });
+});
+
+// ── Buffer growth guard ─────────────────────────────────────────
+
+test("output capture is capped — a runaway program does not grow the buffer unboundedly", () => {
+  const { parser, events } = makeParser();
+  parser.onCommandEntered("noisy", "/work");
+  const big = "x".repeat(200 * 1024);
+  parser.processData(big);
+  parser.processData(osc(9999, OWN, "PROMPT"));
+  const done = events.find((e) => e.name === "shell:command-done") as
+    | { payload: { output: string } }
+    | undefined;
+  assert.ok(done);
+  // Cap is 128 KB; the captured output must not exceed that meaningfully.
+  assert.ok(done!.payload.output.length <= 128 * 1024);
+});

--- a/tests/shell/pty-smoke.test.ts
+++ b/tests/shell/pty-smoke.test.ts
@@ -1,0 +1,132 @@
+/**
+ * End-to-end PTY smoke test: spawn each installed shell under its strategy's
+ * generated rc, run a single command, and assert that all three OSC markers
+ * (PROMPT/PREEXEC/READY) appeared somewhere in the stream.
+ *
+ * This is intentionally minimal — we only assert markers fire, not what they
+ * carry. Content of PREEXEC depends on history populating, fish prompt
+ * rendering depends on TTY handshake, etc. — those are environment concerns
+ * outside our regression scope. Skip cleanly when a shell isn't installed.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as pty from "node-pty";
+import { bashStrategy } from "../../src/shell/strategies/bash.js";
+import { zshStrategy } from "../../src/shell/strategies/zsh.js";
+import { fishStrategy } from "../../src/shell/strategies/fish.js";
+import type { ShellStrategy } from "../../src/shell/strategies/index.js";
+
+interface Spec {
+  strategy: ShellStrategy;
+  candidates: string[];
+}
+
+const SHELLS: Spec[] = [
+  { strategy: bashStrategy, candidates: ["/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash", "/opt/homebrew/bin/bash"] },
+  { strategy: zshStrategy,  candidates: ["/bin/zsh",  "/usr/bin/zsh",  "/usr/local/bin/zsh",  "/opt/homebrew/bin/zsh"] },
+  { strategy: fishStrategy, candidates: ["/usr/bin/fish", "/usr/local/bin/fish", "/opt/homebrew/bin/fish"] },
+];
+
+function findBinary(candidates: string[]): string | null {
+  for (const c of candidates) {
+    try {
+      if (fs.statSync(c).isFile()) return c;
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+interface SmokeResult {
+  data: string;
+  reason: "all-markers" | "timeout" | "exit";
+}
+
+function smokeRun(shellBin: string, strategy: ShellStrategy, timeoutMs: number): Promise<SmokeResult> {
+  const tmpDirRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-pty-smoke-"));
+  const userHome = process.env.HOME || os.homedir();
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+
+  const cfg = strategy.prepareSpawn({
+    tmpDirRoot,
+    instanceTag: "id=smoketest",
+    showIndicator: false,
+    userHome,
+    env,
+  });
+  Object.assign(env, cfg.envOverrides);
+
+  const term = pty.spawn(shellBin, cfg.args, {
+    name: "xterm-256color",
+    cols: 80,
+    rows: 24,
+    cwd: userHome,
+    env,
+  });
+
+  return new Promise((resolve) => {
+    let data = "";
+    let commandSent = false;
+    let done = false;
+
+    const PROMPT = /\x1b\]9999;id=smoketest;PROMPT\x07/g;
+    const PREEXEC = /\x1b\]9997;id=smoketest;[^\x07]*\x07/;
+    const READY = /\x1b\]9998;id=smoketest;READY\x07/;
+
+    const cleanup = (reason: SmokeResult["reason"]): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try { term.kill(); } catch { /* noop */ }
+      fs.rmSync(tmpDirRoot, { recursive: true, force: true });
+      if (cfg.tmpDir && cfg.tmpDir !== tmpDirRoot) {
+        try { fs.rmSync(cfg.tmpDir, { recursive: true, force: true }); } catch { /* noop */ }
+      }
+      resolve({ data, reason });
+    };
+
+    const timer = setTimeout(() => cleanup("timeout"), timeoutMs);
+
+    term.onData((chunk) => {
+      data += chunk;
+      const promptCount = (data.match(PROMPT) ?? []).length;
+
+      // First PROMPT means the initial prompt is up — send the command.
+      if (!commandSent && promptCount >= 1) {
+        commandSent = true;
+        term.write("true\r");
+      }
+
+      // After our command, look for all three markers having appeared.
+      if (commandSent && PROMPT.test(data) && PREEXEC.test(data) && READY.test(data)) {
+        cleanup("all-markers");
+      }
+    });
+
+    term.onExit(() => cleanup("exit"));
+  });
+}
+
+for (const spec of SHELLS) {
+  const bin = findBinary(spec.candidates);
+  const skipReason = bin === null ? `${spec.strategy.name} not installed on this host` : false;
+
+  test(`${spec.strategy.name}: live PTY emits PROMPT, PREEXEC, and READY markers`, { timeout: 20000, skip: skipReason }, async () => {
+    const { data, reason } = await smokeRun(bin!, spec.strategy, 15000);
+
+    const promptOk = /\x1b\]9999;id=smoketest;PROMPT\x07/.test(data);
+    const preexecOk = /\x1b\]9997;id=smoketest;[^\x07]*\x07/.test(data);
+    const readyOk = /\x1b\]9998;id=smoketest;READY\x07/.test(data);
+
+    const detail = `reason=${reason}\nPROMPT seen: ${promptOk}\nPREEXEC seen: ${preexecOk}\nREADY seen: ${readyOk}\n--- captured (first 1KB) ---\n${data.slice(0, 1024)}`;
+
+    assert.ok(promptOk, `PROMPT (OSC 9999) never observed\n${detail}`);
+    assert.ok(preexecOk, `PREEXEC (OSC 9997) never observed\n${detail}`);
+    assert.ok(readyOk, `READY (OSC 9998) never observed\n${detail}`);
+  });
+}

--- a/tests/shell/rc-syntax.test.ts
+++ b/tests/shell/rc-syntax.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `<shell> -n` syntax check on the rc file each strategy generates.
+ *
+ * Catches "we generated syntactically broken shell" regressions cheaply —
+ * the shell parses the rc but does not execute it. Skips for any shell
+ * not installed on the host.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { bashStrategy } from "../../src/shell/strategies/bash.js";
+import { zshStrategy } from "../../src/shell/strategies/zsh.js";
+import { fishStrategy } from "../../src/shell/strategies/fish.js";
+import type { ShellStrategy } from "../../src/shell/strategies/index.js";
+
+interface Spec {
+  strategy: ShellStrategy;
+  candidates: string[];
+  rcFilename: string;
+}
+
+const SHELLS: Spec[] = [
+  { strategy: bashStrategy, rcFilename: ".bashrc",   candidates: ["/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash", "/opt/homebrew/bin/bash"] },
+  { strategy: zshStrategy,  rcFilename: ".zshrc",    candidates: ["/bin/zsh",  "/usr/bin/zsh",  "/usr/local/bin/zsh",  "/opt/homebrew/bin/zsh"] },
+  { strategy: fishStrategy, rcFilename: "init.fish", candidates: ["/usr/bin/fish", "/usr/local/bin/fish", "/opt/homebrew/bin/fish"] },
+];
+
+function findBinary(candidates: string[]): string | null {
+  for (const c of candidates) {
+    try {
+      if (fs.statSync(c).isFile()) return c;
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+for (const spec of SHELLS) {
+  const bin = findBinary(spec.candidates);
+  const skipReason = bin === null ? `${spec.strategy.name} not installed on this host` : false;
+
+  test(`${spec.strategy.name}: generated rc passes \`${spec.strategy.name} -n\` syntax check`, { skip: skipReason }, () => {
+    const tmpDirRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-rc-syntax-"));
+    try {
+      const cfg = spec.strategy.prepareSpawn({
+        tmpDirRoot,
+        instanceTag: "id=deadbeef",
+        showIndicator: true,
+        userHome: process.env.HOME || os.homedir(),
+        env: { HOME: process.env.HOME || os.homedir() },
+      });
+
+      const rcPath = path.join(cfg.tmpDir!, spec.rcFilename);
+      assert.ok(fs.existsSync(rcPath), `expected ${rcPath} to exist`);
+
+      const result = spawnSync(bin!, ["-n", rcPath], { encoding: "utf8" });
+      assert.equal(
+        result.status,
+        0,
+        `${spec.strategy.name} -n failed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}\nrc file:\n${fs.readFileSync(rcPath, "utf8")}`,
+      );
+
+      if (cfg.tmpDir) fs.rmSync(cfg.tmpDir, { recursive: true, force: true });
+    } finally {
+      fs.rmSync(tmpDirRoot, { recursive: true, force: true });
+    }
+  });
+
+  test(`${spec.strategy.name}: rc still passes syntax check with showIndicator=false`, { skip: skipReason }, () => {
+    const tmpDirRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-rc-syntax-"));
+    try {
+      const cfg = spec.strategy.prepareSpawn({
+        tmpDirRoot,
+        instanceTag: "id=deadbeef",
+        showIndicator: false,
+        userHome: process.env.HOME || os.homedir(),
+        env: { HOME: process.env.HOME || os.homedir() },
+      });
+      const rcPath = path.join(cfg.tmpDir!, spec.rcFilename);
+      const result = spawnSync(bin!, ["-n", rcPath], { encoding: "utf8" });
+      assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+      if (cfg.tmpDir) fs.rmSync(cfg.tmpDir, { recursive: true, force: true });
+    } finally {
+      fs.rmSync(tmpDirRoot, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/shell/strategies.test.ts
+++ b/tests/shell/strategies.test.ts
@@ -1,0 +1,246 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  pickStrategy,
+  SUPPORTED_SHELL_NAMES,
+  FALLBACK_STRATEGY,
+} from "../../src/shell/strategies/index.js";
+import { bashStrategy } from "../../src/shell/strategies/bash.js";
+import { zshStrategy } from "../../src/shell/strategies/zsh.js";
+import { fishStrategy } from "../../src/shell/strategies/fish.js";
+import type { PrepareSpawnOpts } from "../../src/shell/strategies/types.js";
+
+function makeOpts(overrides: Partial<PrepareSpawnOpts> = {}): PrepareSpawnOpts {
+  const tmpDirRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-sh-strategies-test-"));
+  return {
+    tmpDirRoot,
+    instanceTag: "id=deadbeef",
+    showIndicator: true,
+    userHome: "/home/test",
+    env: { HOME: "/home/test" },
+    ...overrides,
+  };
+}
+
+function cleanup(tmpDir: string | undefined): void {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ── pickStrategy / supported names ───────────────────────────────
+
+test("pickStrategy returns the bash strategy for any path ending in bash", () => {
+  assert.equal(pickStrategy("/bin/bash")?.name, "bash");
+  assert.equal(pickStrategy("/usr/local/bin/bash")?.name, "bash");
+  assert.equal(pickStrategy("/opt/homebrew/bin/bash")?.name, "bash");
+});
+
+test("pickStrategy returns the zsh strategy for any path ending in zsh", () => {
+  assert.equal(pickStrategy("/bin/zsh")?.name, "zsh");
+  assert.equal(pickStrategy("/usr/local/bin/zsh")?.name, "zsh");
+});
+
+test("pickStrategy returns the fish strategy for any path ending in fish", () => {
+  assert.equal(pickStrategy("/usr/local/bin/fish")?.name, "fish");
+  assert.equal(pickStrategy("/opt/homebrew/bin/fish")?.name, "fish");
+});
+
+test("pickStrategy returns null for unrecognized shells", () => {
+  assert.equal(pickStrategy("/usr/bin/nu"), null);
+  assert.equal(pickStrategy("/usr/bin/pwsh"), null);
+  assert.equal(pickStrategy("/bin/sh"), null);
+});
+
+test("SUPPORTED_SHELL_NAMES lists all three first-class shells", () => {
+  assert.deepEqual([...SUPPORTED_SHELL_NAMES].sort(), ["bash", "fish", "zsh"]);
+});
+
+test("FALLBACK_STRATEGY is bash (used when the requested shell is unknown)", () => {
+  assert.equal(FALLBACK_STRATEGY.name, "bash");
+});
+
+// ── bash strategy ────────────────────────────────────────────────
+
+test("bash strategy writes a .bashrc that sources the user's bashrc and installs all three OSC hooks", () => {
+  const opts = makeOpts();
+  const cfg = bashStrategy.prepareSpawn(opts);
+  try {
+    assert.ok(cfg.tmpDir);
+    const rc = fs.readFileSync(path.join(cfg.tmpDir!, ".bashrc"), "utf8");
+
+    assert.match(rc, /source "\/home\/test\/\.bashrc"/);
+    assert.match(rc, /\\e\]9999;id=deadbeef;PROMPT\\a/);
+    assert.match(rc, /\\e\]9997;id=deadbeef;%s\\a/);
+    assert.match(rc, /\\e\]9998;id=deadbeef;READY\\a/);
+    assert.match(rc, /PROMPT_COMMAND=/);
+    assert.match(rc, /trap '__agent_sh_emit_preexec' DEBUG/);
+    assert.match(rc, /redraw-current-line/);
+  } finally {
+    cleanup(cfg.tmpDir);
+    cleanup(opts.tmpDirRoot);
+  }
+});
+
+test("bash strategy spawn args use --rcfile pointing at the tmp .bashrc", () => {
+  const opts = makeOpts();
+  const cfg = bashStrategy.prepareSpawn(opts);
+  try {
+    assert.equal(cfg.args[0], "--rcfile");
+    assert.equal(cfg.args[1], path.join(cfg.tmpDir!, ".bashrc"));
+    assert.deepEqual(cfg.envOverrides, {});
+  } finally {
+    cleanup(cfg.tmpDir);
+    cleanup(opts.tmpDirRoot);
+  }
+});
+
+test("bash strategy omits the title indicator when showIndicator is false", () => {
+  const opts = makeOpts({ showIndicator: false });
+  const cfg = bashStrategy.prepareSpawn(opts);
+  try {
+    const rc = fs.readFileSync(path.join(cfg.tmpDir!, ".bashrc"), "utf8");
+    assert.doesNotMatch(rc, /agent-sh:/);
+  } finally {
+    cleanup(cfg.tmpDir);
+    cleanup(opts.tmpDirRoot);
+  }
+});
+
+test("bash strategy substitutes a different instance tag per call (nested instances)", () => {
+  const a = bashStrategy.prepareSpawn(makeOpts({ instanceTag: "id=aaaaaa" }));
+  const b = bashStrategy.prepareSpawn(makeOpts({ instanceTag: "id=bbbbbb" }));
+  try {
+    const rcA = fs.readFileSync(path.join(a.tmpDir!, ".bashrc"), "utf8");
+    const rcB = fs.readFileSync(path.join(b.tmpDir!, ".bashrc"), "utf8");
+    assert.match(rcA, /id=aaaaaa/);
+    assert.doesNotMatch(rcA, /id=bbbbbb/);
+    assert.match(rcB, /id=bbbbbb/);
+    assert.doesNotMatch(rcB, /id=aaaaaa/);
+  } finally {
+    cleanup(a.tmpDir);
+    cleanup(b.tmpDir);
+  }
+});
+
+test("bash envCaptureCommand sources bashrc then runs env -0", () => {
+  assert.match(bashStrategy.envCaptureCommand(), /source ~\/\.bashrc/);
+  assert.match(bashStrategy.envCaptureCommand(), /env -0/);
+});
+
+test("bash redrawEscape returns the CSI 9999~ sequence", () => {
+  assert.equal(bashStrategy.redrawEscape(), "\x1b[9999~");
+});
+
+// ── zsh strategy ─────────────────────────────────────────────────
+
+test("zsh strategy writes a .zshrc that sources the user's zshrc and installs all three OSC hooks", () => {
+  const opts = makeOpts({ env: { HOME: "/home/test", ZDOTDIR: "/home/test/.config/zsh" } });
+  const cfg = zshStrategy.prepareSpawn(opts);
+  try {
+    const rc = fs.readFileSync(path.join(cfg.tmpDir!, ".zshrc"), "utf8");
+    assert.match(rc, /ZDOTDIR="\/home\/test\/\.config\/zsh"/);
+    assert.match(rc, /source "\/home\/test\/\.config\/zsh\/\.zshrc"/);
+    assert.match(rc, /\\e\]9999;id=deadbeef;PROMPT\\a/);
+    assert.match(rc, /\\e\]9997;id=deadbeef;%s\\a/);
+    assert.match(rc, /\\e\]9998;id=deadbeef;READY\\a/);
+    assert.match(rc, /precmd_functions\+=\(__agent_sh_precmd\)/);
+    assert.match(rc, /preexec_functions\+=\(__agent_sh_preexec\)/);
+    assert.match(rc, /zle -N __agent_sh_redraw/);
+  } finally {
+    cleanup(cfg.tmpDir);
+    cleanup(opts.tmpDirRoot);
+  }
+});
+
+test("zsh strategy spawn config sets ZDOTDIR to the tmp dir and uses --no-globalrcs", () => {
+  const opts = makeOpts();
+  const cfg = zshStrategy.prepareSpawn(opts);
+  try {
+    assert.deepEqual(cfg.args, ["--no-globalrcs"]);
+    assert.equal(cfg.envOverrides.ZDOTDIR, cfg.tmpDir);
+  } finally {
+    cleanup(cfg.tmpDir);
+    cleanup(opts.tmpDirRoot);
+  }
+});
+
+test("zsh strategy falls back to HOME when ZDOTDIR is unset", () => {
+  const opts = makeOpts({ env: { HOME: "/home/other" } });
+  const cfg = zshStrategy.prepareSpawn(opts);
+  try {
+    const rc = fs.readFileSync(path.join(cfg.tmpDir!, ".zshrc"), "utf8");
+    assert.match(rc, /ZDOTDIR="\/home\/other"/);
+    assert.match(rc, /source "\/home\/other\/\.zshrc"/);
+  } finally {
+    cleanup(cfg.tmpDir);
+    cleanup(opts.tmpDirRoot);
+  }
+});
+
+test("zsh strategy chains onto an existing zle-line-init widget rather than clobbering it", () => {
+  const cfg = zshStrategy.prepareSpawn(makeOpts());
+  try {
+    const rc = fs.readFileSync(path.join(cfg.tmpDir!, ".zshrc"), "utf8");
+    assert.match(rc, /if \(\( \$\{\+widgets\[zle-line-init\]\} \)\); then/);
+    assert.match(rc, /zle -A zle-line-init __agent_sh_orig_line_init/);
+  } finally {
+    cleanup(cfg.tmpDir);
+  }
+});
+
+test("zsh envCaptureCommand sources zshrc then runs env -0", () => {
+  assert.match(zshStrategy.envCaptureCommand(), /source ~\/\.zshrc/);
+  assert.match(zshStrategy.envCaptureCommand(), /env -0/);
+});
+
+test("zsh redrawEscape returns the CSI 9999~ sequence", () => {
+  assert.equal(zshStrategy.redrawEscape(), "\x1b[9999~");
+});
+
+// ── fish strategy ────────────────────────────────────────────────
+
+test("fish strategy writes an init.fish that installs all three OSC hooks via event handlers", () => {
+  const cfg = fishStrategy.prepareSpawn(makeOpts());
+  try {
+    const init = fs.readFileSync(path.join(cfg.tmpDir!, "init.fish"), "utf8");
+    assert.match(init, /__agent_sh_precmd --on-event fish_prompt/);
+    assert.match(init, /__agent_sh_preexec --on-event fish_preexec/);
+    assert.match(init, /\\e\]9999;id=deadbeef;PROMPT\\a/);
+    assert.match(init, /\\e\]9997;id=deadbeef;%s\\a/);
+    assert.match(init, /\\e\]9998;id=deadbeef;READY\\a/);
+  } finally {
+    cleanup(cfg.tmpDir);
+  }
+});
+
+test("fish strategy spawn config layers init via `-l -i -C source <init>`", () => {
+  const cfg = fishStrategy.prepareSpawn(makeOpts());
+  try {
+    assert.deepEqual(cfg.args.slice(0, 3), ["-l", "-i", "-C"]);
+    assert.equal(cfg.args[3], `source ${path.join(cfg.tmpDir!, "init.fish")}`);
+    assert.deepEqual(cfg.envOverrides, {});
+  } finally {
+    cleanup(cfg.tmpDir);
+  }
+});
+
+test("fish strategy chains onto an existing fish_prompt rather than clobbering it", () => {
+  const cfg = fishStrategy.prepareSpawn(makeOpts());
+  try {
+    const init = fs.readFileSync(path.join(cfg.tmpDir!, "init.fish"), "utf8");
+    assert.match(init, /functions --copy fish_prompt __agent_sh_orig_fish_prompt/);
+    assert.match(init, /__agent_sh_orig_fish_prompt/);
+  } finally {
+    cleanup(cfg.tmpDir);
+  }
+});
+
+test("fish envCaptureCommand just runs env -0 (fish -l sources config itself)", () => {
+  assert.equal(fishStrategy.envCaptureCommand(), "env -0");
+});
+
+test("fish redrawEscape returns the CSI-u sequence with private-use codepoint U+E028", () => {
+  assert.equal(fishStrategy.redrawEscape(), "\x1b[57400u");
+});


### PR DESCRIPTION
## Summary

Covers the regression surface for the three shells listed as supported in the README. Defends both sides of the strategy ↔ parser boundary, the format contract between them, generated-rc syntax validity, and a live PTY pass.

- `strategies.test.ts` (23) — rc-file content, spawn args, env overrides, per-instance tag substitution (nested isolation), `pickStrategy` / fallback selection
- `output-parser.test.ts` (15) — OSC 7/9997/9998/9999 handling, foreign-tag isolation, capture-buffer cap
- `contract.test.ts` (13) — each strategy's emitted OSC format is parseable by `OutputParser` (closes the previously invisible "we changed the OSC number on one side and forgot the other" gap); nested-instance isolation verified across chunked PTY streams
- `rc-syntax.test.ts` (6) — `bash -n` / `zsh -n` / `fish -n` on the generated rc, skips cleanly when the shell binary is not installed
- `pty-smoke.test.ts` (3) — real PTY spawn per installed shell, asserts PROMPT/PREEXEC/READY markers appear end-to-end; intentionally minimal content claims (PREEXEC payload depends on shell version / history config — out of regression scope)

60 new tests, ~12 s wall locally. Full `npm test` is 121/121.

## Test plan

- [x] `node --import tsx --test tests/shell/*.test.ts` — 60/60 pass
- [x] `npm test` — 121/121 pass
- [ ] CI on a host without `fish` installed: the 4 fish-dependent rc-syntax + smoke cases should skip cleanly, others should still pass