### PR TITLE
agent: add core-tools:collect pipe so extensions own their core-tool declaration

### DIFF
--- a/examples/extensions/ash-scheme/index.ts
+++ b/examples/extensions/ash-scheme/index.ts
@@ -2058,6 +2058,10 @@ export default function activate(ctx: AgentContext): void {
     for (const name of HIDDEN_IN_SCHEME_ONLY) {
       try { ctx.agent.unregisterTool(name); } catch { /* not registered — fine */ }
     }
+    ctx.bus.onPipe("agent:core-tools:collect", (ev) => ({
+      ...ev,
+      names: [...ev.names, "scheme_eval"],
+    }));
   }
 
   ctx.agent.registerTool({

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -144,9 +144,11 @@ export class AgentLoop implements AgentBackend {
     this.activeMode = config.initialMode ?? { model: config.llmClient.model };
 
     // Tool protocol — controls how tools are presented to the LLM
+    const { names: fromExtensions } = this.bus.emitPipe("agent:core-tools:collect", { names: [] });
+    const coreTools = Array.from(new Set([...(getSettings().coreTools ?? []), ...fromExtensions]));
     this.toolProtocol = createToolProtocol(
       getSettings().toolMode ?? "api",
-      getSettings().coreTools ?? [],
+      coreTools,
     );
 
     // Register core tools

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -13,6 +13,9 @@ export interface AgentIdentity {
 
 declare module "../core/event-bus.js" {
   interface BusEvents {
+    /** Sync pipe: extensions append core tool names; unioned with settings.coreTools. */
+    "agent:core-tools:collect": { names: string[] };
+
     "agent:providers": { providers: ProviderRegistration[] };
     "agent:providers:changed": Record<string, never>;
     "provider:configure": {


### PR DESCRIPTION
## Summary

Lets extensions declare a tool as \"core\" (schema stays resident in the
API tool list under deferred-lookup) without coupling to the top-level
\`settings.coreTools\` array. AgentLoop emits the new
\`core-tools:collect\` sync pipe at construction time and unions
contributions with \`settings.coreTools\` before building the tool
protocol.

The motivating case is ash-scheme: in scheme-only mode the user
previously had to set BOTH \`scheme.only: true\` (extension setting) AND
\`coreTools: [\"scheme_eval\"]\` (kernel setting) to get scheme_eval's
schema into the API tool list. Two places, both must align. With this
pipe, ash-scheme contributes scheme_eval automatically when schemeOnly
is on; user config collapses to \`{ \"scheme\": { \"only\": true } }\`.

## Changes

- \`src/agent/events.ts\` — declare \`core-tools:collect\` bus event
  (sync pipe shape: \`{ names: string[] }\`).
- \`src/agent/agent-loop.ts\` — emit the pipe at construction; union the
  result with \`settings.coreTools\`; dedupe; pass to \`createToolProtocol\`.
- \`examples/extensions/ash-scheme/index.ts\` — in \`schemeOnly\` branch,
  subscribe to the pipe and append \"scheme_eval\".

## Backward compatibility

\`settings.coreTools\` still works exactly as before — users can declare
core tools manually. Pipe contributions are additive; no extension that
ignores the pipe sees any behavior change.

## Test plan

- [ ] Set \`{ \"scheme\": { \"only\": true } }\` in \`~/.agent-sh/settings.json\`
      with no \`coreTools\`; restart; verify scheme_eval's schema is
      present in the API tool list (e.g. via \`/context\` or a
      single-turn LLM check).
- [ ] Set both \`scheme.only\` and \`coreTools: [\"bash\"]\`; verify both
      bash and scheme_eval are core (union, dedupe works).
- [ ] Leave \`scheme.only\` unset; verify nothing extra is added.