### PR TITLE
examples: add ads extension; agent: add ollama, zai, opencode as built-in providers

### DIFF
--- a/examples/extensions/ads/SKILL.md
+++ b/examples/extensions/ads/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: ads
+description: >-
+  Full ADS query syntax reference and search strategy for the ads_search, ads_paper, ads_citations,
+  and ads_download_pdf tools. Load this before composing ADS queries — the tool descriptions only
+  cover basic field prefixes. Contains: fielded search syntax, date/class filters (entdate, arxiv_class),
+  citation operators, wildcards, positional search, properties, doctypes, daily arXiv listing patterns,
+  and query recipes.
+---
+
+# ADS Query Syntax & Search Strategy
+
+Reference: <https://ui.adsabs.harvard.edu/help/search/>
+
+## Query Basics
+
+- Space = AND, `OR`, `NOT` / `-` (exclude), `()` group, `"phrase"`
+- Precedence: `NOT` > `AND` > `OR` > implicit-AND > `-`
+
+## Fielded Search
+
+### Text Fields
+
+| Field | Syntax |
+|-------|--------|
+| Title+Abstract+Keywords | `abs:"phrase"` |
+| Title only | `title:"phrase"` |
+| Abstract only | `abstract:"phrase"` |
+| Keywords | `keyword:"phrase"` |
+| Full text (body+abs+title+ack+kw) | `full:"phrase"` |
+| Body only | `body:"phrase"` |
+| Acknowledgements | `ack:"phrase"` |
+
+### Author
+
+| Syntax | Meaning |
+|--------|---------|
+| `author:"Last, F"` | Greedy match (initials, variations) |
+| `author:"Last, First M"` | More precise (recommended) |
+| `author:"^Last, F"` | First-author only |
+| `=author:"Last, F"` | Exact match, no synonym expansion |
+
+Precision: `author:"murray, s"` (broadest) → `"murray, stephen"` → `"murray, stephen s"` (tightest)
+
+### Identifiers & Publication
+
+`bibcode:ID`, `doi:DOI`, `arXiv:ID`, `identifier:ID`, `bibstem:ApJ`, `volume:N`, `issue:N`, `page:N`, `year:YYYY` or `year:YYYY-YYYY`, `pubdate:[YYYY-MM TO YYYY-MM]`
+
+### Affiliation
+
+`aff:"phrase"` (raw), `inst:"Harvard U"` (curated, matches variants), `inst:"UCLA/IGPP"` (department), `aff_id:ID`
+
+### Object & Position
+
+`object:Andromeda` (SIMBAD+NED), `object:"(SMC OR LMC) AND M31"` (combined), cone search: `object:"RA Dec:radius"` (decimal deg or sexagesimal, default 2', max 60')
+
+### Classification & Counts
+
+`database:astronomy|physics|general`, `doctype:type`, `arxiv_class:"class"`, `property:flag`, `bibgroup:name`, `citation_count:[10 TO 100]`, `author_count:[10 TO 100]`, `read_count:N`, `facility:/regex/`, `orcid:ID`, `grant:agency`
+
+## Synonyms & Case Sensitivity
+
+- lowercase → matches variations + synonyms (e.g. `title:star` → star, stars, stellar…)
+- UPPERCASE → acronym-only (`title:STAR` → only "STAR")
+- `=field:` prefix → exact match, no synonym expansion
+
+## Wildcards & Proximity
+
+| Syntax | Meaning |
+|--------|---------|
+| `*` / `?` | Multi/single-char wildcard |
+| `NEAR[N]` | ≤N words apart, any order |
+| `"term1 term2"~N` | In-order proximity within N positions |
+| `/regex/` | Lucene regex on indexed tokens |
+
+## Positional Search — `pos(query, positions...)`
+
+Works on: `author`, `aff`, `title`. Examples: `pos(author:"Oort, J", 2)` (2nd author), `pos(author:"Oort", 1,3)` (1st–3rd), `pos(author:"Oort", -1)` (last), `pos(aff:"harvard", 1)` (1st author at Harvard)
+
+## Citation & Reference Operators
+
+`citations(query)` = papers citing query results, `references(query)` = papers cited by query results. Nestable with other terms.
+
+## Second-Order Operators
+
+`similar(query)` (textually similar), `trending(query)` (read by same readers), `useful(query)` (frequently cited by results), `reviews(query)` (citing papers ranked by freq), `topn(N, query, sort)`
+
+Tip: `similar()` excludes originals; use disjoint `entdate` ranges to control overlap.
+
+## Properties
+
+`refereed`, `notrefereed`, `article`, `nonarticle`, `openaccess`, `ads_openaccess`, `pub_openaccess`, `eprint_openaccess`, `author_openaccess`, `data`, `esource`, `inspire`, `toc`
+
+## Document Types
+
+`article`, `eprint`, `inproceedings`, `inbook`, `abstract`, `book`, `bookreview`, `catalog`, `circular`, `erratum`, `mastersthesis`, `newsletter`, `obituary`, `phdthesis`, `pressrelease`, `proceedings`, `proposal`, `software`, `talk`, `techreport`, `misc`
+
+## Bibliographic Groups
+
+Institutional: ARI, CfA, CFHT, Leiden, USNO | Telescope: ALMA, CXC, ESO, Gemini, Herschel, HST, ISO, IUE, JCMT, Keck, Magellan, NOIRLab, NRAO, ROSAT, SDO, SMA, Spitzer, Subaru, Swift, UKIRT, XMM
+
+## Daily arXiv Listings
+
+Use `entdate` (day-resolution) with `doctype:eprint` and `arxiv_class`. Note: `pubdate` is month-resolution only.
+
+```
+# Today's astro-ph.CO (±2 day window)
+arxiv_class:"astro-ph.CO" entdate:[2026-04-07 TO 2026-04-09] doctype:eprint
+
+# All astro-ph classes
+arxiv_class:("astro-ph.CO" OR "astro-ph.GA" OR "astro-ph.HE" OR "astro-ph.IM" OR "astro-ph.EP" OR "astro-ph.SR") entdate:[2026-04-07 TO 2026-04-09] doctype:eprint
+```
+
+Subclasses: `CO` (Cosmology), `EP` (Earth & Planetary), `GA` (Galaxy Astrophysics), `HE` (High Energy), `IM` (Instrumentation), `SR` (Solar & Stellar).
+
+## Search Strategy: Simplicity First
+
+- Start with 2–3 core nouns. If too many results, add constraints (year, author, title:). Don't start with a sentence.
+- ADS is keyword/metadata matching, not semantic search. Overloading queries kills recall.
+- Use `detail='full'` on fewer results rather than compact on many — abstracts often contain the answer.
+
+### Common Pitfalls
+
+**1. Compound multi-concept queries → zero results.**
+Fix: 1–2 core terms + `sort_by` + `year_from:`. Scan abstracts for specifics.
+```
+# Bad: "Population III He II helium 1640 JWST metal-poor galaxy candidate"
+# Good: "Population III JWST"  sort_by:date  year_from:2024
+```
+
+**2. Non-article doctypes polluting results.**
+Fix: `doctype:article` or `property:refereed`.
+
+**3. Iterative reformulation without simplifying.**
+If 2+ zero-result queries on the same topic: strip to 1–2 broadest terms, or use `web_search` first to find titles/authors, then look up in ADS.
+
+**4. Use `web_search` → ADS as a two-step pipeline.**
+For complex/emerging topics, start with `web_search` (plural `queries`, 2–4 varied angles) to identify key papers/arXiv IDs, then verify via `ads_paper` or targeted `ads_search`.
+
+### When Keyword Search Fails, Use Citation Networks
+
+For interdisciplinary connections, find a known paper then walk citations (`ads_citations`) or references. Citation chains beat keyword matching for cross-domain discovery.
+
+## Quick Query Recipes
+
+```
+# Recent refereed articles on a topic
+abs:"dark energy" year:2023-2025 property:refereed doctype:article
+
+# Papers by first author at an institution
+author:"^smith, john" inst:"MIT"
+
+# Highly-cited reviews
+reviews("machine learning astronomy") property:refereed
+
+# Papers citing a specific work, sorted by citations
+citations(bibcode:2023ApJ...950L..12A) sort:citation_count
+
+# Object in specific journal
+object:Andromeda bibstem:ApJ
+
+# Open access with data links
+property:openaccess property:data keyword:"gravitational waves"
+
+# Exclude preprints, keep only journal articles
+abs:"transiting exoplanet" doctype:article -arxiv_class:*
+
+# Cone search
+object:"12h30m49.4s +12d29m40s:5"
+```

--- a/examples/extensions/ads/index.ts
+++ b/examples/extensions/ads/index.ts
@@ -1,0 +1,699 @@
+/**
+ * ADS extension — NASA Astrophysics Data System tools for agent-sh.
+ *
+ * Provides four tools:
+ *   - ads_search:       Search ADS for papers
+ *   - ads_paper:        Fetch details of a specific paper by bibcode/DOI/arXiv ID
+ *   - ads_citations:    Find citing or referenced papers
+ *   - ads_download_pdf: Download paper PDFs
+ *
+ * Requires: ADS_API_TOKEN environment variable
+ *   Get one at https://ui.adsabs.harvard.edu/#user/settings/token
+ *
+ * Configuration (~/.agent-sh/settings.json):
+ *   {
+ *     "ads": { "pdfDownloadDir": "~/papers" }
+ *   }
+ */
+import type { AgentContext } from "agent-sh/types";
+import * as path from "path";
+import * as fs from "fs/promises";
+import { homedir } from "os";
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const ADS_SEARCH_API = "https://api.adsabs.harvard.edu/v1/search/query";
+const ADS_EXPORT_API = "https://api.adsabs.harvard.edu/v1/export";
+const ADS_LINK_GATEWAY = "https://ui.adsabs.harvard.edu/link_gateway";
+
+const SEARCH_FIELDS = [
+  "bibcode", "title", "author", "abstract", "pubdate", "year",
+  "citation_count", "read_count", "doi", "identifier", "pub",
+  "arxiv_class", "keyword", "database", "doctype", "aff",
+  "volume", "issue", "page", "bibstem",
+].join(",");
+
+const PDF_SOURCES = {
+  publisher: "PUB_PDF",
+  ads: "ADS_PDF",
+  arxiv: "EPRINT_PDF",
+} as const;
+
+type PDFSource = keyof typeof PDF_SOURCES;
+
+const PDF_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface ADSPaper {
+  bibcode: string;
+  title: string;
+  authors: string[];
+  affiliations: string[];
+  abstract: string;
+  pubdate: string;
+  year: string;
+  citationCount: number;
+  readCount: number;
+  doi: string[];
+  identifier: string[];
+  pub: string;
+  bibstem: string;
+  volume: string;
+  issue: string;
+  page: string;
+  arxivClass: string[];
+  keywords: string[];
+  database: string[];
+  doctype: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function parseDoc(doc: any): ADSPaper {
+  return {
+    bibcode: doc.bibcode ?? "",
+    title: Array.isArray(doc.title) ? doc.title.join(" ") : (doc.title ?? ""),
+    authors: Array.isArray(doc.author) ? doc.author : doc.author ? [doc.author] : [],
+    affiliations: Array.isArray(doc.aff) ? doc.aff : doc.aff ? [doc.aff] : [],
+    abstract: doc.abstract ?? "",
+    pubdate: doc.pubdate ?? "",
+    year: doc.year ?? "",
+    citationCount: doc.citation_count ?? 0,
+    readCount: doc.read_count ?? 0,
+    doi: Array.isArray(doc.doi) ? doc.doi : doc.doi ? [doc.doi] : [],
+    identifier: Array.isArray(doc.identifier) ? doc.identifier : doc.identifier ? [doc.identifier] : [],
+    pub: doc.pub ?? "",
+    bibstem: Array.isArray(doc.bibstem) ? doc.bibstem[0] ?? "" : (doc.bibstem ?? ""),
+    volume: doc.volume ?? "",
+    issue: doc.issue ?? "",
+    page: doc.page ?? "",
+    arxivClass: Array.isArray(doc.arxiv_class) ? doc.arxiv_class : doc.arxiv_class ? [doc.arxiv_class] : [],
+    keywords: Array.isArray(doc.keyword) ? doc.keyword : doc.keyword ? [doc.keyword] : [],
+    database: Array.isArray(doc.database) ? doc.database : doc.database ? [doc.database] : [],
+    doctype: doc.doctype ?? "",
+  };
+}
+
+function truncateAuthors(authors: string[], maxAuthors = 10): string {
+  if (authors.length <= maxAuthors) return authors.join("; ");
+  return `${authors.slice(0, maxAuthors).join("; ")}; ... +${authors.length - maxAuthors} more`;
+}
+
+function formatPaper(p: ADSPaper, index?: number): string {
+  const prefix = index !== undefined ? `[${index + 1}] ` : "";
+  const lines: string[] = [
+    `${prefix}${p.title}`,
+    `    Bibcode: ${p.bibcode}`,
+    `    Authors: ${truncateAuthors(p.authors)}`,
+    `    Published: ${p.pubdate}  Year: ${p.year}`,
+    `    Journal: ${p.pub}`,
+  ];
+  if (p.doi.length > 0) lines.push(`    DOI: ${p.doi.join(", ")}`);
+  if (p.arxivClass.length > 0) lines.push(`    arXiv: ${p.arxivClass.join(", ")}`);
+  if (p.keywords.length > 0) lines.push(`    Keywords: ${p.keywords.slice(0, 10).join(", ")}`);
+  lines.push(`    Citations: ${p.citationCount}  Reads: ${p.readCount}`);
+  lines.push(`    ADS URL: ${ADS_LINK_GATEWAY}/${p.bibcode}`);
+  if (p.abstract) lines.push(`    Abstract: ${p.abstract}`);
+  return lines.join("\n");
+}
+
+function formatPaperCompact(p: ADSPaper, index?: number): string {
+  const prefix = index !== undefined ? `[${index + 1}] ` : "";
+  const authorStr = p.authors.length > 0
+    ? p.authors.length === 1 ? p.authors[0] : `${p.authors[0]} et al.`
+    : "Unknown";
+  return `${prefix}${p.title}\n    ${p.bibcode} | ${authorStr} | ${p.year} | ${p.bibstem || p.pub} | ${p.citationCount} cit`;
+}
+
+function getToken(): string {
+  const token = process.env.ADS_API_TOKEN ?? "";
+  if (!token) {
+    throw new Error(
+      "ADS_API_TOKEN environment variable not set. " +
+      "Get a token from https://ui.adsabs.harvard.edu/#user/settings/token"
+    );
+  }
+  return token;
+}
+
+async function adsFetch(url: string, options?: RequestInit): Promise<any> {
+  const token = getToken();
+  const resp = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(options?.headers ?? {}),
+    },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`ADS API error: ${resp.status} ${resp.statusText}${body ? ` - ${body}` : ""}`);
+  }
+  return resp.json();
+}
+
+function buildIdQuery(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.startsWith("10.") || trimmed.startsWith("doi:")) {
+    return `doi:"${trimmed.replace(/^doi:/, "")}"`;
+  } else if (trimmed.toLowerCase().startsWith("arxiv:") || /^\d{4}\.\d{4,5}/.test(trimmed)) {
+    return `arxiv:"${trimmed.replace(/^arxiv:/i, "")}"`;
+  }
+  return `bibcode:${trimmed}`;
+}
+
+async function resolveBibcode(id: string): Promise<{ bibcode: string; title: string }> {
+  const query = buildIdQuery(id);
+  const url = `${ADS_SEARCH_API}?q=${encodeURIComponent(query)}&fl=bibcode,title&rows=1`;
+  const data = await adsFetch(url);
+  const docs: any[] = (data.response ?? data).docs ?? [];
+  if (docs.length === 0) throw new Error(`Paper not found: ${id}`);
+  return {
+    bibcode: docs[0].bibcode ?? "",
+    title: Array.isArray(docs[0].title) ? docs[0].title.join(" ") : (docs[0].title ?? ""),
+  };
+}
+
+function buildSortParam(sortBy: string): string {
+  const map: Record<string, string> = {
+    relevance: "score desc",
+    date: "date desc",
+    citation_count: "citation_count desc",
+    read_count: "read_count desc",
+  };
+  return map[sortBy] ?? "score desc";
+}
+
+function isBibcode(id: string): boolean {
+  return /^\d{4}.{15}$/.test(id);
+}
+
+function bibcodeToFilename(bibcode: string): string {
+  return bibcode.replace(/\./g, "_");
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function getPdfDownloadDir(): Promise<string> {
+  const settingsPath = path.join(homedir(), ".agent-sh", "settings.json");
+  try {
+    const raw = await fs.readFile(settingsPath, "utf8");
+    const settings = JSON.parse(raw);
+    const dir = settings?.ads?.pdfDownloadDir;
+    if (typeof dir === "string" && dir.length > 0) {
+      return dir.replace(/^~/, homedir());
+    }
+  } catch { /* settings may not exist */ }
+  // Default: ~/.agent-sh/papers
+  return path.join(homedir(), ".agent-sh", "papers");
+}
+
+async function fetchPDF(bibcode: string, sourceKey: PDFSource): Promise<ArrayBuffer> {
+  const url = `${ADS_LINK_GATEWAY}/${encodeURIComponent(bibcode)}/${PDF_SOURCES[sourceKey]}`;
+  const resp = await fetch(url, {
+    redirect: "follow",
+    headers: { "User-Agent": PDF_UA },
+  });
+
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} ${resp.statusText} from ${sourceKey} source`);
+  }
+
+  const contentType = resp.headers.get("content-type") ?? "";
+  if (contentType.includes("text/html")) {
+    const body = await resp.text();
+    if (body.includes("CAPTCHA")) {
+      throw new Error(`CAPTCHA detected from ${sourceKey} source. Try a different source.`);
+    }
+    throw new Error(`Expected PDF but got HTML from ${sourceKey} source. The paper may be behind a paywall. Try source='arxiv'.`);
+  }
+  if (!contentType.includes("application/pdf")) {
+    throw new Error(`Unexpected Content-Type '${contentType}' from ${sourceKey} source.`);
+  }
+
+  return resp.arrayBuffer();
+}
+
+// ── Extension entry point ────────────────────────────────────────────
+
+export default function activate(ctx: AgentContext): void {
+  // Register the ADS query syntax skill — grouped with our tools in the system prompt
+  const skillPath = path.join(
+    path.dirname(
+      import.meta.url.replace(/^file:\/\//, "").replace(/^\/\/\//, "/")
+    ),
+    "SKILL.md",
+  );
+  ctx.agent.registerSkill(
+    "ads",
+    "Full ADS query syntax reference and search strategy. Load before composing ADS queries — the tool descriptions only cover basic field prefixes.",
+    skillPath,
+  );
+
+  // ── ads_search ─────────────────────────────────────────────────────
+
+  ctx.agent.registerTool({
+    name: "ads_search",
+    displayName: "search",
+    description:
+      "Search astronomy/physics papers (ADS) — preferred over web_search for literature queries.\n" +
+      "Supports fielded syntax (title:, author:, year:, bibcode:, doi:), database filters, sort options.\n" +
+      "⚠️ Load the ads skill BEFORE using this tool for advanced syntax and search strategies.\n" +
+      "Requires ADS_API_TOKEN.",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            'Search query. Supports fielded searches like "title:exoplanets", ' +
+            '"author:\\"Hubble, E\\"", "keyword:dark matter", "year:2023". ' +
+            'Unfielded terms search all metadata. Use quotes for phrases, +/- for inclusion/exclusion.',
+        },
+        database: {
+          type: "string",
+          enum: ["astronomy", "physics", "general"],
+          description: "Filter by ADS database. Default: searches all databases.",
+        },
+        doctype: {
+          type: "string",
+          enum: ["article", "proceedings", "thesis", "book", "catalog", "software", "proposal"],
+          description: "Filter by document type.",
+        },
+        refereed: {
+          type: "boolean",
+          description: "Filter to only refereed (peer-reviewed) papers.",
+        },
+        year_from: {
+          type: "string",
+          description: "Start year for date range filter, e.g. '2020'.",
+        },
+        year_to: {
+          type: "string",
+          description: "End year for date range filter, e.g. '2024'.",
+        },
+        max_results: {
+          type: "number",
+          description: "Max papers to return (default 10, max 50).",
+        },
+        sort_by: {
+          type: "string",
+          enum: ["relevance", "date", "citation_count", "read_count"],
+          description: "Sort order (default: relevance).",
+        },
+        start: {
+          type: "number",
+          description: "Start index for pagination (default 0).",
+        },
+        detail: {
+          type: "string",
+          enum: ["compact", "full"],
+          description: "Output detail level. 'compact' (default): title, first author, year, bibcode, citations. 'full': includes abstract, all authors, keywords, DOI.",
+        },
+      },
+      required: ["query"],
+    },
+
+    async execute(args) {
+      const query = args.query as string;
+      const maxResults = Math.min((args.max_results as number) ?? 10, 50);
+      const start = (args.start as number) ?? 0;
+      const sort = buildSortParam((args.sort_by as string) ?? "relevance");
+      const detail = (args.detail as string) ?? "compact";
+
+      const fq: string[] = [];
+      if (args.database) fq.push(`database:${args.database}`);
+      if (args.doctype) fq.push(`doctype:${args.doctype}`);
+      if (args.refereed) fq.push("property:refereed");
+      if (args.year_from || args.year_to) {
+        fq.push(`year:[${args.year_from ?? "*"} TO ${args.year_to ?? "*"}]`);
+      }
+
+      const fqParam = fq.map(f => `&fq=${encodeURIComponent(f)}`).join("");
+      const url =
+        `${ADS_SEARCH_API}?q=${encodeURIComponent(query)}` +
+        `&fl=${SEARCH_FIELDS}&rows=${maxResults}&start=${start}` +
+        `&sort=${encodeURIComponent(sort)}${fqParam}`;
+
+      const data = await adsFetch(url);
+      const response = data.response ?? data;
+      const docs: any[] = response.docs ?? [];
+      const totalResults = response.numFound ?? 0;
+
+      if (docs.length === 0) {
+        return { content: `No papers found for query: ${query}`, exitCode: 0, isError: false };
+      }
+
+      const papers = docs.map(parseDoc);
+      const formatter = detail === "full" ? formatPaper : formatPaperCompact;
+      let text = `Found ${totalResults} papers (showing ${start + 1}-${start + papers.length}):\n`;
+      text += papers.map((p, i) => formatter(p, i)).join("\n\n");
+
+      const nextStart = start + papers.length;
+      if (nextStart < totalResults) {
+        text += `\n\n→ Use start=${nextStart} to see the next page of results.`;
+      }
+
+      return { content: text, exitCode: 0, isError: false };
+    },
+
+    getDisplayInfo(args) {
+      return { kind: "search" };
+    },
+
+    formatCall(args) {
+      const parts: string[] = [];
+      if (args.query) parts.push(String(args.query));
+      if (args.year_from || args.year_to) parts.push(`${args.year_from ?? "*"}–${args.year_to ?? "*"}`);
+      if (args.database) parts.push(`db:${args.database}`);
+      if (args.sort_by && args.sort_by !== "relevance") parts.push(`sort:${args.sort_by}`);
+      return parts.join("  ");
+    },
+  });
+
+  // ── ads_paper ──────────────────────────────────────────────────────
+
+  ctx.agent.registerTool({
+    name: "ads_paper",
+    displayName: "paper",
+    description:
+      "Fetch a paper's details from ADS by bibcode, DOI, or arXiv ID.\n" +
+      "Optional BibTeX return. ⚠️ Load the ads skill BEFORE using for field syntax help.\n" +
+      "Requires ADS_API_TOKEN.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description:
+            'Paper identifier: ADS bibcode (e.g. "2023ApJ...950L..12A"), ' +
+            'DOI (e.g. "10.3847/2041-8213/acb7e0"), or arXiv ID (e.g. "arXiv:2301.01234").',
+        },
+        bibtex: {
+          type: "boolean",
+          description: "Include BibTeX citation (default: false).",
+        },
+      },
+      required: ["id"],
+    },
+
+    async execute(args) {
+      const id = (args.id as string).trim();
+      const query = buildIdQuery(id);
+      const url = `${ADS_SEARCH_API}?q=${encodeURIComponent(query)}&fl=${SEARCH_FIELDS}&rows=1`;
+
+      const data = await adsFetch(url);
+      const docs: any[] = (data.response ?? data).docs ?? [];
+
+      if (docs.length === 0) {
+        return { content: `Paper not found: ${id}`, exitCode: 1, isError: true };
+      }
+
+      const paper = parseDoc(docs[0]);
+      let text = formatPaper(paper);
+
+      if (args.bibtex && paper.bibcode) {
+        try {
+          const exportData = await adsFetch(`${ADS_EXPORT_API}/bibtex`, {
+            method: "POST",
+            body: JSON.stringify({ bibcode: [paper.bibcode] }),
+          });
+          const bibtex = exportData.export ?? "";
+          if (bibtex) text += `\n\nBibTeX:\n${bibtex}`;
+        } catch {
+          text += "\n\n[Failed to fetch BibTeX]";
+        }
+      }
+
+      return { content: text, exitCode: 0, isError: false };
+    },
+
+    getDisplayInfo(args) {
+      return { kind: "read" };
+    },
+
+    formatCall(args) {
+      return String(args.id ?? "");
+    },
+  });
+
+  // ── ads_citations ──────────────────────────────────────────────────
+
+  ctx.agent.registerTool({
+    name: "ads_citations",
+    displayName: "citations",
+    description:
+      "List citations or references of an ADS bibcode.\n" +
+      "detail='compact'|'full'. ⚠️ Load the ads skill BEFORE using for syntax help.\n" +
+      "Requires ADS_API_TOKEN.",
+    input_schema: {
+      type: "object",
+      properties: {
+        bibcode: {
+          type: "string",
+          description: 'ADS bibcode of the paper, e.g. "2023ApJ...950L..12A".',
+        },
+        direction: {
+          type: "string",
+          enum: ["citations", "references"],
+          description: '"citations" = papers that cite this paper (default). "references" = papers this paper cites.',
+        },
+        max_results: {
+          type: "number",
+          description: "Max papers to return (default 10, max 50).",
+        },
+        sort_by: {
+          type: "string",
+          enum: ["date", "citation_count", "read_count"],
+          description: "Sort order (default: date).",
+        },
+        start: {
+          type: "number",
+          description: "Start index for pagination (default 0).",
+        },
+        detail: {
+          type: "string",
+          enum: ["compact", "full"],
+          description: "Output detail level. 'compact' (default) or 'full' with abstracts.",
+        },
+      },
+      required: ["bibcode"],
+    },
+
+    async execute(args) {
+      const bibcode = args.bibcode as string;
+      const direction = (args.direction as string) ?? "citations";
+      const maxResults = Math.min((args.max_results as number) ?? 10, 50);
+      const start = (args.start as number) ?? 0;
+      const sort = buildSortParam((args.sort_by as string) ?? "date");
+      const detail = (args.detail as string) ?? "compact";
+
+      const queryFunc = direction === "citations" ? "citations" : "references";
+      const query = `${queryFunc}(${bibcode})`;
+
+      const url =
+        `${ADS_SEARCH_API}?q=${encodeURIComponent(query)}` +
+        `&fl=${SEARCH_FIELDS}&rows=${maxResults}&start=${start}` +
+        `&sort=${encodeURIComponent(sort)}`;
+
+      const data = await adsFetch(url);
+      const response = data.response ?? data;
+      const docs: any[] = response.docs ?? [];
+      const totalResults = response.numFound ?? 0;
+
+      if (docs.length === 0) {
+        const label = direction === "citations" ? "citing" : "referenced by";
+        return { content: `No papers ${label} ${bibcode}`, exitCode: 0, isError: false };
+      }
+
+      const papers = docs.map(parseDoc);
+      const formatter = detail === "full" ? formatPaper : formatPaperCompact;
+      const dirLabel = direction === "citations" ? "citing papers" : "referenced papers";
+      let text = `Found ${totalResults} ${dirLabel} (showing ${start + 1}-${start + papers.length}):\n`;
+      text += papers.map((p, i) => formatter(p, i)).join("\n\n");
+
+      const nextStart = start + papers.length;
+      if (nextStart < totalResults) {
+        text += `\n\n→ Use start=${nextStart} to see the next page of results.`;
+      }
+
+      return { content: text, exitCode: 0, isError: false };
+    },
+
+    getDisplayInfo(args) {
+      return { kind: "search" };
+    },
+
+    formatCall(args) {
+      const dir = (args.direction as string) ?? "citations";
+      return `${args.bibcode} ${dir}`;
+    },
+  });
+
+  // ── ads_download_pdf ───────────────────────────────────────────────
+
+  ctx.agent.registerTool({
+    name: "ads_download_pdf",
+    displayName: "download",
+    description:
+      "Download a paper's PDF (bibcode/DOI/arXiv ID).\n" +
+      "Fallback: publisher → ADS → arXiv. ⚠️ Load the ads skill BEFORE using.\n" +
+      "Requires ADS_API_TOKEN.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description:
+            'Paper identifier: ADS bibcode (e.g. "2023ApJ...950L..12A"), ' +
+            'DOI (e.g. "10.3847/2041-8213/acb7e0"), or arXiv ID (e.g. "arXiv:2301.01234").',
+        },
+        output_path: {
+          type: "string",
+          description:
+            "File path to save the PDF. Defaults to ~/.agent-sh/papers/{bibcode}.pdf. " +
+            "If a directory path is given, saves as {dir}/{bibcode}.pdf.",
+        },
+        source: {
+          type: "string",
+          enum: ["auto", "publisher", "ads", "arxiv"],
+          description:
+            "Preferred PDF source. 'auto' (default) tries publisher → ADS → arXiv. " +
+            "'publisher' = PUB_PDF, 'ads' = ADS_PDF, 'arxiv' = EPRINT_PDF.",
+        },
+      },
+      required: ["id"],
+    },
+    modifiesFiles: true,
+
+    async execute(args) {
+      const sourceParam = (args.source as string) ?? "auto";
+      const trimmedId = (args.id as string).trim();
+      const idIsBibcode = isBibcode(trimmedId);
+      const downloadDir = await getPdfDownloadDir();
+
+      // Fast path: check if already downloaded (bibcode only)
+      if (!args.output_path && idIsBibcode) {
+        const candidatePath = downloadDir
+          ? path.join(downloadDir, `${bibcodeToFilename(trimmedId)}.pdf`)
+          : path.join(process.cwd(), `${bibcodeToFilename(trimmedId)}.pdf`);
+
+        try {
+          const stat = await fs.stat(candidatePath);
+          return {
+            content:
+              `PDF already exists: ${candidatePath}\n` +
+              `  Bibcode: ${trimmedId}\n` +
+              `  Size: ${formatFileSize(stat.size)}\n` +
+              `  Modified: ${stat.mtime.toISOString()}\n\n` +
+              `To re-download, delete the file first or specify a different output_path.`,
+            exitCode: 0,
+            isError: false,
+          };
+        } catch { /* not cached, continue */ }
+      }
+
+      // Resolve identifier to bibcode
+      let resolved: { bibcode: string; title: string };
+      try {
+        resolved = await resolveBibcode(args.id as string);
+      } catch {
+        return { content: `Paper not found: ${args.id}`, exitCode: 1, isError: true };
+      }
+
+      const { bibcode, title } = resolved;
+      const safeName = `${bibcodeToFilename(bibcode)}.pdf`;
+
+      let outputPath: string;
+      if (!args.output_path) {
+        outputPath = downloadDir
+          ? path.join(downloadDir, safeName)
+          : path.join(process.cwd(), safeName);
+      } else {
+        const op = args.output_path as string;
+        outputPath = (op.endsWith("/") || !path.extname(op))
+          ? path.join(op, safeName)
+          : op;
+      }
+
+      // Check if already exists (post-resolution)
+      try {
+        const stat = await fs.stat(outputPath);
+        return {
+          content:
+            `PDF already exists: ${outputPath}\n` +
+            `  Bibcode: ${bibcode}\n` +
+            `  Title: ${title}\n` +
+            `  Size: ${formatFileSize(stat.size)}\n` +
+            `  Modified: ${stat.mtime.toISOString()}\n\n` +
+            `To re-download, delete the file first or specify a different output_path.`,
+          exitCode: 0,
+          isError: false,
+        };
+      } catch { /* proceed with download */ }
+
+      // Try sources in order
+      const sourceOrder: PDFSource[] =
+        sourceParam === "auto"
+          ? ["publisher", "ads", "arxiv"]
+          : [sourceParam as PDFSource];
+
+      let pdfBuffer: ArrayBuffer | undefined;
+      let usedSource: PDFSource | undefined;
+      let lastError = "";
+
+      for (const src of sourceOrder) {
+        try {
+          pdfBuffer = await fetchPDF(bibcode, src);
+          usedSource = src;
+          break;
+        } catch (err: any) {
+          lastError = err.message ?? String(err);
+        }
+      }
+
+      if (!pdfBuffer || !usedSource) {
+        return {
+          content:
+            `Failed to download PDF for ${bibcode} (${title}).\n` +
+            `Tried sources: ${sourceOrder.join(" → ")}.\n` +
+            `Last error: ${lastError}\n\n` +
+            `Try downloading manually: ${ADS_LINK_GATEWAY}/${bibcode}/EPRINT_PDF`,
+          exitCode: 1,
+          isError: true,
+        };
+      }
+
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, Buffer.from(pdfBuffer));
+
+      const sourceLabel = { publisher: "publisher", ads: "ADS", arxiv: "arXiv" }[usedSource];
+      return {
+        content:
+          `Downloaded PDF for: ${title}\n` +
+          `  Bibcode: ${bibcode}\n` +
+          `  Source: ${sourceLabel}\n` +
+          `  Saved to: ${outputPath}\n` +
+          `  Size: ${formatFileSize(pdfBuffer.byteLength)}`,
+        exitCode: 0,
+        isError: false,
+      };
+    },
+
+    getDisplayInfo(args) {
+      return { kind: "write" };
+    },
+
+    formatCall(args) {
+      return String(args.id ?? "");
+    },
+  });
+}

--- a/examples/extensions/ads/index.ts
+++ b/examples/extensions/ads/index.ts
@@ -19,6 +19,7 @@ import type { AgentContext } from "agent-sh/types";
 import * as path from "path";
 import * as fs from "fs/promises";
 import { homedir } from "os";
+import { fileURLToPath } from "url";
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -246,12 +247,7 @@ async function fetchPDF(bibcode: string, sourceKey: PDFSource): Promise<ArrayBuf
 
 export default function activate(ctx: AgentContext): void {
   // Register the ADS query syntax skill — grouped with our tools in the system prompt
-  const skillPath = path.join(
-    path.dirname(
-      import.meta.url.replace(/^file:\/\//, "").replace(/^\/\/\//, "/")
-    ),
-    "SKILL.md",
-  );
+  const skillPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "SKILL.md");
   ctx.agent.registerSkill(
     "ads",
     "Full ADS query syntax reference and search strategy. Load before composing ADS queries — the tool descriptions only cover basic field prefixes.",
@@ -285,7 +281,7 @@ export default function activate(ctx: AgentContext): void {
         },
         doctype: {
           type: "string",
-          enum: ["article", "proceedings", "thesis", "book", "catalog", "software", "proposal"],
+          enum: ["article", "eprint", "inproceedings", "proceedings", "inbook", "book", "phdthesis", "mastersthesis", "catalog", "software", "proposal"],
           description: "Filter by document type.",
         },
         refereed: {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -26,6 +26,9 @@ import activateOpenrouter from "./providers/openrouter.js";
 import activateOpenai from "./providers/openai.js";
 import activateOpenaiCompatible from "./providers/openai-compatible.js";
 import activateDeepseek from "./providers/deepseek.js";
+import activateOllama from "./providers/ollama.js";
+import activateZaiCodingPlan from "./providers/zai-coding-plan.js";
+import activateOpencode from "./providers/opencode.js";
 import { findBash } from "../utils/executor.js";
 import { createBashTool } from "./tools/bash.js";
 import { createPwshTool } from "./tools/pwsh.js";
@@ -530,4 +533,7 @@ export function activateAgent(ctx: ExtensionContext): void {
   activateOpenai(agentCtx);
   if (process.env.OPENAI_BASE_URL) activateOpenaiCompatible(agentCtx);
   activateDeepseek(agentCtx);
+  activateOllama(agentCtx);
+  activateZaiCodingPlan(agentCtx);
+  activateOpencode(agentCtx);
 }

--- a/src/agent/providers/ollama.ts
+++ b/src/agent/providers/ollama.ts
@@ -20,6 +20,7 @@ export default function activate(ctx: AgentContext): void {
   const id = cloudKey ? "ollama-cloud" : "ollama";
 
   const sdkKey = cloudKey || "no-key";
+  const noAuth = !cloudKey;
   const baseURL = `${host}/v1`;
   const headers: Record<string, string> = {};
   if (cloudKey) headers.Authorization = `Bearer ${cloudKey}`;
@@ -31,7 +32,7 @@ export default function activate(ctx: AgentContext): void {
     },
   });
 
-  ctx.agent.providers.register({ id, apiKey: sdkKey, baseURL, models: [] });
+  ctx.agent.providers.register({ id, apiKey: sdkKey, baseURL, models: [], noAuth });
 
   fetchCatalog(host, headers).then((models) => {
     if (models.length === 0) return;
@@ -41,6 +42,7 @@ export default function activate(ctx: AgentContext): void {
       baseURL,
       defaultModel: models[0]!.id,
       models,
+      noAuth,
     });
   }).catch(() => {});
 }

--- a/src/agent/providers/ollama.ts
+++ b/src/agent/providers/ollama.ts
@@ -1,0 +1,90 @@
+/**
+ * Ollama provider — local daemon or Ollama Cloud.
+ *
+ * Cloud auth:  agent-sh auth login ollama-cloud
+ * Local host:  OLLAMA_HOST (default http://localhost:11434)
+ *
+ * Catalog comes from /api/tags; per-model context length is fetched
+ * from /api/show. Chat goes through the OpenAI-compatible /v1 shim.
+ */
+import type { AgentContext } from "../host-types.js";
+import { resolveApiKey } from "../../cli/auth/keys.js";
+
+const ECHO_REASONING_PATTERNS: RegExp[] = [/deepseek/i];
+
+export default function activate(ctx: AgentContext): void {
+  const cloudKey = resolveApiKey("ollama-cloud").key ?? process.env.OLLAMA_API_KEY;
+  const host = cloudKey
+    ? "https://ollama.com"
+    : (process.env.OLLAMA_HOST ?? "http://localhost:11434").replace(/\/$/, "");
+  const id = cloudKey ? "ollama-cloud" : "ollama";
+
+  const sdkKey = cloudKey || "no-key";
+  const baseURL = `${host}/v1`;
+  const headers: Record<string, string> = {};
+  if (cloudKey) headers.Authorization = `Bearer ${cloudKey}`;
+
+  ctx.agent.providers.configure(id, {
+    reasoningParams: (level) => {
+      if (level === "off") return { reasoning_effort: "none" };
+      return { reasoning_effort: level === "xhigh" ? "high" : level };
+    },
+  });
+
+  ctx.agent.providers.register({ id, apiKey: sdkKey, baseURL, models: [] });
+
+  fetchCatalog(host, headers).then((models) => {
+    if (models.length === 0) return;
+    ctx.agent.providers.register({
+      id,
+      apiKey: sdkKey,
+      baseURL,
+      defaultModel: models[0]!.id,
+      models,
+    });
+  }).catch(() => {});
+}
+
+async function fetchCatalog(
+  host: string,
+  headers: Record<string, string>,
+): Promise<{ id: string; contextWindow?: number; echoReasoning: boolean }[]> {
+  const tagsRes = await fetch(`${host}/api/tags`, { headers });
+  if (!tagsRes.ok) return [];
+  const tagsData = await tagsRes.json() as { models?: { name: string }[] };
+  const names = (tagsData.models ?? []).map((m) => m.name);
+  if (names.length === 0) return [];
+
+  const ctxs = await Promise.all(
+    names.map((name) => fetchContextLength(host, headers, name).catch(() => undefined)),
+  );
+  return names.map((name, i) => ({
+    id: name,
+    contextWindow: ctxs[i],
+    echoReasoning: ECHO_REASONING_PATTERNS.some((re) => re.test(name)),
+  }));
+}
+
+async function fetchContextLength(
+  host: string,
+  headers: Record<string, string>,
+  name: string,
+): Promise<number | undefined> {
+  const res = await fetch(`${host}/api/show`, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) return undefined;
+  const data = await res.json() as { model_info?: Record<string, unknown> };
+  const info = data.model_info ?? {};
+  const arch = info["general.architecture"] as string | undefined;
+  if (arch) {
+    const ctx = info[`${arch}.context_length`];
+    if (typeof ctx === "number") return ctx;
+  }
+  for (const [k, v] of Object.entries(info)) {
+    if (k.endsWith(".context_length") && typeof v === "number") return v;
+  }
+  return undefined;
+}

--- a/src/agent/providers/opencode.ts
+++ b/src/agent/providers/opencode.ts
@@ -1,0 +1,142 @@
+/**
+ * OpenCode Zen & Go providers — runtime model discovery via /models +
+ * models.dev metadata enrichment.
+ *
+ * Registers two providers:
+ *   - opencode     — Zen tier  (https://opencode.ai/zen/v1)
+ *   - opencode-go  — Go tier   (https://opencode.ai/zen/go/v1)
+ */
+import type { AgentContext } from "../host-types.js";
+import { resolveApiKey } from "../../cli/auth/keys.js";
+
+const ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+const GO_BASE_URL = "https://opencode.ai/zen/go/v1";
+const MODELS_DEV_ENDPOINT = "https://models.dev/api.json";
+
+const DEFAULT_CTX = 128_000;
+const DEFAULT_MAX_TOKENS = 16_384;
+
+const ZEN_FALLBACK = ["claude-sonnet-4-6"];
+const GO_FALLBACK = ["gpt-5.2"];
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface ModelsDevLimit { context?: number; output?: number; }
+interface ModelsDevEntry {
+  id?: string; name?: string; reasoning?: boolean;
+  limit?: ModelsDevLimit; modalities?: { input?: readonly string[] };
+}
+type ModelsDevResponse = Record<string, { models?: Record<string, ModelsDevEntry> }>;
+
+interface ModelDef {
+  id: string; reasoning: boolean; contextWindow: number;
+  maxTokens: number; modalities: ("text" | "image")[];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as T;
+}
+
+function findEntry(provider: ModelsDevResponse[string] | undefined, id: string): ModelsDevEntry | undefined {
+  const direct = provider?.models?.[id];
+  if (direct) return direct;
+  if (!provider?.models) return undefined;
+  return Object.values(provider.models).find((m) => m.id === id);
+}
+
+function resolveModel(id: string, meta: ModelsDevEntry | undefined): ModelDef {
+  const raw = meta?.modalities?.input;
+  const modalities: ("text" | "image")[] = Array.isArray(raw)
+    ? raw.filter((v): v is "text" | "image" => v === "text" || v === "image")
+    : ["text"];
+  return {
+    id,
+    reasoning: meta?.reasoning ?? false,
+    contextWindow: (typeof meta?.limit?.context === "number" && meta.limit.context > 0)
+      ? meta.limit.context : DEFAULT_CTX,
+    maxTokens: (typeof meta?.limit?.output === "number" && meta.limit.output > 0)
+      ? meta.limit.output : DEFAULT_MAX_TOKENS,
+    modalities,
+  };
+}
+
+function reasoningParams(level: string): Record<string, unknown> {
+  if (level === "off") return {};
+  return { reasoning_effort: level === "xhigh" ? "high" : level };
+}
+
+// ── Activation ───────────────────────────────────────────────────
+
+export default function activate(ctx: AgentContext): void {
+  const apiKey =
+    process.env.OPENCODE_API_KEY ??
+    resolveApiKey("opencode").key ?? undefined;
+
+  ctx.agent.providers.configure("opencode", { reasoningParams });
+  ctx.agent.providers.register({
+    id: "opencode", apiKey, baseURL: ZEN_BASE_URL,
+    defaultModel: ZEN_FALLBACK[0], models: ZEN_FALLBACK,
+    supportsReasoningEffort: true,
+  });
+
+  ctx.agent.providers.configure("opencode-go", { reasoningParams });
+  ctx.agent.providers.register({
+    id: "opencode-go", apiKey, baseURL: GO_BASE_URL,
+    defaultModel: GO_FALLBACK[0], models: GO_FALLBACK,
+    supportsReasoningEffort: true,
+  });
+
+  if (!apiKey) return;
+
+  fetchModelsDev()
+    .then(async (md) => {
+      const zenIds = await fetchModelIds(ZEN_BASE_URL);
+      const goIds = await fetchModelIds(GO_BASE_URL);
+
+      const resolve = (ids: string[], prov: ModelsDevResponse[string] | undefined, fb: string[]) =>
+        (ids.length > 0 ? ids : fb).map((id) => resolveModel(id, findEntry(prov, id)));
+
+      const zen = resolve(zenIds, md?.opencode, ZEN_FALLBACK);
+      const go = resolve(goIds, md?.["opencode-go"], GO_FALLBACK);
+
+      ctx.agent.providers.register({
+        id: "opencode", apiKey, baseURL: ZEN_BASE_URL,
+        defaultModel: zen[0]?.id ?? ZEN_FALLBACK[0], models: zen,
+        supportsReasoningEffort: true,
+      });
+      ctx.agent.providers.register({
+        id: "opencode-go", apiKey, baseURL: GO_BASE_URL,
+        defaultModel: go[0]?.id ?? GO_FALLBACK[0], models: go,
+        supportsReasoningEffort: true,
+      });
+    })
+    .catch(() => {});
+}
+
+async function fetchModelsDev(): Promise<ModelsDevResponse | undefined> {
+  try {
+    const payload = await fetchJson<ModelsDevResponse>(MODELS_DEV_ENDPOINT);
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+    return payload;
+  } catch { return undefined; }
+}
+
+async function fetchModelIds(baseURL: string): Promise<string[]> {
+  try {
+    const res = await fetch(`${baseURL}/models`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return [];
+    const payload = await res.json() as { data?: { id: string }[] };
+    if (!Array.isArray(payload.data)) return [];
+    return [...new Set(payload.data.map((e) => e.id).filter(Boolean))];
+  } catch { return []; }
+}

--- a/src/agent/providers/opencode.ts
+++ b/src/agent/providers/opencode.ts
@@ -68,7 +68,7 @@ function resolveModel(id: string, meta: ModelsDevEntry | undefined): ModelDef {
 }
 
 function reasoningParams(level: string): Record<string, unknown> {
-  if (level === "off") return {};
+  if (level === "off") return { reasoning_effort: "none" };
   return { reasoning_effort: level === "xhigh" ? "high" : level };
 }
 

--- a/src/agent/providers/zai-coding-plan.ts
+++ b/src/agent/providers/zai-coding-plan.ts
@@ -1,0 +1,33 @@
+/**
+ * Z.AI Coding Plan — Zhipu AI's subscription GLM models for coding.
+ */
+import type { AgentContext } from "../host-types.js";
+import { resolveApiKey } from "../../cli/auth/keys.js";
+
+const BASE_URL = "https://api.z.ai/api/coding/paas/v4";
+const ID = "zai-coding-plan";
+
+const DEFAULT_MODELS = [
+  { id: "glm-5.1",     reasoning: true, contextWindow: 200_000 },
+  { id: "glm-5-turbo", reasoning: true, contextWindow: 200_000 },
+  { id: "glm-4.7",     reasoning: true, contextWindow: 204_800 },
+  { id: "glm-4.5-air", reasoning: true, contextWindow: 131_072 },
+];
+
+function buildReasoningParams(level: string, _model?: string): Record<string, unknown> {
+  if (level === "off") return { thinking: { type: "disabled" } };
+  const effort = level === "xhigh" ? "high" : level;
+  return { thinking: { type: "enabled" }, reasoning_effort: effort };
+}
+
+export default function activate(ctx: AgentContext): void {
+  const { key } = resolveApiKey(ID);
+  ctx.agent.providers.configure(ID, { reasoningParams: buildReasoningParams });
+  ctx.agent.providers.register({
+    id: ID,
+    apiKey: key ?? process.env.ZAI_API_KEY ?? process.env.ZHIPU_API_KEY,
+    baseURL: BASE_URL,
+    defaultModel: DEFAULT_MODELS[0].id,
+    models: DEFAULT_MODELS,
+  });
+}


### PR DESCRIPTION
## ads extension (examples/extensions/ads/)
Copied from user extensions. Provides four tools for NASA ADS literature search with a bundled SKILL.md query reference.

## Built-in providers
Previously only available as user extensions — now auto-activate alongside openai, deepseek, etc.

- **ollama**: local daemon + Ollama Cloud, catalog discovery via /api/tags + /api/show
- **zai-coding-plan**: Zhipu AI's GLM coding models (glm-5.1, turbo, 4.7, 4.5-air)
- **opencode**: OpenCode Zen & Go tiers with models.dev metadata enrichment