### PR TITLE
Show image-paste marker instantly instead of after the clipboard read

### DIFF
--- a/examples/extensions/ashi/src/clipboard-image.ts
+++ b/examples/extensions/ashi/src/clipboard-image.ts
@@ -25,7 +25,7 @@ export async function readClipboardImage(): Promise<CapturedImage | null> {
       "-e", `set fp to open for access POSIX file ${JSON.stringify(tmp)} with write permission`,
       "-e", "write png_data to fp",
       "-e", "close access fp",
-    ]);
+    ], { timeout: 10_000 });
   } catch {
     return null;
   }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -251,15 +251,9 @@ export function mountAshi(
         bus.emit("command:execute", { name: action.name, args: action.args });
         return;
       case "agent": {
-        const imgs = pendingImages.filter((p) => action.query.includes(`[Image #${p.id}]`));
+        const matched = pendingImages.filter((p) => action.query.includes(`[Image #${p.id}]`));
         pendingImages = [];
-        if (processing) {
-          queuedQueries.push({ query: action.query, images: imgs });
-          renderQueueSlot();
-          app.requestRender();
-          return;
-        }
-        bus.emit("agent:submit", { query: action.query, images: imgs.length ? toImageContent(imgs) : undefined });
+        submitAgentQuery(action.query, matched);
         return;
       }
     }
@@ -325,7 +319,10 @@ export function mountAshi(
   let loader: LoaderView | null = null;
   let loaderGap: RenderNode | null = null;
   let processing = false;
-  type PendingImage = { id: number; data: string; mimeType: string };
+  // The [Image #N] marker text — not these bytes — is the source of truth for which images
+  // a message carries; the slot starts byte-less and `settled` resolves true once the
+  // background read fills data/mimeType, false if it found no image or errored.
+  type PendingImage = { id: number; data: string; mimeType: string; settled: Promise<boolean> };
   let pendingImages: PendingImage[] = [];
   let imageCounter = 0;
   const toImageContent = (imgs: PendingImage[]) =>
@@ -359,6 +356,52 @@ export function mountAshi(
     pendingUserShell.push({ private: !!opts?.private });
     if (opts?.private) bus.emit("shell:user-exec-exclude-next", {});
     bus.emit("shell:pty-write", { data: line + "\n" });
+  };
+
+  const stripImageMarker = (text: string, id: number): string =>
+    text.replace(`[Image #${id}] `, "").replace(`[Image #${id}]`, "");
+
+  /** Pull a marker out of the live input when its clipboard read came back empty. */
+  const dropPendingImage = (id: number): void => {
+    pendingImages = pendingImages.filter((p) => p.id !== id);
+    const text = input.getText();
+    const cleaned = stripImageMarker(text, id);
+    if (cleaned !== text) {
+      input.setText(cleaned);
+      app.requestRender();
+    }
+  };
+
+  const dispatchAgentQuery = (query: string, images: PendingImage[]): void => {
+    if (processing) {
+      queuedQueries.push({ query, images });
+      renderQueueSlot();
+      app.requestRender();
+      return;
+    }
+    bus.emit("agent:submit", { query, images: images.length ? toImageContent(images) : undefined });
+  };
+
+  // A submit carrying a still-loading image must await its read; later submits join the
+  // same chain so a text-only query can't overtake the image query ahead of it (FIFO).
+  // With no submit in flight (the common case) we dispatch synchronously.
+  let submitChain: Promise<void> = Promise.resolve();
+  let submitsInFlight = 0;
+  const submitAgentQuery = (query: string, matched: PendingImage[]): void => {
+    if (matched.length === 0 && submitsInFlight === 0) {
+      dispatchAgentQuery(query, []);
+      return;
+    }
+    submitsInFlight++;
+    submitChain = submitChain.catch(() => {}).then(async () => {
+      const ready: PendingImage[] = [];
+      let q = query;
+      for (const img of matched) {
+        if (await img.settled) ready.push(img);
+        else q = stripImageMarker(q, img.id);
+      }
+      dispatchAgentQuery(q, ready);
+    }).finally(() => { submitsInFlight--; });
   };
   let hideThinking = true;
 
@@ -579,19 +622,24 @@ export function mountAshi(
     app.requestRender();
   });
 
-  // Only [Image #N] markers still in the text at submit are sent — deleting one drops its image.
-  const attachImage = (img: { data: string; mimeType: string }): void => {
+  // Ctrl+V (wired below) and /paste attach a clipboard image; Cmd+V stays text paste.
+  const captureClipboardImage = (): void => {
     const id = ++imageCounter;
-    pendingImages.push({ id, data: img.data, mimeType: img.mimeType });
+    const slot: PendingImage = { id, data: "", mimeType: "", settled: Promise.resolve(false) };
+    slot.settled = (async () => {
+      const img = await readClipboardImage();
+      if (img) {
+        slot.data = img.data;
+        slot.mimeType = img.mimeType;
+        return true;
+      }
+      dropPendingImage(id);
+      bus.emit("ui:info", { message: "No image found on the clipboard." });
+      return false;
+    })().catch(() => false); // settled must never reject, or a submit awaiting it wedges
+    pendingImages.push(slot);
     input.replaceBeforeCursor(0, `[Image #${id}] `);
     app.requestRender();
-  };
-  // Ctrl+V (wired below) and /paste capture a clipboard image; Cmd+V stays text paste.
-  const captureClipboardImage = (): void => {
-    void readClipboardImage().then((img) => {
-      if (img) attachImage(img);
-      else bus.emit("ui:info", { message: "No image found on the clipboard." });
-    });
   };
   ctx.registerCommand("paste", "Attach an image from the clipboard to your next message", async () => {
     captureClipboardImage();

--- a/tests/core/single-file-extension-imports.test.ts
+++ b/tests/core/single-file-extension-imports.test.ts
@@ -16,8 +16,6 @@ const KNOWN_OFFENDERS: ReadonlySet<string> = new Set([
   `interactive-prompts.ts: from "agent-sh/utils/palette.js"`,
   `interactive-prompts.ts: from "agent-sh/utils/diff.js"`,
   `questionnaire.ts: from "agent-sh/utils/palette.js"`,
-  `overlay-agent.ts: from "agent-sh/utils/floating-panel"`,
-  `overlay-agent.ts: from "agent-sh/utils/terminal-buffer"`,
   `subagents.ts: from "agent-sh/agent/subagent"`,
 ]);
 


### PR DESCRIPTION
## Problem

In ashi, pasting a clipboard image (Ctrl+V / `/paste`) briefly hangs before the `[Image #N]` marker appears, whereas the equivalent in other terminals feels instant.

The cause is on the critical path: the macOS clipboard read runs `osascript` to coerce the pasteboard to PNG, which takes ~0.5–1.5s and scales with image size. The marker was only inserted inside that read's `.then()`, so nothing showed in the input until the read finished. (There is no fast dependency-free alternative on stock macOS — `pbpaste` is text-only, and a native NSPasteboard reader would require a compiled module.)

## Change

Insert the `[Image #N]` marker synchronously on keypress and run the clipboard read in the background, filling the slot's bytes when it returns. The marker text remains the source of truth for which images a message carries, so the existing submit-time filter is unchanged.

Robustness:
- **Submit-before-read race:** submit waits on the slot's `settled` promise only when it out-races the read; otherwise it dispatches synchronously as before.
- **Empty / failed read:** the marker is stripped — from the live input if still there, or from the query if already submitted — and the message still goes out.
- **Ordering:** while an image read is in flight, submits route through a FIFO chain so a later text-only query can't overtake the image query ahead of it.
- **Bounded read:** since submit now depends on the read resolving, the `osascript` call gets a 10s timeout, and the slot's `settled` promise is guaranteed never to reject — so a wedged or pathologically slow read can't freeze the submit chain.

## Scope

Frontend wiring + a timeout on the existing reader; the osascript read itself is otherwise unchanged. Image paste remains macOS-only — a `pngpaste` fast-path and Windows/Linux clipboard readers are left as separate follow-ups.

---

**Note:** this branch also carries a small unrelated CI fix — `Drop stale overlay-agent entries from the import ratchet`. The import-ratchet test was already red on `main`: `d3c7ca0` made `overlay-agent.ts`'s floating-panel/terminal-buffer access type-only + `ctx.call`, but left the now-stale `KNOWN_OFFENDERS` entries behind. Kept as a separate commit.
