### PR TITLE
ashi: bash readability — trim trailing newline, truncate + highlight, expandable call line

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -68,7 +68,7 @@ Ctrl+C       Clear editor
 Ctrl+D       Quit (when editor is empty)
 Ctrl+T       Toggle thinking-block visibility (hidden by default)
 Shift+Tab    Cycle thinking level (off → low → medium → high → …)
-Ctrl+O       Expand/collapse the most recent tool result
+Ctrl+O       Expand/collapse all tool calls and results in chat
 ```
 
 The current thinking level is shown in the footer as `[level]` next to the model name.
@@ -142,7 +142,7 @@ Per-tool compactness lives under `ashi.display` in `~/.agent-sh/settings.json`:
 
 For `edit_file` / `write_file`, the diff frame is treated as the output and follows the same gating: shown for `preview`, hidden for `hidden`/`summary` (the call line already carries `+12 -3` stats). The line-count hint is suppressed for diff-producing tools so edits stay quiet.
 
-Hit `Ctrl+O` to expand the most recent tool result inline regardless of mode. Press again to collapse.
+Hit `Ctrl+O` to toggle expansion across all tool entries in chat — result bodies show their full output regardless of mode, and call lines with truncated labels (e.g. long `bash` commands) reveal their full text. Press again to collapse.
 
 Each tool inherits from `default` and is overridden by its own block. Unknown tool names fall through to `default`.
 
@@ -173,8 +173,8 @@ Tool rendering is split into a call line (the input header) and a result body (s
 
 `state` is a per-call mutable bag; `invalidate()` requests a re-render.
 
-- `ToolCallView` extends `Component` with `setStatus({ exitCode, elapsedMs, summary })` — called once on completion.
-- `ToolResultView` extends `Component` with `appendChunk(chunk)`, `setDiff(lines)`, `finalize({ exitCode, summary })`, and `toggleExpanded()` — ashi mutates the result view as output streams in and when the user hits `Ctrl+O`.
+- `ToolCallView` extends `Component` with `setStatus({ exitCode, elapsedMs, summary })` — called once on completion. Optional `toggleExpanded()` lets long labels reveal their full text on Ctrl+O.
+- `ToolResultView` extends `Component` with `appendChunk(chunk)`, `setDiff(lines)`, `finalize({ exitCode, summary })`, and `toggleExpanded()` — ashi mutates the result view as output streams in and toggles it on Ctrl+O.
 
 `mode` and `previewLines` on result args come from `ashi.display.{name}` config so renderers can honor the user's compactness preference without re-implementing the resolution logic.
 

--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -166,8 +166,11 @@ export class ToolResultBody extends Container {
       this.outputText.setText("");
       return;
     }
+    // POSIX-style outputs typically end with \n; rendering that trailing
+    // newline as a real line produces a phantom blank gap below the tool.
+    const display = this.outputBuffer.replace(/\n+$/, "");
     if (this.expanded) {
-      this.outputText.setText(theme.fg("toolOutput", this.outputBuffer));
+      this.outputText.setText(theme.fg("toolOutput", display));
       return;
     }
     if (this.mode === "hidden") {
@@ -178,14 +181,14 @@ export class ToolResultBody extends Container {
     if (this.mode === "summary") {
       if (!this.finalized) {
         // Brief tail while streaming; collapses to a line count on finalize.
-        const tail = this.outputBuffer.split("\n").slice(-2).join("\n");
+        const tail = display.split("\n").slice(-2).join("\n");
         this.outputText.setText(theme.fg("muted", tail));
         return;
       }
       this.outputText.setText(lineCountHint(this.outputBuffer, this.exitCode));
       return;
     }
-    const lines = this.outputBuffer.split("\n");
+    const lines = display.split("\n");
     const trimmed = lines.slice(-this.previewLines).join("\n");
     const remaining = Math.max(0, lines.length - this.previewLines);
     const overflow = remaining > 0

--- a/examples/extensions/ashi/src/default-renderers.ts
+++ b/examples/extensions/ashi/src/default-renderers.ts
@@ -1,4 +1,5 @@
 import { Container, Spacer, Text } from "@earendil-works/pi-tui";
+import { highlight, supportsLanguage } from "cli-highlight";
 import type { ExtensionContext } from "agent-sh/types";
 import { theme } from "./theme.js";
 import { GROUP_ICONS } from "./components.js";
@@ -66,12 +67,14 @@ function statusSuffix(opts?: StatusOpts): string {
   return `  ${mark}${elapsed}${sum}`;
 }
 
-/** Renders a one-line tool call header from a label producer. The label is
- *  recomputed on setStatus so the trailing status mark updates in place. */
+/** Renders a one-line tool call header from a label producer. The label
+ *  receives an `expanded` flag so producers like bash can truncate when
+ *  collapsed and reveal the full command on Ctrl+O. */
 class LabeledCallLine extends Container implements ToolCallView {
   private line: Text;
   private status?: StatusOpts;
-  constructor(private label: () => string) {
+  private expanded = false;
+  constructor(private label: (opts: { expanded: boolean }) => string) {
     super();
     this.line = new Text("", 1, 0);
     this.addChild(new Spacer(1));
@@ -82,8 +85,12 @@ class LabeledCallLine extends Container implements ToolCallView {
     this.status = opts;
     this.repaint();
   }
+  toggleExpanded(): void {
+    this.expanded = !this.expanded;
+    this.repaint();
+  }
   private repaint(): void {
-    this.line.setText(`${this.label()}${statusSuffix(this.status)}`);
+    this.line.setText(`${this.label({ expanded: this.expanded })}${statusSuffix(this.status)}`);
   }
 }
 
@@ -91,12 +98,24 @@ const bold = (t: string): string => theme.bold(theme.fg("toolTitle", t));
 const accent = (t: string): string => theme.fg("accent", t);
 const muted = (t: string): string => theme.fg("muted", t);
 
-function bashLabel(args: ToolCallArgs): string {
+function highlightBash(src: string): string {
+  if (!supportsLanguage("bash")) return src;
+  try { return highlight(src, { language: "bash", ignoreIllegals: true }); }
+  catch { return src; }
+}
+
+function compactPreview(src: string, max = 80): string {
+  const compact = src.replace(/\s+/g, " ").trim();
+  return compact.length > max ? compact.slice(0, max - 1) + "…" : compact;
+}
+
+function bashLabel(args: ToolCallArgs, opts: { expanded: boolean }): string {
   const r = parseRaw(args.rawInput);
   const command = str(r.command) ?? "…";
   const timeout = num(r.timeout);
   const to = timeout ? muted(` (timeout ${timeout}s)`) : "";
-  return `${bold("$")} ${accent(command)}${to}`;
+  const text = opts.expanded ? command : compactPreview(command);
+  return `${bold("$")} ${highlightBash(text)}${to}`;
 }
 
 function readLabel(args: ToolCallArgs): string {
@@ -153,7 +172,7 @@ export function registerDefaultToolRenderers(ctx: ExtensionContext): void {
     ctx.define(`ashi:render-tool-call:${name}`, fn);
   };
 
-  define("bash", (args) => new LabeledCallLine(() => bashLabel(args)));
+  define("bash", (args) => new LabeledCallLine((opts) => bashLabel(args, opts)));
   define("read_file", (args) => new LabeledCallLine(() => readLabel(args)));
   define("grep", (args) => new LabeledCallLine(() => grepLabel(args)));
   define("glob", (args) => new LabeledCallLine(() => globLabel(args)));

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -39,9 +39,12 @@ export interface ToolResultArgs extends RenderState {
 }
 
 /** Mutated by ashi when the tool completes. Renderers may ignore setStatus
- *  if they encode status differently (e.g. a sigil in the call line). */
+ *  if they encode status differently (e.g. a sigil in the call line).
+ *  Optional toggleExpanded lets long labels (e.g. bash commands) reveal
+ *  their full form on Ctrl+O. */
 export interface ToolCallView extends Component {
   setStatus(opts: { exitCode: number | null; elapsedMs: number; summary?: string }): void;
+  toggleExpanded?(): void;
 }
 
 /** Mutated by ashi as output streams in and when the tool completes.


### PR DESCRIPTION
## Summary

Two separable ashi tweaks for `bash` tool readability. Each is one commit.

### 1. Strip trailing newlines from tool output before display

POSIX commands terminate their last output line with `\n`. ashi was streaming raw chunks into `outputBuffer` and feeding the buffer straight to pi-tui's `Text` component, which renders a trailing `\n` as a real empty line. The result was a phantom blank gap below every bash tool — two-line gap to the next entry instead of the one-line gap the next call's leading spacer provides.

Normalize the buffer for display in `ToolResultBody.repaint()` (drop trailing `\n+`), leaving `outputBuffer` intact so streaming append still works. Affects preview mode (bash, edit), expanded mode (any tool the user Ctrl+O's), and the streaming-tail in summary mode (grep, glob). `lineCountHint` already filtered empty lines, so finalize-time summary is unchanged.

### 2. Bash: truncate + highlight call line, expand on Ctrl+O

Long bash commands (heredocs, piped chains) rendered as wide single lines that wrapped across many rows in chat, with no syntax color. Two changes:

- **`LabeledCallLine` becomes expandable.** Adds `toggleExpanded()` and threads an `{ expanded }` flag to the label producer. Ctrl+O's existing global walk (post PR #186) already targets anything with `toggleExpanded()` — call lines now participate alongside result bodies.
- **`bashLabel` opts in.** Whitespace-normalized + truncated at 80 chars when collapsed; full command when expanded. Both modes run through `cli-highlight` with `language: "bash"`. Truncation runs *before* highlighting so ANSI bytes can't be clipped mid-sequence.

Other label producers (read, grep, glob, ls, edit, write, default) keep their existing 0-arg signature; TypeScript's function variance makes that assignable to the new label-producer type, and they get a no-op toggle since their labels weren't truncated.

`ToolCallView` interface declares `toggleExpanded` as **optional**, so external view implementations (e.g. a scheme call-line renderer in a user-personal extension) can opt in without being forced to implement it.

README updated: clarifies Ctrl+O is global across all tool entries, and call lines participate when their labels support expansion.

## Out of scope

The dev note I wrote up considered also threading expansion into grep/glob (long patterns/paths). Left for follow-up — bash is the immediate friction. Once that pattern is exercised in practice, the others can opt in trivially.

`scheme-render.ts` (user-personal extension) has its own `SchemeCallLine` class that currently has truncation but no `toggleExpanded`. That's outside this repo. Adding the method is a one-line change that the user can apply when convenient.

## Test plan

- [ ] Run a bash command with multi-line output. Visual gap between this tool and the next entry should be one blank line, not two.
- [ ] Run a long bash command (e.g. `find . -name "*.ts" | xargs grep TODO | head`). Call line shows compacted preview + `…` truncation marker + bash-highlighted text.
- [ ] Ctrl+O on chat: long bash call line expands to full command; previously-collapsed result bodies expand too.
- [ ] Ctrl+O again: collapses back.
- [ ] Other tools (read, edit, grep) render unchanged.
- [ ] `/resume` a session with bash calls: replayed calls render with the same truncation + highlighting.