### PR TITLE
Skip keyless providers in default-provider fallback

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -352,8 +352,12 @@ export default function agentBackend(ctx: ExtensionContext): void {
     resolvedProviders = computeResolvedProviders();
 
     const settings = getSettings();
-    const providerName = config.provider ?? settings.defaultProvider
-      ?? (resolvedProviders.size > 0 ? resolvedProviders.keys().next().value : undefined);
+    // Built-ins register unconditionally so `auth list` can enumerate them;
+    // the fallback must skip keyless entries or it lands on openrouter and
+    // bails at the `!effectiveApiKey` guard below.
+    const providerName = config.provider
+      ?? settings.defaultProvider
+      ?? [...resolvedProviders].find(([, p]) => p.apiKey)?.[0];
     const activeProvider = providerName ? resolvedProviders.get(providerName) ?? null : null;
 
     // Persisted defaultModel wins over openrouter's hardcoded DEFAULT_MODELS[0].

--- a/tests/agent/builtin-provider-activation.test.ts
+++ b/tests/agent/builtin-provider-activation.test.ts
@@ -1,0 +1,87 @@
+/** Regression coverage for the "fresh install + `auth login deepseek` →
+ *  no backend found" bug. Two invariants:
+ *    1. Built-ins still register without a key (auth-discovery feature).
+ *    2. With only one keyed provider, the ash backend activates against it
+ *       — the default-provider fallback must skip keyless entries. */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DRIVER = fileURLToPath(new URL("../fixtures/builtin-provider-driver.ts", import.meta.url));
+
+interface DriverResult {
+  registeredIds: string[];
+  backendRegistrations: { name: string }[];
+}
+
+async function run(opts: {
+  keys?: Record<string, string>;
+  settings?: Record<string, unknown>;
+}): Promise<DriverResult> {
+  const home = mkdtempSync(join(tmpdir(), "agent-sh-bpa-"));
+  writeFileSync(join(home, "settings.json"), JSON.stringify(opts.settings ?? {}));
+  if (opts.keys) writeFileSync(join(home, "keys.json"), JSON.stringify(opts.keys));
+  try {
+    return await new Promise<DriverResult>((resolve, reject) => {
+      const child = spawn("node", ["--import", "tsx", DRIVER], {
+        env: {
+          PATH: process.env.PATH,
+          HOME: home,
+          AGENT_SH_HOME: home,
+          AGENT_SH_SKIP_SHELL_ENV: "1",
+          OPENROUTER_API_KEY: "",
+          OPENAI_API_KEY: "",
+          DEEPSEEK_API_KEY: "",
+          OPENAI_BASE_URL: "",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout!.on("data", (c) => { stdout += c.toString(); });
+      child.stderr!.on("data", (c) => { stderr += c.toString(); });
+      const timer = setTimeout(() => child.kill("SIGKILL"), 15000);
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        try {
+          const line = stdout.trim().split(/\r?\n/).pop() ?? "";
+          resolve(JSON.parse(line) as DriverResult);
+        } catch (err) {
+          reject(new Error(`driver output not JSON. exit=${code} stdout=${stdout} stderr=${stderr} err=${(err as Error).message}`));
+        }
+      });
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test("no keys configured: built-in providers still register for auth discovery", async () => {
+  const result = await run({});
+  // discoverExtensionProviders() depends on these registering even without
+  // a key, so the auth login picker can list unconfigured built-ins.
+  assert.ok(result.registeredIds.includes("openrouter"));
+  assert.ok(result.registeredIds.includes("openai"));
+  assert.ok(result.registeredIds.includes("deepseek"));
+});
+
+test("only deepseek keyed: ash backend registers against deepseek", async () => {
+  const result = await run({ keys: { deepseek: "sk-test" } });
+  const ash = result.backendRegistrations.find((b) => b.name === "ash");
+  assert.ok(ash, `ash backend did not register; got ${JSON.stringify(result.backendRegistrations)}`);
+});
+
+test("only deepseek keyed but settings.defaultProvider=openrouter: ash does not register", async () => {
+  // Explicit user choice must still win — this guards against an overly
+  // aggressive fallback that ignores defaultProvider.
+  const result = await run({
+    keys: { deepseek: "sk-test" },
+    settings: { defaultProvider: "openrouter" },
+  });
+  const ash = result.backendRegistrations.find((b) => b.name === "ash");
+  assert.equal(ash, undefined, "ash should not register when user pointed at keyless openrouter");
+});

--- a/tests/fixtures/builtin-provider-driver.ts
+++ b/tests/fixtures/builtin-provider-driver.ts
@@ -1,0 +1,40 @@
+/** Subprocess driver for tests/agent/builtin-provider-activation.test.ts.
+ *  Runs activateAgent (which calls every built-in provider activator),
+ *  fires core:extensions-loaded, then dumps the registered provider ids
+ *  and any agent:register-backend events that fired. */
+import { createCore } from "../../src/core/index.js";
+import { activateAgent } from "../../src/agent/index.js";
+import type { AppConfig } from "../../src/shell/host-types.js";
+import type { ProviderRegistration } from "../../src/agent/host-types.js";
+
+async function main() {
+  const core = createCore({} as AppConfig);
+  const backendRegistrations: Array<{ name: string }> = [];
+
+  core.bus.on("agent:register-backend" as never, (payload: { name: string }) => {
+    backendRegistrations.push({ name: payload.name });
+  });
+
+  const ctx = core.extensionContext({ quit: () => {} });
+  activateAgent(ctx);
+
+  core.bus.emit("core:extensions-loaded", { names: [] });
+  await new Promise((r) => setImmediate(r));
+
+  const { providers } = core.bus.emitPipe("agent:providers", {
+    providers: [] as ProviderRegistration[],
+  });
+  const registeredIds = providers.map((p) => p.id).sort();
+
+  process.stdout.write(JSON.stringify({ registeredIds, backendRegistrations }) + "\n");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("driver error:", err);
+  process.exit(1);
+});
+
+// Silence unhandled rejections from openrouter's background fetchModels —
+// the driver exits before the in-flight network call lands.
+process.on("unhandledRejection", () => {});


### PR DESCRIPTION
## Summary

- On a fresh install with only one provider keyed (e.g. `auth login deepseek`), the agent's default-provider fallback picked the first entry in `resolvedProviders` — openrouter, which registers keyless so `auth list` can enumerate it. The `!effectiveApiKey` guard then bailed and the ash backend never registered, surfacing as "no agent backend registered".
- Fallback now picks the first provider with an `apiKey`, preserving the unconditional registration that auth discovery depends on.
- Tests pin both invariants: (1) built-ins still register without a key (discovery), (2) one-keyed-provider triggers ash backend registration, (3) explicit `settings.defaultProvider` still wins.

## Test plan

- [x] `npx tsx --test tests/agent/builtin-provider-activation.test.ts` — 3 new tests pass
- [x] `npx tsx --test tests/agent/provider-modes.test.ts` — existing 4 tests pass
- [x] `tsc` clean