### PR TITLE
Rework ashi equation rendering and decouple latex from the renderer

### DIFF
--- a/examples/extensions/ashi/src/chat/assistant.ts
+++ b/examples/extensions/ashi/src/chat/assistant.ts
@@ -1,23 +1,11 @@
 import type { ContainerView, MarkdownView, RenderNode, RenderNodes } from "../renderer.js";
 
-export type EquationRenderer = (latexSrc: string) => RenderNode | null;
+export type RenderBlock =
+  | { type: "text"; text: string }
+  | { type: "code-block"; language: string; code: string }
+  | { type: "image"; data: Buffer };
 
-type LatexSegment = { type: "text"; value: string } | { type: "latex"; value: string };
-
-function segmentLatex(text: string): LatexSegment[] {
-  const segments: LatexSegment[] = [];
-  let i = 0;
-  while (i < text.length) {
-    const open = text.indexOf("$$", i);
-    if (open === -1) { segments.push({ type: "text", value: text.slice(i) }); break; }
-    const close = text.indexOf("$$", open + 2);
-    if (close === -1) { segments.push({ type: "text", value: text.slice(i) }); break; }
-    if (open > i) segments.push({ type: "text", value: text.slice(i, open) });
-    segments.push({ type: "latex", value: text.slice(open + 2, close).trim() });
-    i = close + 2;
-  }
-  return segments;
-}
+export type ContentTransform = (blocks: RenderBlock[]) => RenderBlock[];
 
 export class AssistantMessage {
   readonly node: RenderNode;
@@ -25,7 +13,7 @@ export class AssistantMessage {
   private md: MarkdownView;
   private buffer = "";
 
-  constructor(private nodes: RenderNodes, private renderEquation?: EquationRenderer) {
+  constructor(private nodes: RenderNodes, private transform: ContentTransform = (b) => b) {
     this.container = nodes.container();
     this.md = nodes.markdown({ paddingX: 1, bullet: true });
     this.container.addChild(nodes.spacer(1));
@@ -46,37 +34,29 @@ export class AssistantMessage {
 
   finalize(): void {
     if (this.buffer === "") this.buffer = " ";
-    if (this.renderEquation && this.buffer.includes("$$")) {
-      this.rebuildWithEquations();
-    } else {
-      this.md.setText(this.buffer);
-    }
-  }
-
-  private rebuildWithEquations(): void {
-    const segments = segmentLatex(this.buffer);
-    if (!segments.some((s) => s.type === "latex")) {
+    const blocks = this.transform([{ type: "text", text: this.buffer }]);
+    if (blocks.every((b) => b.type === "text")) {
       this.md.setText(this.buffer);
       return;
     }
+    this.rebuild(blocks);
+  }
+
+  private rebuild(blocks: RenderBlock[]): void {
     this.container.clear();
     this.container.addChild(this.nodes.spacer(1));
-    for (const seg of segments) {
-      if (seg.type === "text") {
-        if (seg.value.trim()) {
-          const m = this.nodes.markdown({ paddingX: 1 });
-          m.setText(seg.value);
-          this.container.addChild(m.node);
-        }
-      } else {
-        const eq = this.renderEquation!(seg.value);
-        if (eq) {
-          this.container.addChild(eq);
-        } else {
-          const m = this.nodes.markdown({ paddingX: 1 });
-          m.setText(`$$${seg.value}$$`);
-          this.container.addChild(m.node);
-        }
+    for (const block of blocks) {
+      if (block.type === "image") {
+        const img = this.nodes.image(block.data);
+        if (img) this.container.addChild(img);
+      } else if (block.type === "code-block") {
+        const m = this.nodes.markdown({ paddingX: 1 });
+        m.setText(`\`\`\`${block.language}\n${block.code}\n\`\`\``);
+        this.container.addChild(m.node);
+      } else if (block.text.trim()) {
+        const m = this.nodes.markdown({ paddingX: 1 });
+        m.setText(block.text);
+        this.container.addChild(m.node);
       }
     }
   }

--- a/examples/extensions/ashi/src/display-config.ts
+++ b/examples/extensions/ashi/src/display-config.ts
@@ -31,6 +31,7 @@ interface AshiSettings extends Record<string, unknown> {
   display?: Record<string, Partial<ToolEntryConfig>>;
   groupMaxVisible?: number;
   renderer?: string;
+  imageScale?: number;
 }
 
 export function loadRendererPreference(): string | undefined {
@@ -43,6 +44,12 @@ export function loadGroupMaxVisible(): number {
   const v = ashi.groupMaxVisible;
   if (typeof v !== "number" || !Number.isFinite(v) || v < 2) return Infinity;
   return Math.floor(v);
+}
+
+export function loadImageScale(): number {
+  const v = getExtensionSettings<AshiSettings>("ashi", {}).imageScale;
+  if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return 1;
+  return v;
 }
 
 function mergeEntry(base: ToolEntryConfig, patch?: Partial<ToolEntryConfig>): ToolEntryConfig {

--- a/examples/extensions/ashi/src/hooks.ts
+++ b/examples/extensions/ashi/src/hooks.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "agent-sh/types";
 import type { Renderer, RenderNodes, ToolCallView, ToolResultView } from "./renderer.js";
 import { UserMessage } from "./chat/user-message.js";
-import { AssistantMessage, type EquationRenderer } from "./chat/assistant.js";
+import { AssistantMessage, type RenderBlock } from "./chat/assistant.js";
 import { ThinkingBlock } from "./chat/thinking.js";
 import { loadDisplayResolver, type ToolResultMode } from "./display-config.js";
 import { isRenderModel, type RenderModel } from "./schema.js";
@@ -19,22 +19,16 @@ export interface ThinkingArgs extends RenderState { text: string; hidden: boolea
 const SCHEMA_PREFIX = "ashi:render-tool:";
 
 export function registerRenderDefaults(ctx: ExtensionContext, renderer: Renderer): void {
-  // Cache the PNG, not the node: finalize/rehydrate can render an equation twice.
-  const equationPng = new Map<string, Buffer | null>();
-  const renderEquation: EquationRenderer = (src) => {
-    if (!equationPng.has(src)) {
-      equationPng.set(src, (ctx.call("latex:render-equation", src) as Buffer | null) ?? null);
-    }
-    const png = equationPng.get(src) ?? null;
-    return png && renderer.capabilities.images ? renderer.image(png) : null;
-  };
+  const transformContent = (blocks: RenderBlock[]): RenderBlock[] =>
+    (ctx.bus.emitPipe as unknown as (e: string, p: { blocks: RenderBlock[]; images: boolean }) => { blocks: RenderBlock[] })(
+      "render:assistant-content", { blocks, images: renderer.capabilities.images },
+    ).blocks;
 
   ctx.define("ashi:render-user-message", (args: UserMessageArgs) =>
     new UserMessage(renderer, args.text));
 
   ctx.define("ashi:render-assistant", (args: AssistantArgs) => {
-    const eq = ctx.list().includes("latex:render-equation") ? renderEquation : undefined;
-    const msg = new AssistantMessage(renderer, eq);
+    const msg = new AssistantMessage(renderer, transformContent);
     if (args.text) {
       msg.appendText(args.text);
       msg.finalize();

--- a/examples/extensions/ashi/src/renderers/pi-tui/index.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/index.ts
@@ -1,16 +1,17 @@
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { getCapabilities, visibleWidth } from "@earendil-works/pi-tui";
 import type { Renderer } from "../../renderer.js";
 import { createNodes } from "./nodes.js";
 import { createApp } from "./app.js";
 import { mountCall, mountResult } from "./schema-mount.js";
 import { createPiTuiToolGroup } from "./tool-group.js";
+import { loadImageScale } from "../../display-config.js";
 
 export function createPiTuiRenderer(): Renderer {
-  const nodes = createNodes();
+  const nodes = createNodes({ imageScale: loadImageScale() });
   return {
     ...nodes,
     capabilities: {
-      images: true,
+      images: getCapabilities().images !== null,
       markdownStreaming: true,
       rawOutput: true,
     },

--- a/examples/extensions/ashi/src/renderers/pi-tui/nodes.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/nodes.ts
@@ -1,7 +1,12 @@
 import {
+  allocateImageId,
   Container,
+  encodeITerm2,
+  encodeKitty,
+  getCapabilities,
+  getCellDimensions,
   getImageDimensions,
-  Image,
+  imageFallback,
   Markdown,
   Spacer,
   Text,
@@ -20,6 +25,64 @@ import type {
 
 const asNode = (c: Component): RenderNode => c as unknown as RenderNode;
 const asComponent = (n: RenderNode): Component => n as unknown as Component;
+
+const DEFAULT_IMAGE_SCALE = 1;
+const IMAGE_INDENT = 1;
+
+class TerminalImage {
+  private readonly base64: string;
+  private imageId: number | undefined;
+  private cache: { width: number; lines: string[] } | undefined;
+
+  constructor(
+    base64: string,
+    private readonly dims: { widthPx: number; heightPx: number },
+    private readonly indent: number,
+    private readonly scale: number,
+  ) {
+    this.base64 = base64;
+  }
+
+  invalidate(): void {
+    this.cache = undefined;
+  }
+
+  render(width: number): string[] {
+    if (this.cache?.width === width) return this.cache.lines;
+    const lines = this.build(width);
+    this.cache = { width, lines };
+    return lines;
+  }
+
+  private build(width: number): string[] {
+    const pad = " ".repeat(this.indent);
+    const caps = getCapabilities();
+    if (!caps.images) {
+      return [pad + theme.fg("muted", imageFallback("image/png", this.dims))];
+    }
+    const cell = getCellDimensions();
+    const avail = Math.max(1, width - this.indent);
+    const want = (this.dims.widthPx * this.scale) / cell.widthPx;
+    const cols = Math.max(1, Math.min(avail, Math.round(want)));
+    const fit = (cols * cell.widthPx) / this.dims.widthPx;
+    const rows = Math.max(1, Math.ceil((this.dims.heightPx * fit) / cell.heightPx));
+
+    if (caps.images === "kitty") {
+      if (this.imageId === undefined) this.imageId = allocateImageId();
+      // Width only — the terminal preserves aspect. Passing rows too makes
+      // Kitty/Ghostty stretch the image to fill the c×r box.
+      const seq = encodeKitty(this.base64, { columns: cols, imageId: this.imageId, moveCursor: false });
+      const lines = [pad + seq];
+      for (let i = 0; i < rows - 1; i++) lines.push("");
+      return lines;
+    }
+    const seq = encodeITerm2(this.base64, { width: cols, height: "auto", preserveAspectRatio: true });
+    const lines: string[] = [];
+    for (let i = 0; i < rows - 1; i++) lines.push("");
+    lines.push((rows > 1 ? `\x1b[${rows - 1}A` : "") + pad + seq);
+    return lines;
+  }
+}
 
 class MeasuredText extends Text {
   private fn: ((width: number) => string[]) | null = null;
@@ -75,7 +138,8 @@ export function footerContainer(hasContentAbove: () => boolean): ContainerView {
   };
 }
 
-export function createNodes(): RenderNodes {
+export function createNodes(opts: { imageScale?: number } = {}): RenderNodes {
+  const imageScale = opts.imageScale ?? DEFAULT_IMAGE_SCALE;
   return {
     text(opts) {
       const t = new MeasuredText("", opts?.paddingX ?? 0, opts?.paddingY ?? 0);
@@ -106,14 +170,7 @@ export function createNodes(): RenderNodes {
       const base64 = png.toString("base64");
       const dims = getImageDimensions(base64, "image/png");
       if (!dims) return null;
-      const img = new Image(
-        base64,
-        "image/png",
-        { fallbackColor: (t) => theme.fg("muted", t) },
-        { maxWidthCells: 60, maxHeightCells: 20 },
-        dims,
-      );
-      return asNode(img);
+      return asNode(new TerminalImage(base64, dims, IMAGE_INDENT, imageScale));
     },
 
     container(): ContainerView {

--- a/examples/extensions/latex-images.ts
+++ b/examples/extensions/latex-images.ts
@@ -96,6 +96,42 @@ function renderEquation(equation: string): Buffer | null {
   }
 }
 
+const equationCache = new Map<string, Buffer | null>();
+function renderEquationCached(equation: string): Buffer | null {
+  if (!equationCache.has(equation)) {
+    equationCache.set(equation, renderEquation(equation));
+  }
+  return equationCache.get(equation) ?? null;
+}
+
+const EQ_DELIM = "$$";
+
+type Block =
+  | { type: "text"; text: string }
+  | { type: "image"; data: Buffer }
+  | { type: "code-block"; language: string; code: string };
+type ContentPipe = { blocks: Block[]; images?: boolean };
+
+function splitEquations(text: string): Block[] {
+  const out: Block[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const open = text.indexOf(EQ_DELIM, i);
+    if (open === -1) {
+      const rest = text.slice(i);
+      if (rest) out.push({ type: "text", text: rest });
+      break;
+    }
+    const close = text.indexOf(EQ_DELIM, open + EQ_DELIM.length);
+    if (close === -1) { out.push({ type: "text", text: text.slice(i) }); break; }
+    if (open > i) out.push({ type: "text", text: text.slice(i, open) });
+    const png = renderEquationCached(text.slice(open + EQ_DELIM.length, close).trim());
+    out.push(png ? { type: "image", data: png } : { type: "text", text: text.slice(open, close + EQ_DELIM.length) });
+    i = close + EQ_DELIM.length;
+  }
+  return out;
+}
+
 // ── Extension entry point ────────────────────────────────────────
 
 export default function activate(ctx: ExtensionContext) {
@@ -115,26 +151,38 @@ export default function activate(ctx: ExtensionContext) {
     return;
   }
 
-  ctx.define("latex:render-equation", (equation: string): Buffer | null => renderEquation(equation));
+  ctx.define("latex:render-equation", (equation: string): Buffer | null => renderEquationCached(equation));
 
-  // Shell-only — ashi has no shell surface; it uses the capability above instead.
   if (ctx.shell) {
+    // Shell streams output, so it buffers $$ spanning chunks; finalized-content
+    // renderers (below) get whole blocks instead.
     ctx.shell.createBlockTransform({
-      open: "$$",
-      close: "$$",
-      transform(latex) {
-        const png = renderEquation(latex);
-        if (!png) return null;
-        return { type: "image", data: png };
+      open: EQ_DELIM,
+      close: EQ_DELIM,
+      transform(latex: string) {
+        const png = renderEquationCached(latex);
+        return png ? { type: "image" as const, data: png } : null;
       },
     });
 
     ctx.advise("render:code-block", (next, language: string, code: string, width: number) => {
       if (language !== "latex" && language !== "tex") return next(language, code, width);
-      const png = renderEquation(code);
+      const png = renderEquationCached(code);
       if (!png) return next(language, code, width);
       ctx.call("render:image", png);
     });
+  } else {
+    (bus.onPipe as unknown as (e: string, fn: (p: ContentPipe) => ContentPipe) => void)(
+      "render:assistant-content",
+      (payload) => {
+        // Can't show images reliably → leave $$…$$ as text.
+        if (!payload.images) return payload;
+        return {
+          ...payload,
+          blocks: payload.blocks.flatMap((b) => (b.type === "text" ? splitEquations(b.text) : [b])),
+        };
+      },
+    );
   }
 
   process.on("exit", () => {


### PR DESCRIPTION
## Summary

ashi rendered `$$…$$` equations by reaching into the `latex-images` extension by name and scaling each PNG to fill a fixed `60×20` cell box. On Kitty-protocol terminals (Kitty/Ghostty/WezTerm) that box-fill **stretches the image to the `c×r` rectangle**, so equations came out oversized and horizontally squeezed, and they weren't aligned with the surrounding text. This reworks the rendering and, while there, removes ashi's knowledge of LaTeX.

## Changes

**Rendering (`renderers/pi-tui`)**
- New `TerminalImage` node renders at the terminal's real cell size with a text-matching left indent. It preserves aspect ratio by emitting Kitty `c` (columns) only — letting the terminal derive the height — instead of `c,r`, which Ghostty/Kitty stretch to fill.
- At the default scale this is ~1:1 with the source pixels, so the 300-DPI `dvipng` output is shown essentially without resampling (crispest; full detail in dense notation).
- iTerm2 path uses `width`+`height=auto`+`preserveAspectRatio`.
- Falls back to a muted `[Image: …]` placeholder when the terminal can't show images; no escape bytes are emitted. Width is capped to the viewport so wide equations downscale to fit rather than overflow.

**Configurable size**
- `ashi.imageScale` setting (default `1` = native resolution), read via `display-config` like the other `ashi.*` settings. Lower it to shrink equations.

**Decoupling (the main architectural change)**
- ashi no longer knows about LaTeX or `$$`. `AssistantMessage` runs its finalized content through a generic `render:assistant-content` `emitPipe`; extensions transform the block list.
- `latex-images` owns the `$$` delimiters and its own scanner, registering via `bus.onPipe` (ashi) or `ctx.shell.createBlockTransform` (shell). The two paths share one render+cache.

**Graceful fallback**
- `$$…$$` stays as plain text when images can't render reliably — non-graphics terminals **and** tmux/screen. `capabilities.images` now reflects the runtime terminal instead of being a static `true`, and the capability rides the pipe so the transform skips (no wasted `dvipng`).

**Misc**
- `latex-images` caches rendered PNGs (rendering moved here from ashi).

## Testing
- `tsc` clean for ashi and `latex-images`.
- ashi test suite: 51/51 pass.
- Manually verified on Ghostty: equations render aspect-correct, text-aligned, and crisp at the default scale.

## Notes
- `ashi.imageScale` default `1` is the native (no-resample) size. It's display-dependent — on a non-HiDPI screen native is visually larger — which is what the setting is for; it never overflows (capped to viewport width).
- Scope is the ashi path; the shell path is unchanged. The `render:assistant-content` pipe is renderer-agnostic, so if the shell later emits it at `response-done`, `latex-images` could drop its `if (ctx.shell)` branch and the two transform paths collapse to one.
- `ashi.imageScale` is a global image scale (applies to pasted images too); a per-image scale hint on the block is a possible follow-up.