### PR TITLE
rolling-history: one-time migration from legacy ~/.agent-sh/history

### DIFF
--- a/src/agent/extensions/rolling-history/index.ts
+++ b/src/agent/extensions/rolling-history/index.ts
@@ -1,10 +1,14 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionContext } from "../../../shell/host-types.js";
 import type { AgentShMessage } from "../../llm-client.js";
 import { contentText, type ToolDefinition } from "../../types.js";
-import { SharedFileStore, type Store } from "../../store.js";
+import { SharedFileStore, newEntryId, type Store, type Entry } from "../../store.js";
+import { CONFIG_DIR, getSettings } from "../../../core/settings.js";
+import { deserializeEntry, isReadOnly } from "../../nuclear-form.js";
 import {
   activate as activateSummaryStrategy,
+  nuclearToEntry,
   readSummaryLines,
   type SummaryCtx,
 } from "./strategy.js";
@@ -19,12 +23,59 @@ const INSTRUCTION_TEXT =
   "If a search returns nothing useful, try: shorter queries, alternate terms, or browse to scan the full timeline. " +
   "Recall only covers this and recent sessions — for older context, also search the filesystem (grep, glob).";
 
+/** One-time migration: old ~/.agent-sh/history → rolling-history store. */
+export function migrateFromLegacy(
+  storeDir: string,
+  legacyPath: string,
+  ctx: Pick<ExtensionContext, "bus">,
+): void {
+  const sentinel = path.join(storeDir, ".migrated");
+  if (fs.existsSync(sentinel)) return;
+
+  const newFile = path.join(storeDir, "history.jsonl");
+  if (fs.existsSync(newFile) && fs.statSync(newFile).size > 0) {
+    try { fs.writeFileSync(sentinel, ""); } catch { /* ignore */ }
+    return;
+  }
+
+  if (!fs.existsSync(legacyPath)) {
+    try { fs.writeFileSync(sentinel, ""); } catch { /* ignore */ }
+    return;
+  }
+
+  let migrated = 0;
+  try {
+    const lines = fs.readFileSync(legacyPath, "utf-8").split("\n").filter(Boolean);
+    const entries: Entry[] = [];
+    for (const line of lines) {
+      const ne = deserializeEntry(line);
+      if (!ne) continue;
+      if (isReadOnly(ne)) continue;
+      entries.push(nuclearToEntry(ne, newEntryId()));
+    }
+    if (entries.length > 0) {
+      fs.writeFileSync(newFile, entries.map((e) => JSON.stringify(e) + "\n").join(""));
+      migrated = entries.length;
+    }
+  } catch {
+    return; // retry next start
+  }
+
+  try { fs.writeFileSync(sentinel, ""); } catch { /* ignore */ }
+  if (migrated > 0) {
+    ctx.bus.emit("ui:info", { message: `history: migrated ${migrated} entries from legacy ~/.agent-sh/history` });
+  }
+}
+
 export default function activate(ctx: ExtensionContext): void {
   const { maxBytes, prefetchEntries } = ctx.getExtensionSettings("rolling-history", {
     maxBytes: undefined as number | undefined,
     prefetchEntries: 50,
   });
   const storeDir = ctx.getStoragePath("rolling-history");
+  const settings = getSettings();
+  const legacyPath = settings.historyFilePath ?? path.join(CONFIG_DIR, "history");
+  migrateFromLegacy(storeDir, legacyPath, ctx);
   const summaryStore = new SharedFileStore({
     filePath: path.join(storeDir, "history.jsonl"),
     maxBytes,

--- a/src/agent/extensions/rolling-history/strategy.ts
+++ b/src/agent/extensions/rolling-history/strategy.ts
@@ -143,7 +143,7 @@ function nucleateFromMessage(m: AgentShMessage, iid: string): NuclearEntry | nul
   return null;
 }
 
-function nuclearToEntry(ne: NuclearEntry, id: string): Entry {
+export function nuclearToEntry(ne: NuclearEntry, id: string): Entry {
   const { seq: _seq, ts, kind, ...rest } = ne;
   return { id, ts, kind, payload: rest };
 }

--- a/tests/agent/extensions/rolling-history/migration.test.ts
+++ b/tests/agent/extensions/rolling-history/migration.test.ts
@@ -1,0 +1,156 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import EventEmitter from "node:events";
+
+import { migrateFromLegacy } from "../../../../src/agent/extensions/rolling-history/index.js";
+
+function makeNuclearLine(opts: {
+  seq: number;
+  ts?: number;
+  iid?: string;
+  kind?: string;
+  tool?: string;
+  sum?: string;
+  body?: string;
+}): string {
+  return JSON.stringify({
+    seq: opts.seq,
+    ts: opts.ts ?? Date.now(),
+    iid: opts.iid ?? "a1b2",
+    kind: opts.kind ?? "tool",
+    tool: opts.tool,
+    sum: opts.sum ?? "test entry",
+    body: opts.body,
+  });
+}
+
+function fakeBus(): { bus: EventEmitter } {
+  return { bus: new EventEmitter() };
+}
+
+test("migrates entries from legacy history file", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-migrate-"));
+  const storeDir = path.join(tmpDir, "rolling-history");
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  try {
+    const legacyPath = path.join(tmpDir, "history");
+    const entry1 = makeNuclearLine({ seq: 1, sum: "first entry", body: "body one" });
+    const entry2 = makeNuclearLine({ seq: 2, kind: "user", sum: 'user: "hello"' });
+    const entry3 = makeNuclearLine({ seq: 3, tool: "read_file", sum: "read_file foo.txt", body: "file contents" });
+    fs.writeFileSync(legacyPath, [entry1, entry2, entry3].join("\n") + "\n");
+
+    const historyFile = path.join(storeDir, "history.jsonl");
+    assert.ok(!fs.existsSync(historyFile), "new file should not exist before migration");
+
+    migrateFromLegacy(storeDir, legacyPath, fakeBus());
+
+    // New file should exist and contain 2 entries (read_file filtered out).
+    assert.ok(fs.existsSync(historyFile), "new file should exist after migration");
+    const lines = fs.readFileSync(historyFile, "utf-8").trim().split("\n");
+    assert.equal(lines.length, 2, "should have 2 entries (read-only tool filtered)");
+
+    // Verify entry shape.
+    const parsed0 = JSON.parse(lines[0]!);
+    assert.ok(typeof parsed0.id === "string" && parsed0.id.length === 8, "id should be 8-char hex");
+    assert.equal(typeof parsed0.ts, "number");
+    assert.equal(parsed0.kind, "tool");
+    assert.ok(typeof parsed0.payload === "object");
+    assert.equal(parsed0.payload.sum, "first entry");
+    assert.equal(parsed0.payload.body, "body one");
+
+    // Sentinel should exist.
+    assert.ok(fs.existsSync(path.join(storeDir, ".migrated")), "sentinel should be created");
+
+    // Legacy file untouched.
+    assert.ok(fs.existsSync(legacyPath), "legacy file should not be deleted");
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("skips migration when sentinel exists", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-sentinel-"));
+  const storeDir = path.join(tmpDir, "rolling-history");
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  try {
+    const legacyPath = path.join(tmpDir, "history");
+    fs.writeFileSync(legacyPath, makeNuclearLine({ seq: 1 }) + "\n");
+    fs.writeFileSync(path.join(storeDir, ".migrated"), "");
+
+    migrateFromLegacy(storeDir, legacyPath, fakeBus());
+
+    const historyFile = path.join(storeDir, "history.jsonl");
+    const size = fs.existsSync(historyFile) ? fs.statSync(historyFile).size : 0;
+    assert.equal(size, 0, "new file should be empty when sentinel blocked migration");
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("skips migration when legacy file doesn't exist", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-no-legacy-"));
+  const storeDir = path.join(tmpDir, "rolling-history");
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  try {
+    const legacyPath = path.join(tmpDir, "history"); // does not exist
+    migrateFromLegacy(storeDir, legacyPath, fakeBus());
+
+    assert.ok(fs.existsSync(path.join(storeDir, ".migrated")), "sentinel should be created even when no legacy file");
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("skips migration when new file already has content", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-new-content-"));
+  const storeDir = path.join(tmpDir, "rolling-history");
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  try {
+    const legacyPath = path.join(tmpDir, "history");
+    fs.writeFileSync(legacyPath, makeNuclearLine({ seq: 1 }) + "\n");
+
+    const historyFile = path.join(storeDir, "history.jsonl");
+    fs.writeFileSync(historyFile, "existing content\n");
+
+    migrateFromLegacy(storeDir, legacyPath, fakeBus());
+
+    const content = fs.readFileSync(historyFile, "utf-8");
+    assert.equal(content, "existing content\n", "new file should be untouched when it already has content");
+    assert.ok(fs.existsSync(path.join(storeDir, ".migrated")), "sentinel should be created");
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("survives malformed lines in the legacy file", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "rh-malform-"));
+  const storeDir = path.join(tmpDir, "rolling-history");
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  try {
+    const legacyPath = path.join(tmpDir, "history");
+    const lines = [
+      makeNuclearLine({ seq: 1, sum: "good entry" }),
+      "not valid json at all",
+      makeNuclearLine({ seq: 2, kind: "user", sum: 'user: "another good"' }),
+      '{ "seq": 3 }', // valid JSON but no "sum" field → deserializeEntry returns null
+    ];
+    fs.writeFileSync(legacyPath, lines.join("\n") + "\n");
+
+    migrateFromLegacy(storeDir, legacyPath, fakeBus());
+
+    const historyFile = path.join(storeDir, "history.jsonl");
+    const content = fs.readFileSync(historyFile, "utf-8").trim().split("\n");
+    assert.equal(content.length, 2, "only well-formed nuclear entries should be migrated");
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem
The rolling-history PR (#205) replaced the old `~/.agent-sh/history` file (NuclearEntry JSONL) with a new `~/.agent-sh/rolling-history/history.jsonl` (Entry JSONL with payload wrapping). The commit explicitly left the old history orphaned — users who upgraded lost access to all prior conversation records.

## Solution
One-time migration that runs on first activation of the rolling-history extension:

- Reads the legacy file (`~/.agent-sh/history` or custom `historyFilePath` setting)
- Converts each NuclearEntry → Entry via the existing `nuclearToEntry()` (reused from strategy.ts)
- Writes to `~/.agent-sh/rolling-history/history.jsonl`
- Touches `.migrated` sentinel so it never re-runs

Edge cases:
- Sentinel exists → skip
- No legacy file → skip + set sentinel
- New file already has content → skip + set sentinel (user started fresh)
- Malformed JSON in legacy file → skip those lines, migrate the rest
- Migration failure → don't set sentinel, retry next start
- Read-only tools filtered during migration (defense in depth)

## Changes
- `strategy.ts` — exported `nuclearToEntry` for reuse
- `index.ts` — added `migrateFromLegacy()` + call in `activate()`
- `migration.test.ts` — 5 tests covering all cases