### PR TITLE
agent: never route a provider's key to a foreign endpoint

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -45,6 +45,13 @@ function persistedModelFor(providerName: string | undefined): string | undefined
   return getSettings().providers?.[providerName]?.defaultModel;
 }
 
+/** The OpenAI SDK silently defaults an empty baseURL to api.openai.com, so a
+ *  provider with a key but no endpoint would misroute its key there. `openai`
+ *  is exempt: that default is its endpoint. */
+function usableProvider(p: ResolvedProvider | null | undefined): boolean {
+  return !!p?.apiKey && (!!p.baseURL || p.id === "openai");
+}
+
 type ModelCap = { reasoning?: boolean; contextWindow?: number; maxTokens?: number; echoReasoning?: boolean; modalities?: ("text" | "image")[] };
 
 function defaultReasoningBuilder(level: string): Record<string, unknown> {
@@ -296,6 +303,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
     const out: AgentMode[] = [];
     for (const [id, p] of resolvedProviders) {
       if (!p.apiKey) continue;
+      if (!usableProvider(p)) continue;
       const shapeId = p.reasoningShape ?? id;
       for (const model of p.models) {
         const mc = p.modelCapabilities?.get(model);
@@ -365,13 +373,32 @@ export default function agentBackend(ctx: ExtensionContext): void {
     resolvedProviders = computeResolvedProviders();
 
     const settings = getSettings();
-    // Built-ins register unconditionally so `auth list` can enumerate them;
-    // the fallback must skip keyless entries or it lands on openrouter and
-    // bails at the `!effectiveApiKey` guard below.
-    const providerName = config.provider
-      ?? settings.defaultProvider
-      ?? [...resolvedProviders].find(([, p]) => p.apiKey)?.[0];
-    const activeProvider = providerName ? resolvedProviders.get(providerName) ?? null : null;
+
+    let providerName: string | undefined = config.provider ?? settings.defaultProvider;
+    let activeProvider = providerName ? resolvedProviders.get(providerName) ?? null : null;
+
+    // Inline CLI credentials carry their own endpoint, so they skip the
+    // usable-provider fallback that registry-driven selection needs.
+    if (!config.apiKey) {
+      if (!providerName) {
+        const first = [...resolvedProviders].find(([, p]) => usableProvider(p));
+        providerName = first?.[0];
+        activeProvider = first?.[1] ?? null;
+      } else if (!usableProvider(activeProvider)) {
+        const reason = !activeProvider ? "is not registered"
+          : !activeProvider.apiKey ? "has no API key configured"
+          : "has no endpoint configured";
+        const next = [...resolvedProviders].find(([, p]) => usableProvider(p));
+        if (next) {
+          bus.emit("ui:error", { message: `Provider "${providerName}" ${reason}; falling back to "${next[0]}".` });
+          providerName = next[0];
+          activeProvider = next[1];
+        } else {
+          bus.emit("ui:error", { message: `Provider "${providerName}" ${reason}, and no other configured provider has both an API key and an endpoint. Run \`agent-sh auth\` to configure one.` });
+          return;
+        }
+      }
+    }
 
     // Persisted defaultModel wins over openrouter's hardcoded DEFAULT_MODELS[0].
     const effectiveApiKey = config.apiKey ?? activeProvider?.apiKey;
@@ -492,6 +519,10 @@ export default function agentBackend(ctx: ExtensionContext): void {
     }
     if (!p.apiKey) {
       bus.emit("ui:error", { message: `Provider "${name}" has no API key configured` });
+      return;
+    }
+    if (!p.baseURL && p.id !== "openai") {
+      bus.emit("ui:error", { message: `Provider "${name}" has no endpoint configured` });
       return;
     }
     const switchModel = p.defaultModel ?? p.models[0];

--- a/tests/agent/builtin-provider-activation.test.ts
+++ b/tests/agent/builtin-provider-activation.test.ts
@@ -1,8 +1,4 @@
-/** Regression coverage for the "fresh install + `auth login deepseek` →
- *  no backend found" bug. Two invariants:
- *    1. Built-ins still register without a key (auth-discovery feature).
- *    2. With only one keyed provider, the ash backend activates against it
- *       — the default-provider fallback must skip keyless entries. */
+/** Provider resolution at backend activation. */
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
@@ -16,6 +12,7 @@ const DRIVER = fileURLToPath(new URL("../fixtures/builtin-provider-driver.ts", i
 interface DriverResult {
   registeredIds: string[];
   backendRegistrations: { name: string }[];
+  uiErrors: string[];
 }
 
 async function run(opts: {
@@ -75,13 +72,36 @@ test("only deepseek keyed: ash backend registers against deepseek", async () => 
   assert.ok(ash, `ash backend did not register; got ${JSON.stringify(result.backendRegistrations)}`);
 });
 
-test("only deepseek keyed but settings.defaultProvider=openrouter: ash does not register", async () => {
-  // Explicit user choice must still win — this guards against an overly
-  // aggressive fallback that ignores defaultProvider.
+test("defaultProvider keyless but another provider usable: warn + fall through", async () => {
   const result = await run({
     keys: { deepseek: "sk-test" },
     settings: { defaultProvider: "openrouter" },
   });
   const ash = result.backendRegistrations.find((b) => b.name === "ash");
-  assert.equal(ash, undefined, "ash should not register when user pointed at keyless openrouter");
+  assert.ok(ash, `ash should fall through to the keyed provider; got ${JSON.stringify(result.backendRegistrations)}`);
+  const warn = result.uiErrors.join("\n");
+  assert.match(warn, /openrouter/, `expected a warning naming openrouter; got: ${warn}`);
+  assert.match(warn, /falling back/i);
+});
+
+test("keyed provider without an endpoint never silently routes to OpenAI", async () => {
+  const result = await run({
+    settings: { defaultProvider: "myproxy", providers: { myproxy: { apiKey: "sk-orphan", defaultModel: "m1" } } },
+  });
+  const ash = result.backendRegistrations.find((b) => b.name === "ash");
+  assert.equal(ash, undefined, "ash must not register an endpointless provider against the OpenAI default");
+  const err = result.uiErrors.join("\n");
+  assert.match(err, /myproxy/);
+  assert.match(err, /endpoint/i);
+});
+
+test("custom settings provider with both key and endpoint registers", async () => {
+  const result = await run({
+    settings: {
+      defaultProvider: "myproxy",
+      providers: { myproxy: { apiKey: "sk-p", baseURL: "https://proxy.local/v1", defaultModel: "m1" } },
+    },
+  });
+  const ash = result.backendRegistrations.find((b) => b.name === "ash");
+  assert.ok(ash, `ash should register a fully-configured custom provider; got ${JSON.stringify(result)}`);
 });

--- a/tests/agent/multimodal.test.ts
+++ b/tests/agent/multimodal.test.ts
@@ -38,7 +38,7 @@ interface DriverResult {
 }
 
 async function runDriver(
-  provider: { id: string; apiKey?: string; models: Array<{ id: string; modalities?: ("text" | "image")[] }> },
+  provider: { id: string; apiKey?: string; baseURL?: string; models: Array<{ id: string; modalities?: ("text" | "image")[] }> },
 ): Promise<DriverResult> {
   const home = mkdtempSync(join(tmpdir(), "agent-sh-mm-"));
   try {
@@ -211,6 +211,7 @@ test("system prompt includes Image Support when model has image modality", async
   const result = await runDriver({
     id: "test-vision",
     apiKey: "sk-test",
+    baseURL: "https://vision.test/v1",
     models: [{ id: "vision-model", modalities: ["text", "image"] }],
   });
 
@@ -224,6 +225,7 @@ test("system prompt excludes Image Support when model has no modalities", async 
   const result = await runDriver({
     id: "test-text",
     apiKey: "sk-test",
+    baseURL: "https://text.test/v1",
     models: [{ id: "text-model" }],
   });
 
@@ -237,6 +239,7 @@ test("system prompt excludes Image Support when modalities is text-only", async 
   const result = await runDriver({
     id: "test-text-only",
     apiKey: "sk-test",
+    baseURL: "https://text.test/v1",
     models: [{ id: "text-model", modalities: ["text"] }],
   });
 

--- a/tests/agent/provider-modes.test.ts
+++ b/tests/agent/provider-modes.test.ts
@@ -129,7 +129,7 @@ test("active mode missing from refreshed catalog stays as ghost + emits ui:info 
   const settings = {
     defaultProvider: "openrouter",
     providers: {
-      openrouter: { apiKey: "x", defaultModel: "m-b" },
+      openrouter: { apiKey: "x", baseURL: "https://openrouter.ai/api/v1", defaultModel: "m-b" },
     },
   };
 
@@ -165,7 +165,7 @@ test("active mode missing from refreshed catalog stays as ghost + emits ui:info 
 test("persisted default not in initial catalog → stub used as initial active mode", async () => {
   const settings = {
     defaultProvider: "openrouter",
-    providers: { openrouter: { apiKey: "x", defaultModel: "future/model" } },
+    providers: { openrouter: { apiKey: "x", baseURL: "https://openrouter.ai/api/v1", defaultModel: "future/model" } },
   };
 
   const result = await runDriver(settings, {
@@ -190,7 +190,7 @@ test("persisted default not in initial catalog → stub used as initial active m
 test("late catalog containing persisted default does not switch away from active override", async () => {
   const settings = {
     defaultProvider: "openrouter",
-    providers: { openrouter: { apiKey: "x", defaultModel: "persisted/m" } },
+    providers: { openrouter: { apiKey: "x", baseURL: "https://openrouter.ai/api/v1", defaultModel: "persisted/m" } },
   };
 
   const result = await runDriver(settings, {

--- a/tests/fixtures/builtin-provider-driver.ts
+++ b/tests/fixtures/builtin-provider-driver.ts
@@ -10,9 +10,13 @@ import type { ProviderRegistration } from "../../src/agent/host-types.js";
 async function main() {
   const core = createCore({} as AppConfig);
   const backendRegistrations: Array<{ name: string }> = [];
+  const uiErrors: string[] = [];
 
   core.bus.on("agent:register-backend" as never, (payload: { name: string }) => {
     backendRegistrations.push({ name: payload.name });
+  });
+  core.bus.on("ui:error" as never, (payload: { message: string }) => {
+    uiErrors.push(payload.message);
   });
 
   const ctx = core.extensionContext({ quit: () => {} });
@@ -26,7 +30,7 @@ async function main() {
   });
   const registeredIds = providers.map((p) => p.id).sort();
 
-  process.stdout.write(JSON.stringify({ registeredIds, backendRegistrations }) + "\n");
+  process.stdout.write(JSON.stringify({ registeredIds, backendRegistrations, uiErrors }) + "\n");
   process.exit(0);
 }
 


### PR DESCRIPTION
## Problem

A provider configured with an API key but **no resolvable `baseURL`** was activated anyway. The OpenAI SDK silently defaults an empty `baseURL` to `https://api.openai.com/v1`, so that provider's key was sent to OpenAI and rejected with a **401** — while the UI still showed the original provider as active.

Concretely: asHub bundles an older `agent-sh` that lacks the `zai-coding-plan` provider plugin, so `zai-coding-plan` resolved with a valid key from `keys.json` but an `undefined` endpoint → the zai key went to OpenAI → 401. The same class of bug hits any settings-only provider whose plugin isn't present.

## Fix

A provider is **usable only with BOTH a key and an endpoint** (`usableProvider()`); the built-in `openai` is the lone exception, since the SDK default *is* its real endpoint. Enforced at three points:

1. **Startup resolution** (`core:extensions-loaded`) — if the configured `defaultProvider` isn't usable, emit a visible `ui:error` and **fall through to the next usable provider**; if none qualifies, error instead of silently misrouting. Inline CLI `--api-key`/`--base-url` keep their existing self-sufficient behavior.
2. **`config:switch-provider`** — refuses a switch to an endpointless provider with a clear message.
3. **`buildModes()`** — never offers an endpointless non-openai provider as a switchable model, closing the model-picker path into the same trap.

## Tests

- `builtin-provider-activation`: replaced the old "keyless default → don't register" assertion with **warn + fall-through**, and added cases for endpointless-provider → no registration + error, and a fully-configured custom provider → registers. Driver now captures `ui:error`.
- `multimodal` / `provider-modes`: fixtures now register realistic `baseURL`s, matching production where every non-openai provider sets one.

Full suite: **244/244 green**, `tsc` clean.