### PR TITLE
shell: introduce Terminal abstraction for host I/O

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/shell/strategies/index.d.ts",
       "default": "./dist/shell/strategies/index.js"
     },
+    "./shell/terminal": {
+      "types": "./dist/shell/terminal.d.ts",
+      "default": "./dist/shell/terminal.js"
+    },
     "./utils/stream-transform": {
       "types": "./dist/utils/stream-transform.d.ts",
       "default": "./dist/utils/stream-transform.js"

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -6,12 +6,13 @@
 import "./events.js"; // augments BusEvents with shell-owned events
 import type { ExtensionContext, RemoteSession, RemoteSessionOptions, ShellSurface } from "./host-types.js";
 import { Shell } from "./shell.js";
-import { DefaultCompositor, StdoutSurface } from "../utils/compositor.js";
+import { DefaultCompositor } from "../utils/compositor.js";
 import { TerminalBuffer } from "../utils/terminal-buffer.js";
 import { setPalette } from "../utils/palette.js";
 import * as streamTransform from "../utils/stream-transform.js";
 import activateShellContext from "./shell-context.js";
 import activateTuiRenderer from "./tui-renderer.js";
+import { type Terminal, processTerminal, surfaceFromTerminal } from "./terminal.js";
 
 export interface ShellActivateOptions {
   cols: number;
@@ -21,6 +22,11 @@ export interface ShellActivateOptions {
   cwd: string;
   /** Optional callback used by the inline status indicator. */
   onShowAgentInfo?: () => { info: string; model?: string };
+  /**
+   * Host-side I/O endpoint. Defaults to processTerminal() so the CLI
+   * works unchanged; headless callers (web hubs, tests) supply their own.
+   */
+  terminal?: Terminal;
 }
 
 export interface ShellHandle {
@@ -104,10 +110,11 @@ export function activateShell(
   ctx: ExtensionContext,
   opts: ShellActivateOptions,
 ): ShellHandle {
-  const stdoutSurface = new StdoutSurface();
-  ctx.shell!.compositor.setDefault("agent", stdoutSurface);
-  ctx.shell!.compositor.setDefault("query", stdoutSurface);
-  ctx.shell!.compositor.setDefault("status", stdoutSurface);
+  const terminal = opts.terminal ?? processTerminal();
+  const surface = surfaceFromTerminal(terminal);
+  ctx.shell!.compositor.setDefault("agent", surface);
+  ctx.shell!.compositor.setDefault("query", surface);
+  ctx.shell!.compositor.setDefault("status", surface);
 
   const shell = new Shell({
     bus: ctx.bus,
@@ -118,15 +125,13 @@ export function activateShell(
     cwd: opts.cwd,
     instanceId: ctx.instanceId,
     onShowAgentInfo: opts.onShowAgentInfo,
+    terminal,
   });
 
-  const onResize = () => {
-    shell.resize(process.stdout.columns || 80, process.stdout.rows || 24);
-  };
-  process.stdout.on("resize", onResize);
+  const offResize = terminal.onResize((cols, rows) => shell.resize(cols, rows));
 
   ctx.onDispose(() => {
-    process.stdout.off("resize", onResize);
+    offResize();
     shell.kill();
   });
 

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -6,7 +6,7 @@ import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
 import { getSettings } from "../core/settings.js";
 import { clearOpost } from "../utils/tty.js";
-import type { Terminal } from "./terminal.js";
+import { processTerminal, type Terminal } from "./terminal.js";
 import {
   pickStrategy,
   FALLBACK_STRATEGY,
@@ -58,9 +58,9 @@ export class Shell implements InputContext {
     shell: string;
     cwd: string;
     instanceId: string;
-    terminal: Terminal;
+    terminal?: Terminal;
   }) {
-    this.terminal = opts.terminal;
+    this.terminal = opts.terminal ?? processTerminal();
 
     // Build environment — filter out undefined values (node-pty's native
     // posix_spawnp fails if any env value is undefined)

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -6,6 +6,7 @@ import { InputHandler, type InputContext } from "./input-handler.js";
 import { OutputParser } from "./output-parser.js";
 import { getSettings } from "../core/settings.js";
 import { clearOpost } from "../utils/tty.js";
+import type { Terminal } from "./terminal.js";
 import {
   pickStrategy,
   FALLBACK_STRATEGY,
@@ -35,6 +36,8 @@ export class Shell implements InputContext {
   private handlers: ShellHandlers;
   private inputHandler: InputHandler;
   private outputParser: OutputParser;
+  private terminal: Terminal;
+  private inputDispose: (() => void) | null = null;
   // hardMute is unconditional (overlay compositing); softMute is overridable
   // by unmute (terminal_keys, permission UI). Gate: hard wins; otherwise
   // muted iff softMute held without an unmute.
@@ -55,7 +58,9 @@ export class Shell implements InputContext {
     shell: string;
     cwd: string;
     instanceId: string;
+    terminal: Terminal;
   }) {
+    this.terminal = opts.terminal;
 
     // Build environment — filter out undefined values (node-pty's native
     // posix_spawnp fails if any env value is undefined)
@@ -96,17 +101,10 @@ export class Shell implements InputContext {
     Object.assign(env, spawnConfig.envOverrides);
     const shellArgs = spawnConfig.args;
 
-    // Pause stdin before spawning PTY to avoid TTY contention on macOS.
-    // The PTY will become the controlling terminal for the child shell.
-    const wasRaw = process.stdin.isTTY && (process.stdin as any).isRaw;
-    if (process.stdin.isTTY) {
-      try {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
-      } catch {
-        // Ignore
-      }
-    }
+    // The PTY will become the controlling terminal for the child shell;
+    // suspend the host terminal's input around spawn to avoid TTY contention
+    // on macOS. Headless terminals make this a no-op.
+    const suspended = this.terminal.suspendInput?.();
 
     this.ptyProcess = pty.spawn(shellBin, shellArgs, {
       name: "xterm-256color",
@@ -116,17 +114,7 @@ export class Shell implements InputContext {
       env,
     });
 
-    // Restore stdin after PTY is created
-    if (process.stdin.isTTY) {
-      try {
-        process.stdin.resume();
-        if (wasRaw) {
-          process.stdin.setRawMode(true);
-        }
-      } catch {
-        // Ignore - will be set up later in index.ts
-      }
-    }
+    suspended?.resume();
 
     clearOpost();
 
@@ -305,17 +293,16 @@ export class Shell implements InputContext {
         if (nlIdx === -1) return;
         this.pendingEchoSkips--;
         const rest = data.slice(nlIdx + 1);
-        if (rest) process.stdout.write(rest);
+        if (rest) this.terminal.write(rest);
         return;
       }
 
-      process.stdout.write(data);
+      this.terminal.write(data);
     });
   }
 
   private setupInput(): void {
-    process.stdin.on("data", (data: Buffer) => {
-      const str = data.toString("utf-8");
+    this.inputDispose = this.terminal.onInput((str) => {
       this.inputHandler.handleInput(str);
     });
   }
@@ -358,7 +345,7 @@ export class Shell implements InputContext {
     this.bus.onPipeAsync("shell:exec-request", async (payload) => {
       const visible = this.acquireUnmute("exec-request");
       this.skipNextLine();
-      process.stdout.write("\r\n");
+      this.terminal.write("\r\n");
       this.bus.emit("shell:agent-exec-start", {});
 
       try {
@@ -409,6 +396,8 @@ export class Shell implements InputContext {
   }
 
   kill(): void {
+    this.inputDispose?.();
+    this.inputDispose = null;
     this.ptyProcess.kill();
     if (this.tmpDir) {
       fs.rmSync(this.tmpDir, { recursive: true, force: true });

--- a/src/shell/terminal.ts
+++ b/src/shell/terminal.ts
@@ -44,8 +44,7 @@ export function processTerminal(): Terminal {
     cols() { return process.stdout.columns || 80; },
     rows() { return process.stdout.rows || 24; },
     suspendInput() {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const wasRaw = process.stdin.isTTY && (process.stdin as any).isRaw;
+      const wasRaw = process.stdin.isTTY && (process.stdin as { isRaw?: boolean }).isRaw;
       if (process.stdin.isTTY) {
         try {
           process.stdin.setRawMode(false);
@@ -62,7 +61,6 @@ export function processTerminal(): Terminal {
           }
         },
       };
-      /* eslint-enable @typescript-eslint/no-explicit-any */
     },
   };
 }
@@ -73,15 +71,12 @@ export function processTerminal(): Terminal {
  * since the PTY has OPOST disabled.
  */
 export function surfaceFromTerminal(terminal: Terminal): RenderSurface {
+  const write = (text: string) => terminal.write(text.replace(/(?<!\r)\n/g, "\r\n"));
   return {
-    write(text: string) {
-      terminal.write(text.replace(/(?<!\r)\n/g, "\r\n"));
-    },
-    writeLine(line: string) {
-      this.write(line + "\n");
-    },
+    write,
+    writeLine: (line) => write(line + "\n"),
     get columns() { return terminal.cols(); },
     get rows() { return terminal.rows(); },
-    onResize(cb) { return terminal.onResize(cb); },
+    onResize: (cb) => terminal.onResize(cb),
   };
 }

--- a/src/shell/terminal.ts
+++ b/src/shell/terminal.ts
@@ -1,0 +1,87 @@
+/**
+ * Terminal — the user-facing I/O endpoint that a Shell talks to.
+ *
+ * Shell wraps a *pseudo*-terminal (the PTY the child shell sees). This
+ * interface is the *real* terminal (or its substitute) on the other end:
+ * bytes in, bytes out, dimensions, resize notifications. The default
+ * factory wires it to process.stdin/stdout for the CLI; headless hosts
+ * (multi-session web hubs, tests) supply their own.
+ */
+import type { RenderSurface } from "../utils/compositor.js";
+
+export interface Terminal {
+  write(data: string): void;
+  onInput(cb: (data: string) => void): () => void;
+  onResize(cb: (cols: number, rows: number) => void): () => void;
+  cols(): number;
+  rows(): number;
+  /**
+   * Called around PTY spawn to avoid TTY contention: the child PTY becomes
+   * the controlling tty for the spawned shell. No-op when the terminal
+   * isn't a real tty.
+   */
+  suspendInput?(): { resume(): void };
+}
+
+/** Default Terminal: wraps process.stdin/stdout. */
+export function processTerminal(): Terminal {
+  return {
+    write(data) {
+      if (process.stdout.writable) {
+        try { process.stdout.write(data); } catch { /* ignore */ }
+      }
+    },
+    onInput(cb) {
+      const handler = (b: Buffer) => cb(b.toString("utf-8"));
+      process.stdin.on("data", handler);
+      return () => { process.stdin.off("data", handler); };
+    },
+    onResize(cb) {
+      const handler = () => cb(process.stdout.columns || 80, process.stdout.rows || 24);
+      process.stdout.on("resize", handler);
+      return () => { process.stdout.off("resize", handler); };
+    },
+    cols() { return process.stdout.columns || 80; },
+    rows() { return process.stdout.rows || 24; },
+    suspendInput() {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const wasRaw = process.stdin.isTTY && (process.stdin as any).isRaw;
+      if (process.stdin.isTTY) {
+        try {
+          process.stdin.setRawMode(false);
+          process.stdin.pause();
+        } catch { /* ignore */ }
+      }
+      return {
+        resume() {
+          if (process.stdin.isTTY) {
+            try {
+              process.stdin.resume();
+              if (wasRaw) process.stdin.setRawMode(true);
+            } catch { /* ignore */ }
+          }
+        },
+      };
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+    },
+  };
+}
+
+/**
+ * Adapt a Terminal to a RenderSurface (the compositor's sink type). Adds
+ * the OPOST-cleared `\n` → `\r\n` translation that StdoutSurface applies,
+ * since the PTY has OPOST disabled.
+ */
+export function surfaceFromTerminal(terminal: Terminal): RenderSurface {
+  return {
+    write(text: string) {
+      terminal.write(text.replace(/(?<!\r)\n/g, "\r\n"));
+    },
+    writeLine(line: string) {
+      this.write(line + "\n");
+    },
+    get columns() { return terminal.cols(); },
+    get rows() { return terminal.rows(); },
+    onResize(cb) { return terminal.onResize(cb); },
+  };
+}

--- a/tests/shell/shell-terminal.test.ts
+++ b/tests/shell/shell-terminal.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration test: Shell routes PTY I/O through its injected Terminal,
+ * not through process.stdin/stdout.
+ *
+ * The refactor's central invariant — "Shell never reaches for process.*" —
+ * is hard to prove by reading the code (the next refactor could regress it
+ * silently). This test wires a real PTY but swaps in a recording fake
+ * Terminal, then asserts:
+ *   - PTY output reaches the fake's write()
+ *   - suspendInput() is called around pty.spawn (and resumed after)
+ *   - process.stdout.write is never invoked from Shell while alive
+ * Skipped when no bash is installed (matches pty-smoke).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { EventBus } from "../../src/core/event-bus.js";
+import { Shell, type ShellHandlers } from "../../src/shell/shell.js";
+import type { Terminal } from "../../src/shell/terminal.js";
+
+interface Recording {
+  writes: string[];
+  inputs: Array<(s: string) => void>;
+  suspendCallCount: number;
+  resumeCallCount: number;
+}
+
+function makeFakeTerminal(): Terminal & { _rec: Recording } {
+  const rec: Recording = { writes: [], inputs: [], suspendCallCount: 0, resumeCallCount: 0 };
+  return {
+    write(data) { rec.writes.push(data); },
+    onInput(cb) {
+      rec.inputs.push(cb);
+      return () => {
+        const i = rec.inputs.indexOf(cb);
+        if (i >= 0) rec.inputs.splice(i, 1);
+      };
+    },
+    onResize(_cb) { return () => {}; },
+    cols() { return 80; },
+    rows() { return 24; },
+    suspendInput() {
+      rec.suspendCallCount++;
+      return { resume: () => { rec.resumeCallCount++; } };
+    },
+    _rec: rec,
+  };
+}
+
+function makeHandlers(): ShellHandlers {
+  const fns = new Map<string, (...a: unknown[]) => unknown>();
+  return {
+    define(name, fn) { fns.set(name, fn as (...a: unknown[]) => unknown); },
+    call(name, ...args) {
+      const fn = fns.get(name);
+      return fn ? fn(...args) : undefined;
+    },
+  };
+}
+
+function findBash(): string | null {
+  for (const p of ["/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash", "/opt/homebrew/bin/bash"]) {
+    try { if (fs.statSync(p).isFile()) return p; } catch { /* try next */ }
+  }
+  return null;
+}
+
+const bash = findBash();
+const skipReason = bash === null ? "bash not installed" : false;
+
+test("Shell routes PTY output to terminal.write, never to process.stdout", { timeout: 10000, skip: skipReason }, async () => {
+  const fake = makeFakeTerminal();
+
+  // Hijack process.stdout.write to detect any stray writes from Shell.
+  const realWrite = process.stdout.write.bind(process.stdout);
+  const stdoutLeaks: string[] = [];
+  process.stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]): boolean => {
+    // Allow node:test reporter writes (tap output goes through here too).
+    // We only flag chunks that look like raw PTY bytes from our bash —
+    // anything containing an OSC marker or terminal escape from the shell.
+    const s = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+    if (/\x1b\][0-9]+;/.test(s) || /AGENT_SH_BASH_OK/.test(s)) {
+      stdoutLeaks.push(s);
+    }
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    return (realWrite as any)(chunk, ...rest);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  }) as typeof process.stdout.write;
+
+  const bus = new EventBus();
+  const handlers = makeHandlers();
+  const shell = new Shell({
+    bus,
+    handlers,
+    cols: 80,
+    rows: 24,
+    shell: bash!,
+    cwd: os.homedir(),
+    instanceId: "shell-terminal-test",
+    terminal: fake,
+  });
+
+  try {
+    // suspendInput must fire exactly once around pty.spawn, and resume must
+    // fire after it. The Shell constructor is the only place this happens.
+    assert.equal(fake._rec.suspendCallCount, 1, "suspendInput should be called exactly once during construction");
+    assert.equal(fake._rec.resumeCallCount, 1, "resume should be called after pty.spawn");
+
+    // onInput must be subscribed so keystrokes from the terminal can flow in.
+    assert.ok(fake._rec.inputs.length >= 1, "Shell should subscribe to terminal.onInput");
+
+    // Wait for the bash prompt + our marker to come back through the PTY.
+    // Write a sentinel via the bus pty-write API and look for it in fake.write.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timeout waiting for PTY output through fake terminal")), 8000);
+      const tick = () => {
+        const combined = fake._rec.writes.join("");
+        if (combined.includes("AGENT_SH_BASH_OK")) {
+          clearTimeout(timer);
+          resolve();
+        } else {
+          setTimeout(tick, 50);
+        }
+      };
+      // Wait one tick for PTY to come up, then send the sentinel.
+      setTimeout(() => {
+        bus.emit("shell:pty-write", { data: "echo AGENT_SH_BASH_OK\r" });
+        tick();
+      }, 200);
+    });
+
+    assert.ok(fake._rec.writes.length > 0, "PTY output should reach terminal.write");
+    assert.equal(stdoutLeaks.length, 0, `Shell leaked PTY bytes to process.stdout:\n${stdoutLeaks.join("\n---\n").slice(0, 500)}`);
+  } finally {
+    process.stdout.write = realWrite as typeof process.stdout.write;
+    shell.kill();
+  }
+});

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for src/shell/terminal.ts.
+ *
+ * surfaceFromTerminal is pure (just routes through a Terminal), so we
+ * exercise it directly with a recording fake.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { surfaceFromTerminal, type Terminal } from "../../src/shell/terminal.js";
+
+interface Recording {
+  writes: string[];
+  resizeCbs: ((cols: number, rows: number) => void)[];
+}
+
+function makeFakeTerminal(initialCols = 100, initialRows = 30): Terminal & { _rec: Recording; _cols: number; _rows: number } {
+  const rec: Recording = { writes: [], resizeCbs: [] };
+  let cols = initialCols;
+  let rows = initialRows;
+  const t = {
+    write(data: string) { rec.writes.push(data); },
+    onInput(_cb: (s: string) => void) { return () => {}; },
+    onResize(cb: (c: number, r: number) => void) {
+      rec.resizeCbs.push(cb);
+      return () => {
+        const i = rec.resizeCbs.indexOf(cb);
+        if (i >= 0) rec.resizeCbs.splice(i, 1);
+      };
+    },
+    cols() { return cols; },
+    rows() { return rows; },
+    _rec: rec,
+    get _cols() { return cols; },
+    set _cols(v: number) { cols = v; },
+    get _rows() { return rows; },
+    set _rows(v: number) { rows = v; },
+  };
+  return t;
+}
+
+test("surfaceFromTerminal: translates lone \\n to \\r\\n on write", () => {
+  const t = makeFakeTerminal();
+  const surface = surfaceFromTerminal(t);
+  surface.write("hello\nworld\n");
+  assert.deepEqual(t._rec.writes, ["hello\r\nworld\r\n"]);
+});
+
+test("surfaceFromTerminal: preserves existing \\r\\n (no double-CR)", () => {
+  const t = makeFakeTerminal();
+  const surface = surfaceFromTerminal(t);
+  surface.write("a\r\nb\n");
+  assert.deepEqual(t._rec.writes, ["a\r\nb\r\n"]);
+});
+
+test("surfaceFromTerminal: writeLine appends \\n then translates", () => {
+  const t = makeFakeTerminal();
+  const surface = surfaceFromTerminal(t);
+  surface.writeLine("hi");
+  assert.deepEqual(t._rec.writes, ["hi\r\n"]);
+});
+
+test("surfaceFromTerminal: writeLine survives destructuring (no `this` self-reference)", () => {
+  const t = makeFakeTerminal();
+  const surface = surfaceFromTerminal(t);
+  const { writeLine } = surface;
+  writeLine("detached");
+  assert.deepEqual(t._rec.writes, ["detached\r\n"]);
+});
+
+test("surfaceFromTerminal: columns/rows reflect terminal state at access time", () => {
+  const t = makeFakeTerminal(80, 24);
+  const surface = surfaceFromTerminal(t);
+  assert.equal(surface.columns, 80);
+  assert.equal(surface.rows, 24);
+  t._cols = 132;
+  t._rows = 50;
+  assert.equal(surface.columns, 132);
+  assert.equal(surface.rows, 50);
+});
+
+test("surfaceFromTerminal: onResize wires through to the underlying terminal", () => {
+  const t = makeFakeTerminal();
+  const surface = surfaceFromTerminal(t);
+  const seen: Array<[number, number]> = [];
+  const off = surface.onResize((c, r) => seen.push([c, r]));
+  assert.equal(t._rec.resizeCbs.length, 1);
+
+  t._rec.resizeCbs[0](120, 40);
+  assert.deepEqual(seen, [[120, 40]]);
+
+  off();
+  assert.equal(t._rec.resizeCbs.length, 0);
+});


### PR DESCRIPTION
## Summary
- `Shell` wrapped a *pseudo*-terminal but was hard-wired to `process.stdin/stdout` for the *real* terminal on the other side, plus a `process.stdout.on("resize")` listener and raw-mode juggling around `pty.spawn`. Headless callers (web hubs running many sessions in one process, tests) couldn't reuse it — they had to spawn their own PTY, reimplement `OutputParser`, and duplicate the strategy spawn dance.
- New `src/shell/terminal.ts` factors the host endpoint into a `Terminal` interface (`write`, `onInput`, `onResize`, `cols`, `rows`, `suspendInput`). `processTerminal()` is the default factory and preserves the CLI's exact behavior, including the raw-mode dance.
- `activateShell` now takes an optional `opts.terminal` and builds the default compositor surface via `surfaceFromTerminal(terminal)`, so the `StdoutSurface` special case disappears from the headless path too.
- `Terminal` is exported via `agent-sh/shell/terminal` for external consumers.

## Behavior change for the CLI
None. The default `opts.terminal = processTerminal()` reproduces every previous `process.stdin/stdout` touch line-for-line. Minor bonus: `setupInput` now disposes its listener on `kill()` (it was previously leaked).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 136/136 pass
- [ ] Manual: `npm run dev` and confirm shell still behaves normally (raw mode, resize, ctrl-c, agent turn)