### PR TITLE
opencode-bridge permission picker + install pin-drift warning

### DIFF
--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -70,7 +70,10 @@ async function main(): Promise<void> {
 
   if (sub === "install" || sub === "uninstall" || sub === "list") {
     const { runInstall, runUninstall, runList } = await import("agent-sh/cli/install");
-    if (sub === "install") await runInstall(rest[0] ?? "", { force: rest.includes("--force") });
+    if (sub === "install") await runInstall(rest[0] ?? "", {
+      force: rest.includes("--force"),
+      syncDeps: rest.includes("--sync-deps"),
+    });
     else if (sub === "uninstall") await runUninstall(rest[0] ?? "");
     else runList();
     process.exit(0);

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -319,7 +319,13 @@ export default function activate(ctx: ExtensionContext): void {
             }
           } finally {
             pickerOpen = false;
-            drainQueue();
+            if (result.cancelled) {
+              eventQueue.length = 0;
+              pendingTurnEnd?.();
+              bus.emit("agent:processing-done", {});
+            } else {
+              drainQueue();
+            }
           }
         });
         break;
@@ -371,7 +377,15 @@ export default function activate(ctx: ExtensionContext): void {
             finish(result.reply, result.cancelled ? { skipReply: true } : undefined);
           } finally {
             pickerOpen = false;
-            drainQueue();
+            if (result.cancelled) {
+              // Drop queued SSE — replaying would render tool indicators
+              // for a turn the user just aborted.
+              eventQueue.length = 0;
+              pendingTurnEnd?.();
+              bus.emit("agent:processing-done", {});
+            } else {
+              drainQueue();
+            }
           }
         });
         break;

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -343,7 +343,6 @@ export default function activate(ctx: ExtensionContext): void {
               eventQueue.length = 0;
               cancelledTurn = true;
               pendingTurnEnd?.();
-              bus.emit("agent:processing-done", {});
             } else {
               drainQueue();
             }
@@ -400,11 +399,14 @@ export default function activate(ctx: ExtensionContext): void {
             pickerOpen = false;
             if (result.cancelled) {
               // Drop queued SSE — replaying would render tool indicators
-              // for a turn the user just aborted.
+              // for a turn the user just aborted. pendingTurnEnd?.() lets
+              // onSubmit's await idlePromise resolve so its finally block
+              // emits the single agent:processing-done; emitting one here
+              // too races with onSubmit's still-pending session.prompt()
+              // and leaves the TUI with two stacked prompts.
               eventQueue.length = 0;
               cancelledTurn = true;
               pendingTurnEnd?.();
-              bus.emit("agent:processing-done", {});
             } else {
               drainQueue();
             }

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -13,6 +13,7 @@ import {
   type ToolPart,
   type QuestionRequest,
   type QuestionInfo,
+  type PermissionRequest,
 } from "@opencode-ai/sdk/v2";
 import type { ExtensionContext } from "agent-sh/types";
 import type { InteractiveSession } from "agent-sh/agent/types";
@@ -306,16 +307,51 @@ export default function activate(ctx: ExtensionContext): void {
         });
         break;
       }
-      // Without a reply the gated tool hangs forever. The bridge has no
-      // interactive approval UI, so auto-approve — mirrors claude-code-
-      // bridge's permissionMode: "acceptEdits". Set permission.edit:
-      // "allow" in opencode.json to skip the round-trip entirely.
+      // opencode.json's `permission.*` settings short-circuit before we
+      // get here; this branch surfaces whatever opencode still wants asked.
       case "permission.asked": {
-        const requestID = props.id as string | undefined;
-        if (!requestID || !runtime) break;
-        runtime.client.permission
-          .reply({ requestID, reply: "once", directory: sessionDirectory ?? undefined })
-          .catch(() => { /* approval is best-effort */ });
+        const req = props as PermissionRequest;
+        if (!runtime) break;
+        const callID = `permission-${req.id}`;
+        const detail = req.patterns.length > 0
+          ? `${req.permission}: ${req.patterns.join(", ")}`
+          : req.permission;
+        bus.emit("agent:tool-started", {
+          title: "permission",
+          toolCallId: callID,
+          kind: "execute",
+          displayDetail: detail,
+        });
+        const finish = (reply: "once" | "always" | "reject", note?: string) => {
+          const exitCode = reply === "reject" ? 1 : 0;
+          const summary = note ? `${reply} (${note})` : `${reply}: ${detail}`;
+          bus.emitTransform("agent:tool-completed", {
+            toolCallId: callID,
+            exitCode,
+            rawOutput: summary,
+            kind: "execute",
+            resultDisplay: { summary },
+          });
+          if (!runtime) return;
+          runtime.client.permission
+            .reply({ requestID: req.id, reply, directory: sessionDirectory ?? undefined })
+            .catch((err) => {
+              bus.emit("agent:error", {
+                message: err instanceof Error ? err.message : String(err),
+              });
+            });
+        };
+        if (!compositor) {
+          finish("reject", "no shell host");
+          bus.emit("ui:error", {
+            message: `opencode-bridge: rejected permission (no shell host): ${detail}`,
+          });
+          break;
+        }
+        const ui = createToolUI(bus, compositor.surface("agent"));
+        ui.custom(createPermissionSession(req)).then((result: PermissionResult) => {
+          finish(result.reply);
+        });
         break;
       }
     }
@@ -481,6 +517,7 @@ export default function activate(ctx: ExtensionContext): void {
 // ── Interactive question picker ──────────────────────────────────
 
 type QuestionResult = { answers: string[][]; cancelled: boolean };
+type PermissionResult = { reply: "once" | "always" | "reject" };
 
 function isKey(data: string, key: string): boolean {
   switch (key) {
@@ -607,6 +644,56 @@ function createQuestionSession(questions: QuestionInfo[]): InteractiveSession<Qu
           tab = next;
           optionIdx = 0;
         }
+      }
+    },
+  };
+}
+
+function createPermissionSession(req: PermissionRequest): InteractiveSession<PermissionResult> {
+  return {
+    render(width) {
+      const w = Math.min(80, width);
+      const lines: string[] = [];
+
+      lines.push(`${p.muted}${"─".repeat(w)}${p.reset}`);
+      lines.push(` ${p.warning}${p.bold}Permission required: ${req.permission}${p.reset}`);
+      lines.push("");
+
+      const meta = req.metadata ?? {};
+      const cmd = typeof meta.command === "string" ? meta.command : null;
+      const file = typeof meta.file === "string"
+        ? meta.file
+        : typeof meta.path === "string" ? meta.path : null;
+      if (cmd) {
+        for (const line of cmd.split("\n").slice(0, 6)) {
+          lines.push(`   ${p.dim}${line}${p.reset}`);
+        }
+        lines.push("");
+      } else if (file) {
+        lines.push(`   ${p.dim}${file}${p.reset}`);
+        lines.push("");
+      }
+
+      if (req.patterns.length > 0) {
+        lines.push(` ${p.muted}Patterns:${p.reset}`);
+        for (const pat of req.patterns) {
+          lines.push(`   ${pat}`);
+        }
+        lines.push("");
+      }
+
+      lines.push(` ${p.dim}[y] allow once  [a] allow always  [n] reject${p.reset}`);
+      lines.push(`${p.muted}${"─".repeat(w)}${p.reset}`);
+      return lines;
+    },
+
+    handleInput(data, done) {
+      if (isKey(data, "escape") || data === "n" || data === "N") {
+        done({ reply: "reject" });
+      } else if (data === "y" || data === "Y" || isKey(data, "enter")) {
+        done({ reply: "once" });
+      } else if (data === "a" || data === "A") {
+        done({ reply: "always" });
       }
     },
   };

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -222,12 +222,11 @@ export default function activate(ctx: ExtensionContext): void {
 
     if (cancelledTurn) {
       // Pass through only what we need to unblock onSubmit; suppress
-      // tool / delta / error renders for the aborted turn.
-      if (evType === "session.idle") {
-        turnIdleSeen = true;
-        pendingTurnEnd?.();
-      } else if (evType === "session.error") {
-        cancelledTurn = false;
+      // everything else for the aborted turn. cancelledTurn is reset by
+      // onSubmit on the next turn — clearing it earlier (e.g. on
+      // session.error) lets opencode's later message.part.updated for
+      // the cancelled bash tool slip through and restart the spinner.
+      if (evType === "session.idle" || evType === "session.error") {
         turnIdleSeen = true;
         pendingTurnEnd?.();
       }

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -60,7 +60,8 @@ function parseUnifiedDiff(patch: string): DiffResult | null {
 }
 
 export default function activate(ctx: ExtensionContext): void {
-  const { bus, call } = ctx; const { compositor } = ctx.shell;
+  const { bus, call } = ctx;
+  const compositor = ctx.shell?.compositor;
 
   const cwd = (): string => {
     const v = call("cwd");
@@ -242,6 +243,15 @@ export default function activate(ctx: ExtensionContext): void {
       case "question.asked": {
         const req = props as QuestionRequest;
         if (!runtime) break;
+        if (!compositor) {
+          runtime.client.question
+            .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
+            .catch(() => { /* best-effort */ });
+          bus.emit("ui:error", {
+            message: `opencode-bridge: rejected interactive question (no shell host): ${req.questions.map((q) => q.question).join("; ")}`,
+          });
+          break;
+        }
         const ui = createToolUI(bus, compositor.surface("agent"));
         ui.custom(createQuestionSession(req.questions)).then(async (result: QuestionResult) => {
           if (!runtime) return;

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -307,8 +307,6 @@ export default function activate(ctx: ExtensionContext): void {
         });
         break;
       }
-      // opencode.json's `permission.*` settings short-circuit before we
-      // get here; this branch surfaces whatever opencode still wants asked.
       case "permission.asked": {
         const req = props as PermissionRequest;
         if (!runtime) break;
@@ -316,8 +314,6 @@ export default function activate(ctx: ExtensionContext): void {
           ? `${req.permission}: ${req.patterns.join(", ")}`
           : req.permission;
         const finish = (reply: "once" | "always" | "reject", opts?: { note?: string; skipReply?: boolean }) => {
-          // Only emit a timeline entry on reject — once/always are followed
-          // by the actual tool run, which is its own record.
           if (reply === "reject") {
             const callID = `permission-${req.id}`;
             const summary = opts?.note ? `denied (${opts.note})` : `denied: ${detail}`;

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -653,8 +653,7 @@ function createPermissionSession(
   bus: { on: (e: "agent:cancel-request", fn: () => void) => void; off: (e: "agent:cancel-request", fn: () => void) => void },
 ): InteractiveSession<PermissionResult> {
   let cancelHandler: (() => void) | null = null;
-  // Framework passes (invalidate, done) to onMount; the vendored type only
-  // declares (invalidate), so widen via cast at the assignment site.
+  // Cast widens onMount: the vendored agent-sh type still declares the 1-arg signature.
   const onMount = ((_invalidate: () => void, done: (r: PermissionResult) => void): void => {
     cancelHandler = () => done({ reply: "reject", cancelled: true });
     bus.on("agent:cancel-request", cancelHandler);

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -315,12 +315,12 @@ export default function activate(ctx: ExtensionContext): void {
         const detail = req.patterns.length > 0
           ? `${req.permission}: ${req.patterns.join(", ")}`
           : req.permission;
-        const finish = (reply: "once" | "always" | "reject", note?: string) => {
+        const finish = (reply: "once" | "always" | "reject", opts?: { note?: string; skipReply?: boolean }) => {
           // Only emit a timeline entry on reject — once/always are followed
           // by the actual tool run, which is its own record.
           if (reply === "reject") {
             const callID = `permission-${req.id}`;
-            const summary = note ? `denied (${note})` : `denied: ${detail}`;
+            const summary = opts?.note ? `denied (${opts.note})` : `denied: ${detail}`;
             bus.emit("agent:tool-started", {
               title: "permission",
               toolCallId: callID,
@@ -335,7 +335,7 @@ export default function activate(ctx: ExtensionContext): void {
               resultDisplay: { summary },
             });
           }
-          if (!runtime) return;
+          if (!runtime || opts?.skipReply) return;
           runtime.client.permission
             .reply({ requestID: req.id, reply, directory: sessionDirectory ?? undefined })
             .catch((err) => {
@@ -345,15 +345,15 @@ export default function activate(ctx: ExtensionContext): void {
             });
         };
         if (!compositor) {
-          finish("reject", "no shell host");
+          finish("reject", { note: "no shell host" });
           bus.emit("ui:error", {
             message: `opencode-bridge: rejected permission (no shell host): ${detail}`,
           });
           break;
         }
         const ui = createToolUI(bus, compositor.surface("agent"));
-        ui.custom(createPermissionSession(req)).then((result: PermissionResult) => {
-          finish(result.reply);
+        ui.custom(createPermissionSession(req, bus)).then((result: PermissionResult) => {
+          finish(result.reply, result.cancelled ? { skipReply: true } : undefined);
         });
         break;
       }
@@ -520,7 +520,7 @@ export default function activate(ctx: ExtensionContext): void {
 // ── Interactive question picker ──────────────────────────────────
 
 type QuestionResult = { answers: string[][]; cancelled: boolean };
-type PermissionResult = { reply: "once" | "always" | "reject" };
+type PermissionResult = { reply: "once" | "always" | "reject"; cancelled?: boolean };
 
 function isKey(data: string, key: string): boolean {
   switch (key) {
@@ -652,8 +652,23 @@ function createQuestionSession(questions: QuestionInfo[]): InteractiveSession<Qu
   };
 }
 
-function createPermissionSession(req: PermissionRequest): InteractiveSession<PermissionResult> {
+function createPermissionSession(
+  req: PermissionRequest,
+  bus: { on: (e: "agent:cancel-request", fn: () => void) => void; off: (e: "agent:cancel-request", fn: () => void) => void },
+): InteractiveSession<PermissionResult> {
+  let cancelHandler: (() => void) | null = null;
+  // Framework passes (invalidate, done) to onMount; the vendored type only
+  // declares (invalidate), so widen via cast at the assignment site.
+  const onMount = ((_invalidate: () => void, done: (r: PermissionResult) => void): void => {
+    cancelHandler = () => done({ reply: "reject", cancelled: true });
+    bus.on("agent:cancel-request", cancelHandler);
+  }) as InteractiveSession<PermissionResult>["onMount"];
   return {
+    onMount,
+    onUnmount() {
+      if (cancelHandler) bus.off("agent:cancel-request", cancelHandler);
+      cancelHandler = null;
+    },
     render(_width) {
       const lines: string[] = [];
       lines.push(` ${p.warning}${p.bold}Permission required: ${req.permission}${p.reset}`);

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -312,26 +312,29 @@ export default function activate(ctx: ExtensionContext): void {
       case "permission.asked": {
         const req = props as PermissionRequest;
         if (!runtime) break;
-        const callID = `permission-${req.id}`;
         const detail = req.patterns.length > 0
           ? `${req.permission}: ${req.patterns.join(", ")}`
           : req.permission;
-        bus.emit("agent:tool-started", {
-          title: "permission",
-          toolCallId: callID,
-          kind: "execute",
-          displayDetail: detail,
-        });
         const finish = (reply: "once" | "always" | "reject", note?: string) => {
-          const exitCode = reply === "reject" ? 1 : 0;
-          const summary = note ? `${reply} (${note})` : `${reply}: ${detail}`;
-          bus.emitTransform("agent:tool-completed", {
-            toolCallId: callID,
-            exitCode,
-            rawOutput: summary,
-            kind: "execute",
-            resultDisplay: { summary },
-          });
+          // Only emit a timeline entry on reject — once/always are followed
+          // by the actual tool run, which is its own record.
+          if (reply === "reject") {
+            const callID = `permission-${req.id}`;
+            const summary = note ? `denied (${note})` : `denied: ${detail}`;
+            bus.emit("agent:tool-started", {
+              title: "permission",
+              toolCallId: callID,
+              kind: "execute",
+              displayDetail: detail,
+            });
+            bus.emitTransform("agent:tool-completed", {
+              toolCallId: callID,
+              exitCode: 1,
+              rawOutput: summary,
+              kind: "execute",
+              resultDisplay: { summary },
+            });
+          }
           if (!runtime) return;
           runtime.client.permission
             .reply({ requestID: req.id, reply, directory: sessionDirectory ?? undefined })
@@ -651,13 +654,9 @@ function createQuestionSession(questions: QuestionInfo[]): InteractiveSession<Qu
 
 function createPermissionSession(req: PermissionRequest): InteractiveSession<PermissionResult> {
   return {
-    render(width) {
-      const w = Math.min(80, width);
+    render(_width) {
       const lines: string[] = [];
-
-      lines.push(`${p.muted}${"─".repeat(w)}${p.reset}`);
       lines.push(` ${p.warning}${p.bold}Permission required: ${req.permission}${p.reset}`);
-      lines.push("");
 
       const meta = req.metadata ?? {};
       const cmd = typeof meta.command === "string" ? meta.command : null;
@@ -668,22 +667,17 @@ function createPermissionSession(req: PermissionRequest): InteractiveSession<Per
         for (const line of cmd.split("\n").slice(0, 6)) {
           lines.push(`   ${p.dim}${line}${p.reset}`);
         }
-        lines.push("");
       } else if (file) {
         lines.push(`   ${p.dim}${file}${p.reset}`);
-        lines.push("");
       }
 
-      if (req.patterns.length > 0) {
-        lines.push(` ${p.muted}Patterns:${p.reset}`);
+      if (req.patterns.length > 0 && !cmd && !file) {
         for (const pat of req.patterns) {
-          lines.push(`   ${pat}`);
+          lines.push(`   ${p.dim}${pat}${p.reset}`);
         }
-        lines.push("");
       }
 
       lines.push(` ${p.dim}[y] allow once  [a] allow always  [n] reject${p.reset}`);
-      lines.push(`${p.muted}${"─".repeat(w)}${p.reset}`);
       return lines;
     },
 

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -106,6 +106,13 @@ export default function activate(ctx: ExtensionContext): void {
     for (const ev of events) handleEvent(ev);
   };
 
+  // After Ctrl+C through a picker, opencode keeps emitting tool / error
+  // state for the aborted turn (e.g. final "errored" state on the bash
+  // tool we never ran). Those events restart spinners and replay tool
+  // entries the user already knows are dead. Drop them until the abort
+  // is acknowledged by session.error (or a fresh turn).
+  let cancelledTurn = false;
+
   const listeners: Array<{ event: string; fn: Function }> = [];
 
   function toolKind(name: string): string {
@@ -212,6 +219,20 @@ export default function activate(ctx: ExtensionContext): void {
     const props = (event as any).properties ?? {};
     const sid = props.sessionID;
     if (typeof sid === "string" && sid !== sessionId) return;
+
+    if (cancelledTurn) {
+      // Pass through only what we need to unblock onSubmit; suppress
+      // tool / delta / error renders for the aborted turn.
+      if (evType === "session.idle") {
+        turnIdleSeen = true;
+        pendingTurnEnd?.();
+      } else if (evType === "session.error") {
+        cancelledTurn = false;
+        turnIdleSeen = true;
+        pendingTurnEnd?.();
+      }
+      return;
+    }
 
     switch (evType) {
       // message.part.delta is undocumented in the SDK's Event union but
@@ -321,6 +342,7 @@ export default function activate(ctx: ExtensionContext): void {
             pickerOpen = false;
             if (result.cancelled) {
               eventQueue.length = 0;
+              cancelledTurn = true;
               pendingTurnEnd?.();
               bus.emit("agent:processing-done", {});
             } else {
@@ -381,6 +403,7 @@ export default function activate(ctx: ExtensionContext): void {
               // Drop queued SSE — replaying would render tool indicators
               // for a turn the user just aborted.
               eventQueue.length = 0;
+              cancelledTurn = true;
               pendingTurnEnd?.();
               bus.emit("agent:processing-done", {});
             } else {
@@ -421,6 +444,7 @@ export default function activate(ctx: ExtensionContext): void {
       bus.emit("agent:query", { query: userQuery });
       bus.emit("agent:processing-start", {});
       turnText = "";
+      cancelledTurn = false;
       turnIdleSeen = false;
       turnError = null;
       // Set the idle waiter BEFORE prompt() so a fast session.idle can't

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -96,6 +96,16 @@ export default function activate(ctx: ExtensionContext): void {
   let turnIdleSeen = false;
   let turnError: string | null = null;
 
+  // While a picker is open, queue SSE events so subsequent tool-started /
+  // delta renders don't paint above or below the picker. Replayed in order
+  // once the user resolves the picker.
+  let pickerOpen = false;
+  const eventQueue: Event[] = [];
+  const drainQueue = (): void => {
+    const events = eventQueue.splice(0);
+    for (const ev of events) handleEvent(ev);
+  };
+
   const listeners: Array<{ event: string; fn: Function }> = [];
 
   function toolKind(name: string): string {
@@ -196,6 +206,7 @@ export default function activate(ctx: ExtensionContext): void {
 
 
   function handleEvent(event: Event): void {
+    if (pickerOpen) { eventQueue.push(event); return; }
     if (!sessionId) return;
     const evType = (event as any).type as string;
     const props = (event as any).properties ?? {};
@@ -253,56 +264,62 @@ export default function activate(ctx: ExtensionContext): void {
           });
           break;
         }
+        pickerOpen = true;
         const ui = createToolUI(bus, compositor.surface("agent"));
         ui.custom(createQuestionSession(req.questions)).then(async (result: QuestionResult) => {
-          if (!runtime) return;
-          // Record the question + answer as a synthetic tool entry so the
-          // timeline shows what was asked and what the user picked.
-          const callID = `question-${req.id}`;
-          const detail = req.questions.length === 1
-            ? req.questions[0]!.question
-            : req.questions.map((q, i) => `${q.header || `Q${i + 1}`}: ${q.question}`).join("; ");
-          bus.emit("agent:tool-started", {
-            title: "question",
-            toolCallId: callID,
-            kind: "execute",
-            displayDetail: detail,
-          });
-          if (result.cancelled) {
+          try {
+            if (!runtime) return;
+            // Record the question + answer as a synthetic tool entry so the
+            // timeline shows what was asked and what the user picked.
+            const callID = `question-${req.id}`;
+            const detail = req.questions.length === 1
+              ? req.questions[0]!.question
+              : req.questions.map((q, i) => `${q.header || `Q${i + 1}`}: ${q.question}`).join("; ");
+            bus.emit("agent:tool-started", {
+              title: "question",
+              toolCallId: callID,
+              kind: "execute",
+              displayDetail: detail,
+            });
+            if (result.cancelled) {
+              bus.emitTransform("agent:tool-completed", {
+                toolCallId: callID,
+                exitCode: 1,
+                rawOutput: "cancelled",
+                kind: "execute",
+                resultDisplay: { summary: "cancelled" },
+              });
+              runtime.client.question
+                .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
+                .catch(() => { /* best-effort */ });
+              return;
+            }
+            const summary = result.answers.length === 1
+              ? result.answers[0]!.join(", ")
+              : result.answers
+                  .map((ans, i) => `${req.questions[i]!.header || `Q${i + 1}`}: ${ans.join(", ")}`)
+                  .join("; ");
             bus.emitTransform("agent:tool-completed", {
               toolCallId: callID,
-              exitCode: 1,
-              rawOutput: "cancelled",
+              exitCode: 0,
+              rawOutput: summary,
               kind: "execute",
-              resultDisplay: { summary: "cancelled" },
+              resultDisplay: { summary },
             });
-            runtime.client.question
-              .reject({ requestID: req.id, directory: sessionDirectory ?? undefined })
-              .catch(() => { /* best-effort */ });
-            return;
-          }
-          const summary = result.answers.length === 1
-            ? result.answers[0]!.join(", ")
-            : result.answers
-                .map((ans, i) => `${req.questions[i]!.header || `Q${i + 1}`}: ${ans.join(", ")}`)
-                .join("; ");
-          bus.emitTransform("agent:tool-completed", {
-            toolCallId: callID,
-            exitCode: 0,
-            rawOutput: summary,
-            kind: "execute",
-            resultDisplay: { summary },
-          });
-          try {
-            await runtime.client.question.reply({
-              requestID: req.id,
-              answers: result.answers,
-              directory: sessionDirectory ?? undefined,
-            });
-          } catch (err) {
-            bus.emit("agent:error", {
-              message: err instanceof Error ? err.message : String(err),
-            });
+            try {
+              await runtime.client.question.reply({
+                requestID: req.id,
+                answers: result.answers,
+                directory: sessionDirectory ?? undefined,
+              });
+            } catch (err) {
+              bus.emit("agent:error", {
+                message: err instanceof Error ? err.message : String(err),
+              });
+            }
+          } finally {
+            pickerOpen = false;
+            drainQueue();
           }
         });
         break;
@@ -347,9 +364,15 @@ export default function activate(ctx: ExtensionContext): void {
           });
           break;
         }
+        pickerOpen = true;
         const ui = createToolUI(bus, compositor.surface("agent"));
         ui.custom(createPermissionSession(req, bus)).then((result: PermissionResult) => {
-          finish(result.reply, result.cancelled ? { skipReply: true } : undefined);
+          try {
+            finish(result.reply, result.cancelled ? { skipReply: true } : undefined);
+          } finally {
+            pickerOpen = false;
+            drainQueue();
+          }
         });
         break;
       }

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -96,8 +96,6 @@ export default function activate(ctx: ExtensionContext): void {
   let turnIdleSeen = false;
   let turnError: string | null = null;
 
-  // Queue SSE while a picker is open; replay on resolve so renders don't
-  // interleave with the picker's own writes.
   let pickerOpen = false;
   const eventQueue: Event[] = [];
   const drainQueue = (): void => {
@@ -393,9 +391,8 @@ export default function activate(ctx: ExtensionContext): void {
           } finally {
             pickerOpen = false;
             if (result.cancelled) {
-              // Drop queued SSE; let onSubmit's finally be the single
-              // emitter of agent:processing-done (a second one here races
-              // and produces stacked prompts).
+              // Let onSubmit's finally emit the single agent:processing-done;
+              // a second one here races and stacks prompts.
               eventQueue.length = 0;
               cancelledTurn = true;
               pendingTurnEnd?.();

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -96,9 +96,8 @@ export default function activate(ctx: ExtensionContext): void {
   let turnIdleSeen = false;
   let turnError: string | null = null;
 
-  // While a picker is open, queue SSE events so subsequent tool-started /
-  // delta renders don't paint above or below the picker. Replayed in order
-  // once the user resolves the picker.
+  // Queue SSE while a picker is open; replay on resolve so renders don't
+  // interleave with the picker's own writes.
   let pickerOpen = false;
   const eventQueue: Event[] = [];
   const drainQueue = (): void => {
@@ -106,11 +105,9 @@ export default function activate(ctx: ExtensionContext): void {
     for (const ev of events) handleEvent(ev);
   };
 
-  // After Ctrl+C through a picker, opencode keeps emitting tool / error
-  // state for the aborted turn (e.g. final "errored" state on the bash
-  // tool we never ran). Those events restart spinners and replay tool
-  // entries the user already knows are dead. Drop them until the abort
-  // is acknowledged by session.error (or a fresh turn).
+  // After Ctrl+C, opencode emits a tail of tool / error state for the
+  // aborted turn. Suppress until the next turn so it doesn't restart the
+  // spinner or replay dead tool entries.
   let cancelledTurn = false;
 
   const listeners: Array<{ event: string; fn: Function }> = [];
@@ -221,11 +218,9 @@ export default function activate(ctx: ExtensionContext): void {
     if (typeof sid === "string" && sid !== sessionId) return;
 
     if (cancelledTurn) {
-      // Pass through only what we need to unblock onSubmit; suppress
-      // everything else for the aborted turn. cancelledTurn is reset by
-      // onSubmit on the next turn — clearing it earlier (e.g. on
-      // session.error) lets opencode's later message.part.updated for
-      // the cancelled bash tool slip through and restart the spinner.
+      // Only let through what unblocks onSubmit. Clearing the flag earlier
+      // (e.g. on session.error) lets the trailing bash part.updated slip
+      // past and restart the spinner.
       if (evType === "session.idle" || evType === "session.error") {
         turnIdleSeen = true;
         pendingTurnEnd?.();
@@ -398,12 +393,9 @@ export default function activate(ctx: ExtensionContext): void {
           } finally {
             pickerOpen = false;
             if (result.cancelled) {
-              // Drop queued SSE — replaying would render tool indicators
-              // for a turn the user just aborted. pendingTurnEnd?.() lets
-              // onSubmit's await idlePromise resolve so its finally block
-              // emits the single agent:processing-done; emitting one here
-              // too races with onSubmit's still-pending session.prompt()
-              // and leaves the TUI with two stacked prompts.
+              // Drop queued SSE; let onSubmit's finally be the single
+              // emitter of agent:processing-done (a second one here races
+              // and produces stacked prompts).
               eventQueue.length = 0;
               cancelledTurn = true;
               pendingTurnEnd?.();

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -55,8 +55,7 @@ export interface InteractiveSession<T> {
   render(width: number): string[];
   /** Handle raw input. Call done(result) to finish the session. */
   handleInput(data: string, done: (result: T) => void): void;
-  /** Called when session starts. invalidate() triggers a re-render; done()
-   *  resolves the session from outside handleInput (cancellation, timeouts). */
+  /** done() lets the session resolve itself from outside handleInput. */
   onMount?(invalidate: () => void, done: (result: T) => void): void;
   /** Called when session ends (cleanup). */
   onUnmount?(): void;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -55,9 +55,8 @@ export interface InteractiveSession<T> {
   render(width: number): string[];
   /** Handle raw input. Call done(result) to finish the session. */
   handleInput(data: string, done: (result: T) => void): void;
-  /** Called when session starts. Receives invalidate() for async re-renders,
-   *  and done() so sessions can resolve from external triggers (cancellation,
-   *  timeouts, bus events). */
+  /** Called when session starts. invalidate() triggers a re-render; done()
+   *  resolves the session from outside handleInput (cancellation, timeouts). */
   onMount?(invalidate: () => void, done: (result: T) => void): void;
   /** Called when session ends (cleanup). */
   onUnmount?(): void;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -55,8 +55,10 @@ export interface InteractiveSession<T> {
   render(width: number): string[];
   /** Handle raw input. Call done(result) to finish the session. */
   handleInput(data: string, done: (result: T) => void): void;
-  /** Called when session starts. Receives invalidate() for async re-renders. */
-  onMount?(invalidate: () => void): void;
+  /** Called when session starts. Receives invalidate() for async re-renders,
+   *  and done() so sessions can resolve from external triggers (cancellation,
+   *  timeouts, bus events). */
+  onMount?(invalidate: () => void, done: (result: T) => void): void;
   /** Called when session ends (cleanup). */
   onUnmount?(): void;
 }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -5,7 +5,9 @@ const HELP_TEXT = `agent-sh — a shell-first terminal where AI is one keystroke
 
 Usage: agent-sh [options]
        agent-sh init [--force]            Scaffold ~/.agent-sh/ (settings, examples, AGENTS.md)
-       agent-sh install <spec> [--force]  Install an extension (bundled name, file:, npm:, github:)
+       agent-sh install <spec> [--force] [--sync-deps]
+                                          Install an extension (bundled name, file:, npm:, github:)
+                                          --sync-deps rewrites a stale agent-sh pin to the host version
        agent-sh uninstall <name>          Remove an installed extension
        agent-sh list                      List installed extensions
        agent-sh auth login [provider]     Store an API key for a built-in provider

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -17,6 +17,7 @@ const EXT_DIR = path.join(CONFIG_DIR, "extensions");
 
 interface InstallOpts {
   force?: boolean;
+  syncDeps?: boolean;
 }
 
 interface ResolvedSource {
@@ -142,11 +143,12 @@ function satisfies(version: string, spec: string): boolean {
   return vMaj === 0 && vMin === 0 && vPatch === sPatch;
 }
 
-/** Pin the extension's `agent-sh` dep to the host's exact version when the
- *  existing range *doesn't* admit the host version (e.g. bridge shipping
- *  `^0.12.0` against a 0.14.x host). Ranges that already satisfy the host
- *  are left untouched so authored intent survives. */
-function syncAgentShVersion(target: string): void {
+/** When the extension's `agent-sh` dep doesn't admit the host version
+ *  (e.g. bridge shipping `^0.12.0` against a 0.14.x host), warn so the
+ *  user knows drift is imminent. Only rewrites the pin when explicitly
+ *  asked via `--sync-deps` — silently mutating the bridge's package.json
+ *  on every install would hide drift from the source-of-truth on github. */
+function syncAgentShVersion(target: string, syncDeps: boolean): void {
   const hostVersion = hostAgentShVersion();
   if (!hostVersion) return;
   // Prerelease hosts (e.g. `0.15.0-pre`) likely aren't on npm; rewriting
@@ -158,7 +160,9 @@ function syncAgentShVersion(target: string): void {
   const raw = fs.readFileSync(pkgJson, "utf-8");
   const pkg = JSON.parse(raw) as Record<string, unknown>;
   const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+  const name = path.basename(target);
   let changed = false;
+  let warned = false;
   for (const section of sections) {
     const deps = pkg[section];
     if (!deps || typeof deps !== "object") continue;
@@ -167,9 +171,18 @@ function syncAgentShVersion(target: string): void {
     if (typeof current !== "string") continue;
     if (current.startsWith("file:")) continue;
     if (satisfies(hostVersion, current)) continue;
-    console.log(`agent-sh: ${path.basename(target)} pinned agent-sh ${current} doesn't admit host ${hostVersion}; bumping to ${hostVersion}.`);
-    d["agent-sh"] = hostVersion;
-    changed = true;
+    if (syncDeps) {
+      console.log(`agent-sh: rewriting ${name} agent-sh ${current} -> ${hostVersion}.`);
+      d["agent-sh"] = hostVersion;
+      changed = true;
+    } else if (!warned) {
+      console.warn(
+        `agent-sh: ${name} pins agent-sh ${current}, which doesn't admit host ${hostVersion}. ` +
+        `npm install will land an older agent-sh inside the extension and drift from the running host. ` +
+        `Re-run with --sync-deps to rewrite the pin to ${hostVersion}, or update the bridge's source pin.`,
+      );
+      warned = true;
+    }
   }
   if (changed) fs.writeFileSync(pkgJson, `${JSON.stringify(pkg, null, 2)}\n`);
 }
@@ -254,7 +267,7 @@ function linkBins(target: string, pkg: PackageJson): string[] {
 export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<void> {
   if (!spec) {
     console.error(
-      "Usage: agent-sh install <name|file:|npm:|github:> [--force]\n\n" +
+      "Usage: agent-sh install <name|file:|npm:|github:> [--force] [--sync-deps]\n\n" +
         "Bundled extensions:\n" +
         listBundled()
           .map((n) => `  ${n}`)
@@ -287,7 +300,7 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
     fs.cpSync(resolved.sourcePath, target, { recursive: true });
     try {
       rewriteFileDeps(target, resolved.sourcePath);
-      syncAgentShVersion(target);
+      syncAgentShVersion(target, opts.syncDeps ?? false);
       const pkg = readPackageJson(target);
       if (pkg) {
         maybeNpmInstall(target, pkg);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -121,13 +121,38 @@ function hostAgentShVersion(): string | null {
   }
 }
 
-/** Pin the extension's `agent-sh` dep to the host's exact version so
- *  `npm install` lands a copy that matches the running host. Without this
- *  an extension shipping `agent-sh: "^0.12.0"` would get 0.12.x even when
- *  the host is 0.14.x, producing runtime/type drift inside the extension. */
+/** Whether `spec` (a small subset of npm semver ranges) admits `version`.
+ *  Conservatively returns true for anything we can't parse so the caller
+ *  leaves authored, intentional ranges alone. */
+function satisfies(version: string, spec: string): boolean {
+  if (spec === version || spec === "*" || spec === "latest") return true;
+  const [vMaj, vMin, vPatch] = version.split(/[.-]/, 3).map(Number);
+  if ([vMaj, vMin, vPatch].some(Number.isNaN)) return true;
+  const m = spec.match(/^([\^~]?)(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return true;
+  const op = m[1];
+  const sMaj = Number(m[2]);
+  const sMin = Number(m[3]);
+  const sPatch = Number(m[4]);
+  if (op === "") return vMaj === sMaj && vMin === sMin && vPatch === sPatch;
+  if (op === "~") return vMaj === sMaj && vMin === sMin && vPatch >= sPatch;
+  // ^x.y.z: zero-major treats minor as the breaking boundary (npm rule).
+  if (sMaj > 0) return vMaj === sMaj && (vMin > sMin || (vMin === sMin && vPatch >= sPatch));
+  if (sMin > 0) return vMaj === 0 && vMin === sMin && vPatch >= sPatch;
+  return vMaj === 0 && vMin === 0 && vPatch === sPatch;
+}
+
+/** Pin the extension's `agent-sh` dep to the host's exact version when the
+ *  existing range *doesn't* admit the host version (e.g. bridge shipping
+ *  `^0.12.0` against a 0.14.x host). Ranges that already satisfy the host
+ *  are left untouched so authored intent survives. */
 function syncAgentShVersion(target: string): void {
   const hostVersion = hostAgentShVersion();
   if (!hostVersion) return;
+  // Prerelease hosts (e.g. `0.15.0-pre`) likely aren't on npm; rewriting
+  // would leave `npm install` unable to resolve. Dev workflows on a
+  // prerelease host should use a file: dep or symlinked node_modules.
+  if (hostVersion.includes("-")) return;
   const pkgJson = path.join(target, "package.json");
   if (!fs.existsSync(pkgJson)) return;
   const raw = fs.readFileSync(pkgJson, "utf-8");
@@ -140,9 +165,9 @@ function syncAgentShVersion(target: string): void {
     const d = deps as Record<string, string>;
     const current = d["agent-sh"];
     if (typeof current !== "string") continue;
-    // file: deps point at a local checkout — rewriteFileDeps handles them.
     if (current.startsWith("file:")) continue;
-    if (current === hostVersion) continue;
+    if (satisfies(hostVersion, current)) continue;
+    console.log(`agent-sh: ${path.basename(target)} pinned agent-sh ${current} doesn't admit host ${hostVersion}; bumping to ${hostVersion}.`);
     d["agent-sh"] = hostVersion;
     changed = true;
   }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -111,6 +111,44 @@ function readPackageJson(target: string): PackageJson | null {
   return JSON.parse(fs.readFileSync(pkgJson, "utf-8")) as PackageJson;
 }
 
+/** Version of the host agent-sh package this CLI is running from. */
+function hostAgentShVersion(): string | null {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, "package.json"), "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pin the extension's `agent-sh` dep to the host's exact version so
+ *  `npm install` lands a copy that matches the running host. Without this
+ *  an extension shipping `agent-sh: "^0.12.0"` would get 0.12.x even when
+ *  the host is 0.14.x, producing runtime/type drift inside the extension. */
+function syncAgentShVersion(target: string): void {
+  const hostVersion = hostAgentShVersion();
+  if (!hostVersion) return;
+  const pkgJson = path.join(target, "package.json");
+  if (!fs.existsSync(pkgJson)) return;
+  const raw = fs.readFileSync(pkgJson, "utf-8");
+  const pkg = JSON.parse(raw) as Record<string, unknown>;
+  const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+  let changed = false;
+  for (const section of sections) {
+    const deps = pkg[section];
+    if (!deps || typeof deps !== "object") continue;
+    const d = deps as Record<string, string>;
+    const current = d["agent-sh"];
+    if (typeof current !== "string") continue;
+    // file: deps point at a local checkout — rewriteFileDeps handles them.
+    if (current.startsWith("file:")) continue;
+    if (current === hostVersion) continue;
+    d["agent-sh"] = hostVersion;
+    changed = true;
+  }
+  if (changed) fs.writeFileSync(pkgJson, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
 /** Relative `file:` deps in bundled extensions (e.g. `"agent-sh": "file:../../.."`)
  *  point at the wrong location after the source is copied into ~/.agent-sh/extensions/.
  *  Resolve them against the original source dir so npm install in the target succeeds. */
@@ -224,6 +262,7 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
     fs.cpSync(resolved.sourcePath, target, { recursive: true });
     try {
       rewriteFileDeps(target, resolved.sourcePath);
+      syncAgentShVersion(target);
       const pkg = readPackageJson(target);
       if (pkg) {
         maybeNpmInstall(target, pkg);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -112,7 +112,6 @@ function readPackageJson(target: string): PackageJson | null {
   return JSON.parse(fs.readFileSync(pkgJson, "utf-8")) as PackageJson;
 }
 
-/** Version of the host agent-sh package this CLI is running from. */
 function hostAgentShVersion(): string | null {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, "package.json"), "utf-8"));
@@ -122,9 +121,7 @@ function hostAgentShVersion(): string | null {
   }
 }
 
-/** Whether `spec` (a small subset of npm semver ranges) admits `version`.
- *  Conservatively returns true for anything we can't parse so the caller
- *  leaves authored, intentional ranges alone. */
+/** Returns true for unparseable specs so authored ranges survive untouched. */
 function satisfies(version: string, spec: string): boolean {
   if (spec === version || spec === "*" || spec === "latest") return true;
   const [vMaj, vMin, vPatch] = version.split(/[.-]/, 3).map(Number);
@@ -143,17 +140,13 @@ function satisfies(version: string, spec: string): boolean {
   return vMaj === 0 && vMin === 0 && vPatch === sPatch;
 }
 
-/** When the extension's `agent-sh` dep doesn't admit the host version
- *  (e.g. bridge shipping `^0.12.0` against a 0.14.x host), warn so the
- *  user knows drift is imminent. Only rewrites the pin when explicitly
- *  asked via `--sync-deps` — silently mutating the bridge's package.json
- *  on every install would hide drift from the source-of-truth on github. */
+/** Warn when the extension's `agent-sh` pin can't admit the host version;
+ *  rewrite only when explicitly opted in via `--sync-deps`, since silent
+ *  edits diverge the installed package.json from the upstream source. */
 function syncAgentShVersion(target: string, syncDeps: boolean): void {
   const hostVersion = hostAgentShVersion();
   if (!hostVersion) return;
-  // Prerelease hosts (e.g. `0.15.0-pre`) likely aren't on npm; rewriting
-  // would leave `npm install` unable to resolve. Dev workflows on a
-  // prerelease host should use a file: dep or symlinked node_modules.
+  // Prerelease hosts aren't on npm; rewriting would leave npm install unable to resolve.
   if (hostVersion.includes("-")) return;
   const pkgJson = path.join(target, "package.json");
   if (!fs.existsSync(pkgJson)) return;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -141,8 +141,8 @@ function satisfies(version: string, spec: string): boolean {
 }
 
 /** Warn when the extension's `agent-sh` pin can't admit the host version;
- *  rewrite only when explicitly opted in via `--sync-deps`, since silent
- *  edits diverge the installed package.json from the upstream source. */
+ *  only rewrite when `--sync-deps` is set so the installed package.json
+ *  doesn't silently diverge from upstream. */
 function syncAgentShVersion(target: string, syncDeps: boolean): void {
   const hostVersion = hostAgentShVersion();
   if (!hostVersion) return;
@@ -292,9 +292,8 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
   if (resolved.isDirectory) {
     fs.cpSync(resolved.sourcePath, target, {
       recursive: true,
-      // Skip the source's node_modules — stale npm cache there would let
-      // maybeNpmInstall short-circuit on the copy and silently install a
-      // bridge whose dep pin and actual bundled deps disagree.
+      // Skip source node_modules: maybeNpmInstall short-circuits on
+      // existing node_modules, silently leaving the bridge's deps stale.
       filter: (src) => path.basename(src) !== "node_modules",
     });
     try {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -121,7 +121,6 @@ function hostAgentShVersion(): string | null {
   }
 }
 
-/** Returns true for unparseable specs so authored ranges survive untouched. */
 function satisfies(version: string, spec: string): boolean {
   if (spec === version || spec === "*" || spec === "latest") return true;
   const [vMaj, vMin, vPatch] = version.split(/[.-]/, 3).map(Number);
@@ -141,8 +140,7 @@ function satisfies(version: string, spec: string): boolean {
 }
 
 /** Warn when the extension's `agent-sh` pin can't admit the host version;
- *  only rewrite when `--sync-deps` is set so the installed package.json
- *  doesn't silently diverge from upstream. */
+ *  only rewrite when --sync-deps is set. */
 function syncAgentShVersion(target: string, syncDeps: boolean): void {
   const hostVersion = hostAgentShVersion();
   if (!hostVersion) return;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -290,7 +290,13 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
 
   let linkedBins: string[] = [];
   if (resolved.isDirectory) {
-    fs.cpSync(resolved.sourcePath, target, { recursive: true });
+    fs.cpSync(resolved.sourcePath, target, {
+      recursive: true,
+      // Skip the source's node_modules — stale npm cache there would let
+      // maybeNpmInstall short-circuit on the copy and silently install a
+      // bridge whose dep pin and actual bundled deps disagree.
+      filter: (src) => path.basename(src) !== "node_modules",
+    });
     try {
       rewriteFileDeps(target, resolved.sourcePath);
       syncAgentShVersion(target, opts.syncDeps ?? false);

--- a/src/cli/subcommands.ts
+++ b/src/cli/subcommands.ts
@@ -6,7 +6,10 @@ type Subcommand = (args: string[]) => void | Promise<void>;
 
 const SUBCOMMANDS: Record<string, Subcommand> = {
   init: (args) => runInit({ force: args.includes("--force") }),
-  install: (args) => runInstall(args[0] ?? "", { force: args.includes("--force") }),
+  install: (args) => runInstall(args[0] ?? "", {
+    force: args.includes("--force"),
+    syncDeps: args.includes("--sync-deps"),
+  }),
   uninstall: (args) => runUninstall(args[0] ?? ""),
   list: () => runList(),
   auth: (args) => runAuth(args),

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -30,10 +30,8 @@ export function createToolUI(
         const done = (result: T) => {
           if (finished) return;
           finished = true;
-          // Leave the rendered picker as a transcript so the user sees what
-          // was asked and what they picked; subsequent output lands below
-          // it. Clearing on dismiss was a worse trade — it produced an
-          // unexplained gap on terminals where cursor-restore tricks fail.
+          // Leave the rendered picker as a transcript; subsequent output
+          // lands below it.
           bus.offPipe("input:intercept", interceptor);
           bus.emit("shell:stdout-hide", {});
           bus.emit("tool:interactive-end", {});

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -61,6 +61,9 @@ export function createToolUI(
         bus.emit("tool:interactive-start", {});
         bus.emit("shell:stdout-show", {});
         bus.onPipe("input:intercept", interceptor);
+        // Drop to a fresh row in case the cursor was mid-line; uncounted
+        // so clearLines on dismiss stops at the gap, not above it.
+        surface.write("\n");
         session.onMount?.(() => render(), done);
         render();
       });

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -30,7 +30,10 @@ export function createToolUI(
         const done = (result: T) => {
           if (finished) return;
           finished = true;
-          clearLines(surface, prevLineCount);
+          // Leave the rendered picker as a transcript so the user sees what
+          // was asked and what they picked; subsequent output lands below
+          // it. Clearing on dismiss was a worse trade — it produced an
+          // unexplained gap on terminals where cursor-restore tricks fail.
           bus.offPipe("input:intercept", interceptor);
           bus.emit("shell:stdout-hide", {});
           bus.emit("tool:interactive-end", {});

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -30,8 +30,6 @@ export function createToolUI(
         const done = (result: T) => {
           if (finished) return;
           finished = true;
-          // Leave the rendered picker as a transcript; subsequent output
-          // lands below it.
           bus.offPipe("input:intercept", interceptor);
           bus.emit("shell:stdout-hide", {});
           bus.emit("tool:interactive-end", {});

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -30,11 +30,16 @@ export function createToolUI(
         const done = (result: T) => {
           if (finished) return;
           finished = true;
-          clearLines(surface, prevLineCount);
-          // Restore cursor to where it was before the leading \n so the
-          // caller's next write (e.g. opencode's `✓ 7s` completion marker)
-          // lands inline on the original tool-started row, not below it.
-          surface.write("\x1b8");
+          // Restore cursor to the saved position, then delete the picker's
+          // rows so they don't sit as empty space pushing subsequent content
+          // down. \x1b[B + \x1b[<N>M = cursor down one + delete N lines,
+          // which collapses the picker's vertical footprint while leaving
+          // the saved-position row intact.
+          if (prevLineCount > 0) {
+            surface.write(`\x1b8\x1b[B\x1b[${prevLineCount}M`);
+          } else {
+            surface.write("\x1b8");
+          }
           bus.offPipe("input:intercept", interceptor);
           bus.emit("shell:stdout-hide", {});
           bus.emit("tool:interactive-end", {});

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -61,7 +61,7 @@ export function createToolUI(
         bus.emit("tool:interactive-start", {});
         bus.emit("shell:stdout-show", {});
         bus.onPipe("input:intercept", interceptor);
-        session.onMount?.(() => render());
+        session.onMount?.(() => render(), done);
         render();
       });
     },

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -31,6 +31,10 @@ export function createToolUI(
           if (finished) return;
           finished = true;
           clearLines(surface, prevLineCount);
+          // Restore cursor to where it was before the leading \n so the
+          // caller's next write (e.g. opencode's `✓ 7s` completion marker)
+          // lands inline on the original tool-started row, not below it.
+          surface.write("\x1b8");
           bus.offPipe("input:intercept", interceptor);
           bus.emit("shell:stdout-hide", {});
           bus.emit("tool:interactive-end", {});
@@ -61,9 +65,10 @@ export function createToolUI(
         bus.emit("tool:interactive-start", {});
         bus.emit("shell:stdout-show", {});
         bus.onPipe("input:intercept", interceptor);
-        // Drop to a fresh row in case the cursor was mid-line; uncounted
-        // so clearLines on dismiss stops at the gap, not above it.
-        surface.write("\n");
+        // Save cursor, then drop to a fresh row. On dismiss we restore to
+        // the saved position so the caller's next write (e.g. opencode's
+        // `✓ 7s` completion marker) lands inline on the original row.
+        surface.write("\x1b7\n");
         session.onMount?.(() => render(), done);
         render();
       });

--- a/src/utils/tool-interactive.ts
+++ b/src/utils/tool-interactive.ts
@@ -30,16 +30,7 @@ export function createToolUI(
         const done = (result: T) => {
           if (finished) return;
           finished = true;
-          // Restore cursor to the saved position, then delete the picker's
-          // rows so they don't sit as empty space pushing subsequent content
-          // down. \x1b[B + \x1b[<N>M = cursor down one + delete N lines,
-          // which collapses the picker's vertical footprint while leaving
-          // the saved-position row intact.
-          if (prevLineCount > 0) {
-            surface.write(`\x1b8\x1b[B\x1b[${prevLineCount}M`);
-          } else {
-            surface.write("\x1b8");
-          }
+          clearLines(surface, prevLineCount);
           bus.offPipe("input:intercept", interceptor);
           bus.emit("shell:stdout-hide", {});
           bus.emit("tool:interactive-end", {});
@@ -70,10 +61,9 @@ export function createToolUI(
         bus.emit("tool:interactive-start", {});
         bus.emit("shell:stdout-show", {});
         bus.onPipe("input:intercept", interceptor);
-        // Save cursor, then drop to a fresh row. On dismiss we restore to
-        // the saved position so the caller's next write (e.g. opencode's
-        // `✓ 7s` completion marker) lands inline on the original row.
-        surface.write("\x1b7\n");
+        // Drop to a fresh row in case the cursor was mid-line; uncounted
+        // so clearLines on dismiss stops at the gap, not above it.
+        surface.write("\n");
         session.onMount?.(() => render(), done);
         render();
       });

--- a/tests/bridges/opencode-bridge.test.ts
+++ b/tests/bridges/opencode-bridge.test.ts
@@ -194,16 +194,34 @@ test("agent:cancel-request triggers client.session.abort", async () => {
   assert.equal(after[before]!.sessionID, stubModule.__sessionId());
 });
 
-test("permission.asked is auto-approved via client.permission.reply", async () => {
-  const { bus: _ } = await loadBridge();
+test("permission.asked without a shell host replies reject + emits ui:error", async () => {
+  stubModule.__reset();
+  const core = createCore({} as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  const mod = await import(`${BRIDGE_URL}?t=${Date.now()}`);
+  (mod.default ?? mod.activate)(ctx);
+  await core.activateBackend("opencode");
+  await flush();
+
+  const uiErrors: Array<{ message: string }> = [];
+  core.bus.on("ui:error", (e) => uiErrors.push(e));
+
   stubModule.__emitEvent({
     type: "permission.asked",
-    properties: { id: "req-42" },
+    properties: {
+      id: "req-42",
+      permission: "bash",
+      patterns: ["echo test"],
+      metadata: {},
+      always: [],
+    },
   });
   await flush();
 
   const replies = stubModule.__permissionReplies();
   assert.equal(replies.length, 1);
   assert.equal(replies[0]!.requestID, "req-42");
-  assert.equal(replies[0]!.reply, "once");
+  assert.equal(replies[0]!.reply, "reject");
+  assert.equal(uiErrors.length, 1);
+  assert.match(uiErrors[0]!.message, /no shell host/);
 });


### PR DESCRIPTION
## Summary

Two threads woven together — both surfaced from the same debugging session against the opencode bridge.

### opencode-bridge robustness

The activate function destructured `ctx.shell.compositor` unconditionally, crashing the bridge under any host that doesn't attach a shell surface (per `ShellSurface` contract in `src/shell/host-types.ts`, `ctx.shell` is optional). The permission flow auto-replied `\"once\"` to every `permission.asked` event — silently overriding opencode's own \"please ask the user\" decision instead of acting as a conduit. Ctrl+C while the permission picker was up left the spinner stuck because `createToolUI` passes Ctrl+C through without giving the session a chance to clean up.

- Guard `ctx.shell?.compositor`; the picker falls back to a reject + `ui:error` when no surface is available.
- Replace auto-approve with a real three-way picker (once / always / reject) wired to the structured `PermissionRequest` payload from `@opencode-ai/sdk/v2`. Synthetic timeline entry only on reject (the actual tool run is the record for approve cases).
- Extend `InteractiveSession.onMount` to receive `done` as a second arg so sessions can resolve themselves from external triggers; bridge subscribes to `agent:cancel-request` and closes the picker cleanly.
- `tool-interactive` writes a leading `\n` before first render to handle hosts (like opencode's tool-started indicator) that leave the cursor mid-line — uncounted so `clearLines` on dismiss stops at the gap, not above it.

### install: detect agent-sh pin drift

`agent-sh install <bridge>` runs `npm install` against the bridge's bundled `package.json`, which pins a minimum-supported `agent-sh` (e.g. opencode-bridge ships `^0.12.0`). On a 0.14.x host that resolves to 0.12.x, producing both runtime drift (bundled `tool-interactive.js` without the fresh-row write) and type drift (`ExtensionContext.shell` missing) inside the extension — exactly how the bridge crash started.

- Detect when the extension's `agent-sh` range doesn't admit the host version and **warn by default**, with the exact command to fix.
- Opt-in rewrite via `agent-sh install <bridge> --sync-deps` — silently editing the bridge's `package.json` on every install would diverge the installed copy from the source-of-truth on github.
- Conservative satisfies-check (handles `^`, `~`, exact, `*`; leaves anything unparseable alone). Prerelease hosts (`0.15.0-pre`) are skipped entirely since they're not on npm.
- Flag threaded through both `agent-sh` and `ashi` install passthroughs.

## Behavior matrix (install path)

| Scenario | Without `--sync-deps` | With `--sync-deps` |
|---|---|---|
| `^0.14.0` + host `0.14.0` | silent | silent |
| `^0.12.0` + host `0.14.0` | warns | rewrites pin → installs `0.14.0` |
| `file:` dep | silent | silent |
| Custom range like `>=0.10.0` | silent (conservative) | silent (conservative) |
| Prerelease host | silent | silent |

## Test plan

- [ ] Restart agent-sh; trigger an opencode bash tool. Permission picker renders on a fresh row below `▶ bash: …`; pressing `y` clears cleanly, opencode's `✓` lands on the original row.
- [ ] Press Ctrl+C while the picker is up — picker closes, spinner clears, opencode session aborts (no dangling state).
- [ ] Press `n` (reject) — a `✓ permission: …` timeline entry appears with `denied: …` summary; the bash tool itself doesn't run.
- [ ] `agent-sh install opencode-bridge` against a host whose version doesn't satisfy the bridge's pin — see the warning, no file edits.
- [ ] `agent-sh install opencode-bridge --sync-deps` — see the rewrite log, bridge's installed `package.json` now pins host version.
- [ ] `agent-sh install ashi` against matching host — silent (no warning, no edits).