### PR TITLE
ashi: tail-merge tool groups, sliding-window display, global Ctrl+O

### DIFF
--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -222,85 +222,95 @@ function shortToolName(name: string): string {
   return SHORT_TOOL_NAMES[name] ?? name;
 }
 
-/** A batch of parallel same-kind tool calls. Renders one header, per-call
- *  child branch lines that each carry their own summary on completion, and
- *  a final aggregate. Mirrors ash's grouping (read_file/ls → "read";
- *  grep/glob → "search"). */
+/** An open-ended run of same-kind tool calls. Grows by tail-merge: the caller
+ *  extends an existing group when its `kind` matches the next call and the
+ *  group is still the chat's tail. Trailing child renders with └, others ├.
+ *
+ *  When `maxVisible` is finite and exceeded, the oldest children collapse to
+ *  a summary line ("⋯ N earlier ✓") and the last (maxVisible − 1) stay
+ *  visible. `toggleExpanded()` reveals all; `maxVisible = Infinity` disables
+ *  eviction. */
 export class ToolGroup extends Container {
   private headerText: Text;
+  private summaryText: Text;
   private childContainer: Container;
-  private aggregateText: Text;
-  private kind: string;
-  private total: number;
+  readonly kind: string;
   private maxVisible: number;
-  private visibleChildren = new Map<string, GroupChild>();
-  private hiddenSummaries: string[] = [];
-  private addedCount = 0;
-  private renderedCount = 0;
-  private completedCount = 0;
-  private allOk = true;
+  private allChildren: GroupChild[] = [];
+  private callsById = new Map<string, GroupChild>();
+  private expanded = false;
 
-  constructor(kind: string, total: number, maxVisible = 5) {
+  constructor(kind: string, maxVisible: number = Infinity) {
     super();
     this.kind = kind;
-    this.total = total;
     this.maxVisible = maxVisible;
     this.headerText = new Text("", 1, 0);
+    this.summaryText = new Text("", 1, 0);
     this.childContainer = new Container();
-    this.aggregateText = new Text("", 1, 0);
     this.addChild(new Spacer(1));
     this.addChild(this.headerText);
+    this.addChild(this.summaryText);
     this.addChild(this.childContainer);
-    this.addChild(this.aggregateText);
     this.repaintHeader();
   }
 
   addCall(toolCallId: string, name: string, detail: string): void {
-    this.addedCount++;
-    if (this.renderedCount < this.maxVisible && toolCallId) {
-      const text = new Text("", 1, 0);
-      const child: GroupChild = { name: shortToolName(name), detail: detail || "…", text };
-      this.visibleChildren.set(toolCallId, child);
-      this.childContainer.addChild(text);
-      this.renderedCount++;
-      this.repaintChild(child);
-    }
+    const text = new Text("", 1, 0);
+    const child: GroupChild = { name: shortToolName(name), detail: detail || "…", text };
+    if (toolCallId) this.callsById.set(toolCallId, child);
+    this.allChildren.push(child);
+    this.repaint();
   }
 
   recordCompletion(toolCallId: string, exitCode: number | null, summary?: string): void {
-    this.completedCount++;
-    if (exitCode !== null && exitCode !== 0) this.allOk = false;
-    const child = this.visibleChildren.get(toolCallId);
-    if (child) {
-      child.status = { exitCode, summary };
-      this.repaintChild(child);
-    } else if (summary) {
-      this.hiddenSummaries.push(summary);
-    }
-    if (this.completedCount >= this.total) this.finalize();
+    const child = this.callsById.get(toolCallId);
+    if (!child) return;
+    child.status = { exitCode, summary };
+    this.repaint();
   }
 
-  finalize(): void {
-    const collapsed = this.addedCount - this.renderedCount;
-    // No overflow ⇒ no aggregate; close the tree by promoting the last
-    // visible child's ├ to a └.
-    if (collapsed === 0) {
-      this.aggregateText.setText("");
-      const last = [...this.visibleChildren.values()].pop();
-      if (last) this.repaintChild(last, true);
-      return;
-    }
-    const mark = this.allOk ? theme.fg("success", "✓") : theme.fg("error", "✗");
-    const more = theme.fg("muted", `+${collapsed} more`);
-    const sumText = this.hiddenSummaries.length > 0
-      ? ` ${theme.fg("muted", this.hiddenSummaries.join(", "))}`
-      : "";
-    this.aggregateText.setText(`${theme.fg("muted", "└")} ${more} ${mark}${sumText}`);
+  toggleExpanded(): void {
+    this.expanded = !this.expanded;
+    this.repaint();
   }
 
-  isComplete(): boolean { return this.completedCount >= this.total; }
+  /** How many children at the tail are visible right now. When collapsed and
+   *  over the cap, this is maxVisible − 1 (one line goes to the summary). */
+  private visibleSliceStart(): number {
+    if (this.expanded || !Number.isFinite(this.maxVisible)) return 0;
+    if (this.allChildren.length <= this.maxVisible) return 0;
+    return this.allChildren.length - (this.maxVisible - 1);
+  }
 
-  private repaintChild(child: GroupChild, isLast = false): void {
+  private repaint(): void {
+    const start = this.visibleSliceStart();
+    const evicted = this.allChildren.slice(0, start);
+    const visible = this.allChildren.slice(start);
+
+    if (evicted.length === 0) {
+      this.summaryText.setText("");
+    } else {
+      const allOk = evicted.every(
+        (c) => !c.status || c.status.exitCode === null || c.status.exitCode === 0,
+      );
+      const mark = allOk ? theme.fg("success", "✓") : theme.fg("error", "✗");
+      const noun = evicted.length === 1 ? "earlier call" : "earlier calls";
+      this.summaryText.setText(
+        `${theme.fg("muted", "├")} ${theme.fg("muted", "⋯")} ${theme.fg("muted", `${evicted.length} ${noun}`)} ${mark}`,
+      );
+    }
+
+    // Reconcile childContainer to exactly the `visible` slice, in order. We
+    // rebuild rather than diff because group sizes are small.
+    this.childContainer.clear();
+    visible.forEach((child, idx) => {
+      const isLast = idx === visible.length - 1;
+      this.repaintChild(child, isLast);
+      this.childContainer.addChild(child.text);
+    });
+  }
+
+  private repaintChild(child: GroupChild, isLast: boolean): void {
     let tail: string;
     if (!child.status) {
       tail = ` ${theme.fg("muted", "…")}`;
@@ -311,8 +321,6 @@ export class ToolGroup extends Container {
       tail = ` ${mark}${sum}`;
     }
     const connector = isLast ? "└" : "├";
-    // Tool name omitted when it duplicates the kind header (e.g. read_file
-    // children under "◆ read").
     const namePart = child.name !== this.kind
       ? `${theme.bold(theme.fg("toolTitle", child.name))} `
       : "";

--- a/examples/extensions/ashi/src/display-config.ts
+++ b/examples/extensions/ashi/src/display-config.ts
@@ -29,6 +29,14 @@ const BUILTIN_OVERRIDES: Record<string, Partial<ToolEntryConfig>> = {
 
 interface AshiSettings extends Record<string, unknown> {
   display?: Record<string, Partial<ToolEntryConfig>>;
+  groupMaxVisible?: number;
+}
+
+export function loadGroupMaxVisible(): number {
+  const ashi = getExtensionSettings<AshiSettings>("ashi", {});
+  const v = ashi.groupMaxVisible;
+  if (typeof v !== "number" || !Number.isFinite(v) || v < 2) return Infinity;
+  return Math.floor(v);
 }
 
 function mergeEntry(base: ToolEntryConfig, patch?: Partial<ToolEntryConfig>): ToolEntryConfig {

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -25,6 +25,7 @@ import {
 } from "./components.js";
 import type { ToolCallView, ToolResultView } from "./hooks.js";
 import { createToolHookResolver } from "./hooks.js";
+import { loadGroupMaxVisible } from "./display-config.js";
 
 const GROUPABLE_KINDS = new Set(["read", "search"]);
 const TOOL_KIND: Record<string, string> = {
@@ -120,6 +121,10 @@ function detailFromArgs(argsJson: string | undefined): string {
     if (typeof args.path === "string") return relativize(args.path);
     if (typeof args.file_path === "string") return relativize(args.file_path);
     if (typeof args.query === "string") return `"${args.query}"`;
+    if (typeof args.source === "string") {
+      const compact = args.source.replace(/\s+/g, " ").trim();
+      return compact.length > 80 ? compact.slice(0, 77) + "…" : compact;
+    }
   } catch { /* fall through */ }
   return "";
 }
@@ -229,10 +234,22 @@ export function mountAshi(
   let activeAssistant: AssistantMessage | null = null;
   let activeThinking: ThinkingBlock | null = null;
   const activeTools = new Map<string, LiveToolEntry>();
-  /** Per-batch state from agent:tool-batch — the group is created lazily on
-   *  the first member's tool-started so the chat insertion order is correct. */
-  const batchGroups = new Map<string, { total: number; group: ToolGroup | null }>();
-  let lastToolResult: ToolResultView | null = null;
+  const groupMaxVisible = loadGroupMaxVisible();
+
+  /** Find a same-kind ToolGroup at the chat tail. ThinkingBlocks are
+   *  visually-neutral only when hidden — visible thinking is a hard separator,
+   *  so toggling thinking on splits previously-merged groups at iteration
+   *  boundaries. */
+  const findMergeableGroup = (kind: string): ToolGroup | null => {
+    for (let i = chat.children.length - 1; i >= 0; i--) {
+      const c = chat.children[i]!;
+      if (c instanceof ToolGroup) return c.kind === kind ? c : null;
+      if (c instanceof ThinkingBlock && hideThinking) continue;
+      if (c instanceof AssistantMessage && !c.hasContent()) continue;
+      return null;
+    }
+    return null;
+  };
   let loader: Loader | null = null;
   let processing = false;
   const queuedQueries: string[] = [];
@@ -343,32 +360,18 @@ export function mountAshi(
         chat.addChild(renderAssistantFinal(text));
       }
       if (m.tool_calls) {
-        const calls = m.tool_calls;
-        let i = 0;
-        while (i < calls.length) {
-          const startName = calls[i]!.function?.name ?? "";
-          const startKind = TOOL_KIND[startName];
-          if (startKind && GROUPABLE_KINDS.has(startKind)) {
-            let j = i;
-            while (j < calls.length && TOOL_KIND[calls[j]!.function?.name ?? ""] === startKind) j++;
-            const runLen = j - i;
-            if (runLen > 1) {
-              const group = new ToolGroup(startKind, runLen);
-              chat.addChild(group);
-              for (let k = i; k < j; k++) {
-                const c = calls[k]!;
-                const cid = c.id ?? "";
-                const cname = c.function?.name ?? "tool";
-                group.addCall(cid, cname, detailFromArgs(c.function?.arguments));
-                if (cid) toolMap.set(cid, { kind: "group", group, name: cname });
-              }
-              i = j;
-              continue;
-            }
-          }
-          const tc = calls[i]!;
+        for (const tc of m.tool_calls) {
           const id = tc.id ?? "";
           const name = tc.function?.name ?? "tool";
+          const kind = TOOL_KIND[name];
+          if (kind && GROUPABLE_KINDS.has(kind)) {
+            const mergeable = findMergeableGroup(kind);
+            const group = mergeable
+              ?? (() => { const g = new ToolGroup(kind, groupMaxVisible); chat.addChild(g); return g; })();
+            group.addCall(id, name, detailFromArgs(tc.function?.arguments));
+            if (id) toolMap.set(id, { kind: "group", group, name });
+            continue;
+          }
           const pair = renderToolPair({
             toolCallId: id, name, title: name, kind: undefined,
             displayDetail: detailFromArgs(tc.function?.arguments),
@@ -377,8 +380,6 @@ export function mountAshi(
           chat.addChild(pair.call);
           chat.addChild(pair.result);
           if (id) toolMap.set(id, { kind: "pair", pair, name });
-          lastToolResult = pair.result;
-          i++;
         }
       }
     } else if (m.role === "tool") {
@@ -411,8 +412,6 @@ export function mountAshi(
     activeAssistant = null;
     activeThinking = null;
     activeTools.clear();
-    batchGroups.clear();
-    lastToolResult = null;
     chat.clear();
     const branch = getStore().current().getBranch();
     const toolMap = new Map<string, ReplayEntry>();
@@ -480,13 +479,6 @@ export function mountAshi(
     tui.requestRender();
   });
 
-  bus.on("agent:tool-batch", (e) => {
-    batchGroups.clear();
-    for (const g of e.groups) {
-      batchGroups.set(g.kind, { total: g.tools.length, group: null });
-    }
-  });
-
   bus.on("agent:tool-started", (e) => {
     finalizeThinking();
     if (activeAssistant) {
@@ -500,17 +492,12 @@ export function mountAshi(
     );
 
     const kind = e.kind ?? "";
-    const batchEntry = batchGroups.get(kind);
-    const shouldGroup = !!batchEntry && batchEntry.total > 1 && GROUPABLE_KINDS.has(kind);
-    if (shouldGroup) {
-      if (!batchEntry!.group) {
-        batchEntry!.group = new ToolGroup(kind, batchEntry!.total);
-        chat.addChild(batchEntry!.group);
-      }
-      batchEntry!.group.addCall(id, title, detail);
-      activeTools.set(id, { kind: "group", group: batchEntry!.group });
-      // Grouped tools have no individual result body — Ctrl+O wouldn't have
-      // anything to expand, so leave lastToolResult pointing at the prior tool.
+    if (GROUPABLE_KINDS.has(kind)) {
+      const mergeable = findMergeableGroup(kind);
+      const group = mergeable
+        ?? (() => { const g = new ToolGroup(kind, groupMaxVisible); chat.addChild(g); return g; })();
+      group.addCall(id, title, detail);
+      activeTools.set(id, { kind: "group", group });
       tui.requestRender();
       return;
     }
@@ -522,7 +509,6 @@ export function mountAshi(
     activeTools.set(id, { kind: "pair", pair });
     chat.addChild(pair.call);
     chat.addChild(pair.result);
-    lastToolResult = pair.result;
     tui.requestRender();
   });
 
@@ -743,14 +729,21 @@ export function mountAshi(
   // ── Keybindings ────────────────────────────────────────────────
   const toggleThinking = (): void => {
     hideThinking = !hideThinking;
-    const walk = (node: Container): void => {
-      for (const child of node.children) {
-        if (child instanceof ThinkingBlock) child.setHidden(hideThinking);
-        else if (child instanceof Container) walk(child);
-      }
-    };
-    walk(chat);
-    tui.requestRender();
+    if (processing) {
+      // Mid-turn: in-place show/hide only. Past groups stay as they merged
+      // under the old flag; future tool calls in this turn respect the new
+      // flag via findMergeableGroup. Next idle rebuild reflows everything.
+      const walk = (node: Container): void => {
+        for (const child of node.children) {
+          if (child instanceof ThinkingBlock) child.setHidden(hideThinking);
+          else if (child instanceof Container) walk(child);
+        }
+      };
+      walk(chat);
+      tui.requestRender();
+      return;
+    }
+    void rebuildChat();
   };
 
   tui.addInputListener((data) => {
@@ -807,10 +800,15 @@ export function mountAshi(
       return { consume: true };
     }
     if (matchesKey(data, "ctrl+o")) {
-      if (lastToolResult) {
-        lastToolResult.toggleExpanded();
-        tui.requestRender();
-      }
+      const toggle = (node: Container): void => {
+        for (const child of node.children) {
+          const fn = (child as unknown as { toggleExpanded?: () => void }).toggleExpanded;
+          if (typeof fn === "function") fn.call(child);
+          if (child instanceof Container) toggle(child);
+        }
+      };
+      toggle(chat);
+      tui.requestRender();
       return { consume: true };
     }
     return undefined;


### PR DESCRIPTION
## Summary

Tool display in ashi was sensitive to LLM batch shape — each parallel batch became its own `◆ read` group, even when consecutive batches read more files of the same kind. This PR makes grouping a property of the rendered chat tail instead of the agent's parallel-dispatch envelope, and turns Ctrl+O into a global operation so post-hoc inspection works.

### Tool grouping

- `ToolGroup` is open-ended. Constructor takes `kind` and `maxVisible` (no more `total`). Grows via `addCall`; trailing child renders `└`, others `├`. No `finalize()` step.
- Live and replay paths both check `findMergeableGroup(kind)`: walks the chat tail, skips visually-neutral blocks (hidden `ThinkingBlock`, content-less `AssistantMessage`), returns a same-kind `ToolGroup` to extend or nothing.
- `agent:tool-batch` envelope is no longer wired for UI grouping. `batchGroups` map removed.

### Thinking ↔ grouping interaction

When thinking is hidden, `ThinkingBlock` is skipped during merge — a multi-iteration read run collapses into one group. When thinking is visible, it becomes a hard separator. `toggleThinking` now triggers `rebuildChat()` at idle so historical groups split/merge to match the current flag, producing a proper interleaved view on Ctrl+T. Mid-turn falls back to in-place `setHidden()`; next idle rebuild reflows.

### Sliding-window display

`ashi.groupMaxVisible` setting (default `Infinity`). When finite and exceeded, oldest children collapse to `├ ⋯ N earlier ✓` above the visible window. `toggleExpanded()` reveals all. At `Infinity` the new code is a strict superset of the previous unbounded behavior.

### Ctrl+O is global

Walks `chat.children` recursively; calls `toggleExpanded()` on any descendant exposing one. Hits `ToolResultBody`, `ToolGroup`, and any external custom view that opts into the contract (e.g. a scheme-specific result renderer). Removes the `lastExpandable` pointer that left previous tools unreachable once a newer expandable landed. Motivated by post-hoc inspection: the user may not be watching live.

### Source-arg detail preview

`detailFromArgs` learns `source`: whitespace-normalized, truncated at 80 chars. Helps any tool whose primary argument is a code blob (scheme eval, sql, python eval), bringing ashi in line with agent-sh's own renderer at `src/utils/tool-display.ts:129-131`.

## Test plan

- [ ] Run a query that triggers a multi-iteration read run (e.g. "explore this repo"). Should produce one `◆ read` group with all the reads, not one per LLM iteration.
- [ ] Set `ashi.groupMaxVisible: 5` in settings.json; run a longer read run. Should see `├ ⋯ N earlier ✓` summary line at the top once children exceed 5.
- [ ] Hit Ctrl+O while the read group is collapsed. Expanded view should show every child inline, summary line empty.
- [ ] Hit Ctrl+T mid-turn with thinking off → on. Existing merged group stays merged; new tool calls in the same turn start a fresh group. Next idle Ctrl+T (or query) rebuilds with thinking interleaved between per-iteration groups.
- [ ] Run a tool with a `source` argument. Call line should show compacted source preview, not empty.
- [ ] Ctrl+O on chat with multiple expandables: all of them toggle. Verify previous tools are still reachable (i.e. not just the latest one).
- [ ] `/resume` a session that contains multi-iteration runs: replayed groups should merge the same way live ones do.