### PR TITLE
Return the canonical array from conversation:get-messages

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -321,7 +321,7 @@ export class AgentLoop implements AgentBackend {
     }));
 
     onPipe("context:snapshot", (payload) => {
-      payload.messages = this.conversation.getMessages();
+      payload.messages = this.conversation.get();
       payload.contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       payload.activeTokens = this.conversation.estimateTokens();
       return payload;
@@ -783,12 +783,10 @@ export class AgentLoop implements AgentBackend {
     h.define("conversation:prepare", (messages: unknown[]) => messages);
 
     // ── Conversation primitives for compaction strategies ─────────
-    // Read messages (for inspection / computing new arrays) and replace
-    // the whole array (write side). Extensions implementing
-    // `conversation:compact` use these to observe and mutate.
-    h.define("conversation:get-messages", () => this.conversation.getMessages());
+    // Canonical array (link/replace index space), not forLLM().
+    h.define("conversation:get-messages", () => this.conversation.get());
     h.define("conversation:replace-messages", (msgs: unknown[]) => {
-      this.conversation.replaceMessages(msgs as ReturnType<typeof this.conversation.getMessages>);
+      this.conversation.replace(msgs as ReturnType<typeof this.conversation.get>);
     });
     h.define("conversation:estimate-tokens", () => this.conversation.estimateTokens());
     h.define("conversation:estimate-prompt-tokens", () => this.conversation.estimatePromptTokens());
@@ -806,13 +804,13 @@ export class AgentLoop implements AgentBackend {
       const strategy = opts.strategy;
       if (strategy?.kind === "rewind" || strategy?.kind === "replace") {
         const before = this.conversation.estimatePromptTokens();
-        const beforeLen = this.conversation.getMessages().length;
+        const beforeLen = this.conversation.get().length;
         const next = strategy.kind === "rewind"
-          ? this.conversation.getMessages().slice(0, strategy.toIndex)
-          : (strategy.messages as ReturnType<LiveView["getMessages"]>);
-        this.conversation.replaceMessages(next);
+          ? this.conversation.get().slice(0, strategy.toIndex)
+          : (strategy.messages as ReturnType<LiveView["get"]>);
+        this.conversation.replace(next);
         const after = this.conversation.estimatePromptTokens();
-        const afterLen = this.conversation.getMessages().length;
+        const afterLen = this.conversation.get().length;
         return { before, after, evictedCount: Math.max(0, beforeLen - afterLen) } as CompactResult;
       }
       return null;
@@ -1457,7 +1455,7 @@ export class AgentLoop implements AgentBackend {
     // wrapTrailingWithDynamicContext for the cache-stability rationale.
     const rawMessages = [
       { role: "system" as const, content: systemPrompt },
-      ...wrapTrailingWithDynamicContext(this.conversation.getMessages(), dynamicContext, toolPrompt),
+      ...wrapTrailingWithDynamicContext(this.conversation.forLLM(), dynamicContext, toolPrompt),
     ];
 
     // Let extensions transform the message array (compact, summarize, filter, etc.)

--- a/src/agent/live-view.ts
+++ b/src/agent/live-view.ts
@@ -1,5 +1,4 @@
 import type { ChatCompletionMessageParam, AgentShMessage } from "./llm-client.js";
-import { stripMeta } from "./llm-client.js";
 import type { HandlerFunctions } from "../utils/handler-registry.js";
 import type { ImageContent } from "./types.js";
 
@@ -152,7 +151,8 @@ export class LiveView {
     this.invalidateMessagesCache();
   }
 
-  getMessages(): ChatCompletionMessageParam[] {
+  /** Send-shaped; may be longer than get() (dangling calls stubbed) — never link()/replace() by these indices. */
+  forLLM(): ChatCompletionMessageParam[] {
     return this.normalizeReasoningConsistency(
       this.stubDanglingToolCalls(this.dropOrphanToolMessages(this.messages)),
     );
@@ -160,10 +160,6 @@ export class LiveView {
 
   get(): AgentShMessage[] {
     return this.messages as AgentShMessage[];
-  }
-
-  forLLM(): ChatCompletionMessageParam[] {
-    return this.getMessages().map(stripMeta);
   }
 
   replace(msgs: AgentShMessage[]): void {

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -216,7 +216,7 @@ async function streamOnce(
   const stream = await llmClient.stream({
     messages: [
       { role: "system", content: systemPrompt },
-      ...wrapTrailingWithDynamicContext(conversation.getMessages(), dynamicContext ?? ""),
+      ...wrapTrailingWithDynamicContext(conversation.forLLM(), dynamicContext ?? ""),
     ],
     tools: apiTools.length > 0 ? apiTools : undefined,
     model,

--- a/tests/agent/extensions/rolling-history/strategy.test.ts
+++ b/tests/agent/extensions/rolling-history/strategy.test.ts
@@ -222,12 +222,12 @@ describe("compact end-to-end", () => {
     const ctx = makeCtx(state, store);
     const advisor = makeCompactAdvisor(ctx);
 
-    const beforeLen = state.getMessages().length;
+    const beforeLen = state.get().length;
     const result = await advisor(async () => null, { target: budget });
 
     assert.ok(result, "should compact");
     assert.ok(result.evictedCount > 0, "evictedCount should be > 0");
-    assert.ok(state.getMessages().length < beforeLen, "live view should shrink");
+    assert.ok(state.get().length < beforeLen, "live view should shrink");
   });
 
   test("rebuilt live view keeps the first turn and the last turn", async () => {
@@ -242,7 +242,7 @@ describe("compact end-to-end", () => {
     const result = await advisor(async () => null, { target: budget });
 
     assert.ok(result);
-    const rebuilt = state.getMessages();
+    const rebuilt = state.get();
     // First user turn is pinned (priority PINNED on turns[0]).
     assert.ok(rebuilt.some((m) => m.role === "user" && m.content === firstUserContent),
       "first user turn should be pinned");
@@ -263,7 +263,7 @@ describe("compact end-to-end", () => {
     assert.ok(result);
 
     const marker = "[Conversation history";
-    const block = state.getMessages().find(
+    const block = state.get().find(
       (m) => m.role === "user" && typeof m.content === "string" && m.content.startsWith(marker),
     );
     assert.ok(block, "summary block should be present in live view");

--- a/tests/agent/live-view.test.ts
+++ b/tests/agent/live-view.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LiveView } from "../../src/agent/live-view.js";
+
+// Guards the LiveView.link crash: link() indexes get(), forLLM() may be longer.
+
+function withDanglingCall(): LiveView {
+  const lv = new LiveView();
+  lv.addUserMessage("run ffmpeg on the file");
+  lv.addAssistantMessage("Let me inspect it first.", [
+    { id: "call_1", function: { name: "execute", arguments: "{}" } },
+  ]);
+  return lv;
+}
+
+test("forLLM diverges from get() while a tool call is in flight", () => {
+  const lv = withDanglingCall();
+  assert.equal(lv.get().length, 2);
+  assert.equal(lv.forLLM().length, 3);
+});
+
+test("link() targets canonical indices, not projection indices", () => {
+  const lv = withDanglingCall();
+
+  lv.link(lv.get().length - 1, "entry-assistant");
+  assert.equal((lv.get()[1] as { meta?: { entryId?: string } }).meta?.entryId, "entry-assistant");
+
+  assert.throws(() => lv.link(lv.forLLM().length - 1, "entry-oob"), /no message at index/);
+});

--- a/tests/agent/multimodal.test.ts
+++ b/tests/agent/multimodal.test.ts
@@ -129,7 +129,7 @@ test("LiveView.addToolResult with string produces plain tool message", () => {
   conv.addAssistantMessage(null, [{ id: "call_1", function: { name: "read_file", arguments: "{}" } }]);
   conv.addToolResult("call_1", "file content");
 
-  const msgs = conv.getMessages();
+  const msgs = conv.get();
   const toolMsg = msgs.find((m) => m.role === "tool") as any;
   assert.equal(toolMsg.tool_call_id, "call_1");
   assert.equal(toolMsg.content, "file content");
@@ -140,7 +140,7 @@ test("LiveView.addToolResult with ImageContent[] produces vision content parts",
   conv.addAssistantMessage(null, [{ id: "call_1", function: { name: "read_file", arguments: "{}" } }]);
   conv.addToolResult("call_1", [{ type: "image", data: "Zm9v", mimeType: "image/png" }]);
 
-  const msgs = conv.getMessages();
+  const msgs = conv.get();
   const toolMsg = msgs.find((m) => m.role === "tool") as any;
   assert.ok(Array.isArray(toolMsg.content), "content should be array of content parts");
   assert.equal(toolMsg.content.length, 2);
@@ -159,7 +159,7 @@ test("LiveView.addToolResult with error ImageContent[] still marks error", () =>
   conv.addAssistantMessage(null, [{ id: "call_1", function: { name: "read_file", arguments: "{}" } }]);
   conv.addToolResult("call_1", [{ type: "image", data: "Zm9v", mimeType: "image/png" }], true);
 
-  const msgs = conv.getMessages();
+  const msgs = conv.get();
   const toolMsg = msgs.find((m) => m.role === "tool") as any;
   assert.ok(Array.isArray(toolMsg.content));
   assert.ok(toolMsg.content[0].text.startsWith("Error:"));


### PR DESCRIPTION
## Symptom

```
Error: LiveView.link: no message at index 5
    at LiveView.link (.../agent/live-view.js)
    at Object.linkMessage (.../rolling-history/index.js)
    at .../rolling-history/strategy.js
```

Crashes when an assistant turn carries **both** narration text and an in-flight tool call (e.g. a short message followed by a long-running `execute`).

## Root cause

`conversation:get-messages` returned the send-time message projection (`LiveView.getMessages`), which stubs dangling tool calls. That makes its length — and therefore its index space — diverge from the **canonical** array that `conversation:link` and `conversation:replace-messages` operate on. The rolling-history capture handler computes a live index from the array it reads, then links by that index; reading the inflated projection but linking into the canonical array walks past the end.

PR #174 specified the split: `get()` is the canonical, meta-bearing array (the one `link()`/`replace()` index), and `forLLM()` is the send-only projection. The handler had drifted onto the projection.

## Fix

Restore that contract — one canonical index space, projection confined to the send boundary:

- `conversation:get-messages` / `:replace-messages` read `get()` / `replace()`.
- Rename the projection helper to `forLLM()` and call it only where a request is built (agent-loop main send + subagent); drop the dead meta-stripping `forLLM()` (meta is stripped downstream in `llm-client`).
- Fix the **rewind** and **context:snapshot** paths, which had the same latent bug — they read the projection and then wrote canonical state, baking the stubs in permanently.

## Tests

New `tests/agent/live-view.test.ts` covers the index-space divergence (`forLLM()` longer than `get()` mid-tool-call) and the `link()` bounds, reproducing the original crash. Full suite passes (237/237 with a build).

Refs #174