### PR TITLE
rolling-history: move out of kernel; own recall tool + /history toggle

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -141,7 +141,7 @@ There's no dedicated shell-recall tool: the spill file is just a normal file. Th
 
 ### Conversation — `conversation_recall` tool
 
-Registered by the built-in agent:
+Registered by the built-in `rolling-history` extension (only present when that extension is active; bridges and embedded uses don't ship it):
 
 - `conversation_recall {"action": "browse"}` — list in-context nuclear entries + the 25 most recent history-file entries
 - `conversation_recall {"action": "search", "query": "..."}` — regex search across the in-session archive and the history file (both one-line summaries and full bodies)
@@ -164,6 +164,7 @@ Common override patterns: LLM-summarized compaction (summarize evicted turns bef
 |---|---|
 | `/compact` | Fire the `conversation:compact` handler (effective behavior depends on active advisors) |
 | `/context` | Show context budget usage (active tokens, total tokens, budget) |
+| `/history [on\|off\|status]` | Pause/resume writes to the rolling-history store for this session. Recall stays available; the tool and instruction stay registered, so toggling doesn't perturb the tools array or system prompt (LLM prompt cache is preserved). |
 
 There's no `/clear` — history is continuous by design.
 
@@ -189,5 +190,6 @@ All settings live in `~/.agent-sh/settings.json`:
 | `src/agent/conversation-state.ts` | Messages array, eager nucleation, priority-based compaction, in-memory recall archive |
 | `src/agent/nuclear-form.ts` | One-line-summary primitives (nucleate, serialize, priority classification) |
 | `src/agent/history-file.ts` | Append-only `~/.agent-sh/history` with chunked search/tail-read + front-truncation |
-| `src/agent/agent-loop.ts` | Auto-compact trigger, `conversation:compact` advisor chain, registers the `conversation_recall` tool |
+| `src/agent/agent-loop.ts` | Auto-compact trigger, `conversation:compact` advisor chain |
+| `src/agent/extensions/rolling-history/index.ts` | Rolling-history extension: registers the `conversation_recall` tool, the summary strategy, and the `/history` slash command |
 | `src/agent/index.ts` | `/compact` and `/context` slash commands registered when the ash backend starts |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -300,6 +300,7 @@ This means you can run a failing command, then type `> fix this` and the agent k
 | `/thinking [level]` | Set reasoning effort (off, low, medium, high) |
 | `/compact` | Compact conversation (free up context space) |
 | `/context` | Show context budget usage (active tokens vs. budget) |
+| `/history [on\|off\|status]` | Pause/resume cross-session history writes for this session (no cache invalidation) |
 | `/reload` | Reload user extensions from `~/.agent-sh/extensions/` |
 
 See [Context Management](context-management.md) for how `/compact` and `/context` work, and [Extensions: Custom Agent Backends](extensions.md#custom-agent-backends) for `/backend`.

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -142,9 +142,6 @@ export class AgentLoop implements AgentBackend {
       coreTools,
     );
 
-    // Register core tools
-    this.registerCoreTools();
-
     // Register any protocol-provided tools (e.g. load_tool for deferred-lookup).
     const protocolTools = this.toolProtocol.getProtocolTools?.() ?? [];
     for (const t of protocolTools) this.registerTool(t);
@@ -642,79 +639,6 @@ export class AgentLoop implements AgentBackend {
     // Generic with context
     const context = provider ? ` (${provider}, model: ${model})` : ` (model: ${model})`;
     return `${raw}${context}`;
-  }
-
-  private registerCoreTools(): void {
-    // Stateless core tools register in agentBackend; conversation_recall
-    // stays here because it needs this.conversation.
-    this.toolRegistry.register({
-      name: "conversation_recall",
-      displayName: "recall",
-      description:
-        "Browse, search, or expand evicted conversation turns. " +
-        "Use when you need context from earlier in the conversation that was compacted away. " +
-        "Search is regex-based and covers both summaries and full body text. " +
-        "If search doesn't find what you expect, try broader/shorter terms or browse to scan the timeline.",
-      input_schema: {
-        type: "object",
-        properties: {
-          action: {
-            type: "string",
-            enum: ["browse", "search", "expand"],
-            description: "browse: list evicted turns, search: regex search, expand: show full turn",
-          },
-          query: {
-            type: "string",
-            description: "Search query (for action=search)",
-          },
-          turn_id: {
-            type: "number",
-            description: "Turn ID to expand (for action=expand)",
-          },
-        },
-        required: ["action"],
-      },
-      execute: async (args) => {
-        const action = args.action as string;
-        let content: string;
-        if (action === "search") {
-          content = (await this.handlers.call("recall:search", (args.query as string) ?? "")) as string ?? "No results — no recall strategy registered.";
-        } else if (action === "expand") {
-          content = (await this.handlers.call("recall:expand", args.turn_id)) as string ?? "No expanded content — no recall strategy registered.";
-        } else {
-          content = (await this.handlers.call("recall:browse")) as string ?? "No conversation history — no recall strategy registered.";
-        }
-        return { content, exitCode: 0, isError: false };
-      },
-      formatResult: (args, result) => {
-        const action = args.action as string;
-        const text = contentText(result.content);
-        if (result.isError) return { summary: "error" };
-        if (action === "search") {
-          if (text.startsWith("No results")) return { summary: "0 matches" };
-          const m = text.match(/^Found (\d+)/);
-          return { summary: m ? `${m[1]} matches` : "search done" };
-        }
-        if (action === "browse") {
-          if (text.startsWith("No conversation")) return { summary: "empty" };
-          return { summary: "browsed" };
-        }
-        if (text.includes("no expanded content")) return { summary: "not found" };
-        return { summary: "expanded" };
-      },
-      getDisplayInfo: () => ({ kind: "search", icon: "\u27F2" }),
-    });
-
-    this.registerInstruction(
-      "recall-guidance",
-      "When starting a task that may have been discussed before (conventions, preferences, corrections, prior examples), " +
-      "use conversation_recall to search history for relevant prior entries. " +
-      "Treat recurring user guidance as standing preferences. " +
-      "If a search returns nothing useful, try: shorter queries, alternate terms, or browse to scan the full timeline. " +
-      "Recall only covers this and recent sessions — for older context, also search the filesystem (grep, glob).",
-      "core",
-    );
-
   }
 
   /**

--- a/src/agent/extensions/rolling-history/index.ts
+++ b/src/agent/extensions/rolling-history/index.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import type { ExtensionContext } from "../../../shell/host-types.js";
 import type { AgentShMessage } from "../../llm-client.js";
+import { contentText, type ToolDefinition } from "../../types.js";
 import { SharedFileStore } from "../../store.js";
 import {
   activate as activateSummaryStrategy,
@@ -8,6 +9,15 @@ import {
   type SummaryCtx,
 } from "./strategy.js";
 import { recallSearch, recallExpand, recallBrowse } from "./recall.js";
+
+const TOOL_NAME = "conversation_recall";
+const INSTRUCTION_NAME = "recall-guidance";
+const INSTRUCTION_TEXT =
+  "When starting a task that may have been discussed before (conventions, preferences, corrections, prior examples), " +
+  "use conversation_recall to search history for relevant prior entries. " +
+  "Treat recurring user guidance as standing preferences. " +
+  "If a search returns nothing useful, try: shorter queries, alternate terms, or browse to scan the full timeline. " +
+  "Recall only covers this and recent sessions — for older context, also search the filesystem (grep, glob).";
 
 export default function activate(ctx: ExtensionContext): void {
   const { maxBytes, prefetchEntries } = ctx.getExtensionSettings("rolling-history", {
@@ -20,8 +30,15 @@ export default function activate(ctx: ExtensionContext): void {
     maxBytes,
   });
 
+  // `/history off` gates only store.append; the tool + instruction stay
+  // registered so toggling never perturbs the tools array or system prompt
+  // (i.e. never invalidates the LLM cache).
+  let enabled = true;
+  const gatedStore: typeof summaryStore = Object.create(summaryStore);
+  gatedStore.append = (entries, opts) => enabled ? summaryStore.append(entries, opts) : Promise.resolve();
+
   const summaryCtx: SummaryCtx = {
-    store: summaryStore,
+    store: gatedStore,
     bus: { on: (e, f) => ctx.bus.on(e, f) },
     advise: (op, f) => { ctx.advise(op, f as Parameters<typeof ctx.advise>[1]); },
     iid: ctx.instanceId,
@@ -33,12 +50,87 @@ export default function activate(ctx: ExtensionContext): void {
   };
   activateSummaryStrategy(summaryCtx);
 
-  ctx.define("recall:search", async (query: string) => recallSearch(summaryStore, query));
-  ctx.define("recall:expand", async (id: string) => recallExpand(summaryStore, id));
-  ctx.define("recall:browse", async (limit?: number) => recallBrowse(summaryStore, limit));
+  const toolDef: ToolDefinition = {
+    name: TOOL_NAME,
+    displayName: "recall",
+    description:
+      "Browse, search, or expand evicted conversation turns. " +
+      "Use when you need context from earlier in the conversation that was compacted away. " +
+      "Search is regex-based and covers both summaries and full body text. " +
+      "If search doesn't find what you expect, try broader/shorter terms or browse to scan the timeline.",
+    input_schema: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          enum: ["browse", "search", "expand"],
+          description: "browse: list evicted turns, search: regex search, expand: show full turn",
+        },
+        query: { type: "string", description: "Search query (for action=search)" },
+        turn_id: { type: "number", description: "Turn ID to expand (for action=expand)" },
+      },
+      required: ["action"],
+    },
+    execute: async (args) => {
+      const action = args.action as string;
+      let content: string;
+      if (action === "search") {
+        content = await recallSearch(summaryStore, (args.query as string) ?? "");
+      } else if (action === "expand") {
+        content = await recallExpand(summaryStore, args.turn_id as string);
+      } else {
+        content = await recallBrowse(summaryStore);
+      }
+      return { content, exitCode: 0, isError: false };
+    },
+    formatResult: (args, result) => {
+      const action = args.action as string;
+      const text = contentText(result.content);
+      if (result.isError) return { summary: "error" };
+      if (action === "search") {
+        if (text.startsWith("No results")) return { summary: "0 matches" };
+        const m = text.match(/^Found (\d+)/);
+        return { summary: m ? `${m[1]} matches` : "search done" };
+      }
+      if (action === "browse") {
+        if (text.startsWith("No conversation")) return { summary: "empty" };
+        return { summary: "browsed" };
+      }
+      if (text.includes("no expanded content")) return { summary: "not found" };
+      return { summary: "expanded" };
+    },
+    getDisplayInfo: () => ({ kind: "search", icon: "⟲" }),
+  };
+
+  if (ctx.agent) {
+    ctx.agent.registerTool(toolDef);
+    ctx.agent.registerInstruction(INSTRUCTION_NAME, INSTRUCTION_TEXT);
+  }
+
+  ctx.registerCommand("history", "Toggle conversation history writes (on / off / status).", (args) => {
+    const arg = args.trim().toLowerCase();
+    if (arg === "" || arg === "status") {
+      ctx.bus.emit("ui:info", { message: `history: writes ${enabled ? "on" : "off"} — recall remains available for prior sessions` });
+      return;
+    }
+    if (arg === "on") {
+      if (enabled) { ctx.bus.emit("ui:info", { message: "history: already on" }); return; }
+      enabled = true;
+      ctx.bus.emit("ui:info", { message: "history: on — new turns will be summarized" });
+      return;
+    }
+    if (arg === "off") {
+      if (!enabled) { ctx.bus.emit("ui:info", { message: "history: already off" }); return; }
+      enabled = false;
+      ctx.bus.emit("ui:info", { message: "history: off — new turns won't be summarized (recall still available)" });
+      return;
+    }
+    ctx.bus.emit("ui:info", { message: `history: unknown arg "${arg}" (use on / off / status)` });
+  });
 
   if (prefetchEntries > 0) {
     Promise.resolve().then(async () => {
+      if (!enabled) return;
       const lines = await readSummaryLines(summaryStore, prefetchEntries);
       if (lines.length === 0) return;
       const current = (ctx.call("conversation:get-messages") as AgentShMessage[] | undefined) ?? [];

--- a/src/agent/extensions/rolling-history/index.ts
+++ b/src/agent/extensions/rolling-history/index.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import type { ExtensionContext } from "../../../shell/host-types.js";
 import type { AgentShMessage } from "../../llm-client.js";
 import { contentText, type ToolDefinition } from "../../types.js";
-import { SharedFileStore } from "../../store.js";
+import { SharedFileStore, type Store } from "../../store.js";
 import {
   activate as activateSummaryStrategy,
   readSummaryLines,
@@ -30,12 +30,18 @@ export default function activate(ctx: ExtensionContext): void {
     maxBytes,
   });
 
-  // `/history off` gates only store.append; the tool + instruction stay
-  // registered so toggling never perturbs the tools array or system prompt
-  // (i.e. never invalidates the LLM cache).
+  // `/history off` gates only writes — store.append and the linkMessage
+  // back-stamp. Everything else (meta.tool stamping, compact's reorg,
+  // recall reads) runs identically on both sides. Tool + instruction stay
+  // registered either way so toggling never perturbs the tools array or
+  // system prompt (LLM prompt cache is preserved).
   let enabled = true;
-  const gatedStore: typeof summaryStore = Object.create(summaryStore);
-  gatedStore.append = (entries, opts) => enabled ? summaryStore.append(entries, opts) : Promise.resolve();
+  const gatedStore: Store = {
+    append: (entries, opts) => enabled ? summaryStore.append(entries, opts) : Promise.resolve(),
+    findById: (id) => summaryStore.findById(id),
+    readRecent: (n) => summaryStore.readRecent(n),
+    search: (q) => summaryStore.search(q),
+  };
 
   const summaryCtx: SummaryCtx = {
     store: gatedStore,
@@ -46,7 +52,7 @@ export default function activate(ctx: ExtensionContext): void {
     replaceMessages: (msgs) => { ctx.call("conversation:replace-messages", msgs); },
     estimateTokens: () => (ctx.call("conversation:estimate-tokens") as number | undefined) ?? 0,
     estimatePromptTokens: () => (ctx.call("conversation:estimate-prompt-tokens") as number | undefined) ?? 0,
-    linkMessage: (index, entryId) => { ctx.call("conversation:link", index, entryId); },
+    linkMessage: (index, entryId) => { if (enabled) ctx.call("conversation:link", index, entryId); },
   };
   activateSummaryStrategy(summaryCtx);
 
@@ -67,7 +73,7 @@ export default function activate(ctx: ExtensionContext): void {
           description: "browse: list evicted turns, search: regex search, expand: show full turn",
         },
         query: { type: "string", description: "Search query (for action=search)" },
-        turn_id: { type: "number", description: "Turn ID to expand (for action=expand)" },
+        turn_id: { type: "string", description: "Turn ID to expand (for action=expand)" },
       },
       required: ["action"],
     },
@@ -130,7 +136,6 @@ export default function activate(ctx: ExtensionContext): void {
 
   if (prefetchEntries > 0) {
     Promise.resolve().then(async () => {
-      if (!enabled) return;
       const lines = await readSummaryLines(summaryStore, prefetchEntries);
       if (lines.length === 0) return;
       const current = (ctx.call("conversation:get-messages") as AgentShMessage[] | undefined) ?? [];

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -227,7 +227,6 @@ export default function agentBackend(ctx: ExtensionContext): void {
 
   // Core tools register at activate — before extensions load — so
   // extensions that look them up at activate time (e.g. scheme.ts) find them.
-  // conversation_recall stays in AgentLoop (needs session state).
   const fileReadCache: FileReadCache = new Map();
   ctx.define("agent:file-read-cache", () => fileReadCache);
   const getCwd = () => ctx.call("cwd") as string;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { activateAgent } from "../agent/index.js";
 import { createCore } from "../core/index.js";
 import { palette as p } from "../utils/palette.js";
 import { loadBuiltinExtensions } from "../extensions/index.js";
+import activateRollingHistory from "../agent/extensions/rolling-history/index.js";
 import { loadExtensions } from "../core/extension-loader.js";
 import { getSettings } from "../core/settings.js";
 import { dispatchSubcommand } from "./subcommands.js";
@@ -125,7 +126,9 @@ async function main(): Promise<void> {
   activateAgent(extCtx);
 
   // Load before spawning the shell so PS1 lands below the banner.
-  await loadBuiltinExtensions(extCtx, getSettings().disabledBuiltins);
+  const settings = getSettings();
+  await loadBuiltinExtensions(extCtx, settings.disabledBuiltins);
+  activateRollingHistory(extCtx);
   const loadExtensionsTimeoutMs = 10000;
   let loadedExtensions: string[] = [];
   await Promise.race([
@@ -158,7 +161,6 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const settings = getSettings();
   if (settings.startupBanner !== false) {
     const termW = process.stdout.columns || 80;
     const bannerW = Math.min(termW, 60);

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -3,6 +3,7 @@
  * Module-owned built-ins activate inline:
  *   shell-context, tui-renderer → registerShellHandlers (src/shell/)
  *   ash (a specific backend)    → activateAgent         (src/agent/)
+ *   rolling-history              → activateRollingHistory (src/cli/)
  *   backend registry             → createCore           (src/core/)
  */
 import type { ExtensionContext } from "../shell/host-types.js";
@@ -15,7 +16,6 @@ export const BUILTIN_EXTENSIONS: Array<{
 }> = [
   { name: "slash-commands",    load: () => import("./slash-commands/index.js").then(m => m.default) },
   { name: "file-autocomplete", load: () => import("./file-autocomplete.js").then(m => m.default) },
-  { name: "rolling-history",  load: () => import("../agent/extensions/rolling-history/index.js").then(m => m.default) },
 ];
 
 /**

--- a/tests/agent/extensions/rolling-history/activation.test.ts
+++ b/tests/agent/extensions/rolling-history/activation.test.ts
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { createCore } from "../../../../src/core/index.js";
+import { activateAgent } from "../../../../src/agent/index.js";
+import { loadBuiltinExtensions } from "../../../../src/extensions/index.js";
+import activateRollingHistory from "../../../../src/agent/extensions/rolling-history/index.js";
+import type { AppConfig } from "../../../../src/shell/host-types.js";
+import type { ToolDefinition } from "../../../../src/agent/types.js";
+
+interface CommandReg { name: string; handler: (args: string) => Promise<void> | void; }
+
+async function flush(n = 12): Promise<void> {
+  for (let i = 0; i < n; i++) await new Promise((r) => setImmediate(r));
+}
+
+async function bootWithRollingHistory(storeDir: string): Promise<{
+  core: ReturnType<typeof createCore>;
+  commands: Map<string, CommandReg["handler"]>;
+}> {
+  const core = createCore({ defaultBackend: "ash", historyDir: storeDir } as AppConfig & { historyDir?: string });
+  const ctx = core.extensionContext({ quit: () => {} });
+  // Pin getStoragePath("rolling-history") to a tmpdir.
+  (ctx as { getStoragePath: (ns: string) => string }).getStoragePath = () => storeDir;
+
+  // Capture slash-command registrations so the test can fire /history.
+  const commands = new Map<string, CommandReg["handler"]>();
+  core.bus.on("command:register", ({ name, handler }) => { commands.set(name, handler); });
+
+  // Minimal conversation-state handlers the captureHandler relies on.
+  const messages: Array<{ role: string; content: string; meta?: Record<string, unknown> }> = [];
+  ctx.define("conversation:get-messages", () => messages);
+  ctx.define("conversation:replace-messages", (msgs: typeof messages) => { messages.length = 0; messages.push(...msgs); });
+  ctx.define("conversation:link", (_idx: number, _id: string) => undefined);
+  ctx.define("conversation:estimate-tokens", () => 0);
+  ctx.define("conversation:estimate-prompt-tokens", () => 0);
+
+  activateAgent(ctx);
+  await loadBuiltinExtensions(ctx, ["file-autocomplete"]);
+  activateRollingHistory(ctx);
+  return { core, commands };
+}
+
+test("bridge boot (no activateRollingHistory) → conversation_recall absent from tools", async () => {
+  const core = createCore({ defaultBackend: "ash" } as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  activateAgent(ctx);
+  await loadBuiltinExtensions(ctx, ["file-autocomplete"]);
+  // Deliberately do NOT activateRollingHistory — mirrors what bridges do.
+
+  const { tools } = core.bus.emitPipe("agent:tools", { tools: [] as ToolDefinition[] });
+  const names = tools.map((t) => t.name);
+  assert.ok(!names.includes("conversation_recall"),
+    `bridge boot should not register conversation_recall; got: ${names.join(", ")}`);
+});
+
+test("shell boot (with activateRollingHistory) → conversation_recall registered", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-act-"));
+  try {
+    const { core } = await bootWithRollingHistory(tmpDir);
+    const { tools } = core.bus.emitPipe("agent:tools", { tools: [] as ToolDefinition[] });
+    const names = tools.map((t) => t.name);
+    assert.ok(names.includes("conversation_recall"),
+      `shell boot should register conversation_recall; got: ${names.join(", ")}`);
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("/history off gates writes; /history on resumes", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-toggle-"));
+  const historyFile = path.join(tmpDir, "history.jsonl");
+  try {
+    const { core, commands } = await bootWithRollingHistory(tmpDir);
+    const messages = (core.handlers.call("conversation:get-messages") as Array<{ role: string; content: string }>);
+
+    // Turn 1 — writes on (default).
+    messages.push({ role: "user", content: "first turn while on" });
+    core.bus.emit("conversation:message-appended", { role: "user", content: "first turn while on" });
+    await flush();
+    const sizeAfterFirst = fs.existsSync(historyFile) ? fs.statSync(historyFile).size : 0;
+    assert.ok(sizeAfterFirst > 0, "first turn should have produced disk writes");
+
+    // /history off.
+    const toggle = commands.get("history")!;
+    assert.ok(toggle, "/history command should be registered");
+    await toggle("off");
+
+    // Turn 2 — writes off.
+    messages.push({ role: "user", content: "second turn while off" });
+    core.bus.emit("conversation:message-appended", { role: "user", content: "second turn while off" });
+    await flush();
+    const sizeAfterOff = fs.statSync(historyFile).size;
+    assert.equal(sizeAfterOff, sizeAfterFirst,
+      "file should not grow while /history off");
+    assert.ok(!fs.readFileSync(historyFile, "utf-8").includes("second turn while off"),
+      "off-turn content must not appear on disk");
+
+    // /history on resumes.
+    await toggle("on");
+    messages.push({ role: "user", content: "third turn after re-enable" });
+    core.bus.emit("conversation:message-appended", { role: "user", content: "third turn after re-enable" });
+    await flush();
+    assert.ok(fs.statSync(historyFile).size > sizeAfterOff,
+      "file should grow once writes resume");
+    assert.ok(fs.readFileSync(historyFile, "utf-8").includes("third turn after re-enable"));
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("/history off also gates linkMessage (no stale entryId stamping)", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-link-"));
+  try {
+    const { core, commands } = await bootWithRollingHistory(tmpDir);
+    const messages = (core.handlers.call("conversation:get-messages") as Array<{ role: string; content: string; meta?: Record<string, unknown> }>);
+    const linkCalls: Array<{ idx: number; id: string }> = [];
+    // Replace the no-op link handler with one that records calls.
+    core.handlers.define("conversation:link", (idx: number, id: string) => { linkCalls.push({ idx, id }); });
+
+    await commands.get("history")!("off");
+    messages.push({ role: "user", content: "off-turn" });
+    core.bus.emit("conversation:message-appended", { role: "user", content: "off-turn" });
+    await flush();
+
+    assert.equal(linkCalls.length, 0, "linkMessage should not fire while /history off");
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/agent/extensions/rolling-history/activation.test.ts
+++ b/tests/agent/extensions/rolling-history/activation.test.ts
@@ -22,7 +22,7 @@ async function bootWithRollingHistory(storeDir: string): Promise<{
   core: ReturnType<typeof createCore>;
   commands: Map<string, CommandReg["handler"]>;
 }> {
-  const core = createCore({ defaultBackend: "ash", historyDir: storeDir } as AppConfig & { historyDir?: string });
+  const core = createCore({ defaultBackend: "ash" } as AppConfig);
   const ctx = core.extensionContext({ quit: () => {} });
   // Pin getStoragePath("rolling-history") to a tmpdir.
   (ctx as { getStoragePath: (ns: string) => string }).getStoragePath = () => storeDir;


### PR DESCRIPTION
## Summary

- Rolling-history is no longer a cross-cutting kernel built-in. Removed from `BUILTIN_EXTENSIONS`; activated inline from `src/cli/index.ts` only. Embedders (ash-acp-bridge, ashi, ashub, `auth/discover`) get a clean kernel by default — no shared `~/.agent-sh/rolling-history` writes, no `[Prior session history]` injection.
- `conversation_recall` tool + `recall-guidance` instruction moved from `agent-loop.ts` into the rolling-history extension. Without the extension there is no tool — no more phantom \"no recall strategy registered\" stub in the schema.
- New per-session `/history on|off|status` slash command. The toggle gates only `store.append` via a wrapper; `captureHandler`'s meta stamping and `linkMessage`, compact's reorg, and recall reads all run identically on both sides. Tool + instruction stay registered either way, so toggling doesn't perturb the tools array or system prompt — LLM prompt cache is preserved.

`disabledBuiltins` is back to meaning only the `BUILTIN_EXTENSIONS` array.

## Why this shape

Three earlier conversations were the design pressure:

1. **\"Built-in\" was overloaded.** `BUILTIN_EXTENSIONS` lumped slash-commands and file-autocomplete (cross-cutting) with rolling-history (a particular history-strategy choice with a shared cross-session store). Bridges and ashub had no way to opt out without editing user settings.
2. **The kernel was carrying a tool it didn't implement.** `conversation_recall` delegated to `recall:*` handlers and returned canned \"no recall strategy registered\" strings when none answered. The schema lived in the kernel; the semantics lived in an optional extension. If a future history strategy doesn't implement recall, the agent shouldn't see the tool at all — that's the principle.
3. **The toggle wanted dynamic, not static.** A settings-file `disabledBuiltins` entry is awkward for the \"this session I don't want to track history\" case. `/history off` is the right UX, but only if it doesn't bust the LLM cache. Gating writes (not registrations) makes the toggle cache-stable.

## Notes

- `~/.agent-sh/rolling-history/history.jsonl` path/format unchanged. Consolidating to `~/.agent-sh/history` would need a format migration (old flat `{seq,iid,kind,tool,sum,body}` vs new `Entry{id,ts,kind,payload}`); parked.
- `slash-commands` extension is still loaded under bridge contexts (it's in `BUILTIN_EXTENSIONS`). Separate question whether bridges want `/help` etc. — not in scope here.

## Test plan

- [x] Core builds clean (`tsc`)
- [x] Core tests pass (225/225)
- [x] ashi builds clean
- [ ] Manual: launch shell, confirm `/history status` reports \"on\", run a turn, check `history.jsonl` grew
- [ ] Manual: `/history off`, run a turn, check `history.jsonl` did **not** grow; `/history status` reports \"off\"
- [ ] Manual: `/history off` then `/compact` — compaction completes, summary block appears in context, no new lines in `history.jsonl`
- [ ] Manual: `conversation_recall {\"action\":\"browse\"}` still returns prior entries while `off`
- [ ] Manual: ash-acp-bridge spawn — confirm no `~/.agent-sh/rolling-history` writes and `conversation_recall` is absent from the tool schema