### PR TITLE
Seed resumed conversation after the backend is active

### DIFF
--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -237,13 +237,14 @@ async function main(): Promise<void> {
     rebuildChat: handle.rebuildChat,
   });
 
+  await core.activateBackend(config.backend ?? getSettings().defaultBackend);
+
   if (resumeId) {
+    // After activateBackend: conversation:replace-messages is a no-op until the agent backend exists.
     applyBranchMessages(ctx, getStore, capture);
     await handle.rebuildChat();
     ctx.bus.emit("ui:info", { message: `continued session ${resumeId.slice(0, 12)}…` });
   }
-
-  await core.activateBackend(config.backend ?? getSettings().defaultBackend);
 
   process.on("SIGTERM", cleanup);
   process.on("SIGHUP", cleanup);

--- a/examples/extensions/ashi/src/commands.ts
+++ b/examples/extensions/ashi/src/commands.ts
@@ -40,7 +40,17 @@ export function applyBranchMessages(
   capture: Capture,
 ): void {
   const store = getStore().current();
-  ctx.call("conversation:replace-messages", store.buildMessages());
+  const messages = store.buildMessages();
+  ctx.call("conversation:replace-messages", messages);
+
+  // replace-messages no-ops until the agent backend is active; seeding then desyncs
+  // capture's baseline against an empty conversation and silently drops later turns.
+  const live = ctx.call("conversation:get-messages") as unknown[] | undefined;
+  if ((live?.length ?? 0) !== messages.length) {
+    throw new Error(
+      `applyBranchMessages: conversation not seeded (live ${live?.length ?? 0} vs ${messages.length}); call after the agent backend is active`,
+    );
+  }
 
   const branch = store.getBranch();
   let compaction: { firstKeptId: string } | null = null;

--- a/examples/extensions/ashi/tests/persistence-resume.test.ts
+++ b/examples/extensions/ashi/tests/persistence-resume.test.ts
@@ -111,6 +111,23 @@ test("the exit race: processing-done leaves the turn un-persisted until flush is
   assert.equal(onDisk(), 4, "awaiting the pending flush on exit persists the turn");
 });
 
+test("seeding before the agent backend is active throws instead of silently dropping resumed turns", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-persist-"));
+  const cwd = "/tmp/ashi-persist-cwd-order";
+  const sid = await seededSession(dir, cwd);
+
+  const store = new MultiSessionStore(dir, cwd, { resumeSessionId: sid });
+
+  const handlers = new Map<string, (p?: unknown) => unknown>();
+  const ctx = { bus: { on() {}, emit() {} }, call: (n: string, a?: unknown) => handlers.get(n)?.(a) };
+  const capture = registerCapture(ctx as never, () => store);
+
+  assert.throws(
+    () => applyBranchMessages(ctx as never, () => store, capture),
+    /conversation not seeded/,
+  );
+});
+
 test("a new turn in a session resumed via the in-app picker is persisted", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-persist-"));
   const cwd = "/tmp/ashi-persist-cwd2";


### PR DESCRIPTION
## Problem

`ashi -c` (resume-at-launch) silently dropped every turn made after the resume, and ran with an empty agent context — the agent had no memory of the conversation the UI showed it had resumed.

## Root cause

The `-c` launch seeded the resumed session **before** activating the agent backend:

```
applyBranchMessages(...)   // conversation:replace-messages + capture.resetTo
await handle.rebuildChat()
...
await core.activateBackend(...)   // creates AgentLoop + LiveView + conversation:* handlers
```

`applyBranchMessages` does two things:
- `capture.resetTo(ids)` → hits the **capture extension** (already registered) → persistence baseline jumps to the resumed message count.
- `conversation:replace-messages(msgs)` → hits the **agent backend's** handler, which doesn't exist until `activateBackend` creates the `AgentLoop` and its `LiveView`.

So `replace-messages` was a no-op. The live conversation started empty while capture's baseline was set to e.g. 38. Every new turn then failed capture's append guard (`messages.length <= liveEntryIds.length`) and was never written to disk. The agent's `LiveView` was also empty, so it had no context from the resumed session.

The in-app `/resume` picker was unaffected — it runs while the backend is already active, so `replace-messages` populates the live conversation correctly.

## Fix

Move the resume seeding to **after** `activateBackend`, so the conversation handler exists when `replace-messages` runs.

`applyBranchMessages` now also verifies the live conversation was actually seeded and throws otherwise — converting this silent data-loss class into a loud startup failure if the ordering is ever broken again.

## Tests

Adds a regression test (`persistence-resume.test.ts`): seeding while the conversation handlers are unregistered (the pre-`activateBackend` state) now throws rather than silently dropping resumed turns. The pre-existing tests passed despite the original bug because their mock implemented `conversation:replace-messages` directly and never modeled "the handler doesn't exist until the backend starts."

## Notes

Broken since the `-c` flag was introduced (#188); not a regression from a recent change.