### PR TITLE
Ashi renderer refinements (pi-tui + ink)

### DIFF
--- a/examples/extensions/ashi-ink/src/ink-renderer.tsx
+++ b/examples/extensions/ashi-ink/src/ink-renderer.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Box, Static, Text, render as inkRender, type Instance } from "ink";
 import Spinner from "ink-spinner";
 import { LineEditor } from "agent-sh/utils/line-editor.js";
-import { ProcessTerminal, matchesKey, isKeyRelease, isKeyRepeat, type KeyId } from "@earendil-works/pi-tui";
+import { ProcessTerminal, matchesKey, isKeyRelease, isKeyRepeat, wrapTextWithAnsi, type KeyId } from "@earendil-works/pi-tui";
 import { Marked } from "marked";
 import { markedTerminal } from "marked-terminal";
 import Table from "cli-table3";
@@ -110,6 +110,13 @@ const DOT_ERR = "\x1b[38;2;255;107;128m";
 const DIM_ON = "\x1b[2m";
 const DIM_OFF = "\x1b[22m";
 
+// The frontend hands border color as a text styler (theme.fg truecolor); Ink's
+// borderColor wants a value, so pull the RGB back out as hex.
+function hexFromStyler(fn: (t: string) => string): string {
+  const m = fn("x").match(/38;2;(\d+);(\d+);(\d+)/);
+  return m ? `#${[m[1], m[2], m[3]].map((n) => Number(n).toString(16).padStart(2, "0")).join("")}` : MARKER_GRAY_HEX;
+}
+
 // marked-terminal's legacy table renderer hands us marker-delimited cells sized to
 // content with no max; we split them and rebuild with cli-table3 colWidths that fit.
 const TABLE_CELL_SPLIT = "^*||*^";
@@ -148,6 +155,27 @@ function fitTable(header: string, body: string, width: number): string {
   return `${t.toString()}\n`;
 }
 
+// marked-terminal doesn't reflow list items; reflow each so its list() hang-indents the wraps.
+function makeWrappingList(width: number) {
+  return (body: string, ordered: boolean): string => {
+    const out: string[] = [];
+    let num = 0;
+    let hang = 2;
+    for (const line of body.trim().split("\n")) {
+      if (!line) continue;
+      if (line.startsWith("* ")) {
+        const marker = ordered ? `${++num}. ` : "* ";
+        hang = marker.length;
+        wrapTextWithAnsi(line.slice(2), Math.max(1, width - hang))
+          .forEach((wl, i) => out.push((i === 0 ? marker : " ".repeat(hang)) + wl));
+      } else {
+        wrapTextWithAnsi(line, Math.max(1, width - hang)).forEach((wl) => out.push(" ".repeat(hang) + wl));
+      }
+    }
+    return out.join("\n");
+  };
+}
+
 // marked-terminal defaults to width 80 / no reflow; reflow at the real width (cached).
 const markedCache = new Map<number, Marked>();
 function markedFor(width: number): Marked {
@@ -155,7 +183,7 @@ function markedFor(width: number): Marked {
   if (!m) {
     m = new Marked();
     // tab 0 = flush-left markdown (the bullet is the only indent); flattens nested lists.
-    m.use(markedTerminal({ width, reflowText: true, tab: 0 }) as Parameters<Marked["use"]>[0]);
+    m.use(markedTerminal({ width, reflowText: true, tab: 0, list: makeWrappingList(width) }) as Parameters<Marked["use"]>[0]);
     m.use({ renderer: { table: (h: unknown, b: unknown): string => fitTable(String(h), String(b), width) } } as Parameters<Marked["use"]>[0]);
     markedCache.set(width, m);
   }
@@ -555,6 +583,7 @@ interface AppState {
   keyHandlers: KeyHandler[];
   // [0, committedCount) are settled and render via <Static>; the rest is the live turn.
   committedCount: number;
+  borderColor: string;
 }
 
 // Global key matching shares pi-tui's matcher, so it behaves identically to the
@@ -584,7 +613,7 @@ function Root({ store, state }: { store: Store; state: AppState }): React.ReactE
       {live.map((child, i) => renderBlock(child, cc + i))}
       {renderVNode(state.footer)}
       {renderVNode(state.queue)}
-      <Box marginTop={1} borderStyle="single" borderLeft={false} borderRight={false} borderColor={MARKER_GRAY_HEX}>
+      <Box marginTop={1} borderStyle="single" borderLeft={false} borderRight={false} borderColor={state.borderColor}>
         <Text>{paintInput(state.editor, state.focus === "input")}</Text>
       </Box>
       {renderVNode(state.belowInput)}
@@ -620,6 +649,7 @@ function makeApp(store: Store, req: () => void): {
     activeSelect: null,
     keyHandlers: [],
     committedCount: 0,
+    borderColor: MARKER_GRAY_HEX,
   };
 
   let ink: Instance | null = null;
@@ -718,8 +748,8 @@ function makeApp(store: Store, req: () => void): {
     },
     onChange: (fn) => { state.onChange = fn; },
     onSubmit: (fn) => { state.onSubmit = fn; },
-    defaultBorderColor: (t) => t,
-    setBorderColor: () => {},
+    defaultBorderColor: (t) => `${MARKER_GRAY}${t}${RESET}`,
+    setBorderColor: (fn) => { state.borderColor = hexFromStyler(fn); req(); },
     invalidate: () => req(),
   };
 

--- a/examples/extensions/ashi-ink/test/render.test.tsx
+++ b/examples/extensions/ashi-ink/test/render.test.tsx
@@ -105,6 +105,22 @@ test("streaming markdown (stable-prefix) converges to the one-shot render", () =
   }
 });
 
+test("a long list item wraps with a hanging indent, not back to column 0", () => {
+  const desc = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+  Object.defineProperty(process.stdout, "columns", { value: 40, configurable: true });
+  try {
+    const md = r.markdown();
+    md.setText("- this is a fairly long list item that should wrap across the width here");
+    const lines = frameOf(md.node).split("\n").filter((l) => l.trim());
+    assert.ok(lines.length >= 2, `expected the item to wrap, got ${lines.length} line(s)`);
+    assert.match(lines[0], /^\* this is/); // bullet at column 0
+    assert.match(lines[1], /^ {2}\S/); // continuation hangs under the bullet text, not col 0
+  } finally {
+    if (desc) Object.defineProperty(process.stdout, "columns", desc);
+    else delete (process.stdout as { columns?: number }).columns;
+  }
+});
+
 test("committed scrollback renders via <Static>, alongside the live tail", () => {
   const h = __harness();
   const a = h.nodes.text(); a.setText("first turn");
@@ -304,6 +320,15 @@ test("Shift+Enter inserts a newline; Enter submits", () => {
   h.feedInput("\r"); // Enter
   assert.equal(submitted, "ab\ncd");
   assert.equal(h.editor.text, ""); // onSubmit cleared it
+});
+
+test("the input box border color follows setBorderColor (shell mode)", () => {
+  const h = __harness();
+  const before = render(h.element).lastFrame() ?? "";
+  assert.doesNotMatch(before, /38;2;220;180;0/); // default gray, not yellow
+  h.app.input.setBorderColor((t) => `\x1b[38;2;220;180;0m${t}\x1b[39m`); // a theme.fg-style yellow styler
+  const after = render(h.element).lastFrame() ?? "";
+  assert.match(after, /38;2;220;180;0/); // border now carries the shell-mode color
 });
 
 test("the input box border uses the same gray as the ❯ marker", () => {

--- a/examples/extensions/ashi/src/renderers/pi-tui/app.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/app.ts
@@ -77,7 +77,9 @@ export function createApp(): App {
   const tui = new TUI(terminal);
 
   const scrollback = nodes.container();
-  const footerSlot = footerContainer();
+  const footerSlot = footerContainer(
+    () => (scrollback.node as unknown as { children: unknown[] }).children.length > 0,
+  );
   const queueSlot = nodes.container();
   const status = nodes.text({ paddingX: 1 });
   const belowInput = nodes.container();

--- a/examples/extensions/ashi/src/renderers/pi-tui/nodes.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/nodes.ts
@@ -46,8 +46,9 @@ const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 // OSC 133 zone brackets let terminals navigate between user prompts.
 class ZonedMarkdown extends Markdown {
   override render(width: number): string[] {
-    const lines = super.render(width);
-    if (lines.length === 0) return lines;
+    const base = super.render(width);
+    if (base.length === 0) return base;
+    const lines = base.slice();
     lines[0] = OSC133_ZONE_START + lines[0];
     lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
     return lines;
@@ -55,13 +56,17 @@ class ZonedMarkdown extends Markdown {
 }
 
 class FooterSlot extends Container {
+  constructor(private readonly hasContentAbove: () => boolean) {
+    super();
+  }
   override render(width: number): string[] {
-    return this.children.length === 0 ? [""] : super.render(width);
+    if (this.children.length > 0) return super.render(width);
+    return this.hasContentAbove() ? [""] : [];
   }
 }
 
-export function footerContainer(): ContainerView {
-  const c = new FooterSlot();
+export function footerContainer(hasContentAbove: () => boolean): ContainerView {
+  const c = new FooterSlot(hasContentAbove);
   return {
     node: asNode(c),
     addChild: (child) => c.addChild(asComponent(child)),

--- a/examples/extensions/ashi/tests/chat-controllers.test.ts
+++ b/examples/extensions/ashi/tests/chat-controllers.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { createPiTuiRenderer } from "../src/renderers/pi-tui/index.js";
 import { InfoLine, ErrorLine } from "../src/chat/lines.js";
 import { AssistantMessage } from "../src/chat/assistant.js";
+import { UserMessage } from "../src/chat/user-message.js";
+import { footerContainer } from "../src/renderers/pi-tui/nodes.js";
 import { ThinkingBlock } from "../src/chat/thinking.js";
 import { ToolGroup } from "../src/chat/tool-group.js";
 import { registerDefaultSchemaRenderers } from "../src/default-schema-renderers.js";
@@ -42,6 +44,22 @@ test("AssistantMessage streams text and renders markdown", () => {
 test("AssistantMessage hasContent is false before any text", () => {
   const am = new AssistantMessage(renderer);
   assert.equal(am.hasContent(), false);
+});
+
+test("FooterSlot reserves a gap only when there is content above", () => {
+  const render = (n: RenderNode) => (n as unknown as { render(w: number): string[] }).render(80);
+  assert.deepEqual(render(footerContainer(() => false).node), [], "no blank line at launch (empty transcript)");
+  assert.deepEqual(render(footerContainer(() => true).node), [""], "one gap line once a transcript exists");
+});
+
+test("UserMessage renders identically across repeated renders", () => {
+  const um = new UserMessage(renderer, "Hello **world**, a wrapping user message for the test.");
+  const comp = um.node as unknown as { render(w: number): string[] };
+  const first = comp.render(80);
+  const second = comp.render(80);
+  const third = comp.render(80);
+  assert.deepEqual(second, first, "second render must be byte-identical to the first");
+  assert.deepEqual(third, first, "third render must be byte-identical to the first");
 });
 
 test("ThinkingBlock hides and restores its buffer", () => {


### PR DESCRIPTION
Four renderer fixes across the two ashi renderers, split into two commits (pi-tui, ink).

## pi-tui renderer

**Scroll-while-streaming was broken once the transcript overflowed.** `ZonedMarkdown.render()` did `lines[0] = OSC133_ZONE_START + lines[0]` on the array pi-tui's `Markdown.render()` returns — which is **cached** — so it re-prepended a zone marker to line 0 on every render. With the transcript taller than the viewport, that ever-changing top line is above `viewportTop`, forcing pi-tui into `fullRender(true)` (which emits `\x1b[3J`, wiping scrollback) every frame. Diagnosed via `PI_DEBUG_REDRAW` (628/629 redraws were `firstChanged < viewportTop`, `firstChanged=1`). Fix: copy the array before adding markers.

**Stray blank line above the input box at launch.** `FooterSlot` (added in #222 to keep a gap between a finished response and the input) rendered `[""]` even with an empty transcript. Fix: reserve the gap only when there's content above.

## ashi-ink renderer

**List items didn't wrap with a hanging indent.** marked-terminal reflows paragraphs but not list items, so a long item overflowed and Ink wrapped it back to col 0. Fix: override marked-terminal's `list()` to reflow each item (ANSI-aware, via pi-tui's `wrapTextWithAnsi`); its built-in `list()` then hang-indents the continuations under the bullet.

**Input border ignored `!`/`!!` mode.** `setBorderColor` was a no-op and the border color was hardcoded. Fix: extract the RGB from the frontend's border styler (`theme.fg` truecolor) so the border follows shell mode (yellow) and private mode (green), matching pi-tui.

## Tests
- pi-tui: `UserMessage` renders identically across repeated renders; `FooterSlot` gaps only when there's content above.
- ink: long list item hang-indents (not col 0); input border follows `setBorderColor`.
- All suites green (ashi 51/51, ashi-ink 23/23), both builds clean.