### PR TITLE
Render LaTeX in ashi as a view-layer projection

### DIFF
--- a/examples/extensions/ashi/src/components.ts
+++ b/examples/extensions/ashi/src/components.ts
@@ -1,11 +1,84 @@
 import {
+  type Component,
   Container,
+  getImageDimensions,
+  Image,
   Markdown,
   type MarkdownTheme,
   Spacer,
   Text,
 } from "@earendil-works/pi-tui";
 import { markdownTheme, theme } from "./theme.js";
+
+export function pngToImageComponent(data: Buffer): Image | null {
+  const base64 = data.toString("base64");
+  const dims = getImageDimensions(base64, "image/png");
+  if (!dims) return null;
+  return new Image(
+    base64,
+    "image/png",
+    { fallbackColor: (t) => theme.fg("muted", t) },
+    { maxWidthCells: 60, maxHeightCells: 20 },
+    dims,
+  );
+}
+
+export type EquationRenderer = (latexSrc: string) => Component | null;
+
+type LatexSegment =
+  | { type: "text"; value: string }
+  | { type: "latex"; value: string; raw: string };
+
+/** Inline-$ close index, or -1. Pandoc guards keep "$5 and $10" as text. */
+function findInlineClose(text: string, from: number): number {
+  const openChar = text[from];
+  if (openChar === undefined || openChar === "$" || /\s/.test(openChar)) return -1;
+  for (let j = from; j < text.length; j++) {
+    const c = text[j];
+    if (c === "\n") return -1;
+    if (c === "\\") { j++; continue; }
+    if (c === "$") {
+      const prev = text[j - 1];
+      const next = text[j + 1];
+      const closes = prev !== undefined && !/\s/.test(prev)
+        && !(next !== undefined && /[0-9]/.test(next));
+      return closes ? j : -1;
+    }
+  }
+  return -1;
+}
+
+export function segmentLatex(text: string): LatexSegment[] {
+  const segments: LatexSegment[] = [];
+  let textStart = 0;
+  let i = 0;
+  const flushText = (end: number): void => {
+    if (end > textStart) segments.push({ type: "text", value: text.slice(textStart, end) });
+  };
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "\\" && text[i + 1] === "$") { i += 2; continue; }
+    if (ch !== "$") { i += 1; continue; }
+    if (text[i + 1] === "$") {
+      const close = text.indexOf("$$", i + 2);
+      if (close !== -1) {
+        flushText(i);
+        segments.push({ type: "latex", value: text.slice(i + 2, close).trim(), raw: text.slice(i, close + 2) });
+        i = close + 2; textStart = i; continue;
+      }
+      i += 2; continue;
+    }
+    const close = findInlineClose(text, i + 1);
+    if (close !== -1) {
+      flushText(i);
+      segments.push({ type: "latex", value: text.slice(i + 1, close).trim(), raw: text.slice(i, close + 1) });
+      i = close + 1; textStart = i; continue;
+    }
+    i += 1;
+  }
+  flushText(text.length);
+  return segments;
+}
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
@@ -34,8 +107,12 @@ export class UserMessage extends Container {
 export class AssistantMessage extends Container {
   private md: Markdown;
   private buffer = "";
-  constructor(mdTheme: MarkdownTheme = markdownTheme()) {
+  private mdTheme: MarkdownTheme;
+  private renderEquation?: EquationRenderer;
+  constructor(mdTheme: MarkdownTheme = markdownTheme(), renderEquation?: EquationRenderer) {
     super();
+    this.mdTheme = mdTheme;
+    this.renderEquation = renderEquation;
     this.md = new Markdown("", 1, 0, mdTheme);
     this.addChild(new Spacer(1));
     this.addChild(this.md);
@@ -51,7 +128,27 @@ export class AssistantMessage extends Container {
   }
   finalize(): void {
     if (this.buffer === "") this.buffer = " ";
-    this.md.setText(this.buffer);
+    if (this.renderEquation && this.buffer.includes("$")) {
+      this.rebuildWithEquations();
+    } else {
+      this.md.setText(this.buffer);
+    }
+  }
+  private rebuildWithEquations(): void {
+    const segments = segmentLatex(this.buffer);
+    if (!segments.some((s) => s.type === "latex")) {
+      this.md.setText(this.buffer);
+      return;
+    }
+    this.clear();
+    this.addChild(new Spacer(1));
+    for (const seg of segments) {
+      if (seg.type === "text") {
+        if (seg.value.trim()) this.addChild(new Markdown(seg.value, 1, 0, this.mdTheme));
+      } else {
+        this.addChild(this.renderEquation!(seg.value) ?? new Markdown(seg.raw, 1, 0, this.mdTheme));
+      }
+    }
   }
   hasContent(): boolean {
     return this.buffer.trim().length > 0;

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -3,14 +3,12 @@ import {
   ProcessTerminal,
   Container,
   Editor,
-  Image,
   Loader,
   SelectList,
   Spacer,
   Text,
   type Component,
   type SelectItem,
-  getImageDimensions,
   matchesKey,
   isKeyRelease,
   isKeyRepeat,
@@ -21,6 +19,7 @@ import {
   AssistantMessage,
   ErrorLine,
   InfoLine,
+  pngToImageComponent,
   ThinkingBlock,
   ToolGroup,
 } from "./components.js";
@@ -514,21 +513,9 @@ export function mountAshi(
     tui.requestRender();
   });
 
-  const imageComponentFromPng = (data: Buffer): Image | null => {
-    const base64 = data.toString("base64");
-    const dims = getImageDimensions(base64, "image/png");
-    if (!dims) return null;
-    return new Image(
-      base64, "image/png",
-      { fallbackColor: (t) => theme.fg("muted", t) },
-      { maxWidthCells: 60, maxHeightCells: 20 },
-      dims,
-    );
-  };
-
   /** Drop the live assistant so subsequent text starts fresh markdown below the image. */
   const appendImage = (data: Buffer): void => {
-    const img = imageComponentFromPng(data);
+    const img = pngToImageComponent(data);
     if (!img) return;
     if (activeAssistant) { activeAssistant.finalize(); activeAssistant = null; }
     chat.addChild(img);

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -1,6 +1,7 @@
 import type { Component } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "agent-sh/types";
-import { AssistantMessage, ThinkingBlock, UserMessage } from "./components.js";
+import { AssistantMessage, pngToImageComponent, ThinkingBlock, UserMessage } from "./components.js";
+import { markdownTheme } from "./theme.js";
 import { loadDisplayResolver, type ToolResultMode } from "./display-config.js";
 import { isRenderModel, mountCall, mountResult, type RenderModel } from "./schema.js";
 
@@ -33,12 +34,22 @@ export interface ToolResultView extends Component {
 const SCHEMA_PREFIX = "ashi:render-tool:";
 
 export function registerRenderDefaults(ctx: ExtensionContext): void {
+  const equationPng = new Map<string, Buffer | null>();
+  const renderEquation = (src: string): Component | null => {
+    if (!equationPng.has(src)) {
+      equationPng.set(src, (ctx.call("latex:render-equation", src) as Buffer | null) ?? null);
+    }
+    const png = equationPng.get(src) ?? null;
+    return png ? pngToImageComponent(png) : null;
+  };
+
   ctx.define("ashi:render-user-message", (args: UserMessageArgs): Component => {
     return new UserMessage(args.text);
   });
 
   ctx.define("ashi:render-assistant", (args: AssistantArgs): Component => {
-    const msg = new AssistantMessage();
+    const eq = ctx.list().includes("latex:render-equation") ? renderEquation : undefined;
+    const msg = new AssistantMessage(markdownTheme(), eq);
     if (args.text) {
       msg.appendText(args.text);
       msg.finalize();

--- a/examples/extensions/latex-images.ts
+++ b/examples/extensions/latex-images.ts
@@ -19,7 +19,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ShellContext } from "agent-sh/types";
+import type { ExtensionContext } from "agent-sh/types";
 
 // Settings loaded in activate() via ctx.getExtensionSettings
 let config = { dpi: 300, fgColor: "d4d4d4" };
@@ -98,7 +98,7 @@ function renderEquation(equation: string): Buffer | null {
 
 // ── Extension entry point ────────────────────────────────────────
 
-export default function activate(ctx: ShellContext) {
+export default function activate(ctx: ExtensionContext) {
   const { bus } = ctx;
 
   // Load settings: ~/.agent-sh/settings.json → "latex-images": { dpi, fgColor }
@@ -115,24 +115,27 @@ export default function activate(ctx: ShellContext) {
     return;
   }
 
-  // Handle inline $$...$$ display math
-  ctx.shell.createBlockTransform({
-    open: "$$",
-    close: "$$",
-    transform(latex) {
-      const png = renderEquation(latex);
-      if (!png) return null;
-      return { type: "image", data: png };
-    },
-  });
+  ctx.define("latex:render-equation", (equation: string): Buffer | null => renderEquation(equation));
 
-  // Advise the code block renderer — wrap the default syntax highlighter
-  ctx.advise("render:code-block", (next, language: string, code: string, width: number) => {
-    if (language !== "latex" && language !== "tex") return next(language, code, width);
-    const png = renderEquation(code);
-    if (!png) return next(language, code, width); // render failed — fall through
-    ctx.call("render:image", png);
-  });
+  // Shell-only — ashi has no shell surface; it uses the capability above instead.
+  if (ctx.shell) {
+    ctx.shell.createBlockTransform({
+      open: "$$",
+      close: "$$",
+      transform(latex) {
+        const png = renderEquation(latex);
+        if (!png) return null;
+        return { type: "image", data: png };
+      },
+    });
+
+    ctx.advise("render:code-block", (next, language: string, code: string, width: number) => {
+      if (language !== "latex" && language !== "tex") return next(language, code, width);
+      const png = renderEquation(code);
+      if (!png) return next(language, code, width);
+      ctx.call("render:image", png);
+    });
+  }
 
   process.on("exit", () => {
     if (tmpDir) {


### PR DESCRIPTION
## Problem

The `latex-images` extension worked in the plain TUI shell but failed under ashi:

```
✗ Failed to load extension .../latex-images.ts: Cannot read properties of undefined (reading 'createBlockTransform')
```

ashi calls `activateShellContext` (background PTY/cwd tracking) but not `registerShellHandlers`, so `ctx.shell` is undefined — by design, since ashi renders into pi-tui components, not a terminal shell surface. The extension reached for `ctx.shell.createBlockTransform` and threw at load.

Even with a guard, the underlying approach is wrong for ashi: `createBlockTransform` registers a pipe on `agent:response-chunk`, which only fires while streaming. ashi rebuilds messages from its session store (`renderAssistantFinal` → `ashi:render-assistant`), which never re-emits that event — so an equation would render as an image live but as raw `$$` once the session was reopened or forked.

## Approach

LaTeX→image is a **presentation projection of the canonical message**, not a content edit. The canonical message (what is stored and fed back to the model) stays raw `$$…$$`; the image is derived when rendering store → view.

- **`latex-images`** exposes `latex:render-equation` (LaTeX→PNG) as a capability any frontend can call. Its stream transform and `render:code-block` advice are guarded behind `if (ctx.shell)` for the plain TUI shell (no rehydration there, so a stream transform is fine).
- **ashi** owns the projection at its single render seam. `AssistantMessage.finalize()` splits the settled text into `[Markdown | Image]` segments and runs on **both** live-finalize and rebuild-from-store, so an equation renders identically streamed, reopened, and forked.
- PNG output is memoized by source, so `latex/dvipng` runs once per distinct equation across rebuilds. Without the capability registered, equations fall back to raw text.

## Coverage

- `$$…$$` display math and `$…$` inline math.
- Pandoc guards on inline `$`: open not followed by space, close not preceded by space nor followed by a digit, single-line — so `$5 and $10`, `$PATH`, and escaped `\$` stay as text.

## Rendering notes / limitations

- Terminal images occupy whole rows, so inline `$x$` mid-sentence renders as a **block** (text / image / text on separate lines). `$$…$$` is unaffected.
- Inline math goes through the same `\displaystyle` wrapping as display math.
- ` ```latex ` fenced blocks are not imaged in ashi yet (still imaged in the plain shell). Easy follow-up: extend the segmenter to catch fences.
- `$$` inside a fenced code block is misread as an equation — pre-existing parity with the old transform's naive matching.

Reuses pi-tui's `Image` (its `render(width)` rescales), so segments reflow on resize like any other component. Kernel untouched; change is examples-only.
