### PR TITLE
Stop ash agent:info from clobbering active backend's prompt label

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -170,6 +170,8 @@ async function main(): Promise<void> {
     );
   }
 
+  await core.activateBackend(config.backend);
+
   // 100ms sidesteps macOS SIGTTOU during fg-pgrp handoff.
   await new Promise(resolve => setTimeout(resolve, 100));
   shell = activateShell(extCtx, {
@@ -196,8 +198,6 @@ async function main(): Promise<void> {
     },
     returnToSelf: true,
   });
-
-  core.activateBackend(config.backend);
 
   // ── Terminal lifecycle ────────────────────────────────────────
   process.on("SIGTERM", cleanup);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -94,8 +94,8 @@ export function createCore(config: AppConfig): AgentShellCore {
       return false;
     }
 
-    if (activeBackendName) {
-      backends.get(activeBackendName)?.kill();
+    for (const [otherName, otherBackend] of backends) {
+      if (otherName !== name) otherBackend.kill();
     }
 
     await backend.start?.();


### PR DESCRIPTION
## Summary

- When a non-ash backend is selected (e.g. `ash --backend claude-code`), the prompt label was showing `ash (deepseek-v4-pro)` instead of `claude-code`, even though the bridge was actually routing queries correctly.
- Root cause: the ash subsystem loads eagerly even when not active. Its `AgentLoop` ctor subscribes to `config:add-modes`; openrouter's async catalog fetch fires that event after startup, triggering `emitAgentInfoIfChanged()` and broadcasting stale ash identity that overwrites the active backend's `agent:info` in the UI.

## Fix

Two-line change in `activateByName`:

1. Kill **every** non-active registered backend on activation (not just the previously-active one). This tears down ash's eager `AgentLoop` listeners so late catalog updates can't reach them.
2. Move `core.activateBackend(...)` earlier in `cli/index.ts` so the prompt label reflects the correct backend from the first render.

This is intentionally a symptom patch — it filters the leak by severing the source. The structural fix (lazy ash backend, agent-backend extension separated from core, pull-composition for identity) is being scoped to 0.14 on a separate branch.

## Test plan

- [ ] `ash --backend claude-code` — prompt label reads `claude-code` (not `ash (...)`) from first render.
- [ ] `ash --backend pi` — prompt label reads `pi`.
- [ ] `ash` (default, ash backend) — prompt label still reads `ash (model)` correctly.
- [ ] `/backend ash` then `/backend claude-code` switching mid-session updates the prompt label correctly.
- [ ] Existing bridge tests still pass.