### PR TITLE
ashi rendering fixes: resize, scheme result, unboxed diffs, resume preview

### DIFF
--- a/examples/extensions/ash-scheme/index.ts
+++ b/examples/extensions/ash-scheme/index.ts
@@ -27,7 +27,7 @@ async function withDisplay(
 ): Promise<ToolResult> {
   const toolCallId = `scheme-${toolName}-${++callCounter}`;
   bus.emit("agent:tool-started", {
-    title: toolName, toolCallId, kind, rawInput, displayDetail,
+    title: toolName, toolCallId, kind, rawInput, displayDetail, nested: true,
   });
   const result = await run();
   // Stream the result so the TUI's tracked `output` holds it, not just the summary.
@@ -38,6 +38,7 @@ async function withDisplay(
     rawOutput: result.content,
     kind,
     resultDisplay: result.display,
+    nested: true,
   });
   return result;
 }

--- a/examples/extensions/ashi-scheme-render.ts
+++ b/examples/extensions/ashi-scheme-render.ts
@@ -29,16 +29,25 @@ const model: RenderModel<SchemeInit> = {
       { text: "scheme ", style: { bold: true, color: "toolTitle" } },
       { text: env.expanded ? s.source : compact(s.source), highlight: "scheme" },
     ];
+    // A successful eval echoes no body (the source is in the title), so on expand
+    // the result line is otherwise empty — move the completion summary there
+    // (└ ✓ N lines) rather than stranding it on the wrapped title line.
+    const summaryOnResult = env.expanded && env.finalized && !failed && !!s.status;
     return {
       titleIcon: "scheme",
       title,
       status: s.status,
-      // Title carries the source; body shows the eval result, not an echo of it.
+      hideTitleStatus: summaryOnResult,
       body: failed
         ? { kind: "text", segments: [
             { text: `✗ ${s.output.trim()}`, style: { color: "error" } },
           ] }
-        : { kind: "stream", text: s.output },
+        : summaryOnResult
+          ? { kind: "text", segments: [
+              { text: "✓", style: { color: "success" } },
+              { text: ` ${s.status!.summary ?? "ok"}`, style: { color: "muted" } },
+            ] }
+          : { kind: "stream", text: s.output },
       expandable: true,
       defaultExpanded: failed,
     };

--- a/examples/extensions/ashi-scheme-render.ts
+++ b/examples/extensions/ashi-scheme-render.ts
@@ -29,9 +29,6 @@ const model: RenderModel<SchemeInit> = {
       { text: "scheme ", style: { bold: true, color: "toolTitle" } },
       { text: env.expanded ? s.source : compact(s.source), highlight: "scheme" },
     ];
-    // A successful eval echoes no body (the source is in the title), so on expand
-    // the result line is otherwise empty — move the completion summary there
-    // (└ ✓ N lines) rather than stranding it on the wrapped title line.
     const summaryOnResult = env.expanded && env.finalized && !failed && !!s.status;
     return {
       titleIcon: "scheme",

--- a/examples/extensions/ashi/src/capture.ts
+++ b/examples/extensions/ashi/src/capture.ts
@@ -2,6 +2,10 @@ import type { ExtensionContext } from "agent-sh/types";
 import type { MultiSessionStore } from "./multi-session-store.js";
 import type { AgentShMessage as AgentMessage } from "agent-sh/session-store";
 
+interface DiffEntry { diff: unknown; filePath: string }
+/** A scheme-bridged edit, replayed as its own edit pair; `name` picks the render model. */
+export interface NestedDiff extends DiffEntry { name: string }
+
 // liveEntryIds is parallel to the live messages array; null slots are synthetics (e.g. compaction summaries) with no entry.
 export interface Capture {
   flush(): Promise<void>;
@@ -14,21 +18,45 @@ export function registerCapture(
   getStore: () => MultiSessionStore,
 ): Capture {
   let liveEntryIds: (string | null)[] = [];
-  const diffMeta = new Map<string, { diff: unknown; filePath: string }>();
+  // Direct edits carry their diff on their own tool result. Scheme-bridged edits
+  // run inside scheme_eval and are re-emitted under synthetic `scheme-*` ids with
+  // no conversation message of their own, so their diffs are bucketed under the
+  // enclosing real call and persisted there for replay as separate edit pairs.
+  const diffMeta = new Map<string, DiffEntry>();
+  const nestedDiffs = new Map<string, NestedDiff[]>();
+  const bridgedNames = new Map<string, string>();
+  let activeRealToolId: string | undefined;
+
+  ctx.bus.on("agent:tool-started", (e) => {
+    const id = e.toolCallId;
+    if (!id) return;
+    if (id.startsWith("scheme-")) bridgedNames.set(id, e.name ?? e.title);
+    else activeRealToolId = id;
+  });
 
   ctx.bus.on("agent:tool-completed", (e) => {
     const id = e.toolCallId;
     const body = e.resultDisplay?.body;
-    if (id && body?.kind === "diff") {
+    if (!id || body?.kind !== "diff") return;
+    if (id.startsWith("scheme-")) {
+      if (!activeRealToolId) return;
+      const arr = nestedDiffs.get(activeRealToolId) ?? [];
+      arr.push({ name: bridgedNames.get(id) ?? "edit_file", diff: body.diff, filePath: body.filePath });
+      nestedDiffs.set(activeRealToolId, arr);
+    } else {
       diffMeta.set(id, { diff: body.diff, filePath: body.filePath });
     }
   });
 
   const enrich = (m: AgentMessage): AgentMessage => {
     if (m.role !== "tool" || !m.tool_call_id) return m;
-    const meta = diffMeta.get(m.tool_call_id);
-    if (!meta) return m;
-    return { ...m, meta: { ...m.meta, diff: meta.diff, filePath: meta.filePath } };
+    const single = diffMeta.get(m.tool_call_id);
+    const nested = nestedDiffs.get(m.tool_call_id);
+    if (!single && !nested) return m;
+    const meta: Record<string, unknown> = { ...m.meta };
+    if (single) { meta.diff = single.diff; meta.filePath = single.filePath; }
+    if (nested) meta.diffs = nested;
+    return { ...m, meta };
   };
 
   const writeNewMessages = async (): Promise<void> => {

--- a/examples/extensions/ashi/src/capture.ts
+++ b/examples/extensions/ashi/src/capture.ts
@@ -3,7 +3,6 @@ import type { MultiSessionStore } from "./multi-session-store.js";
 import type { AgentShMessage as AgentMessage } from "agent-sh/session-store";
 
 interface DiffEntry { diff: unknown; filePath: string }
-/** A scheme-bridged edit, replayed as its own edit pair; `name` picks the render model. */
 export interface NestedDiff extends DiffEntry { name: string }
 
 // liveEntryIds is parallel to the live messages array; null slots are synthetics (e.g. compaction summaries) with no entry.
@@ -18,12 +17,12 @@ export function registerCapture(
   getStore: () => MultiSessionStore,
 ): Capture {
   let liveEntryIds: (string | null)[] = [];
-  // Direct edits carry their diff on their own tool result. Scheme-bridged edits
-  // run inside scheme_eval and are re-emitted under synthetic `scheme-*` ids with
-  // no conversation message of their own, so their diffs are bucketed under the
-  // enclosing real call and persisted there for replay as separate edit pairs.
+  // A bridged tool call re-emitted under a synthetic id has no conversation message
+  // of its own, so bucket its diff under the enclosing real call for replay as a
+  // separate edit pair.
   const diffMeta = new Map<string, DiffEntry>();
   const nestedDiffs = new Map<string, NestedDiff[]>();
+  const summaryMeta = new Map<string, string>();
   const bridgedNames = new Map<string, string>();
   let activeRealToolId: string | undefined;
 
@@ -36,26 +35,33 @@ export function registerCapture(
 
   ctx.bus.on("agent:tool-completed", (e) => {
     const id = e.toolCallId;
-    const body = e.resultDisplay?.body;
-    if (!id || body?.kind !== "diff") return;
+    if (!id) return;
+    const display = e.resultDisplay;
+    const body = display?.body;
     if (id.startsWith("scheme-")) {
-      if (!activeRealToolId) return;
-      const arr = nestedDiffs.get(activeRealToolId) ?? [];
-      arr.push({ name: bridgedNames.get(id) ?? "edit_file", diff: body.diff, filePath: body.filePath });
-      nestedDiffs.set(activeRealToolId, arr);
-    } else {
-      diffMeta.set(id, { diff: body.diff, filePath: body.filePath });
+      if (body?.kind === "diff" && activeRealToolId) {
+        const arr = nestedDiffs.get(activeRealToolId) ?? [];
+        arr.push({ name: bridgedNames.get(id) ?? "edit_file", diff: body.diff, filePath: body.filePath });
+        nestedDiffs.set(activeRealToolId, arr);
+      }
+      return;
     }
+    // resultDisplay isn't persisted; capture the summary for every tool so resume
+    // doesn't fall back to re-deriving only a handful.
+    if (typeof display?.summary === "string" && display.summary) summaryMeta.set(id, display.summary);
+    if (body?.kind === "diff") diffMeta.set(id, { diff: body.diff, filePath: body.filePath });
   });
 
   const enrich = (m: AgentMessage): AgentMessage => {
     if (m.role !== "tool" || !m.tool_call_id) return m;
     const single = diffMeta.get(m.tool_call_id);
     const nested = nestedDiffs.get(m.tool_call_id);
-    if (!single && !nested) return m;
+    const summary = summaryMeta.get(m.tool_call_id);
+    if (!single && !nested && !summary) return m;
     const meta: Record<string, unknown> = { ...m.meta };
     if (single) { meta.diff = single.diff; meta.filePath = single.filePath; }
     if (nested) meta.diffs = nested;
+    if (summary) meta.summary = summary;
     return { ...m, meta };
   };
 

--- a/examples/extensions/ashi/src/capture.ts
+++ b/examples/extensions/ashi/src/capture.ts
@@ -26,10 +26,14 @@ export function registerCapture(
   const bridgedNames = new Map<string, string>();
   let activeRealToolId: string | undefined;
 
+  // `nested` is a bridge-set bus convention (a host tool run inside another tool),
+  // not on the core event type — read it defensively.
+  const isNested = (e: unknown): boolean => !!(e as { nested?: boolean }).nested;
+
   ctx.bus.on("agent:tool-started", (e) => {
     const id = e.toolCallId;
     if (!id) return;
-    if (id.startsWith("scheme-")) bridgedNames.set(id, e.name ?? e.title);
+    if (isNested(e)) bridgedNames.set(id, e.name ?? e.title);
     else activeRealToolId = id;
   });
 
@@ -38,7 +42,7 @@ export function registerCapture(
     if (!id) return;
     const display = e.resultDisplay;
     const body = display?.body;
-    if (id.startsWith("scheme-")) {
+    if (isNested(e)) {
       if (body?.kind === "diff" && activeRealToolId) {
         const arr = nestedDiffs.get(activeRealToolId) ?? [];
         arr.push({ name: bridgedNames.get(id) ?? "edit_file", diff: body.diff, filePath: body.filePath });

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -29,7 +29,7 @@ import { stripContextWrappers, type SessionEntry } from "agent-sh/session-store"
 import { formatSessionRow } from "./session-commands.js";
 import { resumeSession } from "./session-commands.js";
 import { applyBranchMessages } from "./commands.js";
-import type { Capture } from "./capture.js";
+import type { Capture, NestedDiff } from "./capture.js";
 import { execSync } from "node:child_process";
 import { readClipboardImage } from "./clipboard-image.js";
 import { renderDiff, detectLanguage, highlightLine } from "agent-sh/utils/diff-renderer.js";
@@ -485,6 +485,22 @@ export function mountAshi(
     | { kind: "pair"; pair: ToolPair; name: string }
     | { kind: "group"; group: ToolGroup; name: string };
 
+  const replayNestedEdit = (toolCallId: string, nd: NestedDiff): void => {
+    const diff = nd.diff as DiffStats & Parameters<typeof renderDiff>[0];
+    const summary = diff.isNewFile ? `+${diff.added}` : `+${diff.added} -${diff.removed}`;
+    const pair = renderToolPair({
+      toolCallId, name: nd.name, title: nd.name, kind: "edit",
+      displayDetail: relativize(nd.filePath), rawInput: { file_path: nd.filePath },
+    });
+    appendEntry(pair.call.node, { t: "plain" });
+    appendEntry(pair.result.node, { t: "pair", result: pair.result });
+    if (!diff.isIdentical) {
+      pair.result.setDiffRenderer(buildDiffRenderer(diff, nd.filePath, renderer.capabilities.diffFrame !== false));
+    }
+    pair.call.setStatus({ exitCode: 0, elapsedMs: 0, summary });
+    pair.result.finalize({ exitCode: 0, summary });
+  };
+
   const replayEntry = (entry: SessionEntry, toolMap: Map<string, ReplayEntry>): void => {
     if (entry.type === "session") return;
     if (entry.type === "compaction") {
@@ -566,7 +582,7 @@ export function mountAshi(
       if (found.kind === "group") {
         found.group.recordCompletion(id, 0, summary);
       } else {
-        const meta = m.meta as { diff?: unknown; filePath?: string } | undefined;
+        const meta = m.meta as { diff?: unknown; filePath?: string; diffs?: NestedDiff[] } | undefined;
         if (meta?.diff && typeof meta.filePath === "string") {
           const diff = meta.diff as DiffStats & Parameters<typeof renderDiff>[0];
           if (!diff.isIdentical) {
@@ -575,6 +591,9 @@ export function mountAshi(
         }
         found.pair.result.finalize({ exitCode: 0, summary });
         found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0, summary });
+        // Edits made inside a scheme_eval are re-emitted live as their own pairs but
+        // aren't conversation messages, so replay them from the persisted bucket.
+        meta?.diffs?.forEach((nd, i) => replayNestedEdit(`${id}-edit-${i}`, nd));
       }
       if (id) toolMap.delete(id);
     }

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -112,8 +112,6 @@ function diffFrameTitle(filePath: string, diff: DiffStats): string {
   return `${theme.fg("muted", filePath)}  ${stats}`;
 }
 
-/** The +N/-M completion summary an edit shows on its call line — recovered from
- *  the persisted diff on resume, since resultDisplay.summary isn't stored. */
 function diffStatsSummary(diff: DiffStats): string {
   return diff.isNewFile ? `+${diff.added}` : `+${diff.added} -${diff.removed}`;
 }
@@ -584,24 +582,21 @@ export function mountAshi(
         appendEntry(new InfoLine(renderer, `tool result (no matching call): ${text.slice(0, 80)}`).node, { t: "plain" });
         return;
       }
-      let summary = inferSummary(found.name, text);
+      const meta = m.meta as { diff?: unknown; filePath?: string; diffs?: NestedDiff[]; summary?: string } | undefined;
+      // Persisted summary wins; diff stats and inferSummary are resume fallbacks for older sessions.
+      let summary = meta?.summary ?? inferSummary(found.name, text);
       if (found.kind === "group") {
         found.group.recordCompletion(id, 0, summary);
       } else {
-        const meta = m.meta as { diff?: unknown; filePath?: string; diffs?: NestedDiff[] } | undefined;
         if (meta?.diff && typeof meta.filePath === "string") {
           const diff = meta.diff as DiffStats & Parameters<typeof renderDiff>[0];
-          // Recover the +N/-M summary from the diff — inferSummary has no edit case,
-          // and the boxed title that used to carry the stats is gone now.
-          summary = diffStatsSummary(diff);
+          if (!meta.summary) summary = diffStatsSummary(diff);
           if (!diff.isIdentical) {
             found.pair.result.setDiffRenderer(buildDiffRenderer(diff, meta.filePath, renderer.capabilities.diffFrame !== false));
           }
         }
         found.pair.result.finalize({ exitCode: 0, summary });
         found.pair.call.setStatus({ exitCode: 0, elapsedMs: 0, summary });
-        // Edits made inside a scheme_eval are re-emitted live as their own pairs but
-        // aren't conversation messages, so replay them from the persisted bucket.
         meta?.diffs?.forEach((nd, i) => replayNestedEdit(`${id}-edit-${i}`, nd));
       }
       if (id) toolMap.delete(id);

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -112,6 +112,12 @@ function diffFrameTitle(filePath: string, diff: DiffStats): string {
   return `${theme.fg("muted", filePath)}  ${stats}`;
 }
 
+/** The +N/-M completion summary an edit shows on its call line — recovered from
+ *  the persisted diff on resume, since resultDisplay.summary isn't stored. */
+function diffStatsSummary(diff: DiffStats): string {
+  return diff.isNewFile ? `+${diff.added}` : `+${diff.added} -${diff.removed}`;
+}
+
 function readReasoning(m: unknown): string {
   const mm = m as { reasoning?: unknown; reasoning_content?: unknown };
   const r = mm.reasoning ?? mm.reasoning_content;
@@ -487,7 +493,7 @@ export function mountAshi(
 
   const replayNestedEdit = (toolCallId: string, nd: NestedDiff): void => {
     const diff = nd.diff as DiffStats & Parameters<typeof renderDiff>[0];
-    const summary = diff.isNewFile ? `+${diff.added}` : `+${diff.added} -${diff.removed}`;
+    const summary = diffStatsSummary(diff);
     const pair = renderToolPair({
       toolCallId, name: nd.name, title: nd.name, kind: "edit",
       displayDetail: relativize(nd.filePath), rawInput: { file_path: nd.filePath },
@@ -578,13 +584,16 @@ export function mountAshi(
         appendEntry(new InfoLine(renderer, `tool result (no matching call): ${text.slice(0, 80)}`).node, { t: "plain" });
         return;
       }
-      const summary = inferSummary(found.name, text);
+      let summary = inferSummary(found.name, text);
       if (found.kind === "group") {
         found.group.recordCompletion(id, 0, summary);
       } else {
         const meta = m.meta as { diff?: unknown; filePath?: string; diffs?: NestedDiff[] } | undefined;
         if (meta?.diff && typeof meta.filePath === "string") {
           const diff = meta.diff as DiffStats & Parameters<typeof renderDiff>[0];
+          // Recover the +N/-M summary from the diff — inferSummary has no edit case,
+          // and the boxed title that used to carry the stats is gone now.
+          summary = diffStatsSummary(diff);
           if (!diff.isIdentical) {
             found.pair.result.setDiffRenderer(buildDiffRenderer(diff, meta.filePath, renderer.capabilities.diffFrame !== false));
           }

--- a/examples/extensions/ashi/src/renderers/pi-tui/index.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/index.ts
@@ -16,6 +16,9 @@ export function createPiTuiRenderer(): Renderer {
       images: caps.images !== null,
       markdownStreaming: true,
       rawOutput: true,
+      // Bare hunk lines under the └ elbow, no box frame — the file path and
+      // +N/-M stats already live on the call line, so the frame just repeats them.
+      diffFrame: false,
     },
     measureWidth: (text) => visibleWidth(text),
     mountToolCall: (model, args, env) => mountCall(model, args, env),

--- a/examples/extensions/ashi/src/renderers/pi-tui/index.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/index.ts
@@ -16,8 +16,6 @@ export function createPiTuiRenderer(): Renderer {
       images: caps.images !== null,
       markdownStreaming: true,
       rawOutput: true,
-      // Bare hunk lines under the └ elbow, no box frame — the file path and
-      // +N/-M stats already live on the call line, so the frame just repeats them.
       diffFrame: false,
     },
     measureWidth: (text) => visibleWidth(text),

--- a/examples/extensions/ashi/src/renderers/pi-tui/schema-mount.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/schema-mount.ts
@@ -93,8 +93,6 @@ class SchemaCallComponent extends Container {
     this.handle.dispatch("status", opts);
   }
 
-  // Shared env guard: whichever sibling renders first observes the width change,
-  // so it must re-layout both halves.
   override render(width: number): string[] {
     if (this.handle.cell.env.width !== width) {
       this.handle.cell.env = { ...this.handle.cell.env, width };

--- a/examples/extensions/ashi/src/renderers/pi-tui/schema-mount.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/schema-mount.ts
@@ -93,6 +93,17 @@ class SchemaCallComponent extends Container {
     this.handle.dispatch("status", opts);
   }
 
+  // Shared env guard: whichever sibling renders first observes the width change,
+  // so it must re-layout both halves.
+  override render(width: number): string[] {
+    if (this.handle.cell.env.width !== width) {
+      this.handle.cell.env = { ...this.handle.cell.env, width };
+      this.repaint();
+      this.handle.cell.resultView?.repaint();
+    }
+    return super.render(width);
+  }
+
   repaint(): void {
     const display = this.handle.model.view(this.handle.cell.state as ViewState<unknown>, this.handle.cell.env);
     const icon = iconString(display.titleIcon);
@@ -137,6 +148,7 @@ class SchemaResultComponent extends Container {
     if (this.handle.cell.env.width !== width) {
       this.handle.cell.env = { ...this.handle.cell.env, width };
       this.repaint();
+      this.handle.cell.callView?.repaint();
     }
     return super.render(width);
   }

--- a/examples/extensions/ashi/src/renderers/pi-tui/schema-mount.ts
+++ b/examples/extensions/ashi/src/renderers/pi-tui/schema-mount.ts
@@ -108,7 +108,7 @@ class SchemaCallComponent extends Container {
     const display = this.handle.model.view(this.handle.cell.state as ViewState<unknown>, this.handle.cell.env);
     const icon = iconString(display.titleIcon);
     const title = segmentsToString(display.title);
-    const status = statusSuffix(display.status);
+    const status = display.hideTitleStatus ? "" : statusSuffix(display.status);
     if (display.titleRight && display.titleRight.length > 0) {
       const right = segmentsToString(display.titleRight);
       // width − 2: Text has paddingX=1 each side.

--- a/examples/extensions/ashi/src/schema.ts
+++ b/examples/extensions/ashi/src/schema.ts
@@ -40,6 +40,8 @@ export interface ToolDisplay {
   /** Right-aligned on the title line; framework handles padding and status-suffix spacing. */
   titleRight?: Segment[];
   status?: DisplayStatus;
+  /** Drop the status suffix from the title line — for renderers that surface it on the result line instead. */
+  hideTitleStatus?: boolean;
   body?: Body;
   expandable?: boolean;
   defaultExpanded?: boolean;
@@ -189,6 +191,7 @@ const DEFAULT_EXPANDED_LINES = 200;
 function renderStream(buffer: string, env: Env): string {
   const display = buffer.replace(/\n+$/, "");
   if (env.expanded) {
+    if (!display) return "";
     const cap = env.expandedLines ?? DEFAULT_EXPANDED_LINES;
     const lines = display.split("\n");
     if (lines.length <= cap) return theme.fg("toolOutput", display);

--- a/examples/extensions/ashi/src/session-commands.ts
+++ b/examples/extensions/ashi/src/session-commands.ts
@@ -60,9 +60,7 @@ function formatLocal(ts: number): string {
 export function formatSessionRow(s: SessionInfo, isCurrent: boolean): string {
   const marker = isCurrent ? "●" : " ";
   const when = s.createdAt ? formatLocal(s.createdAt) : "?";
-  // A picker row must stay one line: SelectList truncates to width but not across
-  // newlines, so a multi-line name/preview would render tall and corrupt its
-  // frame-clear. Flatten here regardless of where the text came from.
+  // SelectList truncates to width but not across newlines, so keep the row one line.
   const label = (s.name ?? s.preview).replace(/\s+/g, " ").trim();
   return `${marker} ${when}  ${label}  (${s.entryCount})`;
 }

--- a/examples/extensions/ashi/src/session-commands.ts
+++ b/examples/extensions/ashi/src/session-commands.ts
@@ -60,7 +60,10 @@ function formatLocal(ts: number): string {
 export function formatSessionRow(s: SessionInfo, isCurrent: boolean): string {
   const marker = isCurrent ? "●" : " ";
   const when = s.createdAt ? formatLocal(s.createdAt) : "?";
-  const label = s.name ?? s.preview;
+  // A picker row must stay one line: SelectList truncates to width but not across
+  // newlines, so a multi-line name/preview would render tall and corrupt its
+  // frame-clear. Flatten here regardless of where the text came from.
+  const label = (s.name ?? s.preview).replace(/\s+/g, " ").trim();
   return `${marker} ${when}  ${label}  (${s.entryCount})`;
 }
 

--- a/examples/extensions/ashi/tests/persistence-resume.test.ts
+++ b/examples/extensions/ashi/tests/persistence-resume.test.ts
@@ -150,18 +150,19 @@ test("a new turn in a session resumed via the in-app picker is persisted", async
   assert.equal(reread.length, 4, "the new turn should be on disk after flush");
 });
 
-test("scheme-bridged edits persist their diff under the enclosing scheme_eval call", async () => {
+test("a nested tool call's diff is bucketed onto the enclosing call (via the nested flag, not an id prefix)", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-persist-"));
-  const cwd = "/tmp/ashi-persist-scheme";
+  const cwd = "/tmp/ashi-persist-nested";
   const store = new MultiSessionStore(dir, cwd);
   const conv = { messages: [] as Msg[] };
   const { ctx, bus } = makeCtx(conv);
   const capture = registerCapture(ctx as never, () => store);
 
-  await bus.emit("agent:tool-started", { toolCallId: "call_1", name: "scheme_eval", title: "scheme" });
-  await bus.emit("agent:tool-started", { toolCallId: "scheme-edit_file-1", title: "edit_file" });
+  // The bridged edit uses an arbitrary id — only `nested: true` marks it.
+  await bus.emit("agent:tool-started", { toolCallId: "call_1", name: "compose", title: "compose" });
+  await bus.emit("agent:tool-started", { toolCallId: "inner-xyz", name: "edit_file", title: "edit_file", nested: true });
   await bus.emit("agent:tool-completed", {
-    toolCallId: "scheme-edit_file-1", exitCode: 0,
+    toolCallId: "inner-xyz", exitCode: 0, nested: true,
     resultDisplay: { body: { kind: "diff", filePath: "/x/a.ts",
       diff: { added: 3, removed: 1, isNewFile: false, isIdentical: false, hunks: [] } } },
   });
@@ -169,7 +170,7 @@ test("scheme-bridged edits persist their diff under the enclosing scheme_eval ca
 
   conv.messages.push({
     role: "assistant", content: "",
-    tool_calls: [{ id: "call_1", type: "function", function: { name: "scheme_eval", arguments: "(edit-file ...)" } }],
+    tool_calls: [{ id: "call_1", type: "function", function: { name: "compose", arguments: "…" } }],
   } as never);
   conv.messages.push({ role: "tool", tool_call_id: "call_1", content: "ok" } as never);
   await capture.flush();
@@ -179,9 +180,9 @@ test("scheme-bridged edits persist their diff under the enclosing scheme_eval ca
     .filter((e) => e.type === "message")
     .map((e) => (e as { message: { role: string; tool_call_id?: string; meta?: { diffs?: unknown[] } } }).message)
     .find((m) => m.role === "tool" && m.tool_call_id === "call_1");
-  assert.ok(toolMsg, "scheme_eval tool result persisted");
+  assert.ok(toolMsg, "enclosing tool result persisted");
   const diffs = toolMsg!.meta?.diffs as Array<{ name: string; filePath: string }> | undefined;
-  assert.ok(Array.isArray(diffs) && diffs.length === 1, "nested edit diff bucketed onto the scheme_eval tool message");
+  assert.ok(Array.isArray(diffs) && diffs.length === 1, "nested edit diff bucketed onto the enclosing tool message");
   assert.equal(diffs![0].name, "edit_file");
   assert.equal(diffs![0].filePath, "/x/a.ts");
 });

--- a/examples/extensions/ashi/tests/persistence-resume.test.ts
+++ b/examples/extensions/ashi/tests/persistence-resume.test.ts
@@ -149,3 +149,41 @@ test("a new turn in a session resumed via the in-app picker is persisted", async
   const reread = new MultiSessionStore(dir, cwd, { resumeSessionId: sid }).current().buildMessages();
   assert.equal(reread.length, 4, "the new turn should be on disk after flush");
 });
+
+test("scheme-bridged edits persist their diff under the enclosing scheme_eval call", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-persist-"));
+  const cwd = "/tmp/ashi-persist-scheme";
+  const store = new MultiSessionStore(dir, cwd);
+  const conv = { messages: [] as Msg[] };
+  const { ctx, bus } = makeCtx(conv);
+  const capture = registerCapture(ctx as never, () => store);
+
+  // scheme_eval (real LLM call) edits a file via the host edit_file bridge, which
+  // re-emits the lifecycle under a synthetic `scheme-*` id.
+  await bus.emit("agent:tool-started", { toolCallId: "call_1", name: "scheme_eval", title: "scheme" });
+  await bus.emit("agent:tool-started", { toolCallId: "scheme-edit_file-1", title: "edit_file" });
+  await bus.emit("agent:tool-completed", {
+    toolCallId: "scheme-edit_file-1", exitCode: 0,
+    resultDisplay: { body: { kind: "diff", filePath: "/x/a.ts",
+      diff: { added: 3, removed: 1, isNewFile: false, isIdentical: false, hunks: [] } } },
+  });
+  await bus.emit("agent:tool-completed", { toolCallId: "call_1", exitCode: 0 });
+
+  conv.messages.push({
+    role: "assistant", content: "",
+    tool_calls: [{ id: "call_1", type: "function", function: { name: "scheme_eval", arguments: "(edit-file ...)" } }],
+  } as never);
+  conv.messages.push({ role: "tool", tool_call_id: "call_1", content: "ok" } as never);
+  await capture.flush();
+
+  const branch = new MultiSessionStore(dir, cwd, { resumeSessionId: store.current().id }).current().getBranch();
+  const toolMsg = branch
+    .filter((e) => e.type === "message")
+    .map((e) => (e as { message: { role: string; tool_call_id?: string; meta?: { diffs?: unknown[] } } }).message)
+    .find((m) => m.role === "tool" && m.tool_call_id === "call_1");
+  assert.ok(toolMsg, "scheme_eval tool result persisted");
+  const diffs = toolMsg!.meta?.diffs as Array<{ name: string; filePath: string }> | undefined;
+  assert.ok(Array.isArray(diffs) && diffs.length === 1, "nested edit diff bucketed onto the scheme_eval tool message");
+  assert.equal(diffs![0].name, "edit_file");
+  assert.equal(diffs![0].filePath, "/x/a.ts");
+});

--- a/examples/extensions/ashi/tests/persistence-resume.test.ts
+++ b/examples/extensions/ashi/tests/persistence-resume.test.ts
@@ -158,8 +158,6 @@ test("scheme-bridged edits persist their diff under the enclosing scheme_eval ca
   const { ctx, bus } = makeCtx(conv);
   const capture = registerCapture(ctx as never, () => store);
 
-  // scheme_eval (real LLM call) edits a file via the host edit_file bridge, which
-  // re-emits the lifecycle under a synthetic `scheme-*` id.
   await bus.emit("agent:tool-started", { toolCallId: "call_1", name: "scheme_eval", title: "scheme" });
   await bus.emit("agent:tool-started", { toolCallId: "scheme-edit_file-1", title: "edit_file" });
   await bus.emit("agent:tool-completed", {
@@ -186,4 +184,31 @@ test("scheme-bridged edits persist their diff under the enclosing scheme_eval ca
   assert.ok(Array.isArray(diffs) && diffs.length === 1, "nested edit diff bucketed onto the scheme_eval tool message");
   assert.equal(diffs![0].name, "edit_file");
   assert.equal(diffs![0].filePath, "/x/a.ts");
+});
+
+test("a tool's call-line summary is persisted for resume (any tool, not just diffs)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ashi-persist-"));
+  const cwd = "/tmp/ashi-persist-summary";
+  const store = new MultiSessionStore(dir, cwd);
+  const conv = { messages: [] as Msg[] };
+  const { ctx, bus } = makeCtx(conv);
+  const capture = registerCapture(ctx as never, () => store);
+
+  await bus.emit("agent:tool-started", { toolCallId: "call_x", name: "bash", title: "bash" });
+  await bus.emit("agent:tool-completed", { toolCallId: "call_x", exitCode: 0, resultDisplay: { summary: "0.3s" } });
+
+  conv.messages.push({
+    role: "assistant", content: "",
+    tool_calls: [{ id: "call_x", type: "function", function: { name: "bash", arguments: "ls" } }],
+  } as never);
+  conv.messages.push({ role: "tool", tool_call_id: "call_x", content: "out" } as never);
+  await capture.flush();
+
+  const branch = new MultiSessionStore(dir, cwd, { resumeSessionId: store.current().id }).current().getBranch();
+  const toolMsg = branch
+    .filter((e) => e.type === "message")
+    .map((e) => (e as { message: { role: string; meta?: { summary?: string } } }).message)
+    .find((m) => m.role === "tool");
+  assert.ok(toolMsg, "tool result persisted");
+  assert.equal(toolMsg!.meta?.summary, "0.3s", "the bash summary is persisted for resume");
 });

--- a/examples/extensions/ashi/tests/session-row.test.ts
+++ b/examples/extensions/ashi/tests/session-row.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatSessionRow } from "../src/session-commands.js";
+
+test("formatSessionRow flattens a multi-line preview so the picker row stays single-line", () => {
+  const row = formatSessionRow(
+    {
+      id: "x",
+      createdAt: 1_700_000_000_000,
+      entryCount: 3,
+      preview: "I'm reading about this:\n\n  some pasted\n  multi-line content",
+    } as never,
+    false,
+  );
+  assert.ok(!row.includes("\n"), "no newline in the picker row");
+  assert.match(row, /I'm reading about this: some pasted multi-line content/);
+  assert.match(row, /\(3\)$/);
+});

--- a/src/agent/session-store.ts
+++ b/src/agent/session-store.ts
@@ -297,7 +297,7 @@ export class SessionStore {
     for (const e of this.entries.values()) {
       if (e.type === "message" && e.message.role === "user") {
         const raw = typeof e.message.content === "string" ? e.message.content : "";
-        const txt = stripContextWrappers(raw);
+        const txt = stripContextWrappers(raw).replace(/\s+/g, " ").trim();
         if (txt) return txt.slice(0, 80);
       }
     }

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -343,7 +343,7 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
 
   const change = (no: string, sigil: string, bg: string, fg: string, text: string): string => {
     if (!gutterLine) {
-      return `${bg}${padToWidth(`${no} ${fg}${sigil}${preserveBg(text, bg)}`, textWidth)}${p.reset}`;
+      return `${bg}${fg}${padToWidth(`${no} ${sigil} ${preserveBg(text, bg)}`, textWidth)}${p.reset}`;
     }
     if (useTrueColor) return gutter(no) + padToWidth(`${bg}${fg}${sigil} ${preserveBg(text, bg)}`, bgWidth) + p.reset;
     return `${gutter(no)}${fg}${sigil} ${text}${p.reset}`;
@@ -359,7 +359,7 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
       const raw = truncateText(line.text, lineTextW);
       const text = lang ? highlightLine(raw, lang) : raw;
       // The flush gutter dims only the line number; the code stays normal/highlighted.
-      out.push(!gutterLine ? `${p.dim}${no}${p.reset}  ${text}` : `${gutter(no)}  ${p.dim}${text}${p.reset}`);
+      out.push(!gutterLine ? `${p.dim}${no}${p.reset}   ${text}` : `${gutter(no)}  ${p.dim}${text}${p.reset}`);
       continue;
     }
 

--- a/src/utils/palette.ts
+++ b/src/utils/palette.ts
@@ -38,10 +38,10 @@ const defaultPalette: ColorPalette = {
   error:   "\x1b[31m",   // red
   muted:   "\x1b[90m",   // gray
 
-  successBg:     "\x1b[48;2;0;60;0m",
-  errorBg:       "\x1b[48;2;50;0;0m",
-  successBgEmph: "\x1b[48;2;0;112;0m",
-  errorBgEmph:   "\x1b[48;2;90;0;0m",
+  successBg:     "\x1b[48;2;34;92;43m",
+  errorBg:       "\x1b[48;2;122;41;54m",
+  successBgEmph: "\x1b[48;2;56;166;96m",
+  errorBgEmph:   "\x1b[48;2;179;89;107m",
 
   bold:      "\x1b[1m",
   dim:       "\x1b[2m",

--- a/tests/agent/session-store.test.ts
+++ b/tests/agent/session-store.test.ts
@@ -120,6 +120,17 @@ describe("SessionStore", () => {
     assert.equal(s.getPreview(), "real question here");
   });
 
+  test("getPreview collapses newlines so the resume picker stays single-line", async () => {
+    const file = path.join(tmpDir, "preview-multiline.jsonl");
+    const s = new SessionStore(file, { create: { cwd: "/x", sessionId: "root" } });
+    await s.appendMessages([
+      { role: "user", content: "incorporate this as an extension?\n\n   Lev Landau's mentor said" },
+    ]);
+    const preview = s.getPreview();
+    assert.ok(!preview.includes("\n"), "no embedded newlines");
+    assert.equal(preview, "incorporate this as an extension? Lev Landau's mentor said");
+  });
+
   test("summarizeMessage formats roles distinctively", () => {
     assert.match(summarizeMessage({ role: "user", content: "hello" }), /^user: hello/);
     assert.match(summarizeMessage({ role: "tool", content: "result" }), /^tool result:/);

--- a/tests/core/diff-renderer.test.ts
+++ b/tests/core/diff-renderer.test.ts
@@ -8,13 +8,13 @@ const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
 const old = "def add(a, b):\n    return a + b\n\nprint(add(1, 2))\n";
 const neu = "def add(a, b):\n    return a + b\n\ndef mul(a, b):\n    return a * b\n\nprint(add(1, 2))\n";
 
-test("gutterLine false: no pipe, sigil hugs the code, line number leads", () => {
+test("gutterLine false: no pipe, space after sigil, line number leads", () => {
   const lines = renderDiff(computeDiff(old, neu), {
     width: 60, filePath: "x.py", mode: "unified", gutterLine: false,
   }).map(strip);
   const added = lines.find((l) => l.includes("def mul"));
   assert.ok(added, "added line present");
-  assert.match(added!, /^\s*\d+ \+def mul/); // `<n> +code`, sigil hugging, no `│`
+  assert.match(added!, /^\s*\d+ \+ def mul/); // `<n> + code`, space after sigil, no `│`
   assert.ok(!lines.some((l) => l.includes("│")), "no pipe rule with the flush gutter");
 });
 


### PR DESCRIPTION
A handful of rendering fixes for the ashi TUI (pi-tui renderer), plus the core
diff renderer, session preview, and resume capture they build on.

## Fixes

- **Resize re-layout.** `SchemaCallComponent` ignored width changes, so the
  right-aligned shell label and the result body could fall a frame out of sync
  on terminal resize. Both halves of a tool pair now re-layout together.

- **Scheme result summary.** A successful `scheme_eval` echoes no body, so on
  expand the result line was empty while the `✓ N` summary sat on the wrapped
  title line. The summary now renders on the result line (`└ ✓ N`) when
  expanded, and an empty stream no longer draws a stray `└`.

- **Unboxed diffs.** pi-tui drops the box frame around diffs (`diffFrame:
  false`), matching the flush-gutter style — the file path and `+N/-M` stats
  already live on the call line, so the frame only repeated them.

- **Flush-gutter polish.** In the flush (no-pipe) gutter, changed-line numbers
  are now tinted green/red to match the sigil instead of staying default white,
  and a space separates the sigil from the code with context rows aligned to
  match.

- **Diff highlight palette.** Brighter, slightly desaturated three-channel
  row and word-emphasis backgrounds so changed lines read clearly on a dark
  terminal.

- **Resume picker corruption.** A multi-line first message rendered as a tall
  picker row, but `SelectList` truncates to width without splitting newlines and
  its frame-clear counts one line per row — so half-erased rows cascaded down
  the list. `getPreview` now collapses whitespace before truncating, and
  `formatSessionRow` flattens the row at the boundary so a renamed session or
  any other source can't reintroduce it.

- **Resume diffs (scheme-only mode).** Edits run inside `scheme_eval` are
  re-emitted under synthetic `scheme-*` ids with no conversation message of
  their own, so their diffs were dropped at capture time and lost on resume.
  Capture now buckets those diffs under the enclosing `scheme_eval` call and
  persists them; resume replays each as its own edit pair, matching the live
  nested view.



- **Resume call-line summaries.** `resultDisplay.summary` isn't persisted and
  `inferSummary` only re-derives a handful of tools, so on resume most tool
  calls (bash, scheme_eval, edits, …) showed a bare `✓`. Capture now stores
  each tool result's summary on its message and replay prefers it (diff stats
  and `inferSummary` remain fallbacks for sessions saved earlier). This is
  especially visible now that diffs are unboxed — the `+N/-M` that used to sit
  in the box title shows on the call line instead.
