### PR TITLE
ashi: gate user_bash rendering on a pending intent FIFO

### DIFF
--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -28,6 +28,7 @@ import type { ToolCallView, ToolResultView } from "./hooks.js";
 import { createToolHookResolver } from "./hooks.js";
 import { loadGroupMaxVisible } from "./display-config.js";
 import { classifySubmit, deriveChangeHandlerResult } from "./shell-mode.js";
+import { UserShellIntents } from "./user-shell-intents.js";
 
 const GROUPABLE_KINDS = new Set(["read", "search"]);
 const TOOL_KIND: Record<string, string> = {
@@ -300,8 +301,7 @@ export function mountAshi(
   let processing = false;
   const queuedQueries: string[] = [];
   const queuedShellLines: { line: string; private: boolean }[] = [];
-  /** FIFO matching pty-writes to their shell:command-start events. */
-  const pendingUserBlockPrivacy: boolean[] = [];
+  const pendingUserShell = new UserShellIntents();
 
   const renderQueueSlot = (): void => {
     queueSlot.clear();
@@ -325,7 +325,7 @@ export function mountAshi(
       tui.requestRender();
       return;
     }
-    pendingUserBlockPrivacy.push(!!opts?.private);
+    pendingUserShell.push({ private: !!opts?.private });
     if (opts?.private) bus.emit("shell:user-exec-exclude-next", {});
     bus.emit("shell:pty-write", { data: line + "\n" });
   };
@@ -637,12 +637,11 @@ export function mountAshi(
   let activeUserShell: { pair: ToolPair; command: string; isPrivate: boolean } | null = null;
   bus.on("shell:command-start", ({ command }) => {
     if (agentShellActive) return;
-    // Defensive: bash DEBUG-trap integrations have been observed firing
-    // before any user input, with an empty command body.
-    if (!command.trim()) return;
+    const intent = pendingUserShell.consume();
+    if (!intent) return;
     finalizeThinking();
     if (activeAssistant) { activeAssistant.finalize(); activeAssistant = null; }
-    const isPrivate = pendingUserBlockPrivacy.shift() ?? false;
+    const isPrivate = intent.private;
     const name = isPrivate ? "user_bash_private" : "user_bash";
     const pair = renderToolPair({
       toolCallId: `user-shell-${Date.now()}`, name, title: name,
@@ -682,7 +681,7 @@ export function mountAshi(
     // Shell queue drains first so its output lands in the next turn's <shell_events>.
     while (queuedShellLines.length > 0) {
       const item = queuedShellLines.shift()!;
-      pendingUserBlockPrivacy.push(item.private);
+      pendingUserShell.push({ private: item.private });
       if (item.private) bus.emit("shell:user-exec-exclude-next", {});
       bus.emit("shell:pty-write", { data: item.line + "\n" });
     }

--- a/examples/extensions/ashi/src/user-shell-intents.ts
+++ b/examples/extensions/ashi/src/user-shell-intents.ts
@@ -1,0 +1,17 @@
+/** Pending intents for ashi-issued shell pty-writes. shell:command-start fires
+ *  for any OSC 9997 — orphans (bash DEBUG-trap noise) are dropped on consume. */
+export interface UserShellIntent {
+  private: boolean;
+}
+
+export class UserShellIntents {
+  private q: UserShellIntent[] = [];
+
+  push(intent: UserShellIntent): void {
+    this.q.push(intent);
+  }
+
+  consume(): UserShellIntent | null {
+    return this.q.shift() ?? null;
+  }
+}

--- a/examples/extensions/ashi/tests/user-shell-intents.test.ts
+++ b/examples/extensions/ashi/tests/user-shell-intents.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { UserShellIntents } from "../src/user-shell-intents.js";
+
+test("consume with no pending intent returns null — the phantom-OSC case", () => {
+  const intents = new UserShellIntents();
+  assert.equal(intents.consume(), null);
+});
+
+test("push then consume returns the pushed intent", () => {
+  const intents = new UserShellIntents();
+  intents.push({ private: false });
+  assert.deepEqual(intents.consume(), { private: false });
+});
+
+test("FIFO order is preserved across multiple pushes", () => {
+  const intents = new UserShellIntents();
+  intents.push({ private: false });
+  intents.push({ private: true });
+  intents.push({ private: false });
+  assert.deepEqual(intents.consume(), { private: false });
+  assert.deepEqual(intents.consume(), { private: true });
+  assert.deepEqual(intents.consume(), { private: false });
+});
+
+test("a single push only matches one command-start; the next is treated as phantom", () => {
+  const intents = new UserShellIntents();
+  intents.push({ private: false });
+  assert.notEqual(intents.consume(), null);
+  assert.equal(intents.consume(), null);
+});


### PR DESCRIPTION
## Summary

- `shell:command-start` fires on every OSC 9997 the kernel's `OutputParser` sees. Ashi was treating "not the agent" as equivalent to "the user", so any non-agent OSC 9997 — bash's DEBUG-trap firing for history-recall echoes, completion edge cases, etc. — rendered as a phantom \`user_bash\` card showing whatever text bash put in the body.
- Invert the trust: \`submitShell\` (and the post-turn drain) push an intent onto a small FIFO before each pty-write; the \`shell:command-start\` handler only renders \`user_bash\` if \`UserShellIntents.consume()\` returns a matching intent. Bash's OSC becomes confirmation, not authorization.
- The empty-body defensive guard added in #202 is subsumed by the intent check and removed. The bash latch from #202 stays — it keeps the OSC stream honest at the source and prevents a latent race where a phantom OSC sitting in the PTY buffer could consume a legitimate intent.

Kept the fix in ashi rather than promoting to the kernel since ashi is the only \`shell:command-start\` listener that infers user provenance; if a second frontend reinvents the same machinery we can promote then.

## Test plan

- [x] \`node --import tsx --test tests/*.test.ts\` in \`examples/extensions/ashi\` — 31/31 (4 new for the intent FIFO, including the regression: a single push only matches one start)
- [x] \`npm run build\` (root + ashi)