### PR TITLE
Surface provider-discovery load errors; drop bare imports from auth-using exts

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -62,6 +62,15 @@ agent-sh list                       # show all loadable extensions (extensions d
 
 For directory-style extensions with declared dependencies, `install` runs `npm install` in the target automatically.
 
+### Single-file vs directory
+
+The two layouts have different contracts, not just different ergonomics:
+
+- **Single-file `.ts`** lives bare in `~/.agent-sh/extensions/`. No `package.json`, no `npm install`. Runtime resolution walks up from that path looking for `node_modules/`, and on a fresh user there's nothing to find. So a single-file extension can only use `ctx` and **type-only** imports (`import type { AgentContext } from "agent-sh/types"`) — these are erased by tsx before execution. A *runtime* `import { foo } from "agent-sh/bar"` throws `Cannot find module` at load.
+- **Directory extension** ships with its own `package.json` declaring `agent-sh` (and any other runtime deps). `install` runs `npm install`, so bare imports resolve normally. Use this layout whenever you need runtime utilities the ctx surface doesn't provide.
+
+Decision rule: if everything you need is on `ctx` (and the surfaces that hang off it — `ctx.agent.*`, `ctx.shell.*`, `ctx.call(...)`), stay single-file. If you find yourself reaching for `agent-sh/utils/*` or `agent-sh/agent/*` at runtime, either there's a missing ctx primitive worth adding, or you should promote the extension to a directory layout.
+
 ## ExtensionContext API
 
 The context is layered: substrate primitives + slash-command registration at the top, host-specific surfaces nested under `ctx.agent` and `ctx.shell`. Both nested surfaces are **optional** — they're attached by their hosts during activation, and headless backends (ACP server, bridges) may skip a host's activation entirely:
@@ -464,7 +473,7 @@ export default function activate(ctx: AgentContext): void {
 | Field | Description |
 |---|---|
 | `id` | Provider name (used as the key in settings, `auth`, `/model`) |
-| `apiKey` | API key; omit for `noAuth` providers, otherwise resolved via `resolveApiKey(id)` |
+| `apiKey` | API key; omit for `noAuth` providers, otherwise resolve via `ctx.call("provider:resolve-api-key", id)` which returns `{ key, source }` (settings → keys.json → env) |
 | `baseURL` | OpenAI-compatible base URL |
 | `defaultModel` | Selected by default when this provider is active |
 | `models` | Catalog. Either `string[]` or `Array<{ id, contextWindow?, reasoning?, echoReasoning? }>` for per-model capabilities |

--- a/examples/extensions/ollama.ts
+++ b/examples/extensions/ollama.ts
@@ -3,7 +3,6 @@
  * `agent-sh auth login ollama-cloud` or OLLAMA_API_KEY). Local host
  * overridable via OLLAMA_HOST.
  */
-import { resolveApiKey } from "agent-sh/auth";
 import type { AgentContext } from "agent-sh/types";
 
 const ECHO_REASONING_PATTERNS: RegExp[] = [/deepseek/i];
@@ -14,7 +13,9 @@ function reasoningParams(level: string): Record<string, unknown> {
 }
 
 export default function activate(ctx: AgentContext): void {
-  const cloudKey = resolveApiKey("ollama-cloud").key ?? process.env.OLLAMA_API_KEY;
+  const cloudKey =
+    (ctx.call("provider:resolve-api-key", "ollama-cloud") as { key: string | null }).key ??
+    process.env.OLLAMA_API_KEY;
   const cloudHost = "https://ollama.com";
   const cloudBaseURL = `${cloudHost}/v1`;
   ctx.agent.providers.configure("ollama-cloud", { reasoningParams });

--- a/examples/extensions/opencode-provider.ts
+++ b/examples/extensions/opencode-provider.ts
@@ -31,7 +31,6 @@
  */
 
 import type { AgentContext } from "agent-sh/types";
-import { resolveApiKey } from "agent-sh/auth";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -180,7 +179,7 @@ function buildReasoningParams(level: string): Record<string, unknown> {
 export default function activate(ctx: AgentContext): void {
   const apiKey =
     process.env.OPENCODE_API_KEY ??
-    resolveApiKey("opencode").key ?? undefined;
+    (ctx.call("provider:resolve-api-key", "opencode") as { key: string | null }).key ?? undefined;
 
   // ── Phase 1: register both providers synchronously with fallback models ──
 

--- a/examples/extensions/zai-coding-plan.ts
+++ b/examples/extensions/zai-coding-plan.ts
@@ -4,7 +4,6 @@
  * Auth:  agent-sh auth login zai-coding-plan
  * Usage: agent-sh -e ./examples/extensions/zai-coding-plan.ts
  */
-import { resolveApiKey } from "agent-sh/auth";
 import type { AgentContext } from "agent-sh/types";
 
 const BASE_URL = "https://api.z.ai/api/coding/paas/v4";
@@ -24,7 +23,7 @@ function buildReasoningParams(level: string, _model?: string): Record<string, un
 }
 
 export default function activate(ctx: AgentContext): void {
-  const { key } = resolveApiKey(ID);
+  const { key } = ctx.call("provider:resolve-api-key", ID) as { key: string | null };
   ctx.agent.providers.configure(ID, { reasoningParams: buildReasoningParams });
   ctx.agent.providers.register({
     id: ID,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -12,6 +12,7 @@ import { createLlmFacade } from "./llm-facade.js";
 import type { ToolDefinition, ToolSchemaView } from "./types.js";
 import { registerReadOnlyTool, unregisterReadOnlyTool } from "./nuclear-form.js";
 import { resolveProvider, getProviderNames, getSettings, type ResolvedProvider } from "../core/settings.js";
+import { resolveApiKey } from "../cli/auth/keys.js";
 import { discoverSkills } from "./skills.js";
 import activateOpenrouter from "./providers/openrouter.js";
 import activateOpenai from "./providers/openai.js";
@@ -213,6 +214,8 @@ export default function agentBackend(ctx: ExtensionContext): void {
     },
   };
   (ctx as { agent?: AgentSurface }).agent = agentSurface;
+
+  ctx.define("provider:resolve-api-key", (id: string) => resolveApiKey(id));
 
   // Core tools register at activate — before extensions load — so
   // extensions that look them up at activate time (e.g. scheme.ts) find them.

--- a/src/cli/auth/discover.ts
+++ b/src/cli/auth/discover.ts
@@ -1,12 +1,16 @@
 /** Bootstrap a throwaway core to enumerate provider ids extensions
  *  would register, so `auth list` shows ids the user hasn't keyed yet. */
+import * as path from "node:path";
 import { createCore } from "../../core/index.js";
 import { activateAgent } from "../../agent/index.js";
 import { loadExtensions } from "../../core/extension-loader.js";
 import { loadBuiltinExtensions } from "../../extensions/index.js";
-import { getSettings } from "../../core/settings.js";
+import { CONFIG_DIR, getSettings } from "../../core/settings.js";
 import type { AppConfig } from "../../shell/host-types.js";
 import type { ProviderRegistration } from "../../agent/host-types.js";
+
+const EXT_DIR = path.join(CONFIG_DIR, "extensions");
+const BARE_IMPORT_RE = /Cannot find (?:package|module) ['"]agent-sh\/[^'"]+['"]/;
 
 export interface DiscoveredProvider {
   id: string;
@@ -18,6 +22,8 @@ let cached: DiscoveredProvider[] | null = null;
 export async function discoverExtensionProviders(): Promise<DiscoveredProvider[]> {
   if (cached) return cached;
   const core = createCore({} as AppConfig);
+  const errors: string[] = [];
+  core.bus.on("ui:error", ({ message }) => { errors.push(message); });
   try {
     const ctx = core.extensionContext({ quit: () => {} });
     activateAgent(ctx);
@@ -25,6 +31,20 @@ export async function discoverExtensionProviders(): Promise<DiscoveredProvider[]
     await loadExtensions(ctx).catch(() => {});
     const { providers } = core.bus.emitPipe("agent:providers", { providers: [] as ProviderRegistration[] });
     cached = providers.map((p) => ({ id: p.id, noAuth: p.noAuth }));
+    if (errors.length > 0) {
+      process.stderr.write(`\n[agent-sh] extension load errors during provider discovery:\n`);
+      for (const msg of errors) {
+        process.stderr.write(`  - ${msg}\n`);
+        if (BARE_IMPORT_RE.test(msg) && msg.includes(EXT_DIR)) {
+          process.stderr.write(
+            `      ↳ Single-file extensions can't runtime-import agent-sh modules from ${EXT_DIR}.\n` +
+            `        Use ctx.call(...) for runtime needs, or convert to a directory extension\n` +
+            `        with its own package.json + node_modules.\n`,
+          );
+        }
+      }
+      process.stderr.write(`\n`);
+    }
     return cached;
   } finally {
     core.kill();

--- a/tests/core/single-file-extension-imports.test.ts
+++ b/tests/core/single-file-extension-imports.test.ts
@@ -1,0 +1,51 @@
+/** Ratchet: bundled single-file extensions can't runtime-import agent-sh
+ *  modules — they fail to resolve from ~/.agent-sh/extensions/ on fresh
+ *  users. Type-only imports are erased by esbuild before the scan. */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { transformSync } from "esbuild";
+
+const BUNDLED_DIR = fileURLToPath(new URL("../../examples/extensions/", import.meta.url));
+
+const KNOWN_OFFENDERS: ReadonlySet<string> = new Set([
+  `interactive-prompts.ts: from "agent-sh/utils/diff-renderer.js"`,
+  `interactive-prompts.ts: from "agent-sh/utils/box-frame.js"`,
+  `interactive-prompts.ts: from "agent-sh/utils/palette.js"`,
+  `interactive-prompts.ts: from "agent-sh/utils/diff.js"`,
+  `questionnaire.ts: from "agent-sh/utils/palette.js"`,
+  `overlay-agent.ts: from "agent-sh/utils/floating-panel"`,
+  `overlay-agent.ts: from "agent-sh/utils/terminal-buffer"`,
+  `subagents.ts: from "agent-sh/agent/subagent"`,
+]);
+
+test("bundled single-file extensions have no new runtime imports of agent-sh/*", () => {
+  const seen = new Set<string>();
+  const introduced: string[] = [];
+  for (const entry of readdirSync(BUNDLED_DIR, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".ts")) continue;
+    const src = readFileSync(join(BUNDLED_DIR, entry.name), "utf8");
+    const { code } = transformSync(src, { loader: "ts", format: "esm" });
+    for (const m of code.matchAll(/from\s+["'](agent-sh\/[^"']+)["']/g)) {
+      const key = `${entry.name}: from "${m[1]}"`;
+      seen.add(key);
+      if (!KNOWN_OFFENDERS.has(key)) introduced.push(key);
+    }
+  }
+  const cleared = [...KNOWN_OFFENDERS].filter((k) => !seen.has(k));
+
+  assert.deepEqual(
+    introduced, [],
+    `New single-file extension has a runtime import of agent-sh/* — it will fail ` +
+    `to load from ~/.agent-sh/extensions/ on fresh users. Use ctx.call(...) or ` +
+    `convert to a directory extension.\n\nNew:\n  ${introduced.join("\n  ")}`,
+  );
+  assert.deepEqual(
+    cleared, [],
+    `KNOWN_OFFENDERS lists entries that no longer appear in the source — ` +
+    `nice work, please remove them from KNOWN_OFFENDERS to keep the ratchet ` +
+    `honest.\n\nCleared:\n  ${cleared.join("\n  ")}`,
+  );
+});


### PR DESCRIPTION
## Summary
- Single-file extensions that runtime-import `agent-sh/*` (e.g. `import { resolveApiKey } from "agent-sh/auth"`) fail to load on fresh users — no `node_modules/agent-sh` on the resolution chain from `~/.agent-sh/extensions/`. `discoverExtensionProviders` swallowed every load error, so the extension's providers silently vanished from `agent-sh auth login`.
- Adds `auth:resolve-api-key` ctx primitive on the agent backend; converts `opencode-provider`, `ollama`, `zai-coding-plan` to use it (their type-only `agent-sh/types` imports remain — esbuild erases them).
- `discover.ts` now subscribes to `ui:error` during the throwaway-core load and prints each failure to stderr. When the error matches the bare-import pattern and the failing path is under `~/.agent-sh/extensions/`, it adds a hint pointing at `ctx.call(...)` or a directory-extension restructure.
- Adds a ratchet test (`tests/core/single-file-extension-imports.test.ts`) that fails CI on any new bundled single-file extension with a runtime `from "agent-sh/*"` import, and also fails if `KNOWN_OFFENDERS` lists entries no longer present in source — so the set ratchets toward zero.

## Boundary established
A single-file extension's declared surface is its ctx type annotation plus type-only imports. Anything reaching into agent-sh runtime modules belongs in a directory extension with its own `package.json`.

Four remaining offenders pinned in `KNOWN_OFFENDERS`, each flagged inline as either a candidate for a new ctx primitive (`subagent:run`) or a candidate for restructuring as a directory extension (frontend-coupled rendering utilities).

## Test plan
- [x] `npm run build` clean
- [x] `node --import tsx --test tests/core/single-file-extension-imports.test.ts` — passes (KNOWN_OFFENDERS matches current state)
- [x] Probed ratchet: temporarily added a new offender → test fails with "New runtime import…"; temporarily removed an existing offender file → test fails with "KNOWN_OFFENDERS lists entries that no longer appear…"
- [x] `tests/cli/provider-gate.test.ts`, `tests/agent/builtin-provider-activation.test.ts`, `tests/agent/provider-modes.test.ts`, `tests/core/extension-loader.test.ts` — 15/15 pass
- [x] Verified end-to-end: copied new `opencode-provider.ts` to a fresh tmp dir with no resolvable `agent-sh` and loaded via `loadExtensions` — succeeds; copied the pre-fix version to the same dir and it fails with the expected `Cannot find module 'agent-sh/auth'` (which the new discovery surfacing now prints).