### PR TITLE
Support pasting images into the ashi prompt

### DIFF
--- a/examples/extensions/ashi/src/clipboard-image.ts
+++ b/examples/extensions/ashi/src/clipboard-image.ts
@@ -1,0 +1,41 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const exec = promisify(execFile);
+
+export interface CapturedImage {
+  /** Base64-encoded image data (no data: URL prefix). */
+  data: string;
+  mimeType: string;
+}
+
+let counter = 0;
+
+/** Terminals don't deliver image bytes through paste, so we read the macOS
+ *  pasteboard directly via osascript. Null when the clipboard holds no image. */
+export async function readClipboardImage(): Promise<CapturedImage | null> {
+  if (process.platform !== "darwin") return null;
+  const tmp = join(tmpdir(), `ashi-clip-${process.pid}-${counter++}.png`);
+  try {
+    await exec("osascript", [
+      "-e", "set png_data to (the clipboard as «class PNGf»)",
+      "-e", `set fp to open for access POSIX file ${JSON.stringify(tmp)} with write permission`,
+      "-e", "write png_data to fp",
+      "-e", "close access fp",
+    ]);
+  } catch {
+    return null;
+  }
+  try {
+    const buf = await readFile(tmp);
+    if (buf.length === 0) return null;
+    return { data: buf.toString("base64"), mimeType: "image/png" };
+  } catch {
+    return null;
+  } finally {
+    void unlink(tmp).catch(() => {});
+  }
+}

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -31,6 +31,7 @@ import { resumeSession } from "./session-commands.js";
 import { applyBranchMessages } from "./commands.js";
 import type { Capture } from "./capture.js";
 import { execSync } from "node:child_process";
+import { readClipboardImage } from "./clipboard-image.js";
 import { renderDiff, detectLanguage, highlightLine } from "agent-sh/utils/diff-renderer.js";
 import { renderBoxFrame } from "agent-sh/utils/box-frame.js";
 
@@ -249,15 +250,18 @@ export function mountAshi(
       case "command":
         bus.emit("command:execute", { name: action.name, args: action.args });
         return;
-      case "agent":
+      case "agent": {
+        const imgs = pendingImages.filter((p) => action.query.includes(`[Image #${p.id}]`));
+        pendingImages = [];
         if (processing) {
-          queuedQueries.push(action.query);
+          queuedQueries.push({ query: action.query, images: imgs });
           renderQueueSlot();
           app.requestRender();
           return;
         }
-        bus.emit("agent:submit", { query: action.query });
+        bus.emit("agent:submit", { query: action.query, images: imgs.length ? toImageContent(imgs) : undefined });
         return;
+      }
     }
   });
 
@@ -316,7 +320,12 @@ export function mountAshi(
   let loader: LoaderView | null = null;
   let loaderGap: RenderNode | null = null;
   let processing = false;
-  const queuedQueries: string[] = [];
+  type PendingImage = { id: number; data: string; mimeType: string };
+  let pendingImages: PendingImage[] = [];
+  let imageCounter = 0;
+  const toImageContent = (imgs: PendingImage[]) =>
+    imgs.map(({ data, mimeType }) => ({ type: "image" as const, data, mimeType }));
+  const queuedQueries: { query: string; images: PendingImage[] }[] = [];
   const queuedShellLines: { line: string; private: boolean }[] = [];
   const pendingUserShell = new UserShellIntents();
 
@@ -329,7 +338,7 @@ export function mountAshi(
       app.queueSlot.addChild(new InfoLine(renderer, `↳ ${tag}: ${preview}`).node);
     }
     for (const q of queuedQueries) {
-      const oneLine = q.replace(/\s+/g, " ");
+      const oneLine = q.query.replace(/\s+/g, " ");
       const preview = oneLine.length > 80 ? oneLine.slice(0, 77) + "…" : oneLine;
       app.queueSlot.addChild(new InfoLine(renderer, `↳ queued: ${preview}`).node);
     }
@@ -452,7 +461,14 @@ export function mountAshi(
     }
     const m = entry.message;
     if (m.role === "user") {
-      const raw = typeof m.content === "string" ? m.content : "";
+      const raw = typeof m.content === "string"
+        ? m.content
+        : Array.isArray(m.content)
+          ? (m.content as Array<{ type?: string; text?: string }>)
+              .filter((p) => p.type === "text")
+              .map((p) => p.text ?? "")
+              .join("")
+          : "";
       if (raw.startsWith("[Compacted conversation summary]")) return;
       appendEntry(renderUserMessage(stripContextWrappers(raw)), { t: "plain" });
     } else if (m.role === "assistant") {
@@ -552,6 +568,24 @@ export function mountAshi(
   ctx.define("render:image", (data: Buffer) => {
     appendImage(data);
     app.requestRender();
+  });
+
+  // Only [Image #N] markers still in the text at submit are sent — deleting one drops its image.
+  const attachImage = (img: { data: string; mimeType: string }): void => {
+    const id = ++imageCounter;
+    pendingImages.push({ id, data: img.data, mimeType: img.mimeType });
+    input.replaceBeforeCursor(0, `[Image #${id}] `);
+    app.requestRender();
+  };
+  // Ctrl+V (wired below) and /paste capture a clipboard image; Cmd+V stays text paste.
+  const captureClipboardImage = (): void => {
+    void readClipboardImage().then((img) => {
+      if (img) attachImage(img);
+      else bus.emit("ui:info", { message: "No image found on the clipboard." });
+    });
+  };
+  ctx.registerCommand("paste", "Attach an image from the clipboard to your next message", async () => {
+    captureClipboardImage();
   });
 
   bus.on("agent:response-chunk", ({ blocks }) => {
@@ -699,7 +733,7 @@ export function mountAshi(
     const next = queuedQueries.shift();
     if (next !== undefined) {
       renderQueueSlot();
-      bus.emit("agent:submit", { query: next });
+      bus.emit("agent:submit", { query: next.query, images: next.images.length ? toImageContent(next.images) : undefined });
     } else {
       renderQueueSlot();
     }
@@ -1010,6 +1044,10 @@ export function mountAshi(
 
   app.onKey((key: KeyEvent) => {
     if (key.isRelease() || key.isRepeat()) return;
+    if (key.matches("ctrl+v")) {
+      captureClipboardImage();
+      return { consume: true };
+    }
     if (key.matches("escape")) {
       if (processing) {
         bus.emit("agent:cancel-request", {});
@@ -1042,7 +1080,8 @@ export function mountAshi(
     if (key.matches("up") && queuedQueries.length > 0 && input.getText().length === 0) {
       const last = queuedQueries.pop()!;
       renderQueueSlot();
-      input.setText(last);
+      input.setText(last.query);
+      pendingImages = last.images;
       app.requestRender();
       return { consume: true };
     }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -17,7 +17,7 @@ import type { LlmClient } from "./llm-client.js";
 import type { HandlerFunctions } from "../utils/handler-registry.js";
 import { setMaxListeners } from "node:events";
 import * as path from "node:path";
-import { contentText, type AgentBackend, type SkillView, type ToolDefinition, type ToolExecutionContext } from "./types.js";
+import { contentText, type AgentBackend, type ImageContent, type SkillView, type ToolDefinition, type ToolExecutionContext } from "./types.js";
 import { ToolRegistry } from "./tool-registry.js";
 import { normalizeToolArgs } from "./normalize-args.js";
 import { LiveView, type CompactResult } from "./live-view.js";
@@ -197,8 +197,8 @@ export class AgentLoop implements AgentBackend {
     });
 
 
-    on("agent:submit", ({ query }) => {
-      this.handleQuery(query).catch(() => {});
+    on("agent:submit", ({ query, images }) => {
+      this.handleQuery(query, images).catch(() => {});
     });
     on("agent:cancel-request", (e) => {
       this.abortController?.abort(e.silent ? "silent" : undefined);
@@ -908,7 +908,7 @@ export class AgentLoop implements AgentBackend {
     });
   }
 
-  private async handleQuery(query: string): Promise<void> {
+  private async handleQuery(query: string, images?: ImageContent[]): Promise<void> {
     // Cancel any in-flight loop (concurrent prompt handling)
     if (this.abortController) {
       this.abortController.abort();
@@ -934,7 +934,15 @@ export class AgentLoop implements AgentBackend {
         ? `<query_context>\n${queryContext}\n</query_context>\n\n${query}`
         : query;
 
-      this.conversation.addUserMessage(userContent);
+      // Fail closed: an image sent to a non-vision model errors and leaves an
+      // unsendable message poisoning history, so require declared image support.
+      let userImages = images?.length ? images : undefined;
+      if (userImages && !this.currentMode.modalities?.includes("image")) {
+        this.bus.emit("ui:info", { message: `Current model has no declared image support — ${userImages.length} image(s) dropped.` });
+        userImages = undefined;
+      }
+
+      this.conversation.addUserMessage(userContent, userImages);
       this.bus.emit("conversation:message-appended", { role: "user", content: query });
 
       responseText = await this.executeLoop(signal);

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -1,7 +1,7 @@
 /** Agent-protocol events. Speak this to be a backend; consume it to be a frontend. */
 import type { ContentBlock } from "../core/event-bus.js";
 import type { ProviderRegistration } from "./host-types.js";
-import type { ToolDefinition, ToolResultDisplay } from "./types.js";
+import type { ImageContent, ToolDefinition, ToolResultDisplay } from "./types.js";
 
 export interface AgentIdentity {
   name: string;
@@ -31,7 +31,7 @@ declare module "../core/event-bus.js" {
     "agent:instructions": { instructions: Array<{ name: string; text: string }> };
     "agent:skills": { skills: Array<{ name: string; description: string; filePath: string }> };
 
-    "agent:submit": { query: string };
+    "agent:submit": { query: string; images?: ImageContent[] };
     "agent:cancel-request": { silent?: boolean };
     "agent:append-user-message": { text: string };
     "agent:query": { query: string };

--- a/src/agent/live-view.ts
+++ b/src/agent/live-view.ts
@@ -43,8 +43,17 @@ export class LiveView {
     this.cachedMessagesJson = null;
   }
 
-  addUserMessage(text: string): void {
-    this.messages.push({ role: "user", content: text });
+  addUserMessage(text: string, images?: ImageContent[]): void {
+    if (images?.length) {
+      const parts: Array<{ type: "text"; text: string } | { type: "image_url"; image_url: { url: string } }> = [];
+      if (text) parts.push({ type: "text", text });
+      for (const img of images) {
+        parts.push({ type: "image_url", image_url: { url: `data:${img.mimeType};base64,${img.data}` } });
+      }
+      this.messages.push({ role: "user", content: parts } as unknown as ChatCompletionMessageParam);
+    } else {
+      this.messages.push({ role: "user", content: text });
+    }
     this.invalidateMessagesCache();
   }
 

--- a/src/agent/providers/openrouter.ts
+++ b/src/agent/providers/openrouter.ts
@@ -29,6 +29,15 @@ interface OpenRouterModel {
   id: string;
   supported_parameters?: string[];
   context_length?: number;
+  architecture?: { input_modalities?: string[] };
+}
+
+/** OpenRouter's input_modalities → the text/image subset; undefined when absent
+ *  so the fail-closed image guard treats the model as text-only. */
+function toModalities(input?: string[]): ("text" | "image")[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const out = input.filter((v): v is "text" | "image" => v === "text" || v === "image");
+  return out.length ? out : undefined;
 }
 
 export default function activate(ctx: AgentContext): void {
@@ -58,6 +67,7 @@ export default function activate(ctx: AgentContext): void {
         reasoning: m.supported_parameters?.includes("reasoning") ?? false,
         contextWindow: m.context_length,
         echoReasoning: userOverrides.get(m.id) ?? patterns.some((re) => re.test(m.id)),
+        modalities: toModalities(m.architecture?.input_modalities),
       })),
     });
   }).catch(() => { /* keep curated defaults */ });

--- a/tests/agent/multimodal.test.ts
+++ b/tests/agent/multimodal.test.ts
@@ -165,6 +165,46 @@ test("LiveView.addToolResult with error ImageContent[] still marks error", () =>
   assert.ok(toolMsg.content[0].text.startsWith("Error:"));
 });
 
+// ── LiveView.addUserMessage ─────────────────────────────────
+
+test("LiveView.addUserMessage without images stays a plain string", () => {
+  const conv = new LiveView();
+  conv.addUserMessage("just text");
+
+  const msg = conv.get()[0] as any;
+  assert.equal(msg.role, "user");
+  assert.equal(msg.content, "just text");
+});
+
+test("LiveView.addUserMessage with images produces text + image_url parts", () => {
+  const conv = new LiveView();
+  conv.addUserMessage("look at this", [
+    { type: "image", data: "Zm9v", mimeType: "image/png" },
+    { type: "image", data: "YmFy", mimeType: "image/jpeg" },
+  ]);
+
+  const msg = conv.get()[0] as any;
+  assert.equal(msg.role, "user");
+  assert.ok(Array.isArray(msg.content), "content should be array of content parts");
+  assert.equal(msg.content.length, 3);
+
+  assert.equal(msg.content[0].type, "text");
+  assert.equal(msg.content[0].text, "look at this");
+  assert.equal(msg.content[1].type, "image_url");
+  assert.equal(msg.content[1].image_url.url, "data:image/png;base64,Zm9v");
+  assert.equal(msg.content[2].image_url.url, "data:image/jpeg;base64,YmFy");
+});
+
+test("LiveView.addUserMessage with empty text omits the text part", () => {
+  const conv = new LiveView();
+  conv.addUserMessage("", [{ type: "image", data: "Zm9v", mimeType: "image/png" }]);
+
+  const msg = conv.get()[0] as any;
+  assert.ok(Array.isArray(msg.content));
+  assert.equal(msg.content.length, 1);
+  assert.equal(msg.content[0].type, "image_url");
+});
+
 // ── System prompt ───────────────────────────────────────────────────
 
 test("system prompt includes Image Support when model has image modality", async () => {


### PR DESCRIPTION
Adds user-turn image input: capture an image in the ashi prompt and send it to the model as image content.

## What

- **Capture** — `Ctrl+V` (or `/paste`) reads a clipboard image via macOS `osascript` and inserts an `[Image #N]` marker. Only markers still present in the text at submit are sent, so deleting a marker drops its image. `Cmd+V` stays standard text paste (no overloading of the standard gesture).
- **Transport** — `agent:submit` carries an optional `images[]`; `LiveView.addUserMessage` builds OpenAI multipart content (`text` + `image_url` data URL), reusing the shape already used for image tool results.
- **Guard (fail closed)** — images are dropped with a warning unless the active model declares an image modality. Sending an image to a non-vision model errors *and* leaves an unsendable message poisoning the conversation history, so we require an explicit declaration.
- **OpenRouter** — derive `modalities` from `architecture.input_modalities` so vision models (Claude/GPT/Gemini) declare image support automatically; text-only models (incl. the OpenRouter default) correctly drop.

## Layers touched

- Core: `agent/events.ts` (`agent:submit.images?`), `agent/live-view.ts` (multipart `addUserMessage`), `agent/agent-loop.ts` (guard), `agent/providers/openrouter.ts` (modality detection)
- ashi: `clipboard-image.ts` (new), `frontend.ts` (capture, `[Image #N]` markers, queue threading, multipart-message rebuild fix)

## Notes / scope

- Clipboard capture is **macOS-only** for now (`osascript`); the helper is structured to add `xclip`/`wl-paste`/PowerShell branches.
- Among built-ins, `opencode` and (now) `openrouter` auto-declare modalities. The native `openai` provider's vision models (gpt-4o/4.1/5, o3) are not yet declared, so vision via that provider still drops — a follow-up.

## Tests

- Added `LiveView.addUserMessage` multipart cases to `tests/agent/multimodal.test.ts`.
- `tests/agent` 89/89, ashi 49/49, both builds clean.