### PR TITLE
Add Kimi coding plan as a built-in provider

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -28,6 +28,7 @@ import activateOpenaiCompatible from "./providers/openai-compatible.js";
 import activateDeepseek from "./providers/deepseek.js";
 import activateOllama from "./providers/ollama.js";
 import activateZaiCodingPlan from "./providers/zai-coding-plan.js";
+import activateKimiCodingPlan from "./providers/kimi-coding-plan.js";
 import activateOpencode from "./providers/opencode.js";
 import { findBash } from "../utils/executor.js";
 import { createBashTool } from "./tools/bash.js";
@@ -566,5 +567,6 @@ export function activateAgent(ctx: ExtensionContext): void {
   activateDeepseek(agentCtx);
   activateOllama(agentCtx);
   activateZaiCodingPlan(agentCtx);
+  activateKimiCodingPlan(agentCtx);
   activateOpencode(agentCtx);
 }

--- a/src/agent/providers/kimi-coding-plan.ts
+++ b/src/agent/providers/kimi-coding-plan.ts
@@ -1,0 +1,27 @@
+/** Kimi Coding Plan — Moonshot's K2 coding subscription on an OpenAI-compatible endpoint. */
+import type { AgentContext } from "../host-types.js";
+import { resolveApiKey } from "../../cli/auth/keys.js";
+
+const BASE_URL = "https://api.kimi.com/coding/v1";
+const ID = "kimi-coding-plan";
+
+const DEFAULT_MODELS = [
+  {
+    id: "kimi-for-coding",
+    reasoning: true,
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+    modalities: ["text", "image"] as ("text" | "image")[],
+  },
+];
+
+export default function activate(ctx: AgentContext): void {
+  const { key } = resolveApiKey(ID);
+  ctx.agent.providers.register({
+    id: ID,
+    apiKey: key ?? process.env.KIMI_API_KEY ?? process.env.MOONSHOT_API_KEY,
+    baseURL: BASE_URL,
+    defaultModel: DEFAULT_MODELS[0].id,
+    models: DEFAULT_MODELS,
+  });
+}


### PR DESCRIPTION
Adds Moonshot's **Kimi coding plan** as a built-in OpenAI-compatible provider, alongside the other subscription providers (`zai-coding-plan`, `deepseek`).

## Details

- **Endpoint:** `https://api.kimi.com/coding/v1` (OpenAI-compatible)
- **Model:** `kimi-for-coding` — a stable alias the backend re-points to the latest K2 release, so the provider registers it statically (no `/models` fetch; there is nothing to enumerate)
- **Capabilities** (from Kimi's third-party-agent config docs): 256K context (`262144`), 32K max output (`32768`), `reasoning_effort` (low/medium/high), and image input
- **Auth:** resolves under id `kimi-coding-plan` via settings.json / keys.json, falling back to `KIMI_API_KEY` or `MOONSHOT_API_KEY`. Discoverable through `agent-sh auth login kimi-coding-plan`.

Reasoning uses the standard `reasoning_effort` parameter (the default builder), so the runtime reasoning toggle drives it directly — no custom request shape needed.

## Test plan

- `npm run build` passes
- `agent-sh auth list` shows `kimi-coding-plan` (not configured until a key is added)
- Live request validation pending a subscription key