### PR TITLE
Fix pi-tui spacing around the input box and thinking spinner

### DIFF
--- a/examples/extensions/ashi/src/renderers/pi-tui/app.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/app.ts
@@ -11,7 +11,7 @@ import {
   type SelectItem as PiSelectItem,
 } from "@earendil-works/pi-tui";
 import { editorTheme, selectListTheme } from "./theme-adapters.js";
-import { createNodes } from "./nodes.js";
+import { createNodes, footerContainer } from "./nodes.js";
 import type {
   App,
   InputView,
@@ -54,13 +54,20 @@ function makeSelect(items: SelectItem[], visibleRows: number): SelectView {
   };
 }
 
+class FlushLoader extends Loader {
+  override render(width: number): string[] {
+    const lines = super.render(width);
+    return lines[0] === "" ? lines.slice(1) : lines;
+  }
+}
+
 function makeLoader(
   tui: TUI,
   label: string,
   color: (t: string) => string,
   muted: (t: string) => string,
 ): LoaderView {
-  const loader = new Loader(tui, color, muted, label);
+  const loader = new FlushLoader(tui, color, muted, label);
   return { node: asNode(loader), stop: () => loader.stop() };
 }
 
@@ -70,7 +77,7 @@ export function createApp(): App {
   const tui = new TUI(terminal);
 
   const scrollback = nodes.container();
-  const footerSlot = nodes.container();
+  const footerSlot = footerContainer();
   const queueSlot = nodes.container();
   const status = nodes.text({ paddingX: 1 });
   const belowInput = nodes.container();

--- a/examples/extensions/ashi/src/renderers/pi-tui/nodes.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/nodes.ts
@@ -54,6 +54,22 @@ class ZonedMarkdown extends Markdown {
   }
 }
 
+class FooterSlot extends Container {
+  override render(width: number): string[] {
+    return this.children.length === 0 ? [""] : super.render(width);
+  }
+}
+
+export function footerContainer(): ContainerView {
+  const c = new FooterSlot();
+  return {
+    node: asNode(c),
+    addChild: (child) => c.addChild(asComponent(child)),
+    removeChild: (child) => c.removeChild(asComponent(child)),
+    clear: () => c.clear(),
+  };
+}
+
 export function createNodes(): RenderNodes {
   return {
     text(opts) {


### PR DESCRIPTION
## Summary

Two vertical-spacing bugs in the **pi-tui** renderer, both fixed renderer-locally (shared frontend and the Ink renderer are untouched).

### 1. No gap between a finished response and the input box

`footerSlot` holds the thinking spinner (with its lead-in spacer) during a turn and is empty at rest. An empty pi-tui `Container` renders nothing, so when `stopLoader` cleared the spinner the gap went with it and the response sat flush against the input box.

`FooterSlot` now renders one blank line when it has no children, so the gap survives the spinner's removal. (This is pi-tui's equivalent of the Ink renderer's always-on input `marginTop`.)

### 2. Two blank lines above `thinking…` instead of one

pi-tui's `Loader.render()` returns `["", ...]` — it prepends its own blank line. Combined with the `loaderGap` spacer the caller already adds to `footerSlot`, that produced **two** blank lines above the spinner. (Ink's loader doesn't self-pad, which is why `loaderGap` exists and why only pi-tui doubled.)

`FlushLoader` drops the built-in blank so pi-tui's loader matches the same "loader doesn't self-pad" contract the Ink renderer follows — `loaderGap` is the single gap.

## Result

| State | Gap above |
|---|---|
| Streaming | one blank above the spinner |
| Done / idle | one blank above the input box |
| Transition | the spinner vanishes, the gap stays at one |

## Test plan

- [ ] `cd examples/extensions/ashi && npm run dev`, send a message.
- [ ] While thinking: exactly one blank line above `thinking…`.
- [ ] After it finishes: exactly one blank line above the input box.
- [ ] Open a picker (e.g. `/fork`) — no regression in footer spacing.