### PR TITLE
settings: session overlay + env overrides for auto-compact

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1140,10 +1140,11 @@ export class AgentLoop implements AgentBackend {
       // Auto-compact when total context approaches the window limit.
       const totalEstimate = this.conversation.estimatePromptTokens();
       const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      const s = getSettings();
       const threshold = Math.floor(
-        (contextWindow - RESPONSE_RESERVE) * getSettings().autoCompactThreshold,
+        (contextWindow - RESPONSE_RESERVE) * s.autoCompactThreshold,
       );
-      if (totalEstimate > threshold) {
+      if (s.autoCompact && totalEstimate > threshold) {
         // Compact deeply — shallow targets buy only 1–2 turns of runway on
         // tool-heavy workloads.
         const target = Math.floor(threshold * 0.25);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -11,7 +11,15 @@ import { LlmClient } from "./llm-client.js";
 import { createLlmFacade } from "./llm-facade.js";
 import type { ToolDefinition, ToolSchemaView } from "./types.js";
 import { registerReadOnlyTool, unregisterReadOnlyTool } from "./nuclear-form.js";
-import { resolveProvider, getProviderNames, getSettings, type ResolvedProvider } from "../core/settings.js";
+import {
+  resolveProvider,
+  getProviderNames,
+  getSettings,
+  setSessionOverlay,
+  clearSessionOverlay,
+  getSettingSource,
+  type ResolvedProvider,
+} from "../core/settings.js";
 import { resolveApiKey } from "../cli/auth/keys.js";
 import { discoverSkills } from "./skills.js";
 import activateOpenrouter from "./providers/openrouter.js";
@@ -409,8 +417,50 @@ export default function agentBackend(ctx: ExtensionContext): void {
         ashActive = true;
         bus.emit("command:register", {
           name: "/compact",
-          description: "Compact conversation via the active compaction strategy",
-          handler: () => bus.emit("agent:compact-request", {}),
+          description: "Compact now, or: off | on | threshold <0..1> | status",
+          handler: (args: string) => {
+            const trimmed = args.trim();
+            if (!trimmed) {
+              bus.emit("agent:compact-request", {});
+              return;
+            }
+            const [sub, ...rest] = trimmed.split(/\s+/);
+            if (sub === "off" || sub === "on") {
+              setSessionOverlay({ autoCompact: sub === "on" });
+              bus.emit("ui:info", { message: `auto-compact: ${sub} (session)` });
+              return;
+            }
+            if (sub === "threshold") {
+              const raw = rest[0];
+              const n = Number(raw);
+              if (!raw || !Number.isFinite(n) || n < 0 || n > 1) {
+                bus.emit("ui:error", { message: "usage: /compact threshold <0.0..1.0>" });
+                return;
+              }
+              setSessionOverlay({ autoCompactThreshold: n });
+              bus.emit("ui:info", { message: `auto-compact threshold: ${n} (session)` });
+              return;
+            }
+            if (sub === "reset") {
+              clearSessionOverlay("autoCompact", "autoCompactThreshold");
+              bus.emit("ui:info", { message: "auto-compact: session overrides cleared" });
+              return;
+            }
+            if (sub === "status") {
+              const s = getSettings();
+              const enabledSrc = getSettingSource("autoCompact");
+              const thSrc = getSettingSource("autoCompactThreshold");
+              bus.emit("ui:info", {
+                message:
+                  `auto-compact: ${s.autoCompact ? "on" : "off"} (${enabledSrc}), ` +
+                  `threshold: ${s.autoCompactThreshold} (${thSrc})`,
+              });
+              return;
+            }
+            bus.emit("ui:error", {
+              message: `unknown subcommand: ${sub}. usage: /compact [off|on|threshold <0..1>|reset|status]`,
+            });
+          },
         });
         bus.emit("command:register", {
           name: "/context",

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -87,7 +87,7 @@ export interface Settings {
    * that boot agent-sh as a library against a specific working tree).
    */
   historyFilePath?: string;
-  /** Auto-compact threshold as fraction of conversation budget (0-1, default 0.5). */
+  autoCompact?: boolean;
   autoCompactThreshold?: number;
 
   // ── Display ───────────────────────────────────────────────
@@ -162,6 +162,7 @@ const DEFAULTS: Required<Settings> = {
   historyMaxBytes: 104857600, // 100MB — history is only accessed via search/expand, never loaded wholesale
   historyStartupEntries: 100,
   historyFilePath: undefined as unknown as string,
+  autoCompact: true,
   autoCompactThreshold: 0.5,
   maxCommandOutputLines: 3,
   readOutputMaxLines: 10,
@@ -176,6 +177,40 @@ const DEFAULTS: Required<Settings> = {
 };
 
 let cached: Settings | null = null;
+let envOverrides: Partial<Settings> | null = null;
+let sessionOverlay: Partial<Settings> = {};
+
+export type SettingSource = "session" | "env" | "file" | "default";
+
+function parseBoolEnv(raw: string | undefined, key: string): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (v === "on" || v === "true" || v === "1") return true;
+  if (v === "off" || v === "false" || v === "0") return false;
+  console.error(`[agent-sh] Warning: ${key}="${raw}" is not a boolean (off|on|true|false|0|1); ignoring.`);
+  return undefined;
+}
+
+function parseUnitFloatEnv(raw: string | undefined, key: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) {
+    console.error(`[agent-sh] Warning: ${key}="${raw}" is not a number in [0, 1]; ignoring.`);
+    return undefined;
+  }
+  return n;
+}
+
+function loadEnvOverrides(): Partial<Settings> {
+  if (envOverrides) return envOverrides;
+  const out: Partial<Settings> = {};
+  const ac = parseBoolEnv(process.env.AGENT_SH_AUTO_COMPACT, "AGENT_SH_AUTO_COMPACT");
+  if (ac !== undefined) out.autoCompact = ac;
+  const th = parseUnitFloatEnv(process.env.AGENT_SH_AUTO_COMPACT_THRESHOLD, "AGENT_SH_AUTO_COMPACT_THRESHOLD");
+  if (th !== undefined) out.autoCompactThreshold = th;
+  envOverrides = out;
+  return envOverrides;
+}
 
 /** Load settings from disk (cached after first call). */
 export function getSettings(): Settings & typeof DEFAULTS {
@@ -190,7 +225,28 @@ export function getSettings(): Settings & typeof DEFAULTS {
       cached = {};
     }
   }
-  return { ...DEFAULTS, ...cached };
+  return { ...DEFAULTS, ...cached, ...loadEnvOverrides(), ...sessionOverlay };
+}
+
+export function setSessionOverlay(patch: Partial<Settings>): void {
+  sessionOverlay = { ...sessionOverlay, ...patch };
+}
+
+export function clearSessionOverlay(...keys: (keyof Settings)[]): void {
+  if (keys.length === 0) {
+    sessionOverlay = {};
+    return;
+  }
+  const next = { ...sessionOverlay };
+  for (const k of keys) delete next[k];
+  sessionOverlay = next;
+}
+
+export function getSettingSource(key: keyof Settings): SettingSource {
+  if (key in sessionOverlay) return "session";
+  if (key in loadEnvOverrides()) return "env";
+  if (cached && key in cached) return "file";
+  return "default";
 }
 
 /**
@@ -218,6 +274,8 @@ export function getExtensionSettings<T extends Record<string, unknown>>(
 /** Reset cached settings (for testing or after external edit). */
 export function reloadSettings(): void {
   cached = null;
+  envOverrides = null;
+  sessionOverlay = {};
 }
 
 /**

--- a/tests/core/settings-compaction.test.ts
+++ b/tests/core/settings-compaction.test.ts
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), "agent-sh-settings-test-"));
+process.env.AGENT_SH_HOME = TEST_HOME;
+
+const {
+  getSettings,
+  reloadSettings,
+  setSessionOverlay,
+  clearSessionOverlay,
+  getSettingSource,
+} = await import("../../src/core/settings.js");
+
+const SETTINGS_PATH = join(TEST_HOME, "settings.json");
+
+function writeSettings(obj: Record<string, unknown>): void {
+  mkdirSync(TEST_HOME, { recursive: true });
+  writeFileSync(SETTINGS_PATH, JSON.stringify(obj));
+}
+
+function clearSettings(): void {
+  try { rmSync(SETTINGS_PATH); } catch {}
+}
+
+function reset(): void {
+  clearSettings();
+  delete process.env.AGENT_SH_AUTO_COMPACT;
+  delete process.env.AGENT_SH_AUTO_COMPACT_THRESHOLD;
+  reloadSettings();
+}
+
+test("autoCompact defaults to true, threshold to 0.5", () => {
+  reset();
+  const s = getSettings();
+  assert.equal(s.autoCompact, true);
+  assert.equal(s.autoCompactThreshold, 0.5);
+  assert.equal(getSettingSource("autoCompact"), "default");
+  assert.equal(getSettingSource("autoCompactThreshold"), "default");
+});
+
+test("settings.json overrides defaults", () => {
+  reset();
+  writeSettings({ autoCompact: false, autoCompactThreshold: 0.8 });
+  reloadSettings();
+  const s = getSettings();
+  assert.equal(s.autoCompact, false);
+  assert.equal(s.autoCompactThreshold, 0.8);
+  assert.equal(getSettingSource("autoCompact"), "file");
+  assert.equal(getSettingSource("autoCompactThreshold"), "file");
+});
+
+test("env vars override file", () => {
+  reset();
+  writeSettings({ autoCompact: false, autoCompactThreshold: 0.8 });
+  process.env.AGENT_SH_AUTO_COMPACT = "on";
+  process.env.AGENT_SH_AUTO_COMPACT_THRESHOLD = "0.3";
+  reloadSettings();
+  const s = getSettings();
+  assert.equal(s.autoCompact, true);
+  assert.equal(s.autoCompactThreshold, 0.3);
+  assert.equal(getSettingSource("autoCompact"), "env");
+  assert.equal(getSettingSource("autoCompactThreshold"), "env");
+});
+
+test("env var boolean parsing accepts on/off/true/false/1/0", () => {
+  for (const [raw, expected] of [
+    ["on", true], ["true", true], ["1", true],
+    ["off", false], ["false", false], ["0", false],
+    ["OFF", false], ["True", true],
+  ] as const) {
+    reset();
+    process.env.AGENT_SH_AUTO_COMPACT = raw;
+    reloadSettings();
+    assert.equal(getSettings().autoCompact, expected, `raw=${raw}`);
+  }
+});
+
+test("malformed env values fall through to file/default", () => {
+  reset();
+  writeSettings({ autoCompact: false });
+  const origErr = console.error;
+  const warnings: string[] = [];
+  console.error = (msg: string) => warnings.push(String(msg));
+  try {
+    process.env.AGENT_SH_AUTO_COMPACT = "maybe";
+    process.env.AGENT_SH_AUTO_COMPACT_THRESHOLD = "2.5";
+    reloadSettings();
+    const s = getSettings();
+    assert.equal(s.autoCompact, false, "fell through to file");
+    assert.equal(s.autoCompactThreshold, 0.5, "fell through to default");
+    assert.equal(getSettingSource("autoCompact"), "file");
+    assert.equal(getSettingSource("autoCompactThreshold"), "default");
+    assert.ok(warnings.some((w) => w.includes("AGENT_SH_AUTO_COMPACT=")), "warned about bool");
+    assert.ok(warnings.some((w) => w.includes("AGENT_SH_AUTO_COMPACT_THRESHOLD=")), "warned about float");
+  } finally {
+    console.error = origErr;
+  }
+});
+
+test("session overlay beats env and file", () => {
+  reset();
+  writeSettings({ autoCompactThreshold: 0.8 });
+  process.env.AGENT_SH_AUTO_COMPACT = "on";
+  reloadSettings();
+
+  setSessionOverlay({ autoCompact: false, autoCompactThreshold: 0.2 });
+  const s = getSettings();
+  assert.equal(s.autoCompact, false);
+  assert.equal(s.autoCompactThreshold, 0.2);
+  assert.equal(getSettingSource("autoCompact"), "session");
+  assert.equal(getSettingSource("autoCompactThreshold"), "session");
+});
+
+test("clearSessionOverlay restores underlying layer", () => {
+  reset();
+  process.env.AGENT_SH_AUTO_COMPACT = "off";
+  reloadSettings();
+
+  setSessionOverlay({ autoCompact: true });
+  assert.equal(getSettings().autoCompact, true);
+  assert.equal(getSettingSource("autoCompact"), "session");
+
+  clearSessionOverlay("autoCompact");
+  assert.equal(getSettings().autoCompact, false);
+  assert.equal(getSettingSource("autoCompact"), "env");
+});
+
+test("clearSessionOverlay with no args clears everything", () => {
+  reset();
+  setSessionOverlay({ autoCompact: false, autoCompactThreshold: 0.9 });
+  clearSessionOverlay();
+  const s = getSettings();
+  assert.equal(s.autoCompact, true);
+  assert.equal(s.autoCompactThreshold, 0.5);
+});
+
+test.after(() => {
+  try { rmSync(TEST_HOME, { recursive: true, force: true }); } catch {}
+});


### PR DESCRIPTION
## Summary

- Adds `autoCompact` boolean setting alongside the existing `autoCompactThreshold`, defaulting to `true`. Gating compaction on a real on/off flag avoids the "set threshold to 1.0 to disable" workaround.
- Reads `AGENT_SH_AUTO_COMPACT` and `AGENT_SH_AUTO_COMPACT_THRESHOLD` env vars once at first `getSettings()` call. Precedence: env > settings.json > default.
- Introduces a session overlay layer (`setSessionOverlay` / `clearSessionOverlay`) that wins over env and file but is never written to disk — runtime toggles are session-scoped by design.
- Subcommands the existing `/compact` slash command:
  - bare `/compact` — manual trigger (unchanged)
  - `/compact off|on` — toggle `autoCompact`
  - `/compact threshold <0..1>` — set threshold
  - `/compact reset` — clear session overrides
  - `/compact status` — print effective values + source attribution

## Why session-only, not persist-to-disk

The existing `/model` and `/backend` slash commands persist via `updateSettings()`. That precedent has a footgun for compaction knobs specifically: tune once for a tricky session, silently keep the new default for every future session. Compaction tuning is typically a "let me try this for now" knob, not a "this is my new default" one. Editing `~/.agent-sh/settings.json` remains the path for permanent changes.

## Test plan

- [x] `npm run build` clean
- [x] New `tests/core/settings-compaction.test.ts`: 8 tests covering env > file > default precedence, boolean parsing variants, malformed env fall-through, session overlay wins, and `clearSessionOverlay` restoring underlying layer
- [x] Full `npm test` suite green
- [ ] Smoke: `/compact status` in a live session shows correct source attribution; `/compact off` skips compaction on the next loop iteration