### PR TITLE
Docs: reframe around the composable agent runtime + fix staleness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # agent-sh
 
-A real shell with an AI agent one keystroke away.
+A composable agent runtime — pair any frontend with any agent backend, over one shared extension layer.
 
 [![npm version](https://img.shields.io/npm/v/agent-sh.svg)](https://www.npmjs.com/package/agent-sh)
 [![license](https://img.shields.io/npm/l/agent-sh.svg)](https://github.com/guanyilun/agent-sh/blob/main/LICENSE)
 
+## Three example apps built on agent-sh
+
+agent-sh is small at its core and does its real work through extensions, so the same runtime drives very different apps. Three to start with — all sharing the same agent backends, tools, providers, and `~/.agent-sh/settings.json`:
+
+### 1. A shell with the agent one keystroke away — bundled with agent-sh
+
+A normal shell on top of node-pty — your rc config, your aliases, vim and tmux all just work. But at the start of any line, type `>` and you're talking to a small agent that already sees your cwd, your last command, and its output. Nothing to set up, no project to explain.
+
 ![demo](assets/demo.gif)
-
-I live in my terminal. A lot of the time I'm not coding — I'm deploying something, poking at a failing `rsync`, figuring out why `docker build` won't start, fixing a one-liner. And very often I need an AI agent to help. Spinning up a full coding agent for this stuff is overkill, and I got tired of copy-pasting errors into a chat window every time.
-
-So I built agent-sh. Under the hood it's a normal shell on top of node-pty — your rc config, your aliases, vim and tmux all just work. But at the start of any line, type `>` and you're talking to a small agent that already sees your cwd, your last command, and its output. Nothing to set up, no project to explain.
 
 ```
 ~ $ ls -la                       # real shell command
@@ -19,7 +23,32 @@ So I built agent-sh. Under the hood it's a normal shell on top of node-pty — y
 ~ $ > draft a commit message     # agent reads your diff and shell history
 ```
 
-agent-sh is built to be agent-agnostic. The recommended path is the built-in agent `ash` — a lightweight agent designed so extensions can plug into the same tool surface. If you'd rather host an existing coding agent (pi, claude-code, opencode), you can [bring your own](#bring-your-own-agent) — with the trade-off that it manages its own separate tools.
+```bash
+npm install -g agent-sh
+```
+
+[Quick Start ↓](#quick-start)
+
+### 2. ashi — a standalone coding agent
+
+[**`@guanyilun/ashi`**](examples/extensions/ashi/) is the same `ash` agent in a chat-style TUI, with no shell underneath — just the agent. Installed separately, it reuses agent-sh's backend, tools, slash commands, providers, and skills, and adds session history, in-session branching, and LLM-driven compaction.
+
+```bash
+npm install -g @guanyilun/ashi
+ashi
+```
+
+### 3. asHub — a GUI coding agent
+
+[**firslov/asHub**](https://github.com/firslov/asHub) is a third-party cross-platform desktop app (Electron) built on the agent-sh runtime: a multi-session sidebar, persistence across restarts, and a live-streaming interface with Markdown, syntax-highlighted code, diffs, and tool-call rendering. macOS / Windows / Linux.
+
+## How it works
+
+agent-sh is a **composable agent runtime**. At its center is a pure kernel — a typed event bus, a named-handler registry, and an extension loader — that knows nothing about terminals, LLMs, shells, or rendering. Everything else plugs into it: the agent backend, its tools, provider management, and the frontend that drives it.
+
+The frontend and the agent backend are both just components on the bus, so you **mix and match** them freely — wire several frontends to one backend, or keep one frontend and swap the backend underneath — all sharing the **same extension layer** of tools, content transforms, slash commands, and themes. `import { createCore } from "agent-sh"` gives you the headless kernel; load the pieces you want and wire your own I/O.
+
+For the kernel design in full — the bus, handlers, the compositor, and the shell ↔ agent boundary — see [Architecture](docs/architecture.md). To embed the runtime in your own frontend, see the [Library Guide](docs/library.md). The rest of this README covers the bundled shell.
 
 ## Quick Start
 
@@ -141,6 +170,8 @@ All three bridges receive agent-sh's per-query shell context (`<shell_events>`) 
 
 ## Key Features
 
+**Pure kernel, everything is an extension.** `createCore()` is a frontend-agnostic runtime — event bus, handler registry, compositor, backend coordinator, and nothing else. The agent, its tools, provider management, shell tracking, and the TUI renderer all load as extensions through one public API. Even the built-in agent can be disabled.
+
 **Real terminal, zero compromise.** Full PTY with your shell config, aliases, and environment. Shell starts instantly — the agent connects asynchronously in the background.
 
 **One entry point, smart tool selection.** Type `>` and agent-sh figures out how to help. Scratchpad tools (`bash`, `read_file`, `grep`, `glob`) for investigation. Extensions add capabilities like running commands in your live shell. No modes to pick — the agent reasons about which tools to use based on your intent.
@@ -151,7 +182,7 @@ All three bridges receive agent-sh's per-query shell context (`<shell_events>`) 
 
 **Extensible by design.** The entire system is built on a typed event bus. Extensions can add custom input modes, content transforms (render LaTeX as images, Mermaid as diagrams), themes, slash commands, or replace the agent backend entirely. The built-in TUI renderer is itself just an extension.
 
-**Embeddable as a library.** The core is a headless kernel — `import { createCore } from "agent-sh"` to build WebSocket servers, REST APIs, Electron apps, or test harnesses. No terminal required.
+**Embeddable as a library.** The core is a headless kernel — `import { createCore } from "agent-sh"` to build WebSocket servers, REST APIs, Electron apps, alternate TUIs, or test harnesses. No terminal required. [ashi](examples/extensions/ashi/) and [asHub](https://github.com/firslov/asHub) are exactly this.
 
 ## Documentation
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -238,7 +238,7 @@ The agent retries transient failures with exponential backoff:
 
 The agent supports configurable thinking/reasoning levels for models that support `reasoning_effort`:
 
-- Levels: `off` (default), `low`, `medium`, `high`
+- Levels: `off` (default), `low`, `medium`, `high`, `xhigh` (`xhigh` falls back to `high` on providers that don't support it)
 - Set via the `config:set-thinking` event (wired to `/thinking` slash command)
 - Query current state via `config:get-thinking` pipe
 - The agent validates that the current model/provider supports reasoning before enabling

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -35,7 +35,7 @@ Every query draws on two distinct streams of context:
 The two streams don't overlap: agent tool outputs live only in the conversation, and shell context tracks only user-initiated activity. When either stream grows large, ash has escape hatches rather than silent truncation:
 
 - **Long shell outputs** are spilled to tempfiles (`<tmpdir>/agent-sh-<pid>/<id>.out`) at capture time. The LLM sees a head+tail stub with the path and recovers the full output via plain `read_file`.
-- **Older conversation turns** are nucleated into one-line summaries and appended to `~/.agent-sh/history` — a persistent, cross-session archive. The `conversation_recall` tool browses, searches, and expands entries from both the in-session archive and the history file.
+- **Older conversation turns** are compacted by the built-in `rolling-history` extension: each is nucleated into a one-line summary in a persistent store (`~/.agent-sh/rolling-history/history.jsonl`), with the full message kept in an ephemeral per-session cache. The `conversation_recall` tool browses, searches, and expands those entries.
 
 Compaction is pluggable: the `conversation:compact` handler is advisable, so extensions can install richer strategies without changing the recall surface. See [Context Management](context-management.md) for the full design.
 
@@ -182,7 +182,9 @@ Extensions can add tools that cross the shell↔agent boundary via `shell:exec-r
 | `glob` | Find files by name pattern | No |
 | `ls` | List directory contents (with timestamps and sizes) | No |
 | `list_skills` | List available skills (name, description, path) | No |
-| `conversation_recall` | Browse/search/expand evicted turns from the in-session archive and `~/.agent-sh/history` | No |
+| `conversation_recall`\* | Browse/search/expand evicted conversation turns from the rolling-history store | No |
+
+\* `conversation_recall` is not a core tool — it's registered by the built-in `rolling-history` extension, so it's absent under headless/bridge backends. Every other row is a core tool registered by `activateAgent(ctx)`.
 
 **Common pattern**: all file-based tools resolve relative paths from the current working directory, looked up via the `cwd` handler (`ctx.call("cwd")`). The shell-context built-in advises this with the PTY-tracked cwd; without it, tools fall back to `process.cwd()`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,8 +150,9 @@ agent-sh/
 │   │   ├── providers/        # openai, openrouter, deepseek, openai-compatible
 │   │   ├── token-budget.ts   # Shared constants (RESPONSE_RESERVE, DEFAULT_CONTEXT_WINDOW)
 │   │   ├── tool-registry.ts, tool-protocol.ts
-│   │   ├── conversation-state.ts  # Messages + eager nucleation + priority compaction + recall
-│   │   ├── nuclear-form.ts, history-file.ts, system-prompt.ts
+│   │   ├── live-view.ts       # In-memory messages array + compaction + recall archive
+│   │   ├── store.ts, session-store.ts  # Append-only entry store; session/message persistence
+│   │   ├── nuclear-form.ts, system-prompt.ts
 │   │   ├── skills.ts, subagent.ts
 │   │   └── tools/            # Built-in tool implementations (bash, read/write/edit, grep, glob, ls, ...)
 │   │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-agent-sh is a shell with a pluggable AI backend. The shell is the product — the agent is a bus-driven component that self-wires to events.
+agent-sh is a composable agent runtime: a pure kernel that any frontend can drive and any agent backend can plug into, over one shared extension layer. Frontends and backends are both bus-driven components that self-wire to events — the bundled shell is just one frontend among several.
 
 ## Design Philosophy: Pure Kernel + Everything Is an Extension
 

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -28,7 +28,7 @@ Captured and owned by the `shell-context` built-in (`src/shell/shell-context.ts`
 
 Agent tool outputs are **not** here — those live in the conversation stream. The boundary is strict: if the user typed it at the PTY, it goes into shell context; if the agent called a tool, it goes into the conversation.
 
-Frontends without a PTY (e.g. agent-sh-hub) simply don't load this extension — the agent runs cwd-aware via the default `cwd` handler (`process.cwd()`) and no `<cwd>` / `<shell_events>` envelope is emitted.
+Frontends without a PTY (e.g. ashi, asHub) simply don't load this extension — the agent runs cwd-aware via the default `cwd` handler (`process.cwd()`) and no `<cwd>` / `<shell_events>` envelope is emitted.
 
 ### Conversation — "what has the agent been working on?"
 

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -32,7 +32,7 @@ Frontends without a PTY (e.g. ashi, asHub) simply don't load this extension — 
 
 ### Conversation — "what has the agent been working on?"
 
-Owned by `ConversationState`. This is the OpenAI-shaped messages array (`user` / `assistant` / `tool`) the LLM actually sees. Contains:
+Owned by `LiveView` (`src/agent/live-view.ts`). This is the OpenAI-shaped messages array (`user` / `assistant` / `tool`) the LLM actually sees. Contains:
 
 - User messages (queries the user sent to the agent)
 - Assistant messages (the LLM's replies)
@@ -44,7 +44,7 @@ The two streams merge at one point: when the user submits a new query, the curre
 
 Each exchange (a shell command + output) gets a sequential `id` as it's captured. The shell-context extension keeps an internal `lastSeq` cursor — the highest id it has already sent to the model.
 
-Shell context is registered as a per-query context producer (`ctx.agent.registerContextProducer("shell-context", …, { mode: "per-query" })`):
+Shell context contributes to the per-query `query-context:build` handler (the `shell-context` extension advises it directly; extensions can equivalently use `ctx.agent.registerContextProducer(name, fn, { mode: "per-query" })`):
 
 1. The producer always emits `<cwd>...</cwd>` with the live PTY-tracked cwd, so every user message anchors where the agent is right now (immune to compaction confusion over historical cwds).
 2. If there are exchanges with id > `lastSeq`, it appends `<shell_events>...</shell_events>` with the deltas; the cursor then advances to the new high-water mark.
@@ -75,43 +75,43 @@ The session directory is removed on process exit (including `SIGINT` / `SIGTERM`
 
 ## Conversation compaction
 
-Unlike shell context — which is a per-query delta and stays small — the conversation grows every turn. Without an active strategy it would eventually blow past the model's window. agent-sh uses a three-tier scheme designed to feel like shell history.
+Unlike shell context — which is a per-query delta and stays small — the conversation grows every turn. Without an active strategy it would eventually blow past the model's window. The kernel owns the *trigger*; the **built-in `rolling-history` extension** owns the *strategy* and the *store*. The result is a three-tier scheme designed to feel like shell history. (Headless or bridge backends that don't load the extension keep the live array and the kernel trigger, but have no summary store, recall, or cross-restart history.)
 
-### Tier 1 — eager nucleation
+### Tier 1 — eager capture
 
-As soon as any message is added to the conversation, it's *nucleated*: a one-line summary is computed immediately (via the advisable `conversation:nucleate-{user,agent,tool}` handlers) and appended to `~/.agent-sh/history` through the `history:append` handler.
+Every time a message is appended to the conversation, the kernel emits a `conversation:message-appended` event. The rolling-history extension listens and, for each message:
 
-#### The history file on disk
+1. Nucleates it into a one-line summary (`nucleate()` in `src/agent/nuclear-form.ts`) and appends that as a persisted `Entry` to its summary **Store**.
+2. Appends an *ephemeral* `recall-cache` child entry holding the full message, so the verbatim text stays expandable for the rest of the process without ever being written to disk.
+3. Links the live message back to its entry id (`conversation:link`, which stamps `meta.entryId`), so a later compaction won't re-summarize it.
 
-`~/.agent-sh/history` is a JSONL log — one serialized `NuclearEntry` per line, with fields like `seq`, `iid` (instance id), `role`, `sum` (one-line summary), and optional `body` (full content, roughly 4000 chars max). Each running agent-sh instance gets a random two-byte instance id that tags its entries for provenance.
+Read-only tool results (`read_file`, `grep`, `glob`, `ls`) are filtered out of the persisted summaries — the agent can just re-run those tools.
 
-- **Concurrency-safe.** Each line is short enough that POSIX `O_APPEND` writes are atomic, so multiple agent-sh instances can share one file without a lock. Only truncation (which rewrites the whole file) takes a lock — `~/.agent-sh/history.lock` via `O_EXCL`, with a 10-second stale-lock timeout to recover from crashes.
-- **Read-only tool results are filtered at write time.** Entries tagged read-only (`read_file`, `grep`, `glob`, `ls`) never touch disk — the agent can re-run those tools if needed. The reader applies the same filter defensively.
-- **Front-truncation.** After each append, the file is checked against `historyMaxBytes` (default 100MB). If it's 150%+ over the limit, the oldest lines are dropped and the remainder rewritten atomically via a temp-file + `rename`. The 150% overshoot prevents frequent rewrites.
-- **Reverse-chunked reads.** Search, `readRecent`, and `findBySeq` stream the file backward in 1MB chunks, stitching lines across chunk boundaries at the byte level so UTF-8 codepoints never split. Search caps at a 20MB scan budget to bound cost on large files.
+#### The summary store on disk
 
-The `history:*` handlers (`append`, `search`, `find-by-seq`, `read-recent`) are all advisable, so extensions can swap the backend (e.g. SQLite, remote store) without changing nucleation.
+The store (`SharedFileStore` in `src/agent/store.ts`) is an append-only JSONL log at `~/.agent-sh/rolling-history/history.jsonl` (`~/.agent-sh` is the config dir, overridable via `AGENT_SH_HOME`). One serialized `Entry` per line — `{ id, parentId?, ts, kind, payload }`, where a summary's payload carries `sum` (the one-liner), optional `body` (full content, capped per kind), and `iid` (the writing instance's id).
+
+- **Concurrency-safe.** Lines are short enough that POSIX `O_APPEND` writes are atomic, so multiple agent-sh instances can share one file without a lock. Only front-truncation (which rewrites the file) takes a lock — `history.jsonl.lock` via `O_EXCL`, with a 10-second stale-lock timeout to recover from crashes.
+- **Ephemeral entries never touch disk.** The `recall-cache` full-body entries are appended with `{ ephemeral: true }`, a no-op on the file store — they live only in the current process.
+- **Front-truncation.** After each append, the file is checked against the extension's `maxBytes` (default 50MB). Past 150% of the cap, the oldest lines are dropped and the rest rewritten atomically via temp-file + `rename`; the overshoot avoids frequent rewrites.
+- **Reverse-chunked reads.** `readRecent`, `findById`, and `search` stream the file backward in 1MB chunks, stitching lines across boundaries at the byte level so UTF-8 codepoints never split. Search caps at a 20MB scan budget to bound cost on large files.
+
+The store sits behind a generic `Store` interface (`append` / `findById` / `readRecent` / `search`), so an extension can swap in a different backend (SQLite, remote service) without changing capture or recall.
 
 ### Tier 2 — active context
 
-The in-memory conversation holds three things at once:
-
-- Full messages for each live turn (verbatim)
-- A rolling in-context "nuclear block" (the one-liners) that gives the agent high-level orientation
-- An in-memory recall archive keyed by sequence id, so evicted content stays searchable within the session
+The live `LiveView` array holds full messages for every turn the LLM currently sees. Alongside it, the rolling-history extension keeps two id-keyed views: the summary Store (one-liners, persisted) and the per-process `recall-cache` (full bodies, ephemeral). So once a turn is evicted from the live array, its summary stays browsable and its full text stays expandable for the rest of the session.
 
 ### Tier 3 — compaction
 
-The kernel watches estimated prompt size against `autoCompactThreshold × (contextWindow − responseReserve)`. When that threshold is crossed (or `/compact` is invoked explicitly, or the API returns a context-overflow error), it fires the `conversation:compact` handler.
+The kernel watches estimated prompt size against `autoCompactThreshold × (contextWindow − RESPONSE_RESERVE)` (default threshold `0.5`). When it's crossed (or `/compact` is invoked, or the API returns a context-overflow error), the kernel calls the advisable `conversation:compact` handler with a token target. The rolling-history extension's advisor implements the strategy:
 
-Built-in strategy:
+1. Parse the live array into turns (a turn starts at each user message).
+2. Pin the first turn and the most recent turns — the newest kept verbatim, a band just behind it "slimmed" (read-only tool calls dropped, long tool/assistant bodies trimmed).
+3. Score the remaining middle turns by *priority × recency* (user messages and errors rank highest; large read-only tool results lowest) and evict lowest-first until the estimate is under target.
+4. Replace the evicted span in place with one synthetic block — `[Conversation history — use conversation_recall to expand any entry]` — built from the recent summary lines, topping up summaries for any messages that missed eager capture.
 
-1. Keep the first turn verbatim (earliest user intent usually matters)
-2. Keep the last `keepRecent` turns verbatim (the live focus)
-3. Score the remaining middle turns by *priority × recency* and evict lowest-priority first
-4. Evicted turns collapse in place to their one-line nuclear summaries
-
-On startup, the most recent `historyStartupEntries` entries from `~/.agent-sh/history` are injected as a `[Prior session history]` preamble — so context carries across restarts the way shell history does.
+On startup, if `prefetchEntries > 0` (default 50) the extension reads the most recent summary lines from the Store and injects them as a `[Prior session history]` message — so context carries across restarts the way shell history does.
 
 ### Token accounting
 
@@ -126,7 +126,7 @@ People often conflate shell output truncation and conversation compaction. They'
 | **Stream** | Shell context (`<shell_events>` deltas) | Conversation messages array |
 | **When** | Once, at the moment each exchange is captured | On threshold crossing, `/compact`, or overflow retry |
 | **State change** | Permanent: `ex.output` becomes head+tail+path | Permanent: evicted turns collapse to one-liners |
-| **Full-text location** | Tempfile on disk | In-memory archive + `~/.agent-sh/history` |
+| **Full-text location** | Tempfile on disk | Ephemeral recall cache + summary store (`~/.agent-sh/rolling-history/history.jsonl`) |
 | **Recovery tool** | `read_file` on the spill path | `conversation_recall` |
 
 They fire independently. An exchange with a huge output spills as soon as it's captured; conversation compaction may not trigger until many turns later, for unrelated reasons.
@@ -143,9 +143,9 @@ There's no dedicated shell-recall tool: the spill file is just a normal file. Th
 
 Registered by the built-in `rolling-history` extension (only present when that extension is active; bridges and embedded uses don't ship it):
 
-- `conversation_recall {"action": "browse"}` — list in-context nuclear entries + the 25 most recent history-file entries
-- `conversation_recall {"action": "search", "query": "..."}` — regex search across the in-session archive and the history file (both one-line summaries and full bodies)
-- `conversation_recall {"action": "expand", "turn_id": 42}` — full content of a specific turn
+- `conversation_recall {"action": "browse"}` — list the 25 most recent summary entries from the store
+- `conversation_recall {"action": "search", "query": "..."}` — regex search across stored entries (one-line summaries plus the ephemeral full-body cache), returning each hit's header and a first-match excerpt
+- `conversation_recall {"action": "expand", "turn_id": "#a1b2c3d4"}` — full content of a specific entry, by the `#id` shown in browse/search output
 
 Extensions that install a custom compaction strategy can reuse `conversation_recall` or advise it with their own semantics.
 
@@ -178,8 +178,13 @@ All settings live in `~/.agent-sh/settings.json`:
 | `shellHeadLines` | 10 | Lines kept from the top when an output is spilled |
 | `shellTailLines` | 10 | Lines kept from the bottom when an output is spilled |
 | `autoCompactThreshold` | 0.5 | Fraction of available context window that triggers auto-compact |
-| `historyMaxBytes` | 104857600 | Max size of `~/.agent-sh/history` before front-truncation (100MB) |
-| `historyStartupEntries` | 100 | Prior history entries injected as `[Prior session history]` on startup |
+
+The `rolling-history` extension reads its own settings, namespaced under `"rolling-history"`:
+
+| Setting | Default | Description |
+|---|---|---|
+| `maxBytes` | 52428800 | Max size of the summary store before front-truncation (50MB) |
+| `prefetchEntries` | 50 | Summary entries injected as `[Prior session history]` on startup (0 disables) |
 
 ## Key files
 
@@ -187,9 +192,9 @@ All settings live in `~/.agent-sh/settings.json`:
 |---|---|
 | `src/shell/shell-context.ts` | Built-in: shell exchange capture, spill-to-tempfile on long outputs, `<shell_events>` per-query producer, `cwd` handler advisor |
 | `src/utils/shell-output-spill.ts` | Per-pid session dir, cleanup on exit + signals, stale-dir sweep for crashed sessions |
-| `src/agent/conversation-state.ts` | Messages array, eager nucleation, priority-based compaction, in-memory recall archive |
+| `src/agent/live-view.ts` | The live messages array the LLM sees; estimate/replace/link + API-grounded token accounting |
 | `src/agent/nuclear-form.ts` | One-line-summary primitives (nucleate, serialize, priority classification) |
-| `src/agent/history-file.ts` | Append-only `~/.agent-sh/history` with chunked search/tail-read + front-truncation |
-| `src/agent/agent-loop.ts` | Auto-compact trigger, `conversation:compact` advisor chain |
-| `src/agent/extensions/rolling-history/index.ts` | Rolling-history extension: registers the `conversation_recall` tool, the summary strategy, and the `/history` slash command |
+| `src/agent/store.ts` | `Store` interface + `SharedFileStore`: append-only JSONL with chunked search/tail-read + front-truncation |
+| `src/agent/agent-loop.ts` | Auto-compact trigger, `conversation:*` handler definitions, `conversation:message-appended` emits |
+| `src/agent/extensions/rolling-history/` | The built-in rolling-history extension: eager capture (`strategy.ts`), `conversation:compact` advisor, `conversation_recall` (`recall.ts`), `/history` command (`index.ts`) |
 | `src/agent/index.ts` | `/compact` and `/context` slash commands registered when the ash backend starts |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -369,7 +369,7 @@ Built-in extensions load first (via a declarative manifest), then user extension
 
 ### Real-world bridges
 
-The echo-backend shows the protocol. The `examples/extensions/` directory has two production bridges that wire real agent SDKs into agent-sh. Both are **pure protocol translators** — they map the external SDK's event stream to agent-sh's bus events, and that's it. Neither bundles any tools of its own; each external agent uses its own built-in tools as-is.
+The echo-backend shows the protocol. The `examples/extensions/` directory has three production bridges that wire real agent SDKs into agent-sh. All are **pure protocol translators** — they map the external SDK's event stream to agent-sh's bus events, and that's it. None bundle any tools of their own; each external agent uses its own built-in tools as-is.
 
 PTY-access tools (`terminal_read`, `terminal_keys`, `user_shell`) are deliberately *not* part of a bridge's job. They're opt-in capabilities that live in their own extensions, registered per backend in that backend's tool format. Keeping this separation means bridges stay narrow and composable.
 
@@ -409,9 +409,25 @@ cd ~/.agent-sh/extensions/pi-bridge && npm install
    - `agent_end` → `agent:response-done` + `agent:processing-done`
 3. **Session management** — `agent:reset-session` creates a new pi session via `runtime.newSession()`
 
+#### OpenCode Bridge (`opencode-bridge/`)
+
+Runs [opencode](https://opencode.ai/) in-process via `@opencode-ai/sdk`. The SDK boots an embedded HTTP server the bridge talks to; opencode brings its own models, tools, and `opencode auth login` credentials.
+
+```bash
+cp -r examples/extensions/opencode-bridge ~/.agent-sh/extensions/
+cd ~/.agent-sh/extensions/opencode-bridge && npm install
+# Requires: opencode configured separately (opencode auth login)
+```
+
+**How it works:**
+
+1. **Registers as backend** with an async `start()` that calls `createOpencode()` to boot the embedded server and open a session
+2. **Subscribes to the SDK's event stream** (`client.event.subscribe()`, iterated with `for await`) — maps opencode events to agent-sh events (`agent:response-chunk`, `agent:tool-started`, …)
+3. **Cancellation and reset** — `agent:cancel-request` and `agent:reset-session` are wired to the SDK's abort and new-session calls
+
 #### Adding PTY access to a bridge
 
-Neither bridge bundles PTY tools. If you want the external agent to observe or mutate the user's live terminal, write a companion extension that registers tools in the target SDK's tool format:
+None of the bridges bundle PTY tools. If you want the external agent to observe or mutate the user's live terminal, write a companion extension that registers tools in the target SDK's tool format:
 
 - **`terminal_read`** — calls `ctx.call("terminal-buffer").readScreen()` and returns the text + cursor + alt-screen state
 - **`terminal_keys`** — emits `shell:pty-write` to send keystrokes to the PTY
@@ -421,14 +437,14 @@ For pi, this is a standalone extension that registers with pi's `customTools` (v
 
 #### Writing your own bridge
 
-Both bridges follow the same 4-step structure:
+All three bridges follow the same 4-step structure:
 
 1. **Register as backend** — emit `agent:register-backend` with `name`, `start()`, `kill()`
 2. **Listen for `agent:submit`** — forward the query to the external agent
 3. **Map the agent's events** to agent-sh bus events (response chunks, tool starts/completions, thinking, errors)
 4. **Handle cancellation and reset** — wire `agent:cancel-request` and `agent:reset-session`
 
-The difference between the two bridges is just SDK shape: Claude Code uses an async iterator you `for await` over; pi uses a subscription callback. The translation layer is the same. Keep PTY tools out — they belong in companion extensions.
+The difference between the bridges is just SDK shape: Claude Code and opencode expose async iterators you `for await` over; pi uses a subscription callback. The translation layer is the same. Keep PTY tools out — they belong in companion extensions.
 
 ##### Forwarding query context
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -13,6 +13,8 @@ agent-sh has two integration points. The difference: **extensions customize the 
 
 If you're adding a Mermaid renderer or a custom slash command, write an extension. If you're building a web server that talks to an LLM, use the library.
 
+Two real frontends are built this way: [**ashi**](../examples/extensions/ashi/) (published as `@guanyilun/ashi`) drives `createCore()` into a standalone chat-style TUI with no shell underneath, and [**asHub**](https://github.com/firslov/asHub) wraps the same kernel in an Electron desktop app. Both reuse the ash backend, tools, and providers — only the frontend differs.
+
 ## Quick Start
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-sh",
   "version": "0.14.10",
-  "description": "A shell-first terminal where AI is one keystroke away",
+  "description": "A composable agent runtime — pair any frontend with any agent backend over one shared extension layer",
   "type": "module",
   "workspaces": [
     "examples/extensions/*"


### PR DESCRIPTION
Docs-only refresh: describe what agent-sh has become — a composable agent runtime — and fix accumulated staleness.

## Reframe
- Lead with the runtime identity: a pure kernel (event bus + handler registry + extension loader + backend coordinator) that any frontend can drive and any agent backend can plug into, over one shared extension layer.
- Surface three example apps built on it: the bundled shell, **ashi** (standalone TUI), and **asHub** (third-party desktop GUI).
- Move the demo gif into the shell example; point kernel internals at the architecture doc instead of an inline diagram.
- Update the `package.json` description and the architecture.md intro off the old "shell is the product" framing.

## Stale references
- architecture.md project tree: `conversation-state.ts`/`history-file.ts` were deleted → `live-view.ts`, `store.ts`, `session-store.ts`.
- agent.md: add the `xhigh` thinking level.
- context-management.md: `agent-sh-hub` → `asHub`.
- library.md: cite ashi and asHub as real `createCore()` consumers.

## Context docs rewrite for rolling-history
context-management.md documented a removed design (`ConversationState`, eager `conversation:nucleate-*`/`history:append` handlers, the `~/.agent-sh/history` file, dead `historyMaxBytes`/`historyStartupEntries` settings). Rewrote the conversation-compaction tiers to match what ships:
- the kernel emits `conversation:message-appended` and owns the compaction trigger;
- the built-in rolling-history extension captures one-line summaries into a `SharedFileStore` (`~/.agent-sh/rolling-history/history.jsonl`) with an ephemeral full-body recall cache, and advises `conversation:compact`;
- corrected the config + key-files tables and the `conversation_recall` actions;
- agent.md: mark `conversation_recall` as a rolling-history extension tool, not core;
- extensions.md: document the opencode bridge alongside claude-code and pi, and fix the "two bridges" counts.

Docs-only; no code changes.