### PR TITLE
ashi: add --continue / -c flag to auto-resume last session

### DIFF
--- a/examples/extensions/ashi/src/capture.ts
+++ b/examples/extensions/ashi/src/capture.ts
@@ -38,6 +38,7 @@ export function registerCapture(
     const newMessages = messages.slice(liveEntryIds.length).map(enrich);
     const newIds = await getStore().current().appendMessages(newMessages);
     liveEntryIds = [...liveEntryIds, ...newIds];
+    getStore().markLastSession();
   };
 
   ctx.bus.on("agent:processing-done", () => { void flush(); });

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -11,7 +11,7 @@ import type { AppConfig } from "agent-sh/types";
 
 import { mountAshi } from "./frontend.js";
 import { MultiSessionStore } from "./multi-session-store.js";
-import { registerForkCommands } from "./commands.js";
+import { registerForkCommands, applyBranchMessages } from "./commands.js";
 import { registerSessionCommands } from "./session-commands.js";
 import { registerCompaction } from "./compaction.js";
 import { registerCapture } from "./capture.js";
@@ -20,12 +20,13 @@ import { registerDefaultToolRenderers } from "./default-renderers.js";
 import * as os from "node:os";
 import * as path from "node:path";
 
-function parseArgs(argv: string[]): AppConfig & { extensions?: string[] } {
+function parseArgs(argv: string[]): AppConfig & { extensions?: string[]; continueLast: boolean } {
   let model: string | undefined;
   let apiKey: string | undefined = process.env.OPENAI_API_KEY ?? process.env.OPENROUTER_API_KEY;
   let baseURL: string | undefined = process.env.OPENAI_BASE_URL;
   let provider: string | undefined;
   let backend: string | undefined;
+  let continueLast = false;
   const extensions: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -37,13 +38,15 @@ function parseArgs(argv: string[]): AppConfig & { extensions?: string[] } {
     else if (a === "--backend" && argv[i + 1]) backend = argv[++i];
     else if ((a === "-e" || a === "--extensions") && argv[i + 1]) {
       extensions.push(...argv[++i]!.split(",").map(s => s.trim()).filter(Boolean));
+    } else if (a === "-c" || a === "--continue") {
+      continueLast = true;
     } else if (a === "-h" || a === "--help") {
       process.stdout.write(MANAGEMENT_HELP + "\n");
       process.exit(0);
     }
   }
 
-  return { shell: "/bin/sh", model, apiKey, baseURL, provider, backend, extensions };
+  return { shell: "/bin/sh", model, apiKey, baseURL, provider, backend, extensions, continueLast };
 }
 
 const MANAGEMENT_HELP = `ashi — ash (agent-sh's built-in agent) in an interactive TUI
@@ -59,7 +62,9 @@ Management:
 
 Launch (default):
   ashi [--provider <name>] [--model <id>] [--api-key <key>] [--base-url <url>]
-       [--backend <name>] [-e <ext>[,<ext>...]]
+       [--backend <name>] [-e <ext>[,<ext>...]] [-c | --continue]
+
+  -c, --continue   Resume the last session in this cwd (fresh session if none)
 
 Reads ~/.agent-sh/settings.json for providers and defaults.`;
 
@@ -110,7 +115,10 @@ async function main(): Promise<void> {
   const cwd = process.cwd();
   const cwdSlug = cwd.replace(/\//g, "-").replace(/^-/, "");
   const sessionsDir = path.join(os.homedir(), ".agent-sh", "ashi", "history", cwdSlug, "sessions");
-  const store = new MultiSessionStore(sessionsDir, cwd);
+  const resumeId = config.continueLast
+    ? MultiSessionStore.readLastSessionId(sessionsDir, { fallbackToLatest: true })
+    : undefined;
+  const store = new MultiSessionStore(sessionsDir, cwd, { resumeSessionId: resumeId });
   const getStore = (): MultiSessionStore => store;
 
   const core = createCore({ ...config, history: new NoopHistory() });
@@ -158,6 +166,12 @@ async function main(): Promise<void> {
     openSessionPicker: handle.openSessionPicker,
     rebuildChat: handle.rebuildChat,
   });
+
+  if (resumeId) {
+    applyBranchMessages(ctx, getStore, capture);
+    await handle.rebuildChat();
+    ctx.bus.emit("ui:info", { message: `continued session ${resumeId.slice(0, 12)}…` });
+  }
 
   await core.activateBackend(config.backend ?? getSettings().defaultBackend);
 

--- a/examples/extensions/ashi/src/multi-session-store.ts
+++ b/examples/extensions/ashi/src/multi-session-store.ts
@@ -13,19 +13,60 @@ export interface SessionInfo {
 }
 
 /** Many sessions per cwd. Each is one .jsonl file under `dir/`. Constructor
- *  always opens a fresh session; /resume callers can `openSession(id)` to
- *  swap the current store to a past session file. */
+ *  always opens a fresh session unless `opts.resumeSessionId` is given and
+ *  points to an existing session file. /resume callers can `openSession(id)`
+ *  to swap the current store to a past session file. */
 export class MultiSessionStore {
   private dir: string;
   private cwd: string;
   private currentStore: SessionStore;
 
-  constructor(dir: string, cwd: string) {
+  constructor(dir: string, cwd: string, opts?: { resumeSessionId?: string }) {
     this.dir = dir;
     this.cwd = cwd;
     fs.mkdirSync(dir, { recursive: true });
     this.migrateLegacy();
+    if (opts?.resumeSessionId) {
+      const filePath = this.sessionFile(opts.resumeSessionId);
+      if (fs.existsSync(filePath)) {
+        this.currentStore = new SessionStore(filePath);
+        return;
+      }
+    }
     this.currentStore = this.createFreshSession();
+  }
+
+  markLastSession(): void {
+    const lastFile = path.join(this.dir, ".last-session");
+    fs.writeFileSync(lastFile, this.currentStore.id);
+  }
+
+  static readLastSessionId(dir: string, opts?: { fallbackToLatest?: boolean }): string | undefined {
+    const lastFile = path.join(dir, ".last-session");
+    try {
+      const id = fs.readFileSync(lastFile, "utf-8").trim();
+      if (id && fs.existsSync(path.join(dir, `${id}.jsonl`))) return id;
+    } catch { /* no .last-session file yet */ }
+
+    if (opts?.fallbackToLatest) {
+      let best: { id: string; createdAt: number } | undefined;
+      let names: string[];
+      try { names = fs.readdirSync(dir); } catch { return undefined; }
+      for (const name of names) {
+        if (!name.endsWith(".jsonl")) continue;
+        const id = name.slice(0, -".jsonl".length);
+        try {
+          const raw = fs.readFileSync(path.join(dir, `${id}.jsonl.meta`), "utf-8");
+          const meta = JSON.parse(raw) as { createdAt?: number };
+          if (typeof meta.createdAt === "number" && (!best || meta.createdAt > best.createdAt)) {
+            best = { id, createdAt: meta.createdAt };
+          }
+        } catch { /* skip unreadable meta */ }
+      }
+      if (best) return best.id;
+    }
+
+    return undefined;
   }
 
   /** One-time import from the previous storage format (sessions stored as


### PR DESCRIPTION
### What

`ashi -c` (or `ashi --continue`) resumes the last session the user was actively working in. Falls back to a fresh session when no prior sessions exist.

### How

- **`.last-session` pointer file** in `~/.agent-sh/ashi/history/<cwd>/sessions/` tracks the last session that received content. Written only on message flush — not on session creation or switch — so idle sessions are never targeted.
- **`MultiSessionStore`** constructor now accepts an optional `resumeSessionId`; adds `markLastSession()` and static `readLastSessionId()` (with fallback to most-recent-by-createdAt for pre-existing cwds that lack a pointer).
- **`Capture.flush()`** calls `markLastSession()` after each `appendMessages`.
- **`cli.ts`** parses the flag, resolves the session ID at startup, and loads the session messages into the conversation before the first render (same code path `/resume` uses).

### Files

| File | Lines |
|---|---|
| `multi-session-store.ts` | +45 |
| `capture.ts` | +1 |
| `cli.ts` | +18 |