### PR TITLE
Add shell:host-write and wire terminal tools into ashi

### DIFF
--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -8,6 +8,7 @@ import { loadExtensions } from "agent-sh/extension-loader";
 import { activateAgent } from "agent-sh/agent";
 import { getSettings } from "agent-sh/settings";
 import { Shell } from "agent-sh/shell";
+import { TerminalBuffer } from "agent-sh/utils/terminal-buffer";
 import type { Terminal } from "agent-sh/shell/terminal";
 import activateShellContext from "agent-sh/shell/context";
 import type { AppConfig } from "agent-sh/types";
@@ -166,6 +167,17 @@ async function main(): Promise<void> {
     terminal: headlessTerminal(),
   });
   shellRef = shell;
+
+  let terminalBuffer: TerminalBuffer | null | undefined;
+  ctx.define("terminal-buffer", (): TerminalBuffer | null => {
+    if (terminalBuffer !== undefined) return terminalBuffer;
+    try {
+      terminalBuffer = TerminalBuffer.createWired(core.bus);
+    } catch {
+      terminalBuffer = null;
+    }
+    return terminalBuffer;
+  });
 
   const loaded = await loadExtensions(ctx, config.extensions);
   core.bus.emit("core:extensions-loaded", { names: loaded });

--- a/examples/extensions/terminal-buffer.ts
+++ b/examples/extensions/terminal-buffer.ts
@@ -206,7 +206,9 @@ export default function activate(ctx: ExtensionContext): void {
       "  - Doom/Spacemacs leader sequences (e.g. <SPC> f f) need timing — set inter_key_ms=50 " +
       "    or higher so the leader timer can resolve each chord.\n" +
       "  - For complex Emacs operations, prefer `emacsclient -e '(...)'` over typing keys.\n\n" +
-      "Always call terminal_read after sending keys to verify the result.",
+      "This tool snapshots the screen before sending, sends the keys, then returns the resulting " +
+      "screen plus a diff — no separate terminal_read is needed to see the effect. For multi-step " +
+      "interactions, send small sequences and check the returned screen between them.",
     input_schema: {
       type: "object",
       properties: {
@@ -272,7 +274,7 @@ export default function activate(ctx: ExtensionContext): void {
       const before = tb.readScreen();
 
       bus.emit("shell:stdout-show", {});
-      process.stdout.write("\n");
+      bus.emit("shell:host-write", { data: "\n" });
 
       for (let i = 0; i < chords.length; i++) {
         bus.emit("shell:pty-write", { data: chords[i] });

--- a/src/shell/events.ts
+++ b/src/shell/events.ts
@@ -21,6 +21,8 @@ declare module "../core/event-bus.js" {
     "shell:pty-write": { data: string };
     "shell:pty-resize": { cols: number; rows: number };
 
+    "shell:host-write": { data: string };
+
     "shell:buffer-request": Record<string, never>;
     "shell:buffer-snapshot": {
       text: string;

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -156,6 +156,10 @@ export class Shell implements InputContext {
       this.ptyProcess.resize(cols, rows);
     });
 
+    this.bus.on("shell:host-write", ({ data }) => {
+      this.terminal.write(data);
+    });
+
     // Compat shims for the bus-event API. shell:stdout-hold maps to hard
     // mute so terminal_keys' stdout-show can't paint through the overlay.
     let holdRefcount = 0;


### PR DESCRIPTION
## What

Lets the agent operate interactive programs (REPLs, `git rebase -i`, ssh prompts, `npm init`, vim, …) inside ashi's shell via the existing `terminal_read` / `terminal_keys` tools. Previously these couldn't run under ashi at all — the `terminal-buffer` provider wasn't registered, and `terminal_keys` wrote directly to `process.stdout`, which a TUI frontend owns.

This is the agent-facing, "tracked but not rendered" half of the interactive-terminal story: a headless `TerminalBuffer` mirrors the live PTY for on-demand reads, with no live renderer — so it sidesteps the async-parse render lag that blocked the buffer-as-renderer approach in #199.

## How

- **New `shell:host-write` bus event** (`src/shell/shell.ts`, `events.ts`) — routes text through the Shell's `terminal` abstraction instead of poking `process.stdout`. The CLI's `processTerminal` paints it to stdout (unchanged); a TUI frontend's headless terminal swallows it rather than corrupting its render loop. This is the primitive the extension was reaching around the abstraction to fake.
- **`terminal_keys` uses it** for its pre-keystroke separator, instead of `process.stdout.write("\n")` — the one write that would have corrupted ashi's frame.
- **ashi registers the `terminal-buffer` provider** (`examples/extensions/ashi/src/cli.ts`), before `loadExtensions` so the tools resolve it at activate time. ashi's headless `Shell` already emits `shell:pty-data`, so a wired `TerminalBuffer` tracks the live PTY. Resilient if `@xterm` is ever absent (tools disable cleanly).
- **`terminal_keys` description** reframed to state its read-before / return-after contract: it snapshots, sends, then returns the resulting screen + diff, so no separate `terminal_read` is needed for the result.

## Verification

Drove the **real** `Shell` + **real** `terminal-buffer` extension against a headless terminal (ashi's exact setup) inside a PTY:

- `terminal_read` returns a screen ✓
- `terminal_keys` reaches the live PTY (`echo` ran) and returns the after-screen ✓
- `shell:host-write` routed to the headless terminal ✓
- **zero stray writes to `process.stdout`** ✓

All shell tests pass, including the existing "Shell routes PTY output to `terminal.write`, never to `process.stdout`" invariant, which `host-write` upholds.

## Notes / scope

- **Opt-in**: the provider makes `ashi -e terminal-buffer` work; the tools aren't on by default. Auto-loading is a possible follow-up.
- **Multi-writer arbitration deferred**: agent tool calls are sequential, so `terminal_keys` can't race the agent's own exec tool, and the stale-foreground hazard is covered by the read-before/return-after contract. The only remaining race is the user typing in shell mode during an agent `terminal_keys` — rare and racy by nature; left for a follow-up rather than building a lock for an edge case.
- **Not verified end-to-end**: a full `ashi -e terminal-buffer` launch needs a backend + TTY, so the mechanism was verified via the harness above rather than a live ashi boot.

Relates to #199 (the buffer-as-live-renderer overlay), which this complements without the rendering path.