### PR TITLE
fix /compact crash; deterministic ashi compaction with summary hook

### DIFF
--- a/examples/extensions/ashi-compact-llm.ts
+++ b/examples/extensions/ashi-compact-llm.ts
@@ -1,0 +1,93 @@
+/**
+ * Replaces ashi's default deterministic compaction summary with an
+ * LLM-generated structured one. Advises `ashi:compact:build-summary`;
+ * orchestration stays in ashi. Falls back to deterministic when the LLM
+ * is unavailable or the call fails.
+ */
+import type { AgentContext } from "agent-sh/types";
+
+interface AgentMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: unknown;
+  tool_calls?: { function?: { name?: string; arguments?: string } }[];
+}
+
+const SUMMARY_PROMPT = `You are compacting a coding-agent conversation so the agent can continue with limited context.
+
+Produce a Markdown summary using EXACTLY this structure:
+
+## Goal
+[What the user is trying to accomplish, one or two sentences]
+
+## Constraints & Preferences
+- [Bulleted user requirements / preferences expressed so far]
+
+## Progress
+### Done
+- [x] [Completed work]
+
+### In Progress
+- [ ] [Active work and current sub-goal]
+
+### Blocked
+- [Issues, or "None"]
+
+## Key Decisions
+- **[Decision]**: [Rationale]
+
+## Next Steps
+1. [What should happen next]
+
+## Critical Context
+- [Specific paths, names, identifiers, or data the agent must remember]
+
+Be concrete. Quote file paths, function names, error strings verbatim when relevant. Do not invent details that aren't in the conversation.`;
+
+export default function activate(ctx: AgentContext): void {
+  ctx.advise(
+    "ashi:compact:build-summary",
+    async (next: (...a: unknown[]) => unknown, evicted: AgentMessage[]) => {
+      const llm = ctx.agent?.llm;
+      if (!llm?.available) return next(evicted);
+      try {
+        const summary = await llm.ask({
+          system: SUMMARY_PROMPT,
+          query: buildQuery(evicted),
+          maxTokens: 16384,
+          reasoningEffort: "low",
+        });
+        return summary.trim();
+      } catch (e) {
+        ctx.bus.emit("ui:error", {
+          message: `ashi-compact-llm: LLM failed (${(e as Error).message}); falling back to deterministic summary`,
+        });
+        return next(evicted);
+      }
+    },
+  );
+}
+
+function buildQuery(messages: AgentMessage[]): string {
+  const lines: string[] = ["Conversation to summarize:"];
+  for (const m of messages) {
+    const text = typeof m.content === "string" ? m.content : "";
+    if (m.role === "user") lines.push(`[User]: ${text}`);
+    else if (m.role === "assistant") {
+      if (text) lines.push(`[Assistant]: ${text}`);
+      if (m.tool_calls) {
+        for (const t of m.tool_calls) {
+          const args = t.function?.arguments ?? "";
+          lines.push(`[Assistant tool call]: ${t.function?.name ?? "?"}(${truncate(args, 400)})`);
+        }
+      }
+    } else if (m.role === "tool") {
+      lines.push(`[Tool result]: ${truncate(text, 2000)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + `\n[…truncated ${s.length - max} chars…]`;
+}

--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -16,6 +16,7 @@
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
     "start": "node dist/cli.js",
+    "test": "node --import tsx --test $(find tests -name '*.test.ts' -type f)",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -21,21 +21,21 @@ export function registerCompaction(
 ): void {
   ctx.define("ashi:compact:build-summary", (_evicted: AgentMessage[]): string | null => null);
 
-  ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
+  ctx.advise("conversation:compact", async (_next: (...a: unknown[]) => unknown, opts: unknown) => {
     await capture.flush();
     const messages = ctx.call("conversation:get-messages") as AgentMessage[] | undefined;
-    if (!messages || messages.length < 4) return next(opts);
+    if (!messages || messages.length < 4) return null;
 
     const o = (opts ?? {}) as { force?: boolean; target?: number };
     const budget = pickBudget(o);
     const minCut = o.force ? 1 : 2;
     const cutIdx = findCutPoint(messages, budget);
-    if (cutIdx < minCut) return next(opts);
+    if (cutIdx < minCut) return null;
 
     const firstKeptId = capture.getEntryIdAt(cutIdx);
     if (!firstKeptId) {
-      ctx.bus.emit("ui:error", { message: "compaction: kept-message has no on-disk entry; falling back" });
-      return next(opts);
+      ctx.bus.emit("ui:error", { message: "compaction: kept-message has no on-disk entry; aborting" });
+      return null;
     }
 
     const older = messages.slice(0, cutIdx);

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -4,7 +4,15 @@ import type { Capture } from "./capture.js";
 import type { AgentMessage } from "./session-store.js";
 
 const KEEP_RECENT_TOKEN_BUDGET = 20_000;
+const FORCE_KEEP_RECENT_TOKEN_BUDGET = 4_000;
 const APPROX_TOKENS_PER_CHAR = 0.25;
+
+export function pickBudget(opts: { force?: boolean; target?: number } | undefined): number {
+  if (opts?.force) return FORCE_KEEP_RECENT_TOKEN_BUDGET;
+  const target = opts?.target ?? 0;
+  if (target > 0) return Math.max(target, FORCE_KEEP_RECENT_TOKEN_BUDGET);
+  return KEEP_RECENT_TOKEN_BUDGET;
+}
 
 export function registerCompaction(
   ctx: ExtensionContext,
@@ -16,10 +24,13 @@ export function registerCompaction(
   ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
     await capture.flush();
     const messages = ctx.call("conversation:get-messages") as AgentMessage[] | undefined;
-    if (!messages || messages.length < 6) return next(opts);
+    if (!messages || messages.length < 4) return next(opts);
 
-    const cutIdx = findCutPoint(messages, KEEP_RECENT_TOKEN_BUDGET);
-    if (cutIdx < 2) return next(opts);
+    const o = (opts ?? {}) as { force?: boolean; target?: number };
+    const budget = pickBudget(o);
+    const minCut = o.force ? 1 : 2;
+    const cutIdx = findCutPoint(messages, budget);
+    if (cutIdx < minCut) return next(opts);
 
     const firstKeptId = capture.getEntryIdAt(cutIdx);
     if (!firstKeptId) {

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -43,8 +43,6 @@ export function registerCompaction(
     capture.resetTo([null, ...keptIds]);
 
     const tokensAfter = (ctx.call("conversation:estimate-prompt-tokens") as number) ?? 0;
-    ctx.bus.emit("ui:info", { message: `compacted ${older.length} messages: ${tokensBefore} → ${tokensAfter} tokens` });
-
     return { before: tokensBefore, after: tokensAfter, evictedCount: older.length };
   });
 }

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -47,7 +47,7 @@ export function registerCompaction(
   });
 }
 
-function findCutPoint(messages: AgentMessage[], tokenBudget: number): number {
+export function findCutPoint(messages: AgentMessage[], tokenBudget: number): number {
   let acc = 0;
   for (let i = messages.length - 1; i >= 0; i--) {
     acc += estimateMessageTokens(messages[i]!);
@@ -60,14 +60,14 @@ function findCutPoint(messages: AgentMessage[], tokenBudget: number): number {
   return 0;
 }
 
-function isSafeCutPoint(messages: AgentMessage[], idx: number): boolean {
+export function isSafeCutPoint(messages: AgentMessage[], idx: number): boolean {
   const m = messages[idx];
   if (!m) return true;
   if (m.role === "tool") return false;
   return !(m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0);
 }
 
-function estimateMessageTokens(m: AgentMessage): number {
+export function estimateMessageTokens(m: AgentMessage): number {
   let chars = 0;
   if (typeof m.content === "string") chars += m.content.length;
   if (m.tool_calls) for (const t of m.tool_calls) chars += (t.function?.arguments?.length ?? 0);

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -43,9 +43,9 @@ export function registerCompaction(
     const tokensBefore = (ctx.call("conversation:estimate-prompt-tokens") as number) ?? 0;
     const customSummary = (await ctx.call("ashi:compact:build-summary", older)) as string | null | undefined;
 
-    await getStore().current().appendCompaction(firstKeptId, tokensBefore, customSummary ?? undefined);
-
-    ctx.call("conversation:replace-messages", getStore().current().buildMessages());
+    const store = getStore().current();
+    await store.appendCompaction(firstKeptId, tokensBefore, customSummary ?? undefined);
+    ctx.call("conversation:replace-messages", store.buildMessages());
 
     const keptIds = kept.map((_, i) => capture.getEntryIdAt(cutIdx + i));
     if (keptIds.some((id) => id === null)) {

--- a/examples/extensions/ashi/src/compaction.ts
+++ b/examples/extensions/ashi/src/compaction.ts
@@ -1,51 +1,19 @@
 import type { ExtensionContext } from "agent-sh/types";
 import type { MultiSessionStore } from "./multi-session-store.js";
 import type { Capture } from "./capture.js";
-import type { AgentMessage, CompactionEntry } from "./session-store.js";
+import type { AgentMessage } from "./session-store.js";
 
 const KEEP_RECENT_TOKEN_BUDGET = 20_000;
 const APPROX_TOKENS_PER_CHAR = 0.25;
-
-const SUMMARY_PROMPT = `You are compacting a coding-agent conversation so the agent can continue with limited context.
-
-Produce a Markdown summary using EXACTLY this structure:
-
-## Goal
-[What the user is trying to accomplish, one or two sentences]
-
-## Constraints & Preferences
-- [Bulleted user requirements / preferences expressed so far]
-
-## Progress
-### Done
-- [x] [Completed work]
-
-### In Progress
-- [ ] [Active work and current sub-goal]
-
-### Blocked
-- [Issues, or "None"]
-
-## Key Decisions
-- **[Decision]**: [Rationale]
-
-## Next Steps
-1. [What should happen next]
-
-## Critical Context
-- [Specific paths, names, identifiers, or data the agent must remember]
-
-Be concrete. Quote file paths, function names, error strings verbatim when relevant. Do not invent details that aren't in the conversation.`;
 
 export function registerCompaction(
   ctx: ExtensionContext,
   getStore: () => MultiSessionStore,
   capture: Capture,
 ): void {
-  ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
-    const llm = ctx.agent?.llm;
-    if (!llm?.available) return next(opts);
+  ctx.define("ashi:compact:build-summary", (_evicted: AgentMessage[]): string | null => null);
 
+  ctx.advise("conversation:compact", async (next: (...a: unknown[]) => unknown, opts: unknown) => {
     await capture.flush();
     const messages = ctx.call("conversation:get-messages") as AgentMessage[] | undefined;
     if (!messages || messages.length < 6) return next(opts);
@@ -61,33 +29,12 @@ export function registerCompaction(
 
     const older = messages.slice(0, cutIdx);
     const kept = messages.slice(cutIdx);
-
-    const branch = getStore().current().getBranch();
-    const prevCompaction = [...branch].reverse().find((e) => e.type === "compaction") as CompactionEntry | undefined;
-    const prevSummary = prevCompaction?.summary;
-
     const tokensBefore = (ctx.call("conversation:estimate-prompt-tokens") as number) ?? 0;
+    const customSummary = (await ctx.call("ashi:compact:build-summary", older)) as string | null | undefined;
 
-    let summary: string;
-    try {
-      summary = await llm.ask({
-        system: SUMMARY_PROMPT,
-        query: buildQuery(older, prevSummary),
-        maxTokens: 16384,
-        reasoningEffort: "low",
-      });
-    } catch (e) {
-      ctx.bus.emit("ui:error", { message: `compaction: LLM failed (${(e as Error).message}); falling back` });
-      return next(opts);
-    }
+    await getStore().current().appendCompaction(firstKeptId, tokensBefore, customSummary ?? undefined);
 
-    await getStore().current().appendCompaction(summary.trim(), firstKeptId, tokensBefore);
-
-    const summaryMessage: AgentMessage = {
-      role: "user",
-      content: `[Compacted conversation summary]\n${summary.trim()}`,
-    };
-    ctx.call("conversation:replace-messages", [summaryMessage, ...kept]);
+    ctx.call("conversation:replace-messages", getStore().current().buildMessages());
 
     const keptIds = kept.map((_, i) => capture.getEntryIdAt(cutIdx + i));
     if (keptIds.some((id) => id === null)) {
@@ -127,31 +74,4 @@ function estimateMessageTokens(m: AgentMessage): number {
   if (typeof m.content === "string") chars += m.content.length;
   if (m.tool_calls) for (const t of m.tool_calls) chars += (t.function?.arguments?.length ?? 0);
   return Math.ceil(chars * APPROX_TOKENS_PER_CHAR) + 20;
-}
-
-function buildQuery(messages: AgentMessage[], prevSummary?: string): string {
-  const lines: string[] = [];
-  if (prevSummary) lines.push("Previous compaction summary (continue iteratively):\n", prevSummary, "\n---\n");
-  lines.push("Conversation to summarize:");
-  for (const m of messages) {
-    const text = typeof m.content === "string" ? m.content : "";
-    if (m.role === "user") lines.push(`[User]: ${text}`);
-    else if (m.role === "assistant") {
-      if (text) lines.push(`[Assistant]: ${text}`);
-      if (m.tool_calls) {
-        for (const t of m.tool_calls) {
-          const args = t.function?.arguments ?? "";
-          lines.push(`[Assistant tool call]: ${t.function?.name ?? "?"}(${truncate(args, 400)})`);
-        }
-      }
-    } else if (m.role === "tool") {
-      lines.push(`[Tool result]: ${truncate(text, 2000)}`);
-    }
-  }
-  return lines.join("\n");
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max) + `\n[…truncated ${s.length - max} chars…]`;
 }

--- a/examples/extensions/ashi/src/session-store.ts
+++ b/examples/extensions/ashi/src/session-store.ts
@@ -73,7 +73,7 @@ function snippet(text: string, max: number): string {
   return cleaned.slice(0, max) + "…";
 }
 
-function summarizeMessage(m: AgentMessage): string {
+export function summarizeMessage(m: AgentMessage): string {
   const role = m.role ?? "?";
   if (role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
     const tools = m.tool_calls.map((tc) => {

--- a/examples/extensions/ashi/src/session-store.ts
+++ b/examples/extensions/ashi/src/session-store.ts
@@ -39,7 +39,7 @@ export interface CompactionEntry {
   id: string;
   parentId: string;
   timestamp: number;
-  summary: string;
+  summary?: string;
   firstKeptId: string;
   tokensBefore: number;
 }
@@ -53,6 +53,44 @@ export interface SessionMeta {
 
 export function newEntryId(): string {
   return crypto.randomBytes(4).toString("hex");
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((p) => {
+      if (typeof p === "string") return p;
+      const part = p as { text?: string; content?: string };
+      return part?.text ?? part?.content ?? "";
+    }).join(" ");
+  }
+  return "";
+}
+
+function snippet(text: string, max: number): string {
+  const cleaned = String(text ?? "").replace(/\s+/g, " ").trim();
+  if (cleaned.length <= max) return cleaned || "(empty)";
+  return cleaned.slice(0, max) + "…";
+}
+
+function summarizeMessage(m: AgentMessage): string {
+  const role = m.role ?? "?";
+  if (role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+    const tools = m.tool_calls.map((tc) => tc.function?.name ?? "tool").join(", ");
+    const text = extractText(m.content);
+    const prefix = text ? `${snippet(text, 60)} → ` : "";
+    return `assistant: ${prefix}called ${tools}`;
+  }
+  if (role === "tool") {
+    const text = typeof m.content === "string" ? m.content : extractText(m.content);
+    return `tool result: ${snippet(text, 80)}`;
+  }
+  return `${role}: ${snippet(extractText(m.content), 100)}`;
+}
+
+export function renderEvictedSummary(evicted: AgentMessage[]): string {
+  const lines = evicted.map((m) => `- ${summarizeMessage(m)}`);
+  return `${lines.length} message(s) elided\n${lines.join("\n")}`;
 }
 
 /** One session = one JSONL file (entries) + sidecar files for leaf & meta.
@@ -152,7 +190,7 @@ export class SessionStore {
     return newIds;
   }
 
-  async appendCompaction(summary: string, firstKeptId: string, tokensBefore: number): Promise<string> {
+  async appendCompaction(firstKeptId: string, tokensBefore: number, summary?: string): Promise<string> {
     if (!this.entries.has(firstKeptId)) throw new Error(`firstKeptId unknown: ${firstKeptId}`);
     this.flushHeader();
     const e: CompactionEntry = {
@@ -160,9 +198,9 @@ export class SessionStore {
       id: newEntryId(),
       parentId: this.activeLeaf,
       timestamp: Date.now(),
-      summary,
       firstKeptId,
       tokensBefore,
+      ...(summary !== undefined ? { summary } : {}),
     };
     this.entries.set(e.id, e);
     this.activeLeaf = e.id;
@@ -203,9 +241,14 @@ export class SessionStore {
     const c = branch[compactionIdx] as CompactionEntry;
     const firstKeptIdx = branch.findIndex((e) => e.id === c.firstKeptId);
     const keepFrom = firstKeptIdx >= 0 ? firstKeptIdx : 0;
+    const summary = c.summary ?? renderEvictedSummary(
+      branch.slice(0, keepFrom)
+        .filter((e): e is MessageEntry => e.type === "message")
+        .map((e) => e.message),
+    );
     const out: AgentMessage[] = [{
       role: "user",
-      content: `[Compacted conversation summary]\n${c.summary}`,
+      content: `[Compacted conversation summary]\n${summary}`,
     }];
     for (let i = keepFrom; i < branch.length; i++) {
       const e = branch[i]!;

--- a/examples/extensions/ashi/src/session-store.ts
+++ b/examples/extensions/ashi/src/session-store.ts
@@ -76,16 +76,24 @@ function snippet(text: string, max: number): string {
 function summarizeMessage(m: AgentMessage): string {
   const role = m.role ?? "?";
   if (role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
-    const tools = m.tool_calls.map((tc) => tc.function?.name ?? "tool").join(", ");
+    const tools = m.tool_calls.map((tc) => {
+      const name = tc.function?.name ?? "tool";
+      const args = tc.function?.arguments;
+      return args ? `${name}(${snippet(args, 200)})` : name;
+    }).join(", ");
     const text = extractText(m.content);
-    const prefix = text ? `${snippet(text, 60)} → ` : "";
+    const prefix = text ? `${snippet(text, 400)} → ` : "";
     return `assistant: ${prefix}called ${tools}`;
   }
   if (role === "tool") {
     const text = typeof m.content === "string" ? m.content : extractText(m.content);
-    return `tool result: ${snippet(text, 80)}`;
+    const isErr = /^error\b|: error\b/i.test(text.slice(0, 200));
+    return `tool result: ${snippet(text, isErr ? 1000 : 400)}`;
   }
-  return `${role}: ${snippet(extractText(m.content), 100)}`;
+  if (role === "user") {
+    return `user: ${snippet(extractText(m.content), 1000)}`;
+  }
+  return `${role}: ${snippet(extractText(m.content), 500)}`;
 }
 
 export function renderEvictedSummary(evicted: AgentMessage[]): string {

--- a/examples/extensions/ashi/tests/compaction.test.ts
+++ b/examples/extensions/ashi/tests/compaction.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { findCutPoint, isSafeCutPoint, estimateMessageTokens } from "../src/compaction.js";
+import type { AgentMessage } from "../src/session-store.js";
+
+const userMsg = (text: string): AgentMessage => ({ role: "user", content: text });
+const assistantMsg = (text: string): AgentMessage => ({ role: "assistant", content: text });
+const assistantCall = (callId: string, name: string, args = ""): AgentMessage => ({
+  role: "assistant",
+  content: "",
+  tool_calls: [{ id: callId, function: { name, arguments: args } }],
+});
+const toolResult = (callId: string, text: string): AgentMessage => ({
+  role: "tool",
+  tool_call_id: callId,
+  content: text,
+});
+
+test("estimateMessageTokens uses 0.25 chars/token + 20 overhead", () => {
+  assert.equal(estimateMessageTokens(userMsg("abcd")), Math.ceil(4 * 0.25) + 20);
+  assert.equal(estimateMessageTokens(userMsg("")), 20);
+});
+
+test("estimateMessageTokens includes tool_call arguments length", () => {
+  const m = assistantCall("c1", "read_file", "x".repeat(40));
+  assert.equal(estimateMessageTokens(m), Math.ceil(40 * 0.25) + 20);
+});
+
+test("isSafeCutPoint rejects tool result positions", () => {
+  const msgs = [userMsg("hi"), assistantCall("c1", "read_file"), toolResult("c1", "ok")];
+  assert.equal(isSafeCutPoint(msgs, 2), false);
+});
+
+test("isSafeCutPoint rejects assistant-with-tool-calls positions", () => {
+  const msgs = [userMsg("hi"), assistantCall("c1", "read_file"), toolResult("c1", "ok")];
+  assert.equal(isSafeCutPoint(msgs, 1), false);
+});
+
+test("isSafeCutPoint accepts plain user/assistant positions", () => {
+  const msgs = [userMsg("hi"), assistantMsg("hello"), userMsg("again")];
+  assert.equal(isSafeCutPoint(msgs, 0), true);
+  assert.equal(isSafeCutPoint(msgs, 1), true);
+  assert.equal(isSafeCutPoint(msgs, 2), true);
+});
+
+test("findCutPoint returns 0 when total tokens < budget", () => {
+  const msgs = [userMsg("hi"), assistantMsg("hello")];
+  assert.equal(findCutPoint(msgs, 10_000), 0);
+});
+
+test("findCutPoint walks back-to-front and lands on the budget-crossing message", () => {
+  const big = "x".repeat(800); // ~200 tokens each
+  const msgs: AgentMessage[] = [
+    userMsg(big),       // idx 0
+    assistantMsg(big),  // idx 1
+    userMsg(big),       // idx 2
+    assistantMsg(big),  // idx 3
+  ];
+  const cut = findCutPoint(msgs, 500);
+  assert.ok(cut >= 1 && cut <= 2, `expected cut in [1,2], got ${cut}`);
+});
+
+test("findCutPoint snaps forward past an unsafe cut (tool result)", () => {
+  const big = "x".repeat(800);
+  const msgs: AgentMessage[] = [
+    userMsg(big),                          // 0
+    assistantCall("c1", "read_file", big), // 1 — unsafe
+    toolResult("c1", big),                 // 2 — unsafe
+    userMsg("ok"),                         // 3 — safe landing
+  ];
+  const cut = findCutPoint(msgs, 100);
+  assert.equal(cut, 3, "must snap past the tool_call/tool_result pair");
+});

--- a/examples/extensions/ashi/tests/compaction.test.ts
+++ b/examples/extensions/ashi/tests/compaction.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { findCutPoint, isSafeCutPoint, estimateMessageTokens } from "../src/compaction.js";
+import { findCutPoint, isSafeCutPoint, estimateMessageTokens, pickBudget } from "../src/compaction.js";
 import type { AgentMessage } from "../src/session-store.js";
 
 const userMsg = (text: string): AgentMessage => ({ role: "user", content: text });
@@ -58,6 +58,22 @@ test("findCutPoint walks back-to-front and lands on the budget-crossing message"
   ];
   const cut = findCutPoint(msgs, 500);
   assert.ok(cut >= 1 && cut <= 2, `expected cut in [1,2], got ${cut}`);
+});
+
+test("pickBudget defaults to 20k when no force or target", () => {
+  assert.equal(pickBudget(undefined), 20_000);
+  assert.equal(pickBudget({}), 20_000);
+});
+
+test("pickBudget returns tight 4k budget when force=true", () => {
+  assert.equal(pickBudget({ force: true }), 4_000);
+  assert.equal(pickBudget({ force: true, target: 50_000 }), 4_000);
+});
+
+test("pickBudget clamps target up to the 4k minimum", () => {
+  assert.equal(pickBudget({ target: 1000 }), 4_000);
+  assert.equal(pickBudget({ target: 0 }), 20_000);
+  assert.equal(pickBudget({ target: 37_500 }), 37_500);
 });
 
 test("findCutPoint snaps forward past an unsafe cut (tool result)", () => {

--- a/examples/extensions/ashi/tests/session-store.test.ts
+++ b/examples/extensions/ashi/tests/session-store.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -11,8 +11,14 @@ import {
   type AgentMessage,
 } from "../src/session-store.js";
 
+const tmpDirs: string[] = [];
+after(() => {
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+});
+
 function tmpSessionPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-store-"));
+  tmpDirs.push(dir);
   return path.join(dir, "session.jsonl");
 }
 

--- a/examples/extensions/ashi/tests/session-store.test.ts
+++ b/examples/extensions/ashi/tests/session-store.test.ts
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
+import {
+  SessionStore,
+  renderEvictedSummary,
+  summarizeMessage,
+  type AgentMessage,
+} from "../src/session-store.js";
+
+function tmpSessionPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-store-"));
+  return path.join(dir, "session.jsonl");
+}
+
+function makeStore(): SessionStore {
+  return new SessionStore(tmpSessionPath(), {
+    create: { cwd: process.cwd(), sessionId: crypto.randomBytes(4).toString("hex") },
+  });
+}
+
+test("summarizeMessage renders user role with cap of 1000", () => {
+  const m: AgentMessage = { role: "user", content: "what's in foo.ts?" };
+  assert.equal(summarizeMessage(m), "user: what's in foo.ts?");
+});
+
+test("summarizeMessage truncates user content past the cap", () => {
+  const long = "a".repeat(1500);
+  const out = summarizeMessage({ role: "user", content: long });
+  assert.match(out, /^user: a{1000}…$/);
+});
+
+test("summarizeMessage renders bare assistant text with cap of 500", () => {
+  const m: AgentMessage = { role: "assistant", content: "thinking about it" };
+  assert.equal(summarizeMessage(m), "assistant: thinking about it");
+});
+
+test("summarizeMessage renders assistant with tool calls and surfaces args", () => {
+  const m: AgentMessage = {
+    role: "assistant",
+    content: "reading the file",
+    tool_calls: [{ id: "c1", function: { name: "read_file", arguments: '{"path":"src/a.ts"}' } }],
+  };
+  const out = summarizeMessage(m);
+  assert.match(out, /^assistant: reading the file → called read_file\(/);
+  assert.match(out, /src\/a\.ts/);
+});
+
+test("summarizeMessage shows tool name without args when arguments empty", () => {
+  const m: AgentMessage = {
+    role: "assistant",
+    content: "",
+    tool_calls: [{ id: "c1", function: { name: "ls", arguments: "" } }],
+  };
+  assert.equal(summarizeMessage(m), "assistant: called ls");
+});
+
+test("summarizeMessage caps tool result text at 400 for success", () => {
+  const m: AgentMessage = { role: "tool", tool_call_id: "c1", content: "ok " + "x".repeat(500) };
+  const out = summarizeMessage(m);
+  const body = out.replace(/^tool result: /, "");
+  assert.ok(body.endsWith("…"));
+  assert.ok(body.length <= 401, `body length ${body.length}`);
+});
+
+test("summarizeMessage caps tool result text at 1000 for errors", () => {
+  const m: AgentMessage = { role: "tool", tool_call_id: "c1", content: "Error: " + "x".repeat(1200) };
+  const out = summarizeMessage(m);
+  const body = out.replace(/^tool result: /, "");
+  assert.ok(body.length > 401, "error result should exceed the 400-char success cap");
+  assert.ok(body.length <= 1001, `body length ${body.length}`);
+});
+
+test("renderEvictedSummary header reports count and one line per message", () => {
+  const evicted: AgentMessage[] = [
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "hi" },
+  ];
+  const out = renderEvictedSummary(evicted);
+  const lines = out.split("\n");
+  assert.equal(lines[0], "2 message(s) elided");
+  assert.equal(lines.length, 3);
+  assert.equal(lines[1], "- user: hello");
+  assert.equal(lines[2], "- assistant: hi");
+});
+
+test("renderEvictedSummary on empty input reports 0", () => {
+  const out = renderEvictedSummary([]);
+  assert.equal(out, "0 message(s) elided\n");
+});
+
+test("buildMessages without compaction returns raw messages", async () => {
+  const store = makeStore();
+  await store.appendMessages([
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "hello" },
+  ]);
+  const msgs = store.buildMessages();
+  assert.equal(msgs.length, 2);
+  assert.equal(msgs[0]!.role, "user");
+  assert.equal(msgs[1]!.role, "assistant");
+});
+
+test("buildMessages with compaction + stored summary uses the stored text", async () => {
+  const store = makeStore();
+  const [_evicted, kept] = await store.appendMessages([
+    { role: "user", content: "old thing" },
+    { role: "user", content: "kept thing" },
+  ]);
+  await store.appendCompaction(kept!, 100, "MY_CUSTOM_SUMMARY");
+  const msgs = store.buildMessages();
+  assert.equal(msgs.length, 2);
+  assert.equal(msgs[0]!.role, "user");
+  assert.match(String(msgs[0]!.content), /MY_CUSTOM_SUMMARY/);
+  assert.equal(msgs[1]!.content, "kept thing");
+});
+
+test("buildMessages with compaction + no summary regenerates via renderEvictedSummary", async () => {
+  const store = makeStore();
+  const [_oldest, _middle, kept] = await store.appendMessages([
+    { role: "user", content: "first" },
+    { role: "assistant", content: "second" },
+    { role: "user", content: "kept" },
+  ]);
+  await store.appendCompaction(kept!, 100);
+  const msgs = store.buildMessages();
+  const expected = renderEvictedSummary([
+    { role: "user", content: "first" },
+    { role: "assistant", content: "second" },
+  ]);
+  assert.equal(msgs.length, 2);
+  assert.equal(msgs[0]!.content, `[Compacted conversation summary]\n${expected}`);
+  assert.equal(msgs[1]!.content, "kept");
+});
+
+test("appendCompaction throws when firstKeptId is unknown", async () => {
+  const store = makeStore();
+  await assert.rejects(() => store.appendCompaction("nonexistent", 0));
+});

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -309,9 +309,9 @@ export class AgentLoop implements AgentBackend {
       this.conversation = new ConversationState(this.handlers, this.instanceId);
       this.lastProjectSkillNames.clear();
     });
-    on("agent:compact-request", () => {
+    on("agent:compact-request", async () => {
       // Force compaction. Strategy lives behind `conversation:compact`.
-      const stats = this.compactWithHooks(0, 0, true);
+      const stats = await this.compactWithHooks(0, 0, true);
       if (stats) {
         this.bus.emit("ui:info", {
           message: `(compacted: ~${stats.before.toLocaleString()} → ~${stats.after.toLocaleString()} tokens)`,
@@ -542,18 +542,18 @@ export class AgentLoop implements AgentBackend {
    * compaction, emit `conversation:after-compact` so listeners
    * (metrics, UI, agent-awareness notes) can react.
    */
-  private compactWithHooks(
+  private async compactWithHooks(
     target: number,
     keepRecent?: number,
     force?: boolean,
     strategy?: BusEvents["context:compact"]["strategy"],
-  ): CompactResult | null {
-    const stats = this.handlers.call("conversation:compact", {
+  ): Promise<CompactResult | null> {
+    const stats = (await this.handlers.call("conversation:compact", {
       target,
       keepRecent,
       force: !!force,
       strategy,
-    }) as CompactResult | null;
+    })) as CompactResult | null;
     if (stats) {
       this.bus.emit("conversation:after-compact", {
         beforeTokens: stats.before,
@@ -1141,7 +1141,7 @@ export class AgentLoop implements AgentBackend {
         // Compact deeply — shallow targets buy only 1–2 turns of runway on
         // tool-heavy workloads.
         const target = Math.floor(threshold * 0.25);
-        const result = this.compactWithHooks(target, 1);
+        const result = await this.compactWithHooks(target, 1);
         if (!result) {
           // Auto-compact fired but nothing was evictable. This can happen
           // in short conversations with heavy tool output where the pin
@@ -1548,7 +1548,7 @@ export class AgentLoop implements AgentBackend {
         if (this.isContextOverflow(e)) {
           const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
           const target = Math.floor((contextWindow - RESPONSE_RESERVE) * 0.6);
-          const stats = this.compactWithHooks(target, 1);
+          const stats = await this.compactWithHooks(target, 1);
           // If compaction freed nothing, retrying will hit the same error.
           // Surface the real failure instead of looping until exhaustion.
           if (!stats || stats.after >= stats.before) {


### PR DESCRIPTION
## Summary

- **Core (`agent-loop.ts`)**: `compactWithHooks` is now `async` and awaits the `conversation:compact` handler. The sync assumption crashed `/compact` whenever an extension advised the handler with an async function (`TypeError: stats.before` on the unawaited Promise).
- **ashi (`compaction.ts`, `session-store.ts`)**: replaces the LLM-based default with a deterministic scrollback summary. `CompactionEntry.summary` is now optional; `buildMessages` regenerates the scrollback from evicted `MessageEntry`s on read when absent. New `ashi:compact:build-summary` handler lets extensions inject a non-derivable summary — returning `null` keeps the default regeneration. Live `replace-messages` now goes through `store.buildMessages()`, so live ≡ rehydrated.
- **`ashi-compact-llm.ts`**: new example extension that opts back into a structured LLM-generated summary by advising `ashi:compact:build-summary`. Falls back to deterministic when the LLM is unavailable or fails.

## Test plan
- [x] `npm test` — 136/136 pass
- [x] Core build (`tsc`) clean
- [x] ashi build (`npm run build`) clean
- [x] Manual: `/compact` in ashi succeeds without crashing
- [x] Manual: resume a compacted session — rebuilt view matches live view
- [ ] Manual: load `ashi-compact-llm` extension; verify LLM summary is persisted on the entry and re-displayed on resume