### PR TITLE
events: carry canonical tool name in agent:tool-started

### DIFF
--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guanyilun/ashi",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Ash in an interactive TUI — agent-sh's built-in agent without the shell underneath",
   "type": "module",
   "main": "dist/cli.js",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
-    "agent-sh": "^0.14.0",
+    "agent-sh": "^0.14.2",
     "chalk": "^5.5.0",
     "cli-highlight": "^2.1.11"
   },

--- a/examples/extensions/ashi/src/default-renderers.ts
+++ b/examples/extensions/ashi/src/default-renderers.ts
@@ -154,18 +154,12 @@ export function registerDefaultToolRenderers(ctx: ExtensionContext): void {
   };
 
   define("bash", (args) => new LabeledCallLine(() => bashLabel(args)));
-
   define("read_file", (args) => new LabeledCallLine(() => readLabel(args)));
-  define("read", (args) => new LabeledCallLine(() => readLabel(args)));
-
   define("grep", (args) => new LabeledCallLine(() => grepLabel(args)));
   define("glob", (args) => new LabeledCallLine(() => globLabel(args)));
   define("ls", (args) => new LabeledCallLine(() => lsLabel(args)));
-
   define("edit_file", (args) => new LabeledCallLine(() => pathOnlyLabel("edit", args)));
-  define("edit", (args) => new LabeledCallLine(() => pathOnlyLabel("edit", args)));
   define("write_file", (args) => new LabeledCallLine(() => pathOnlyLabel("write", args)));
-  define("write", (args) => new LabeledCallLine(() => pathOnlyLabel("write", args)));
 
   define("default", (args) => new LabeledCallLine(() => genericLabel(args)));
 }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -487,6 +487,7 @@ export function mountAshi(
     }
     const id = e.toolCallId ?? `${e.title}-${Date.now()}`;
     const title = e.title.split(":")[0]!.trim();
+    const lookupName = e.name ?? title;
     const detail = e.displayDetail || detailFromArgs(
       typeof e.rawInput === "string" ? e.rawInput : JSON.stringify(e.rawInput ?? {})
     );
@@ -496,14 +497,14 @@ export function mountAshi(
       const mergeable = findMergeableGroup(kind);
       const group = mergeable
         ?? (() => { const g = new ToolGroup(kind, groupMaxVisible); chat.addChild(g); return g; })();
-      group.addCall(id, title, detail);
+      group.addCall(id, lookupName, detail);
       activeTools.set(id, { kind: "group", group });
       tui.requestRender();
       return;
     }
 
     const pair = renderToolPair({
-      toolCallId: id, name: title, title, kind: e.kind,
+      toolCallId: id, name: lookupName, title, kind: e.kind,
       displayDetail: detail, rawInput: e.rawInput,
     });
     activeTools.set(id, { kind: "pair", pair });

--- a/examples/extensions/claude-code-bridge/index.ts
+++ b/examples/extensions/claude-code-bridge/index.ts
@@ -140,6 +140,7 @@ export default function activate(ctx: ExtensionContext): void {
                   const kind = toolKind(meta.name);
                   bus.emit("agent:tool-started", {
                     title: meta.name,
+                    name: meta.name,
                     toolCallId: meta.id,
                     kind,
                     icon: toolIcon(meta.name),
@@ -176,6 +177,7 @@ export default function activate(ctx: ExtensionContext): void {
                   const kind = toolKind(b.name);
                   bus.emit("agent:tool-started", {
                     title: b.name,
+                    name: b.name,
                     toolCallId: b.id,
                     kind,
                     icon: toolIcon(b.name),

--- a/examples/extensions/opencode-bridge/index.ts
+++ b/examples/extensions/opencode-bridge/index.ts
@@ -147,6 +147,7 @@ export default function activate(ctx: ExtensionContext): void {
       announcedTools.add(callID);
       bus.emit("agent:tool-started", {
         title: toolName,
+        name: toolName,
         toolCallId: callID,
         kind,
         locations: toolLocations(state.input ?? {}),
@@ -290,6 +291,7 @@ export default function activate(ctx: ExtensionContext): void {
               : req.questions.map((q, i) => `${q.header || `Q${i + 1}`}: ${q.question}`).join("; ");
             bus.emit("agent:tool-started", {
               title: "question",
+              name: "question",
               toolCallId: callID,
               kind: "execute",
               displayDetail: detail,
@@ -355,6 +357,7 @@ export default function activate(ctx: ExtensionContext): void {
             const summary = opts?.note ? `denied (${opts.note})` : `denied: ${detail}`;
             bus.emit("agent:tool-started", {
               title: "permission",
+              name: "permission",
               toolCallId: callID,
               kind: "execute",
               displayDetail: detail,

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -206,6 +206,7 @@ export default function activate(ctx: ExtensionContext): void {
             }
             bus.emit("agent:tool-started", {
               title: ev.toolName,
+              name: ev.toolName,
               toolCallId: ev.toolCallId,
               kind: kindForTool(ev.toolName),
               rawInput: ev.args,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sh",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "A shell-first terminal where AI is one keystroke away",
   "type": "module",
   "main": "dist/core/index.js",

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1000,6 +1000,7 @@ export class AgentLoop implements AgentBackend {
       const label = tool.displayName ?? name;
       this.bus.emit("agent:tool-started", {
         title: typeof args.description === "string" ? `${label}: ${args.description}` : label,
+        name,
         toolCallId: id,
         kind: display.kind, icon: display.icon, locations: display.locations, rawInput: args,
         displayDetail: tool.formatCall?.(args),
@@ -1258,6 +1259,7 @@ export class AgentLoop implements AgentBackend {
             const display = tool.getDisplayInfo?.(args) ?? { kind: "execute" as const };
             this.bus.emit("agent:tool-started", {
               title: tool.displayName ?? tc.name,
+              name: tc.name,
               toolCallId: tc.id,
               kind: display.kind, icon: display.icon, locations: display.locations, rawInput: args,
               displayDetail: tool.formatCall?.(args),

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -62,6 +62,8 @@ declare module "../core/event-bus.js" {
     };
     "agent:tool-started": {
       title: string;
+      /** Canonical tool name; `title` is the display label and may differ. */
+      name?: string;
       toolCallId?: string;
       kind?: string;
       icon?: string;

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -148,6 +148,7 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
         const display = tool.getDisplayInfo?.(args) ?? { kind: "execute" };
         bus.emit("agent:tool-started", {
           title: tc.name,
+          name: tc.name,
           toolCallId: tc.id,
           kind: display.kind,
           locations: display.locations,


### PR DESCRIPTION
## Summary

Renderers were keying per-tool hook lookups on `title`, which is `displayName ?? name`. For a tool registered as `scheme_eval` with `displayName: "scheme"`, an external render extension registering under `scheme_eval` is never found — ashi's lookup looks up `scheme`. The workaround so far has been dual-registration under both names, which is what ashi's own `default-renderers.ts` does (`:read` AND `:read_file`, `:edit` AND `:edit_file`, etc.) — a clear sign the routing key was misplaced.

The same divergence produces a live-vs-replay mismatch in ashi: replay reads the canonical name from the persisted message log (`tc.function.name`), live reads `title` (displayName), so the two paths disagree for any tool where the names differ. Visible symptom: a scheme call replays with `λ` (correct) and runs live with `⚙` (wrong) in the same session.

## Changes

**Agent-sh (0.14.2):**
- `events.ts`: add optional `name?: string` to `agent:tool-started`.
- `agent-loop.ts`: populate `name` at both emit sites.
- `subagent.ts`: populate `name`.

**In-repo bridges:**
- `opencode-bridge`: populate `name` at all three emit sites.
- `claude-code-bridge`: populate `name` at both emit sites.
- `pi-bridge`: populate `name`.

**Ashi (0.1.6):**
- `frontend.ts`: prefer `e.name` for resolver lookup; fall back to `title.split(":")[0]` when missing.
- `default-renderers.ts`: drop `:read`, `:edit`, `:write` aliases. Canonical `:read_file`, `:edit_file`, `:write_file` remain.
- `package.json`: bump to `0.1.6` and pin `agent-sh: ^0.14.2`.

`title` keeps its existing meaning — the display label with optional `: description` suffix. Only the routing key changes.

## Backwards compatibility

The `agent:tool-started` change is strictly additive — old consumers ignore the new field. The dropped renderer aliases are guarded by ashi's `^0.14.2` pin: npm's dep resolver guarantees ashi 0.1.6 runs against an agent-sh that supplies `name`, so the `e.name` path always succeeds and the `:read`/`:edit`/`:write` fallbacks are unreachable. No mixed-version regression possible through npm install.

The title-split fallback in `frontend.ts` stays as belt-and-suspenders for hand-rolled `agent:tool-started` emits in user-personal extensions (e.g. `scheme.ts withDisplay`) that don't yet supply `name`. Those emitters in the wild that I checked pass canonical names as `title`, which still resolve correctly against the surviving canonical registrations.

## Test plan

- [ ] Live scheme call (with a render extension registered under `scheme_eval`): renders with the custom renderer, not the generic fallback.
- [ ] `/resume` a session containing scheme calls: replayed calls render the same as live ones.
- [ ] Built-in `read_file`, `edit_file`, `write_file` calls: render correctly through the canonical handlers.
- [ ] Bridges (opencode, claude-code, pi): tool calls render same as before (still fall to `:default` for their PascalCase/foreign names).
- [ ] `npm test`: all 125 tests pass.