### PR TITLE
ashi-ink: live tool-group tail, dimmed thinking, coral accent + turn timer

### DIFF
--- a/examples/extensions/ashi-ink/src/ink-renderer.tsx
+++ b/examples/extensions/ashi-ink/src/ink-renderer.tsx
@@ -225,6 +225,16 @@ function renderMarkdownStreaming(v: { source: string; mdc?: MdCache }, width: nu
   return `${c.out}\n\n${tailOut}`;
 }
 
+const FULL_RESET = /\x1b\[0?m/g;
+function tintMarkdown(md: string, styler: (t: string) => string): string {
+  const probe = styler(" ");
+  const cut = probe.indexOf(" ");
+  const open = cut > 0 ? probe.slice(0, cut) : "";
+  return md.split("\n")
+    .map((line) => styler(open ? line.replace(FULL_RESET, (m) => m + open) : line))
+    .join("\n");
+}
+
 interface Store {
   bump: () => void;
   subscribe: (l: () => void) => () => void;
@@ -487,14 +497,14 @@ export function renderVNode(v: VNode, key?: React.Key): React.ReactElement | nul
       if (v.bullet) {
         let md = renderMarkdownStreaming(v, w - 2);
         if (md.replace(ANSI, "").trim() === "") return null;
-        if (v.color) md = md.split("\n").map(v.color).join("\n");
+        if (v.color) md = tintMarkdown(md, v.color);
         const out = md.split("\n").map((l, i) => (i === 0 ? ASSISTANT_MARKER : "  ") + l).join("\n");
         return <Text key={key}>{out}</Text>;
       }
       const pad = v.paddingX ?? 0;
       let md = renderMarkdownStreaming(v, w - pad);
       if (md.replace(ANSI, "").trim() === "") return null;
-      if (v.color) md = md.split("\n").map(v.color).join("\n");
+      if (v.color) md = tintMarkdown(md, v.color);
       const indent = " ".repeat(pad);
       return <Text key={key}>{md.split("\n").map((l) => indent + l).join("\n")}</Text>;
     }

--- a/examples/extensions/ashi-ink/src/ink-renderer.tsx
+++ b/examples/extensions/ashi-ink/src/ink-renderer.tsx
@@ -435,11 +435,10 @@ function childOk(c: ToolGroupModel["children"][number]): boolean {
 }
 function groupSummaryLine(model: ToolGroupModel, blinkOn: boolean): string {
   const total = model.children.length + (model.hidden?.count ?? 0);
-  const running = model.children.some((c) => !c.status);
   const anyErr = model.children.some((c) => !childOk(c)) || (model.hidden ? !model.hidden.ok : false);
-  const dot = statusDot(running ? undefined : { exitCode: anyErr ? 1 : 0 }, blinkOn);
+  const dot = statusDot(model.open ? undefined : { exitCode: anyErr ? 1 : 0 }, blinkOn);
   const hint = model.expanded ? "" : ` ${DIM_ON}(ctrl+o to expand)${DIM_OFF}`;
-  return `${dot} ${summarizeGroup(model.kind, total, running)}${running ? "…" : ""}${hint}`;
+  return `${dot} ${summarizeGroup(model.kind, total, model.open)}${model.open ? "…" : ""}${hint}`;
 }
 function makeToolGroup(req: () => void, blink: Blink): ToolGroupView {
   const v: VNode = { kind: "container", children: [] };
@@ -448,14 +447,14 @@ function makeToolGroup(req: () => void, blink: Blink): ToolGroupView {
   let acquired = false;
   const update = (m: ToolGroupModel): void => {
     model = m;
-    const running = m.children.some((c) => !c.status);
-    if (running && !acquired) { blink.start(v); acquired = true; }
-    else if (!running && acquired) { blink.stop(v); acquired = false; }
+    if (m.open && !acquired) { blink.start(v); acquired = true; }
+    else if (!m.open && acquired) { blink.stop(v); acquired = false; }
     ch.length = 0;
     // Summary via a render fn so the blink clock repaints it in place.
     ch.push({ kind: "text", lines: [], fn: () => (model ? [groupSummaryLine(model, blink.on())] : []), paddingX: 0 });
-    // Collapsed shows only in-flight files; expanded shows every call + summary.
-    const rows = m.expanded ? m.children : m.children.filter((c) => !c.status);
+    const rows = m.expanded
+      ? m.children
+      : m.open && m.children.length > 0 ? [m.children[m.children.length - 1]!] : [];
     for (const c of rows) {
       const elbow = segmentsToString([{ text: "⎿", style: { color: childOk(c) ? "muted" : "error" } }]);
       const sum = m.expanded && c.status?.summary ? ` ${segmentsToString([{ text: c.status.summary, style: { color: "muted" } }])}` : "";

--- a/examples/extensions/ashi-ink/src/ink-renderer.tsx
+++ b/examples/extensions/ashi-ink/src/ink-renderer.tsx
@@ -55,7 +55,7 @@ type VNode =
   | { kind: "markdown"; source: string; color?: (t: string) => string; userMsg?: boolean; bullet?: boolean; paddingX?: number; mdc?: MdCache }
   | { kind: "spacer"; rows: number }
   | { kind: "container"; children: VNode[] }
-  | { kind: "loader"; label: string }
+  | { kind: "loader"; label: string; startedAt: number }
   | { kind: "select"; state: SelectState };
 
 const asNode = (v: VNode): RenderNode => v as unknown as RenderNode;
@@ -92,7 +92,7 @@ function truncateVisible(s: string, width: number): string {
   return `${out}…\x1b[0m`;
 }
 
-const ACCENT_HEX = "#c778dd"; // loader spinner + focused input border
+const ACCENT_HEX = "#d97757"; // coral accent — thinking spinner + select picker highlight
 const RESET = "\x1b[39m";
 const BOLD = "\x1b[1m";
 const BOLD_OFF = "\x1b[22m";
@@ -475,6 +475,11 @@ function makeToolGroup(req: () => void, blink: Blink): ToolGroupView {
   return { node: asNode(v), update };
 }
 
+function fmtElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
 export function renderVNode(v: VNode, key?: React.Key): React.ReactElement | null {
   switch (v.kind) {
     case "text": {
@@ -515,13 +520,15 @@ export function renderVNode(v: VNode, key?: React.Key): React.ReactElement | nul
       if (kids.length === 0) return null; // an empty block renders nothing, like pi-tui
       return <Box key={key} flexDirection="column">{kids}</Box>;
     }
-    case "loader":
+    case "loader": {
+      const elapsed = fmtElapsed(Date.now() - v.startedAt);
       return (
         <Box key={key}>
           <Text color={ACCENT_HEX}><Spinner type="dots" /></Text>
-          <Text color={ACCENT_HEX}>{" " + v.label}</Text>
+          <Text color={ACCENT_HEX}>{` ${v.label} (${elapsed})`}</Text>
         </Box>
       );
+    }
     case "select": {
       // Drawn here; navigated by raw keys in the input dispatch (focus === "select").
       const s = v.state;
@@ -802,8 +809,10 @@ function makeApp(store: Store, req: () => void): {
       };
     },
     createLoader: (label): LoaderView => {
-      const v: VNode = { kind: "loader", label };
-      return { node: asNode(v), stop: () => {} };
+      const v: VNode = { kind: "loader", label, startedAt: Date.now() };
+      const timer = setInterval(req, 1000);
+      (timer as { unref?: () => void }).unref?.();
+      return { node: asNode(v), stop: () => clearInterval(timer) };
     },
   };
   return { app, element, dispatch, editor };

--- a/examples/extensions/ashi-ink/test/render.test.tsx
+++ b/examples/extensions/ashi-ink/test/render.test.tsx
@@ -248,6 +248,17 @@ test("revealed thinking is dim-tinted and survives marked's resets", () => {
   assert.match(frame, /\x1b\[2m/);
 });
 
+test("the thinking loader is coral and shows a per-turn elapsed timer", () => {
+  const h = __harness();
+  const loader = h.app.createLoader("thinking…", (t) => t, (t) => t);
+  const inst = render(__renderNode(loader.node));
+  const frame = inst.lastFrame() ?? "";
+  inst.unmount();
+  loader.stop();
+  assert.match(frame, /38;2;217;119;87m/); // coral accent
+  assert.match(frame, /thinking… \(\d+s\)/);
+});
+
 test("a diff result hangs under the ⎿ gutter with no box frame (flush gutter)", () => {
   const env = { width: 80, mode: "preview" as const, previewLines: 50 };
   const args = { toolCallId: "d1", name: "edit_file", title: "edit", displayDetail: "src/app.ts", rawInput: {} };

--- a/examples/extensions/ashi-ink/test/render.test.tsx
+++ b/examples/extensions/ashi-ink/test/render.test.tsx
@@ -213,23 +213,24 @@ test("multi-line tool output is consistently colored (not first-line-only)", () 
   for (const l of out) assert.match(l, /\x1b\[38;2;/);
 });
 
-test("a read group: gerund + in-flight path while active, count when done, full list on expand", () => {
+test("a read group: tail pinned + flashing while open, summary-only once sealed, full list on expand", () => {
   const g = new ToolGroup(r as never, "read");
   g.addCall("1", "read_file", "src/app.ts");
   g.addCall("2", "read_file", "src/util.ts");
   g.recordCompletion("1", 0, "120 lines");
-  // call 2 still running → active: gerund, ellipsis, ctrl+o hint, in-flight path shown
   let collapsed = frameOf(g.node);
   assert.match(collapsed, /⏺ Reading 2 files…/);
   assert.match(collapsed, /\(ctrl\+o to expand\)/);
-  assert.match(collapsed, /⎿  src\/util\.ts/); // the file being read, not just a count
+  assert.match(collapsed, /⎿  src\/util\.ts/);
   assert.doesNotMatch(collapsed, /[├└]/);
-  // finish it → past tense, no path under the collapsed summary
   g.recordCompletion("2", 0, "45 lines");
+  collapsed = frameOf(g.node);
+  assert.match(collapsed, /⏺ Reading 2 files…/);
+  assert.match(collapsed, /⎿  src\/util\.ts/);
+  g.seal();
   collapsed = frameOf(g.node);
   assert.match(collapsed, /⏺ Read 2 files/);
   assert.doesNotMatch(collapsed, /⎿/);
-  // expand → full list with per-file summaries, no hint
   g.toggleExpanded();
   const expanded = frameOf(g.node);
   assert.match(expanded, /⎿  src\/app\.ts.*120 lines/);

--- a/examples/extensions/ashi-ink/test/render.test.tsx
+++ b/examples/extensions/ashi-ink/test/render.test.tsx
@@ -5,6 +5,7 @@ import { createInkRenderer, __renderNode, __harness } from "../src/ink-renderer.
 import type { RenderModel } from "@guanyilun/ashi/render";
 import type { RenderNode } from "@guanyilun/ashi/renderer";
 import { ToolGroup } from "../../ashi/src/chat/tool-group.js";
+import { ThinkingBlock } from "../../ashi/src/chat/thinking.js";
 import { createAutocompleteController } from "../../ashi/src/autocomplete-controller.js";
 import type { AutocompleteProvider } from "@guanyilun/ashi/renderer";
 
@@ -236,6 +237,15 @@ test("a read group: tail pinned + flashing while open, summary-only once sealed,
   assert.match(expanded, /⎿  src\/app\.ts.*120 lines/);
   assert.match(expanded, /⎿  src\/util\.ts.*45 lines/);
   assert.doesNotMatch(expanded, /\(ctrl\+o to expand\)/);
+});
+
+test("revealed thinking is dim-tinted and survives marked's resets", () => {
+  const tb = new ThinkingBlock(r as never);
+  tb.appendText("Let me think about this plainly.");
+  const frame = render(__renderNode(tb.node)).lastFrame() ?? "";
+  assert.match(strip(frame), /Let me think about this plainly\./);
+  assert.match(frame, /\x1b\[38;2;128;128;128m[^\x1b]/);
+  assert.match(frame, /\x1b\[2m/);
 });
 
 test("a diff result hangs under the ⎿ gutter with no box frame (flush gutter)", () => {

--- a/examples/extensions/ashi/src/chat/thinking.ts
+++ b/examples/extensions/ashi/src/chat/thinking.ts
@@ -2,7 +2,7 @@
 import type { ContainerView, MarkdownView, RenderNode, RenderNodes } from "../renderer.js";
 import { theme } from "../theme.js";
 
-const thinkingColor = (t: string): string => theme.italic(theme.fg("thinkingText", t));
+const thinkingColor = (t: string): string => theme.dim(theme.italic(theme.fg("thinkingText", t)));
 
 export class ThinkingBlock {
   readonly node: RenderNode;

--- a/examples/extensions/ashi/src/chat/tool-group.ts
+++ b/examples/extensions/ashi/src/chat/tool-group.ts
@@ -20,6 +20,7 @@ export class ToolGroup {
   private allChildren: ToolGroupChild[] = [];
   private callsById = new Map<string, ToolGroupChild>();
   private expanded = false;
+  private open = true;
 
   constructor(renderer: Renderer, kind: string, maxVisible: number = Infinity) {
     this.kind = kind;
@@ -48,6 +49,12 @@ export class ToolGroup {
     this.repaint();
   }
 
+  seal(): void {
+    if (!this.open) return;
+    this.open = false;
+    this.repaint();
+  }
+
   // When collapsed and over-cap, one visible slot is reserved for the summary.
   private visibleSliceStart(): number {
     if (this.expanded || !Number.isFinite(this.maxVisible)) return 0;
@@ -70,6 +77,7 @@ export class ToolGroup {
       children: this.allChildren.slice(start),
       hidden,
       expanded: this.expanded,
+      open: this.open,
     };
     this.view.update(model);
   }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -306,6 +306,11 @@ export function mountAshi(
   const activeTools = new Map<string, LiveToolEntry>();
   const groupMaxVisible = loadGroupMaxVisible();
 
+  let openGroup: ToolGroup | null = null;
+  const sealOpenGroup = (): void => {
+    if (openGroup) { openGroup.seal(); openGroup = null; }
+  };
+
   /** Visible thinking acts as a hard separator; hidden thinking is transparent. */
   const findMergeableGroup = (kind: string): ToolGroup | null => {
     for (let i = chatEntries.length - 1; i >= 0; i--) {
@@ -536,16 +541,19 @@ export function mountAshi(
     activeAssistant = null;
     activeThinking = null;
     activeTools.clear();
+    openGroup = null;
     clearChat();
     const branch = getStore().current().getBranch();
     const toolMap = new Map<string, ReplayEntry>();
     for (const e of branch) replayEntry(e, toolMap);
+    for (const entry of chatEntries) if (entry.t === "group") entry.group.seal();
     app.commitScrollback?.();
     app.requestRender();
   };
 
   bus.on("agent:query", ({ query }) => {
     app.commitScrollback?.();
+    sealOpenGroup();
     appendEntry(renderUserMessage(query), { t: "plain" });
     activeAssistant = null;
     app.requestRender();
@@ -560,6 +568,7 @@ export function mountAshi(
   const appendImage = (data: Buffer): void => {
     const img = renderer.image(data);
     if (!img) return;
+    sealOpenGroup();
     if (activeAssistant) { activeAssistant.finalize(); activeAssistant = null; }
     appendEntry(img, { t: "plain" });
   };
@@ -589,6 +598,7 @@ export function mountAshi(
   });
 
   bus.on("agent:response-chunk", ({ blocks }) => {
+    sealOpenGroup();
     finalizeThinking();
     for (const b of blocks) {
       if (b.type === "text") ensureAssistant().appendText(b.text);
@@ -599,6 +609,7 @@ export function mountAshi(
   });
 
   bus.on("agent:thinking-chunk", ({ text }) => {
+    if (!hideThinking) sealOpenGroup();
     if (activeAssistant) { activeAssistant.finalize(); activeAssistant = null; }
     ensureThinking().appendText(text);
     app.requestRender();
@@ -620,14 +631,17 @@ export function mountAshi(
     const kind = e.kind ?? "";
     if (GROUPABLE_KINDS.has(kind) && renderer.mountToolGroup) {
       const mergeable = findMergeableGroup(kind);
+      if (!mergeable) sealOpenGroup();
       const group = mergeable
         ?? (() => { const g = new ToolGroup(renderer, kind, groupMaxVisible); appendEntry(g.node, { t: "group", group: g }); return g; })();
       group.addCall(id, lookupName, detail);
+      openGroup = group;
       activeTools.set(id, { kind: "group", group });
       app.requestRender();
       return;
     }
 
+    sealOpenGroup();
     const pair = renderToolPair({
       toolCallId: id, name: lookupName, title, kind: e.kind,
       displayDetail: detail, rawInput: e.rawInput,
@@ -719,6 +733,7 @@ export function mountAshi(
   bus.on("agent:processing-done", () => {
     processing = false;
     stopLoader();
+    sealOpenGroup();
     finalizeThinking();
     if (activeAssistant) activeAssistant.finalize();
     refreshFooterStats();
@@ -750,6 +765,7 @@ export function mountAshi(
   bus.on("agent:cancelled", () => {
     processing = false;
     stopLoader();
+    sealOpenGroup();
     appendEntry(new InfoLine(renderer, "cancelled").node, { t: "plain" });
     app.requestRender();
   });
@@ -757,6 +773,7 @@ export function mountAshi(
   bus.on("agent:error", ({ message }) => {
     processing = false;
     stopLoader();
+    sealOpenGroup();
     appendEntry(new ErrorLine(renderer, message).node, { t: "plain" });
     app.requestRender();
   });

--- a/examples/extensions/ashi/src/renderer.ts
+++ b/examples/extensions/ashi/src/renderer.ts
@@ -158,6 +158,7 @@ export interface ToolGroupModel {
   children: ToolGroupChild[];
   hidden: { count: number; ok: boolean } | null;
   expanded: boolean;
+  open: boolean;
 }
 
 export interface ToolGroupView {

--- a/examples/extensions/ashi/src/theme.ts
+++ b/examples/extensions/ashi/src/theme.ts
@@ -96,6 +96,7 @@ class Theme {
   bg(color: ThemeColor, text: string): string { return `${this.bgCodes.get(color)}${text}\x1b[49m`; }
   bgCode(color: ThemeColor): string { return this.bgCodes.get(color) ?? ""; }
   bold(text: string): string { return chalk.bold(text); }
+  dim(text: string): string { return chalk.dim(text); }
   italic(text: string): string { return chalk.italic(text); }
   underline(text: string): string { return chalk.underline(text); }
   strikethrough(text: string): string { return chalk.strikethrough(text); }


### PR DESCRIPTION
Three ashi-ink renderer refinements toward Claude-Code-style live feedback.

### Live tool-group tail + flashing marker
A running tool group collapsed to in-flight calls only, so fast/parallel reads vanished the moment they completed (read as "everything collapsed", marker stopped blinking between sequential calls). Give `ToolGroup` an explicit open/sealed state instead of inferring "running" from child status: while open, the collapsed group pins its tail (last call, done or not) and the marker keeps flashing; once sealed it drops to summary-only. The frontend seals a group exactly where it stops being the merge target — assistant content, visible thinking, a new/different run, a non-groupable tool, turn end, a new user query, and replayed history.

### Dimmed revealed thinking
Revealed thinking rendered as plain, unstyled text: the renderer tinted markdown by wrapping each line, but marked-terminal emits `\x1b[0m` resets even around plain prose, and the leading reset cancelled the tint immediately. Re-assert the tint's opening codes after every reset (`tintMarkdown`) so it survives the line, and dim the thinking styler (dim + italic + gray) so reasoning reads as de-emphasized rather than a standard response.

### Coral accent + per-turn timer
The loader hardcoded a violet accent and a static "thinking…" label. Switch the ink accent to coral across both surfaces it drives (spinner + select-picker highlight) and add an elapsed timer that counts the current turn, redrawn once a second (resets each turn since the loader is recreated at processing-start).

### Tests
- ashi: 51/51, ashi-ink: 25/25, both packages typecheck clean.
- Updated the group render test (tail persists while open → summary-only after seal) and added tests for dimmed thinking and the coral timer loader.