### PR TITLE
Add Ctrl-Z suspend/resume to ashi

### DIFF
--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -969,6 +969,22 @@ export function mountAshi(
     void rebuildChat();
   };
 
+  const jobControl = process.platform !== "win32";
+  let suspended = false;
+  const resumeFromSuspend = (): void => {
+    if (!suspended) return;
+    suspended = false;
+    tui.start();
+    tui.requestRender(true);
+  };
+  const suspendToShell = (): void => {
+    if (suspended) return;
+    suspended = true;
+    tui.stop();
+    process.kill(process.pid, "SIGSTOP");
+  };
+  if (jobControl) process.on("SIGCONT", resumeFromSuspend);
+
   tui.addInputListener((data) => {
     if (isKeyRelease(data) || isKeyRepeat(data)) return;
     if (matchesKey(data, "escape")) {
@@ -1022,6 +1038,10 @@ export function mountAshi(
       ctx.quit();
       return { consume: true };
     }
+    if (jobControl && matchesKey(data, "ctrl+z")) {
+      suspendToShell();
+      return { consume: true };
+    }
     if (matchesKey(data, "ctrl+t")) {
       toggleThinking();
       return { consume: true };
@@ -1055,7 +1075,10 @@ export function mountAshi(
 
   return {
     tui,
-    stop: () => { tui.stop(); },
+    stop: () => {
+      process.off("SIGCONT", resumeFromSuspend);
+      tui.stop();
+    },
     openTreePicker,
     openSessionPicker,
     rebuildChat,


### PR DESCRIPTION
## What

Adds Ctrl-Z to suspend ashi back to the parent shell; `fg` resumes it where you left off.

## How

Raw mode delivers `^Z` as a byte (`0x1a`) rather than a terminal-generated `SIGTSTP`, so it's caught in the input listener — consumed ahead of the editor, so it can't be eaten as a forward-delete — and drives the stop explicitly:

- `suspendToShell()` calls `tui.stop()` (restores cursor, raw mode, bracketed paste, Kitty protocol), then raises `SIGSTOP`.
- A `SIGCONT` handler re-enters raw mode via `tui.start()` and forces a full redraw.

`SIGSTOP` is used rather than `SIGTSTP`: a self-raised `SIGTSTP` is silently discarded by the kernel for an orphaned process group, whereas `SIGSTOP` always stops. The parent shell's job control treats both identically (reports `Stopped`, resumes via `fg`/`SIGCONT`).

POSIX-only: Windows has no job control and `process.kill` would throw on the `SIGSTOP` signal name, so the binding is gated off there (Ctrl-Z falls through to the editor's forward-delete instead).

## Verification

Drove pi-tui's suspend/resume primitives with this exact logic inside a PTY harness and confirmed each link:

- startup enters raw mode + hides cursor;
- `^Z` restores the terminal (bracketed-paste off, cursor shown) and `waitpid(WUNTRACED)` reports `WIFSTOPPED` (signal 17 = `SIGSTOP`) — the same syscall a shell uses to detect a stopped job;
- `SIGCONT` resumes, re-enters raw mode, and redraws.

## Known limitation

Suspending mid-turn freezes the in-flight LLM stream. Short pauses survive via TCP backpressure; a long pause hits the provider's request/idle timeout and surfaces as a normal error line on resume (not corruption).