### PR TITLE
ashi: display defaults via RenderModel.display, regression fixes from #194

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -189,6 +189,15 @@ export default function activate(ctx) {
 
 `ToolDisplay` body kinds: `text`, `code` (with syntax highlighting via `lang`), `stream` (preview/summary/hidden policy applied by ashi), `diff` (closure pushed by the frontend orchestrator), `lines`, `compound`. Custom state transitions can be declared via an optional `reducers` map.
 
+To ship a default display policy with your renderer (e.g. "this tool's output is large, default to `summary`"), set `display` on the model. User `settings.json` still wins:
+
+```ts
+const myModel: RenderModel<...> = {
+  initial, view,
+  display: { result: "summary", previewLines: 3 },
+};
+```
+
 For non-render concerns (commands, settings, tools, providers) use the standard `agent-sh` extension API. See the [agent-sh extension docs](https://github.com/guanyilun/agent-sh/blob/main/docs/extensions.md).
 
 ## Install from source

--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -122,11 +122,11 @@ Per-tool compactness lives under `ashi.display` in `~/.agent-sh/settings.json`:
 {
   "ashi": {
     "display": {
-      "default": { "result": "preview", "previewLines": 8 },
+      "default": { "result": "preview", "previewLines": 5 },
       "read":    { "result": "hidden" },
       "ls":      { "result": "hidden" },
       "grep":    { "result": "summary" },
-      "bash":    { "result": "preview", "previewLines": 12 },
+      "bash":    { "result": "preview" },
       "edit":    { "result": "preview" },
       "write":   { "result": "preview" }
     }
@@ -138,7 +138,7 @@ Per-tool compactness lives under `ashi.display` in `~/.agent-sh/settings.json`:
 
 - `"hidden"` — call line only while streaming; line count (`↳ 42 lines`) after completion.
 - `"summary"` — 2-line tail while streaming; line count after completion.
-- `"preview"` — last `previewLines` lines of output (default 8), with a `... (N more lines)` hint when content overflows.
+- `"preview"` — last `previewLines` lines of output (default 5), with a `... (N more lines)` hint when content overflows.
 
 For `edit_file` / `write_file`, the diff frame is treated as the output and follows the same gating: shown for `preview`, hidden for `hidden`/`summary` (the call line already carries `+12 -3` stats). The line-count hint is suppressed for diff-producing tools so edits stay quiet.
 

--- a/examples/extensions/ashi/src/display-config.ts
+++ b/examples/extensions/ashi/src/display-config.ts
@@ -7,9 +7,8 @@ export interface ToolEntryConfig {
   previewLines: number;
 }
 
-export interface ToolDisplayConfig {
-  default: ToolEntryConfig;
-  [toolName: string]: ToolEntryConfig;
+export interface DisplayResolver {
+  resolve(name: string, modelDisplay?: Partial<ToolEntryConfig>): ToolEntryConfig;
 }
 
 const DEFAULT_ENTRY: ToolEntryConfig = { result: "preview", previewLines: 5 };
@@ -47,24 +46,16 @@ function mergeEntry(base: ToolEntryConfig, patch?: Partial<ToolEntryConfig>): To
   };
 }
 
-export function loadToolDisplayConfig(): ToolDisplayConfig {
+export function loadDisplayResolver(): DisplayResolver {
   const ashi = getExtensionSettings<AshiSettings>("ashi", {});
   const userDisplay = ashi.display ?? {};
   const userDefault = mergeEntry(DEFAULT_ENTRY, userDisplay.default);
-  const config: ToolDisplayConfig = { default: userDefault };
-  const names = new Set([
-    ...Object.keys(BUILTIN_OVERRIDES),
-    ...Object.keys(userDisplay).filter((k) => k !== "default"),
-  ]);
-  for (const name of names) {
-    config[name] = mergeEntry(
-      mergeEntry(userDefault, BUILTIN_OVERRIDES[name]),
-      userDisplay[name],
-    );
-  }
-  return config;
-}
-
-export function entryFor(config: ToolDisplayConfig, name: string): ToolEntryConfig {
-  return config[name] ?? config.default;
+  return {
+    resolve(name, modelDisplay) {
+      let entry = mergeEntry(userDefault, BUILTIN_OVERRIDES[name]);
+      if (modelDisplay) entry = mergeEntry(entry, modelDisplay);
+      if (userDisplay[name]) entry = mergeEntry(entry, userDisplay[name]);
+      return entry;
+    },
+  };
 }

--- a/examples/extensions/ashi/src/display-config.ts
+++ b/examples/extensions/ashi/src/display-config.ts
@@ -12,7 +12,7 @@ export interface ToolDisplayConfig {
   [toolName: string]: ToolEntryConfig;
 }
 
-const DEFAULT_ENTRY: ToolEntryConfig = { result: "preview", previewLines: 8 };
+const DEFAULT_ENTRY: ToolEntryConfig = { result: "preview", previewLines: 5 };
 
 const BUILTIN_OVERRIDES: Record<string, Partial<ToolEntryConfig>> = {
   read: { result: "hidden" },
@@ -20,7 +20,7 @@ const BUILTIN_OVERRIDES: Record<string, Partial<ToolEntryConfig>> = {
   grep: { result: "summary" },
   find: { result: "summary" },
   glob: { result: "summary" },
-  bash: { result: "preview", previewLines: 12 },
+  bash: { result: "preview" },
   edit: { result: "preview" },
   edit_file: { result: "preview" },
   write: { result: "preview" },

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -1,7 +1,7 @@
 import type { Component } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
 import { AssistantMessage, ThinkingBlock, UserMessage } from "./components.js";
-import { entryFor, loadToolDisplayConfig, type ToolResultMode } from "./display-config.js";
+import { loadDisplayResolver, type ToolResultMode } from "./display-config.js";
 import { isRenderModel, mountCall, mountResult, type RenderModel } from "./schema.js";
 
 export interface RenderState {
@@ -85,7 +85,7 @@ export interface ToolHookResolver {
 export function createToolHookResolver(
   ctx: ExtensionContext,
 ): ToolHookResolver & { refresh: () => void } {
-  const config = loadToolDisplayConfig();
+  const resolver = loadDisplayResolver();
   let registered = new Set(ctx.list());
 
   const schemaModel = (name: string): RenderModel<unknown> => {
@@ -105,7 +105,7 @@ export function createToolHookResolver(
       registered = new Set(ctx.list());
     },
     modeFor(name: string) {
-      const e = entryFor(config, name);
+      const e = resolver.resolve(name, schemaModel(name).display);
       return { mode: e.result, previewLines: e.previewLines };
     },
     call(args) {

--- a/examples/extensions/ashi/src/schema.ts
+++ b/examples/extensions/ashi/src/schema.ts
@@ -8,7 +8,7 @@
 // buffer policy, diff reflow on resize, expand/collapse — everything that used
 // to leak into renderer subclasses.
 
-import { Container, Text } from "@earendil-works/pi-tui";
+import { Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { Component } from "@earendil-works/pi-tui";
 import type { ThemeColor } from "./theme.js";
 
@@ -312,6 +312,7 @@ class SchemaCallComponent extends Container {
   constructor(private handle: RenderHandle<unknown>) {
     super();
     this.line = new Text("", 1, 0);
+    this.addChild(new Spacer(1));
     this.addChild(this.line);
     handle.cell.callView = this;
     this.repaint();
@@ -319,12 +320,6 @@ class SchemaCallComponent extends Container {
 
   setStatus(opts: { exitCode: number | null; elapsedMs: number; summary?: string }): void {
     this.handle.dispatch("status", opts);
-  }
-
-  toggleExpanded(): void {
-    this.handle.cell.env = { ...this.handle.cell.env, expanded: !this.handle.cell.env.expanded };
-    this.repaint();
-    this.handle.cell.resultView?.repaint();
   }
 
   repaint(): void {

--- a/examples/extensions/ashi/src/schema.ts
+++ b/examples/extensions/ashi/src/schema.ts
@@ -11,6 +11,9 @@
 import { Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { Component } from "@earendil-works/pi-tui";
 import type { ThemeColor } from "./theme.js";
+import type { ToolEntryConfig } from "./display-config.js";
+
+export type { ToolEntryConfig, ToolResultMode } from "./display-config.js";
 
 export type Color = ThemeColor;
 
@@ -89,6 +92,7 @@ export interface RenderModel<S = Record<string, never>> {
    *  reducers here only for tool-specific state transitions. */
   reducers?: Record<string, Reducer<ViewState<S>, never>>;
   view: (state: ViewState<S>, env: Env) => ToolDisplay;
+  display?: Partial<ToolEntryConfig>;
 }
 
 export function isRenderModel(v: unknown): v is RenderModel<unknown> {

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -1,4 +1,5 @@
-import { Container, Text } from "@earendil-works/pi-tui";
+import { basename } from "node:path";
+import { Container, Text, visibleWidth } from "@earendil-works/pi-tui";
 import { theme } from "./theme.js";
 
 interface StatusFields {
@@ -16,6 +17,7 @@ interface StatusFields {
 export class StatusFooter extends Container {
   private text: Text;
   private fields: StatusFields = {};
+  private lastWidth = 0;
 
   constructor() {
     super();
@@ -25,10 +27,28 @@ export class StatusFooter extends Container {
 
   update(patch: Partial<StatusFields>): void {
     this.fields = { ...this.fields, ...patch };
-    this.repaint();
+    this.repaint(this.lastWidth);
   }
 
-  private repaint(): void {
+  render(width: number): string[] {
+    if (width !== this.lastWidth) {
+      this.lastWidth = width;
+      this.repaint(width);
+    }
+    return super.render(width);
+  }
+
+  private repaint(width: number): void {
+    const contentWidth = width > 0 ? Math.max(1, width - 2) : 0;
+    const full = this.buildLine("full");
+    if (contentWidth === 0 || visibleWidth(full) <= contentWidth) {
+      this.text.setText(full);
+      return;
+    }
+    this.text.setText(this.buildLine("basename"));
+  }
+
+  private buildLine(cwdMode: "full" | "basename"): string {
     const { model, provider, contextWindow, cwd, branch, leaf, tokens, compactions, thinking } = this.fields;
     const sep = theme.fg("dim", " | ");
     const parts: string[] = [];
@@ -39,7 +59,7 @@ export class StatusFooter extends Container {
     } else if (provider) {
       parts.push(theme.fg("muted", `@${provider}`));
     }
-    if (cwd) parts.push(theme.fg("muted", shortenCwd(cwd)));
+    if (cwd) parts.push(theme.fg("muted", formatCwd(cwd, cwdMode)));
     if (branch) parts.push(theme.fg("muted", `⎇ ${branch}`));
     if (leaf != null && leaf > 0) parts.push(theme.fg("muted", `#${leaf}`));
     if (tokens != null) {
@@ -48,11 +68,12 @@ export class StatusFooter extends Container {
       parts.push(`${theme.fg("muted", tokStr)}${pct}`);
     }
     if (compactions && compactions > 0) parts.push(theme.fg("muted", `⊟ ${compactions}`));
-    this.text.setText(parts.length === 0 ? "" : parts.join(sep));
+    return parts.length === 0 ? "" : parts.join(sep);
   }
 }
 
-function shortenCwd(cwd: string): string {
+function formatCwd(cwd: string, mode: "full" | "basename"): string {
+  if (mode === "basename") return basename(cwd) || cwd;
   const home = process.env.HOME;
   if (home && cwd.startsWith(`${home}/`)) return `~/${cwd.slice(home.length + 1)}`;
   if (home && cwd === home) return "~";


### PR DESCRIPTION
## Summary

- **Fix #194 regressions** — bash (and every non-grouped tool) lost the one-line gap between consecutive calls, and Ctrl+O stopped expanding tool output. Both are byproducts of the schema migration:
  - `SchemaCallComponent` dropped the leading `Spacer(1)` that the old `LabeledCallLine` had, which commit 680f0b5 (trailing-newline strip) was implicitly relying on as the inter-call gap source.
  - `SchemaCallComponent` and `SchemaResultComponent` are sibling children of `chat`, both implementing `toggleExpanded` against the same shared `cell.env.expanded` — the Ctrl+O walker called both, double-toggling to a net no-op.
- **Lower default `previewLines` from 8 → 5; drop the bash override.** Ctrl+O expand handles the rare case where the full output matters.
- **`RenderModel.display` for extension-shipped display defaults.** External renderers previously had no way to ship sensible `result` / `previewLines` baselines for their tools — the only paths were ashi's hardcoded `BUILTIN_OVERRIDES` or each user editing `settings.json`. New merge order: `DEFAULT_ENTRY` → user `display.default` → `BUILTIN_OVERRIDES[name]` → `model.display` → user `display[name]` (always wins). `display-config.ts` collapses to a single `loadDisplayResolver()` so the model-supplied hint can land between built-ins and user override.
- **Status footer falls back to cwd basename when the full line overflows terminal width** — keeps branch / leaf / token fields visible in deep cwds.

## Test plan

- [ ] Run a session with multiple consecutive `bash` calls and confirm the one-line gap between them.
- [ ] Press Ctrl+O on a long bash output; both the command line (truncated → full) and the output body (preview → full) expand together. Press again to collapse.
- [ ] With no `extensions.ashi.display` in `settings.json`, confirm bash output previews at 5 lines (was 12).
- [ ] In `settings.json`, set `extensions.ashi.display.bash.previewLines: 15` and confirm the user override still wins.
- [ ] Write a throwaway extension whose RenderModel declares `display: { result: "summary" }` and confirm its tool defaults to summary mode without any user setting.
- [ ] Resize the terminal narrow enough that the status line would overflow; confirm cwd shrinks to basename and the other fields stay visible.