### PR TITLE
Add an interactive shell passthrough overlay for ashi

### DIFF
--- a/examples/extensions/ashi-shell-passthrough.ts
+++ b/examples/extensions/ashi-shell-passthrough.ts
@@ -1,0 +1,95 @@
+/**
+ * Interactive shell passthrough for ashi.
+ *
+ * Usage:   ashi -e examples/extensions/ashi-shell-passthrough.ts
+ * Config:  { "ashi-shell-passthrough": { "trigger": "ctrl+]" } }  // or "ctrl+\\", "^]"
+ *
+ * Press the trigger key (or run `/shell`) to hand the terminal to your live
+ * shell PTY; press it again to return to ashi.
+ */
+import type { ExtensionContext } from "agent-sh/types";
+
+interface TerminalBufferView {
+  getScreenLines(rows?: number): string[];
+  getCursor(): { x: number; y: number };
+  readonly altScreen: boolean;
+}
+
+interface AshiKey {
+  matches(name: string): boolean;
+  isRelease(): boolean;
+  isRepeat(): boolean;
+}
+
+function parseTrigger(spec: string): { name: string; byte: string } {
+  const ch = (/^ctrl\+(.)$/i.exec(spec) ?? /^\^(.)$/.exec(spec))?.[1] ?? spec;
+  return {
+    name: `ctrl+${ch.toLowerCase()}`,
+    byte: String.fromCharCode(ch.toUpperCase().charCodeAt(0) & 0x1f),
+  };
+}
+
+function runPassthrough(ctx: ExtensionContext, closeByte: string): Promise<void> {
+  const { bus } = ctx;
+  return new Promise<void>((resolve) => {
+    const tb = ctx.call("terminal-buffer") as TerminalBufferView | null;
+
+    const onPtyData = ({ raw }: { raw: string }): void => { process.stdout.write(raw); };
+    const onResize = (): void => bus.emit("shell:pty-resize", {
+      cols: process.stdout.columns ?? 80,
+      rows: process.stdout.rows ?? 24,
+    });
+    const onStdin = (chunk: Buffer): void => {
+      const data = chunk.toString("latin1");
+      if (data === closeByte) { cleanup(); resolve(); return; }
+      bus.emit("shell:pty-write", { data });
+    };
+    const cleanup = (): void => {
+      bus.off("shell:pty-data", onPtyData);
+      process.stdin.off("data", onStdin);
+      process.stdout.off("resize", onResize);
+    };
+
+    process.stdout.on("resize", onResize);
+    bus.on("shell:pty-data", onPtyData);
+    process.stdin.on("data", onStdin);
+    onResize();
+
+    if (tb && !tb.altScreen) {
+      const cur = tb.getCursor();
+      process.stdout.write(
+        `\x1b[2J\x1b[H${tb.getScreenLines().join("\r\n")}\x1b[${cur.y + 1};${cur.x + 1}H`,
+      );
+    }
+  });
+}
+
+export default function activate(ctx: ExtensionContext): void {
+  const { bus } = ctx;
+  const { trigger } = ctx.getExtensionSettings("ashi-shell-passthrough", { trigger: "ctrl+]" });
+  const { name: triggerName, byte: triggerByte } = parseTrigger(trigger);
+
+  const openShell = async (): Promise<void> => {
+    if (!ctx.list().includes("ashi:terminal:yield")) {
+      bus.emit("ui:error", { message: "shell passthrough needs a newer ashi (missing ashi:terminal:yield)" });
+      return;
+    }
+    await ctx.call("ashi:terminal:yield", () => runPassthrough(ctx, triggerByte));
+  };
+
+  ctx.registerCommand(
+    "shell",
+    "Drop into your live shell — the agent sees what you run; the trigger key returns to ashi",
+    openShell,
+  );
+
+  const bindHotkey = (): void => {
+    const off = ctx.call("ashi:on-key", (key: AshiKey) => {
+      if (key.isRelease() || key.isRepeat()) return;
+      if (key.matches(triggerName)) { void openShell(); return { consume: true }; }
+    });
+    if (typeof off === "function") ctx.onDispose(() => off());
+  };
+  if (ctx.list().includes("ashi:on-key")) bindHotkey();
+  else (bus.on as (event: string, fn: () => void) => void)("ashi:ready", bindHotkey);
+}

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -231,6 +231,8 @@ async function main(): Promise<void> {
   const handle = mountAshi(ctx, getStore, capture, renderer);
   stopFrontend = handle.stop;
 
+  (core.bus.emit as (event: string, payload: unknown) => void)("ashi:ready", {});
+
   registerForkCommands(ctx, getStore, handle.openTreePicker, handle.rebuildChat, capture);
   registerSessionCommands(ctx, getStore, capture, {
     openSessionPicker: handle.openSessionPicker,

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "agent-sh/types";
 import { theme } from "./theme.js";
 import type {
   KeyEvent,
+  KeyHandler,
   LoaderView,
   RenderNode,
   Renderer,
@@ -970,6 +971,7 @@ export function mountAshi(
 
   const jobControl = process.platform !== "win32";
   let suspended = false;
+  let terminalYielded = false;
   const resumeFromSuspend = (): void => {
     if (!suspended) return;
     suspended = false;
@@ -978,12 +980,33 @@ export function mountAshi(
     app.requestRender(true);
   };
   const suspendToShell = (): void => {
-    if (suspended) return;
+    if (suspended || terminalYielded) return;
     suspended = true;
     app.stop();
     process.kill(process.pid, "SIGSTOP");
   };
   if (jobControl) process.on("SIGCONT", resumeFromSuspend);
+
+  ctx.define("ashi:terminal:yield", async (run: () => unknown | Promise<unknown>) => {
+    if (terminalYielded || suspended) return;
+    terminalYielded = true;
+    const wasRaw = process.stdin.isRaw;
+    app.stop();
+    applyOutputMode(true);
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    try {
+      return await run();
+    } finally {
+      process.stdin.setRawMode?.(wasRaw);
+      applyOutputMode(renderer.capabilities.rawOutput);
+      app.start();
+      app.requestRender(true);
+      terminalYielded = false;
+    }
+  });
+
+  ctx.define("ashi:on-key", (handler: KeyHandler) => app.onKey(handler));
 
   app.onKey((key: KeyEvent) => {
     if (key.isRelease() || key.isRepeat()) return;


### PR DESCRIPTION
## Summary

Adds `examples/extensions/ashi-shell-passthrough.ts` — run `/shell` or press the trigger key (default Ctrl+]) to hand the real terminal to your live shell PTY. Keystrokes go straight to the shell and it paints itself natively (vim, htop, less, ssh), and the same key returns to ashi.

The key property: unlike spawning a child with `stdio: "inherit"` (which writes to the terminal fds directly and is invisible to the process), this drives the **existing** agent-sh PTY over the bus. Every byte still flows through `shell:pty-data`, so the agent's `TerminalBuffer` keeps capturing the session — **the agent can see what the user ran**. That observability is the whole point, and it's exactly what a `spawnSync`/`inherit` approach structurally can't give you.

## How it works

On trigger, ashi yields the raw terminal and the extension bridges the PTY:

- `shell:pty-data` → `process.stdout` (the display link ashi otherwise omits)
- raw `stdin` → `shell:pty-write` (interactive input)
- host resize → `shell:pty-resize` (SIGWINCH repaints any running TUI)

Because `app.stop()` restores legacy keyboard mode (pops kitty / modifyOtherKeys), forwarded keys are the bytes the shell expects — **no CSI-u decode round-trip**. And because the display is raw passthrough rather than an xterm-headless re-render, there's **no per-keystroke lag**; `TerminalBuffer` stays off the hot path, used once on entry to repaint context.

## Changes

**ashi substrate primitives** (reusable, used here first):

- `ashi:terminal:yield` (`frontend.ts`) — lends the raw terminal to a callback (stops the render loop, drops stdout to raw) and restores the TUI in `finally`. Modeled on the existing Ctrl+Z suspend handler.
- `ashi:on-key` (`frontend.ts`) — lets extensions claim keys while the TUI is focused (pi-tui runs input listeners before the editor, so a hotkey isn't eaten by the input box).
- `cli.ts` emits `ashi:ready` after `mountAshi`, so the extension — which activates earlier — binds its hotkey once the primitives resolve.

**New extension** — `examples/extensions/ashi-shell-passthrough.ts` (~95 lines): `/shell` command + configurable toggle hotkey, the PTY bridge, and a one-time context repaint from the capture buffer.

No agent-sh kernel change: the PTY bridge is plain bus traffic.

## Test plan

- [ ] `cd examples/extensions/ashi && npm run dev -- -e ../ashi-shell-passthrough.ts`
- [ ] Ctrl+] (or `/shell`) → live shell appears; type at the prompt, output renders.
- [ ] `vim` / `htop` / `less` → colors, cursor, modes work; resize reflows.
- [ ] Ctrl+] again → ashi prompt restored.
- [ ] With `-e ../terminal-buffer.ts` also loaded, the agent's `terminal_read` reflects what was run.
- [ ] Configure a custom trigger: `{ "ashi-shell-passthrough": { "trigger": "ctrl+\\" } }`.

## Notes

- The trigger key is shadowed inside the passthrough (it's the return key) and in ashi's input box (it preempts the editor's jump-forward); both expected. `ctrl+\` is the alternative.
- This extension lazily wires `TerminalBuffer` on first open; load `terminal-buffer` for capture from startup.