### PR TITLE
Frontend surface descriptions + per-surface cwd + provider cache-hit ratio

### DIFF
--- a/examples/extensions/ashi/README.md
+++ b/examples/extensions/ashi/README.md
@@ -175,6 +175,14 @@ export PATH="$HOME/.agent-sh/bin:$PATH"
 
 `agent-sh install` runs `npm install` and `npm run build` in the copied directory and symlinks the built bin into `~/.agent-sh/bin/`.
 
+By default the copy pulls the **published** `agent-sh` from npm. When ashi's source depends on an unreleased core — a kernel change you haven't published yet — add `--dev` so the install links against the checkout you're running instead:
+
+```bash
+agent-sh install ashi --dev --force
+```
+
+`--dev` repoints the copied package's `agent-sh` dependency at the running host's checkout (the one the global `agent-sh` is linked to). The build then sees the local types, and a later `npm run build` at the repo root flows through without reinstalling — the kernel rebuild rule from [Development](#development) applies. Re-run the install to refresh ashi's own dist after frontend changes.
+
 ## Development
 
 `@guanyilun/ashi` depends on the published `agent-sh` package. To iterate against a local checkout, use `npm link`:

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
 
   activateAgent(ctx);
   activateShellContext(ctx);
-  await loadBuiltinExtensions(ctx, ["rolling-history"]);
+  const builtinExtensions = await loadBuiltinExtensions(ctx);
 
   const shell = new Shell({
     bus: core.bus,
@@ -261,6 +261,12 @@ async function main(): Promise<void> {
     applyBranchMessages(ctx, getStore, capture);
     await handle.rebuildChat();
     ctx.bus.emit("ui:info", { message: `continued session ${resumeId.slice(0, 12)}…` });
+  } else {
+    // New-session only: skip on resume so a restored transcript isn't prefixed with this.
+    const loadedExtensions = [...new Set([...builtinExtensions, ...loaded])];
+    if (loadedExtensions.length > 0) {
+      ctx.bus.emit("ui:info", { message: `extensions: ${loadedExtensions.join(" · ")}` });
+    }
   }
 
   process.on("SIGTERM", cleanup);

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -38,6 +38,18 @@ import { loadRendererPreference } from "./display-config.js";
 import { applyOutputMode } from "./terminal-mode.js";
 import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Package root (dist/cli.js and src/cli.ts both sit one level down) — the running copy.
+const ASHI_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const ASHI_SURFACE = `You're attached through ashi, an interactive terminal UI. A person is at the keyboard reading your replies as they render — address them directly and keep the exchange conversational.
+
+Your working directory is ${process.cwd()}; your tools run there and it stays fixed. The user can also run shell commands with a \`!\` prefix — those run in a separate shell that may sit elsewhere, and don't change your working directory.
+
+ashi's own source lives at ${ASHI_ROOT}. Read it when the user asks how the TUI works, or wants to change how it looks or behaves:
+- ${path.join(ASHI_ROOT, "README.md")} — what ashi is and how rendering decouples into swappable render extensions
+- ${path.join(ASHI_ROOT, "EXTENDING.md")} — the render-extension contract
+- ${path.join(ASHI_ROOT, "src")} — the frontend, session capture/resume, and the pi-tui renderer`;
 
 function parseArgs(argv: string[]): AppConfig & { extensions?: string[]; continueLast: boolean; renderer?: string } {
   let model: string | undefined;
@@ -226,7 +238,10 @@ async function main(): Promise<void> {
   registerRenderDefaults(ctx, renderer);
   registerDefaultSchemaRenderers(ctx);
 
-  ctx.advise("system-prompt:build", (next) => `${next()}\n\n<cwd>${process.cwd()}</cwd>`);
+  ctx.advise("system-prompt:frontend", (next) => {
+    const base = (next() as string) ?? "";
+    return base ? `${base}\n\n${ASHI_SURFACE}` : ASHI_SURFACE;
+  });
 
   const handle = mountAshi(ctx, getStore, capture, renderer);
   stopFrontend = handle.stop;

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -987,10 +987,12 @@ export function mountAshi(
     const picker = app.createSelectList(items, { visibleRows: 15 });
     const activeIdx = items.findIndex((it) => it.value === `tip:${activeLeaf}`);
     picker.setSelectedIndex(activeIdx >= 0 ? activeIdx : items.length - 1);
+    const hint = new InfoLine(renderer, "↑↓ move · enter: select · esc: cancel");
 
     const close = (): void => {
       pickerOpen = false;
       app.footerSlot.removeChild(picker.node);
+      app.footerSlot.removeChild(hint.node);
       app.focusInput();
       app.requestRender();
     };
@@ -1021,6 +1023,7 @@ export function mountAshi(
     picker.onCancel(close);
 
     pickerOpen = true;
+    app.footerSlot.addChild(hint.node);
     app.footerSlot.addChild(picker.node);
     app.setFocus(picker.node);
     app.requestRender();

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -828,7 +828,10 @@ export function mountAshi(
 
   bus.on("agent:usage", (u) => {
     if (u.prompt_tokens > 0) {
-      statusFooter.update({ tokens: u.prompt_tokens });
+      const cacheRatio = typeof u.cached_prompt_tokens === "number"
+        ? u.cached_prompt_tokens / u.prompt_tokens
+        : undefined;
+      statusFooter.update({ tokens: u.prompt_tokens, cacheRatio });
       app.requestRender();
     }
   });

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -10,6 +10,7 @@ interface StatusFields {
   branch?: string;
   leaf?: number;
   tokens?: number;
+  cacheRatio?: number;
   compactions?: number;
   thinking?: string;
   shellMode?: "off" | "on" | "private";
@@ -52,7 +53,7 @@ export class StatusFooter {
   }
 
   private buildLine(): string {
-    const { model, provider, contextWindow, cwd, branch, leaf, tokens, compactions, thinking } = this.fields;
+    const { model, provider, contextWindow, cwd, branch, leaf, tokens, cacheRatio, compactions, thinking } = this.fields;
     const sep = theme.fg("dim", " | ");
     const parts: string[] = [];
     if (model) {
@@ -69,6 +70,11 @@ export class StatusFooter {
       const tokStr = contextWindow ? `${fmtTokens(tokens)}/${fmtTokens(contextWindow)}` : fmtTokens(tokens);
       const pct = contextWindow ? ` ${theme.fg("dim", `${Math.round((tokens / contextWindow) * 100)}%`)}` : "";
       parts.push(`${theme.fg("muted", tokStr)}${pct}`);
+    }
+    if (cacheRatio != null) {
+      const cachePct = cacheRatio * 100;
+      const color = cachePct >= 80 ? "success" : cachePct >= 40 ? "warning" : "muted";
+      parts.push(`${theme.fg("muted", "cache ")}${theme.fg(color, `${cachePct.toFixed(1)}%`)}`);
     }
     if (compactions && compactions > 0) parts.push(theme.fg("muted", `⊟ ${compactions}`));
     return parts.length === 0 ? "" : parts.join(sep);

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1458,10 +1458,12 @@ export class AgentLoop implements AgentBackend {
       if ((chunk as any).usage) {
         const u = (chunk as any).usage;
         const promptTokens = u.prompt_tokens ?? 0;
+        const cachedPromptTokens = this.currentMode.extractCachedTokens?.(u);
         this.bus.emit("agent:usage", {
           prompt_tokens: promptTokens,
           completion_tokens: u.completion_tokens ?? 0,
           total_tokens: u.total_tokens ?? 0,
+          ...(typeof cachedPromptTokens === "number" ? { cached_prompt_tokens: cachedPromptTokens } : {}),
         });
         if (promptTokens > 0) {
           this.conversation.updateApiTokenCount(promptTokens);

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -13,7 +13,7 @@ import { contentText, type AgentBackend, type ImageContent, type SkillView, type
 import { ToolRegistry } from "./tool-registry.js";
 import { normalizeToolArgs } from "./normalize-args.js";
 import { LiveView, type CompactResult } from "./live-view.js";
-import { STATIC_SYSTEM_PROMPT, buildStaticByCwd, formatSkillsBlock, loadGlobalAgentsMd } from "./system-prompt.js";
+import { STATIC_IDENTITY, STATIC_GUIDE, buildStaticByCwd, formatSkillsBlock, loadGlobalAgentsMd } from "./system-prompt.js";
 import type { Compositor } from "../utils/compositor.js";
 import { createToolUI } from "../utils/tool-interactive.js";
 import { RESPONSE_RESERVE, DEFAULT_CONTEXT_WINDOW } from "./token-budget.js";
@@ -633,9 +633,14 @@ export class AgentLoop implements AgentBackend {
 
     // System prompt: static identity + behavioral instructions.
     // Extensions can use registerInstruction() for a managed section,
-    // or advise this handler directly for full control.
+    // advise system-prompt:frontend to describe their surface high in the
+    // prompt, or advise this handler directly for full control.
     h.define("system-prompt:build", () => {
-      const parts: string[] = [STATIC_SYSTEM_PROMPT];
+      // The active frontend's surface goes right after the identity; omitted if none.
+      const frontend = ((this.handlers.call("system-prompt:frontend") as string) ?? "").trim();
+      const parts: string[] = [STATIC_IDENTITY];
+      if (frontend) parts.push(frontend);
+      parts.push(STATIC_GUIDE);
 
       // Global behavioral rules (~/.agent-sh/AGENTS.md) — persistent agent memory
       const agentsMd = loadGlobalAgentsMd();

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -21,6 +21,7 @@ declare module "../core/event-bus.js" {
     "provider:configure": {
       id: string;
       reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
+      cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
     };
 
     "agent:modes-changed": Record<string, never>;
@@ -41,7 +42,7 @@ declare module "../core/event-bus.js" {
     "agent:thinking-chunk": { text: string };
     "agent:response-chunk": { blocks: ContentBlock[] };
     "agent:response-done": { response: string };
-    "agent:usage": { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+    "agent:usage": { prompt_tokens: number; completion_tokens: number; total_tokens: number; cached_prompt_tokens?: number };
 
     "agent:processing-start": Record<string, never>;
     "agent:processing-done": Record<string, never>;

--- a/src/agent/host-types.ts
+++ b/src/agent/host-types.ts
@@ -84,6 +84,7 @@ export interface AgentMode {
   /** Input modalities the model supports. Defaults to ["text"]. */
   modalities?: ("text" | "image")[];
   buildReasoningParams?: (level: string) => Record<string, unknown>;
+  extractCachedTokens?: (usage: Record<string, unknown>) => number | undefined;
 }
 
 // ── Agent-host extension surface ─────────────────────────────────
@@ -99,7 +100,10 @@ export interface AgentSurface {
     /** Re-registering the same id replaces the prior contribution. */
     register: (reg: ProviderRegistration) => () => void;
     unregister: (id: string) => void;
-    configure: (id: string, opts: { reasoningParams?: (level: string, model?: string) => Record<string, unknown> }) => void;
+    configure: (id: string, opts: {
+      reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
+      cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
+    }) => void;
   };
 
   // ── Tool registration ────────────────────────────────────────

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -59,6 +59,11 @@ function defaultReasoningBuilder(level: string): Record<string, unknown> {
   return { reasoning_effort: level === "xhigh" ? "high" : level };
 }
 
+function defaultCacheTokens(usage: Record<string, unknown>): number | undefined {
+  const details = usage.prompt_tokens_details as { cached_tokens?: number } | undefined;
+  return typeof details?.cached_tokens === "number" ? details.cached_tokens : undefined;
+}
+
 function mergeCaps(
   settingsCaps: Map<string, ModelCap> | undefined,
   payloadCaps: Map<string, ModelCap>,
@@ -116,13 +121,19 @@ export default function agentBackend(ctx: ExtensionContext): void {
     if (p) settingsProviders.set(name, p);
   }
 
-  const providerHooks = new Map<string, { reasoningParams?: (level: string, model?: string) => Record<string, unknown> }>();
+  const providerHooks = new Map<string, {
+    reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
+    cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
+  }>();
 
   // Bakes model id so AgentMode.buildReasoningParams keeps its (level) signature.
   const bindReasoning = (shapeId: string, model: string) => {
     const hook = providerHooks.get(shapeId)?.reasoningParams;
     return hook ? (level: string) => hook(level, model) : defaultReasoningBuilder;
   };
+
+  const bindCacheTokens = (shapeId: string) =>
+    providerHooks.get(shapeId)?.cacheTokens ?? defaultCacheTokens;
 
   const agentSurface: AgentSurface = {
     llm: createLlmFacade({ list: ctx.list, call: ctx.call }),
@@ -318,6 +329,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
           echoReasoning: mc?.echoReasoning,
           modalities: mc?.modalities,
           buildReasoningParams: bindReasoning(shapeId, model),
+          extractCachedTokens: bindCacheTokens(shapeId),
         });
       }
     }
@@ -362,9 +374,10 @@ export default function agentBackend(ctx: ExtensionContext): void {
     }
   });
 
-  bus.on("provider:configure", ({ id, reasoningParams }) => {
+  bus.on("provider:configure", ({ id, reasoningParams, cacheTokens }) => {
     const prev = providerHooks.get(id) ?? {};
     if (reasoningParams !== undefined) prev.reasoningParams = reasoningParams;
+    if (cacheTokens !== undefined) prev.cacheTokens = cacheTokens;
     providerHooks.set(id, prev);
   });
 

--- a/src/agent/providers/deepseek.ts
+++ b/src/agent/providers/deepseek.ts
@@ -20,7 +20,15 @@ function buildReasoningParams(level: string, _model?: string): Record<string, un
 }
 
 export default function activate(ctx: AgentContext): void {
-  ctx.agent.providers.configure("deepseek", { reasoningParams: buildReasoningParams });
+  ctx.agent.providers.configure("deepseek", {
+    reasoningParams: buildReasoningParams,
+    // Native DeepSeek reports caching as flat hit/miss counts, not the
+    // OpenAI-standard prompt_tokens_details.cached_tokens the default reads.
+    cacheTokens: (u) => {
+      const hit = u.prompt_cache_hit_tokens;
+      return typeof hit === "number" ? hit : undefined;
+    },
+  });
   ctx.agent.providers.register({
     id: "deepseek",
     apiKey: resolveApiKey("deepseek").key ?? undefined,

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -100,14 +100,15 @@ function loadConventionFiles(dir: string): string[] {
 }
 
 /**
- * Static system prompt — identical across all queries, cacheable.
- * Contains only identity and behavioral instructions.
+ * Identity — paragraph one of the system prompt. Surface-agnostic, cacheable.
  */
-export const STATIC_SYSTEM_PROMPT = `You are ash, an AI coding assistant running inside agent-sh — a composable agent runtime with a small core and everything else, including the shell integration, layered on as extensions.
+export const STATIC_IDENTITY = `You are ash, an AI coding assistant running inside agent-sh — a composable agent runtime with a small core and everything else, including the frontend you're attached to, layered on as extensions.`;
 
-You may be paired with a terminal shell that shares the user's CWD, environment, and history — in that mode you can read shell events and act on the user's session. Otherwise you may be embedded as a library, exposed over a bridge protocol, or running headless, with no shell available; in those modes you operate purely through your registered tools.
-
-agent-sh source and documentation live at ${CODE_DIR}. Read them when you need to understand how the runtime works, or when the user asks how to modify or extend it:
+/**
+ * The rest of the static prompt — code map, tool guidance, envelope contract.
+ * Follows the frontend surface description in the assembled prompt.
+ */
+export const STATIC_GUIDE = `agent-sh source and documentation live at ${CODE_DIR}. Read them when you need to understand how the runtime works, or when the user asks how to modify or extend it:
 - ${path.join(CODE_DIR, "docs")} — start with README.md; architecture.md and extensions.md cover the kernel boundary and extension API
 - ${path.join(CODE_DIR, "src")} — kernel in src/core, default backend in src/agent, shell host in src/shell, built-in extensions in src/extensions
 - ${path.join(CODE_DIR, "examples/extensions")} — reference extensions to study or copy when adding functionality
@@ -120,15 +121,12 @@ guidance rather than assuming a particular tool exists. Tool output is
 returned to you for reasoning — the user doesn't see it directly.
 
 # Context Envelopes
-- \`<query_context>\` (contains \`<cwd>\` always, and \`<shell_events>\` when there were user shell commands since the last turn): the user's situation when they sent this turn — \`<cwd>\` anchors where they are right now, \`<shell_events>\` grounds "fix this" / "what just happened" requests. Trust the most recent \`<cwd>\` over any cwd referenced in earlier history.
+
+A turn may be preceded by either of two wrappers:
+- \`<query_context>\`: the user's situation when they sent this turn — the frontend and extensions inject what grounds the request here. Trust the most recent values over anything referenced earlier in history.
 - \`<dynamic_context>\`: current system state — in-flight work, mode markers, warnings.
-\`<dynamic_context>\` may be absent on any turn.
 
-# Preference Learning
-
-Treat the user's past commands as standing preferences. Before acting, check shell history
-and conversation context for recurring patterns — apply them proactively and do not wait to
-be reminded.`;
+Either may be absent on any turn.`;
 
 /**
  * CWD-scoped static context: project conventions (CLAUDE.md / AGENT.md)

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -5,9 +5,10 @@ const HELP_TEXT = `agent-sh — a shell-first terminal where AI is one keystroke
 
 Usage: agent-sh [options]
        agent-sh init [--force]            Scaffold ~/.agent-sh/ (settings, examples, AGENTS.md)
-       agent-sh install <spec> [--force] [--sync-deps]
+       agent-sh install <spec> [--force] [--sync-deps] [--dev]
                                           Install an extension (bundled name, file:, npm:, github:)
                                           --sync-deps rewrites a stale agent-sh pin to the host version
+                                          --dev links the extension against the running host's core (local development)
        agent-sh uninstall <name>          Remove an installed extension
        agent-sh list                      List installed extensions
        agent-sh auth login [provider]     Store an API key for a built-in provider

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -18,6 +18,7 @@ const EXT_DIR = path.join(CONFIG_DIR, "extensions");
 interface InstallOpts {
   force?: boolean;
   syncDeps?: boolean;
+  dev?: boolean;
 }
 
 interface ResolvedSource {
@@ -208,6 +209,29 @@ function rewriteFileDeps(target: string, sourcePath: string): void {
   if (changed) fs.writeFileSync(pkgJson, `${JSON.stringify(pkg, null, 2)}\n`);
 }
 
+/** --dev: repoint the extension's agent-sh dep at the running host's package
+ *  root, so the install builds and runs against the local (possibly unreleased)
+ *  core instead of the published registry version. npm links the file: path, so
+ *  later core rebuilds flow through without reinstalling. */
+function pinHostCore(target: string): void {
+  const pkgJson = path.join(target, "package.json");
+  if (!fs.existsSync(pkgJson)) return;
+  const pkg = JSON.parse(fs.readFileSync(pkgJson, "utf-8")) as Record<string, unknown>;
+  const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+  let changed = false;
+  for (const section of sections) {
+    const deps = pkg[section];
+    if (!deps || typeof deps !== "object") continue;
+    const d = deps as Record<string, string>;
+    if (typeof d["agent-sh"] !== "string") continue;
+    d["agent-sh"] = `file:${PACKAGE_ROOT}`;
+    changed = true;
+  }
+  if (!changed) return;
+  fs.writeFileSync(pkgJson, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`agent-sh: --dev — linking ${path.basename(target)} against host core at ${PACKAGE_ROOT}`);
+}
+
 function maybeNpmInstall(target: string, pkg: PackageJson): void {
   const deps = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}) };
   if (Object.keys(deps).length === 0) return;
@@ -264,7 +288,7 @@ function linkBins(target: string, pkg: PackageJson): string[] {
 export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<void> {
   if (!spec) {
     console.error(
-      "Usage: agent-sh install <name|file:|npm:|github:> [--force] [--sync-deps]\n\n" +
+      "Usage: agent-sh install <name|file:|npm:|github:> [--force] [--sync-deps] [--dev]\n\n" +
         "Bundled extensions:\n" +
         listBundled()
           .map((n) => `  ${n}`)
@@ -302,6 +326,7 @@ export async function runInstall(spec: string, opts: InstallOpts = {}): Promise<
     });
     try {
       rewriteFileDeps(target, resolved.sourcePath);
+      if (opts.dev) pinHostCore(target);
       syncAgentShVersion(target, opts.syncDeps ?? false);
       const pkg = readPackageJson(target);
       if (pkg) {

--- a/src/cli/subcommands.ts
+++ b/src/cli/subcommands.ts
@@ -9,6 +9,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   install: (args) => runInstall(args[0] ?? "", {
     force: args.includes("--force"),
     syncDeps: args.includes("--sync-deps"),
+    dev: args.includes("--dev"),
   }),
   uninstall: (args) => runUninstall(args[0] ?? ""),
   list: () => runList(),

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -51,10 +51,11 @@ export function createCore(config: AppConfig): AgentShellCore {
   handlers.define("config:get-app-config", () => config);
   handlers.define("cwd", () => process.cwd());
 
-  // Empty defaults so registerContextProducer can advise regardless of
-  // backend. Each backend chooses how to consume the strings.
+  // Empty defaults so advisors can wrap these regardless of load order;
+  // system-prompt:frontend is where the active frontend describes its surface.
   handlers.define("dynamic-context:build", () => "");
   handlers.define("query-context:build", () => "");
+  handlers.define("system-prompt:frontend", () => "");
 
   const backends = new Map<string, BackendRegistration>();
   let activeBackendName: string | null = null;

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -16,6 +16,8 @@ import activateShellContext from "./shell-context.js";
 import activateTuiRenderer from "./tui-renderer.js";
 import { type Terminal, processTerminal, surfaceFromTerminal } from "./terminal.js";
 
+const SHELL_SURFACE = `You're attached through a terminal shell. It shares the user's working directory, environment, and command history, and you can act on their live session — everything they run at the prompt is visible to you.`;
+
 export interface ShellActivateOptions {
   cols: number;
   rows: number;
@@ -48,6 +50,11 @@ export interface ShellHandle {
 export function registerShellHandlers(ctx: ExtensionContext): void {
   const { bus } = ctx;
   const compositor = new DefaultCompositor(bus);
+
+  ctx.advise("system-prompt:frontend", (next) => {
+    const base = (next() as string) ?? "";
+    return base ? `${base}\n\n${SHELL_SURFACE}` : SHELL_SURFACE;
+  });
 
   const shellSurface: ShellSurface = {
     compositor,

--- a/src/shell/shell-context.ts
+++ b/src/shell/shell-context.ts
@@ -1,9 +1,17 @@
 /** Tracks PTY commands and cwd, spills long outputs, contributes per-query
- *  `<cwd>` (always) and `<shell_events>` (fresh user exchanges). Frontends
- *  without a PTY skip this and fall back to core's process.cwd() default. */
+ *  `<shell_events>` (fresh user exchanges) and — under the shell frontend —
+ *  `<cwd>`. Frontends without a PTY skip this. */
 import type { ExtensionContext } from "./host-types.js";
 import { getSettings } from "../core/settings.js";
 import { spillOutput } from "../utils/shell-output-spill.js";
+
+// The cwd-drift note applies only under the shell frontend (where the agent shares
+// the user's cwd); other frontends own a fixed cwd.
+const SHELL_EVENTS_NOTE = `When the user runs shell commands, they appear as \`<shell_events>\` inside \`<query_context>\` on your next turn — use them to ground "fix this" / "what just happened" requests.`;
+
+const CWD_DRIFT_NOTE = `\`<cwd>\` is the working directory your own tool calls run in: relative paths resolve against it, and it follows the user's shell \`cd\`, so it can change from one turn to the next. Always act on the latest \`<cwd>\`, not one from earlier in the conversation.`;
+
+const PREFERENCES_NOTE = `Treat the user's commands as standing preferences: check them for recurring patterns and apply them proactively, without waiting to be asked.`;
 
 interface ShellExchange {
   id: number;
@@ -21,6 +29,9 @@ interface ShellExchange {
 
 export default function activate(ctx: ExtensionContext): void {
   const { bus } = ctx;
+  // The agent shares the user's cwd only under the shell frontend (which installs
+  // ctx.shell); other frontends — e.g. ashi — keep their own fixed cwd.
+  const ownsAgentCwd = !!(ctx as { shell?: unknown }).shell;
 
   const exchanges: ShellExchange[] = [];
   let nextId = 1;
@@ -74,24 +85,30 @@ export default function activate(ctx: ExtensionContext): void {
   bus.on("shell:agent-exec-done", () => { agentShellActive = false; });
   bus.on("shell:user-exec-exclude-next", () => { nextUserExcluded = true; });
 
-  ctx.advise("cwd", () => currentCwd);
+  if (ownsAgentCwd) ctx.advise("cwd", () => currentCwd);
 
   // Advise the core handler directly: this loads before the agent host
   // attaches `ctx.agent`, so the sugar isn't available yet.
   ctx.advise("query-context:build", (next) => {
     const base = next() as string;
-    const part = (() => {
-      const cwdTag = `<cwd>${currentCwd}</cwd>`;
-      const fresh = exchanges.filter(
-        (ex) => ex.id > lastSeq && ex.source === "user",
-      );
-      if (fresh.length === 0) return cwdTag;
+    const fresh = exchanges.filter((ex) => ex.id > lastSeq && ex.source === "user");
+    let shellEvents = "";
+    if (fresh.length > 0) {
       lastSeq = exchanges[exchanges.length - 1]!.id;
       const text = fresh.map(formatExchangeTruncated).filter(Boolean).join("\n");
-      if (!text) return cwdTag;
-      return `${cwdTag}\n<shell_events>\n${text}\n</shell_events>`;
-    })();
-    return base ? `${base}\n\n${part}` : part;
+      if (text) shellEvents = `<shell_events>\n${text}\n</shell_events>`;
+    }
+    const part = ownsAgentCwd
+      ? [`<cwd>${currentCwd}</cwd>`, shellEvents].filter(Boolean).join("\n")
+      : shellEvents;
+    return [base, part].filter(Boolean).join("\n\n");
+  });
+
+  bus.onPipe("agent:instructions", (acc) => {
+    const text = [SHELL_EVENTS_NOTE, ownsAgentCwd ? CWD_DRIFT_NOTE : "", PREFERENCES_NOTE]
+      .filter(Boolean).join("\n\n");
+    acc.instructions.push({ name: "shell-events", text });
+    return acc;
   });
 
   ctx.define("shell:context-recent", (n: number = 25) => {

--- a/tests/agent/provider-modes.test.ts
+++ b/tests/agent/provider-modes.test.ts
@@ -15,9 +15,16 @@ interface CapturedEvent {
   payload: any;
 }
 
+interface CacheProbe {
+  model: string;
+  result: number | undefined;
+  found: boolean;
+}
+
 interface DriverResult {
   events: CapturedEvent[];
   modes?: any[];
+  cacheProbes?: CacheProbe[];
   stderr: string;
   stdout: string;
   exitCode: number | null;
@@ -25,7 +32,8 @@ interface DriverResult {
 
 async function runDriver(
   settings: Record<string, unknown>,
-  scenario: { config?: Record<string, unknown>; capture: string[]; dumpModes?: boolean; steps: unknown[] },
+  scenario: { config?: Record<string, unknown>; capture: string[]; dumpModes?: boolean; probeCacheTokens?: unknown[]; steps: unknown[] },
+  envOverride: Record<string, string> = {},
 ): Promise<DriverResult> {
   const home = mkdtempSync(join(tmpdir(), "agent-sh-pmodes-"));
   writeFileSync(join(home, "settings.json"), JSON.stringify(settings, null, 2));
@@ -44,6 +52,7 @@ async function runDriver(
             OPENAI_API_KEY: "",
             DEEPSEEK_API_KEY: "",
             OPENAI_BASE_URL: "",
+            ...envOverride,
           },
           stdio: ["ignore", "pipe", "pipe"],
         },
@@ -57,8 +66,8 @@ async function runDriver(
         clearTimeout(timer);
         try {
           const line = stdout.trim().split(/\r?\n/).pop() ?? "";
-          const parsed = JSON.parse(line) as { events: CapturedEvent[]; modes?: any[] };
-          resolve({ events: parsed.events, modes: parsed.modes, stderr, stdout, exitCode: code });
+          const parsed = JSON.parse(line) as { events: CapturedEvent[]; modes?: any[]; cacheProbes?: CacheProbe[] };
+          resolve({ events: parsed.events, modes: parsed.modes, cacheProbes: parsed.cacheProbes, stderr, stdout, exitCode: code });
         } catch (err) {
           reject(new Error(`driver output not JSON.\nexit=${code}\nstdout:\n${stdout}\nstderr:\n${stderr}\nparse error: ${(err as Error).message}`));
         }
@@ -210,4 +219,46 @@ test("late catalog containing persisted default does not switch away from active
 
   const infos = pickEvents(result.events, "agent:info");
   assert.equal(infos[infos.length - 1].model, "override/m", "active model stays on the override");
+});
+
+test("default mode cache extractor reads OpenAI-standard prompt_tokens_details.cached_tokens", async () => {
+  const settings = {
+    providers: { openrouter: { apiKey: "x", baseURL: "https://openrouter.ai/api/v1" } },
+  };
+
+  const result = await runDriver(settings, {
+    capture: [],
+    probeCacheTokens: [
+      { model: "std/m", usage: { prompt_tokens: 200, prompt_tokens_details: { cached_tokens: 120 } } },
+      { model: "std/m", usage: { prompt_tokens: 200 } },
+    ],
+    steps: [
+      { kind: "providers.register", payload: { id: "openrouter", apiKey: "x", defaultModel: "std/m", models: ["std/m"] } },
+    ],
+  });
+
+  const probes = result.cacheProbes!;
+  assert.ok(probes[0].found, "openrouter mode std/m should exist");
+  assert.equal(probes[0].result, 120, "cached_tokens flows through the default extractor");
+  assert.equal(probes[1].result, undefined, "no cached_tokens field → undefined (no cache chip)");
+});
+
+test("native DeepSeek's flat hit count overrides the default cache extractor", async () => {
+  const result = await runDriver(
+    {},
+    {
+      capture: [],
+      probeCacheTokens: [
+        { model: "deepseek-v4-flash", usage: { prompt_tokens: 200, prompt_cache_hit_tokens: 80, prompt_cache_miss_tokens: 120 } },
+        { model: "deepseek-v4-flash", usage: { prompt_tokens: 200, prompt_tokens_details: { cached_tokens: 50 } } },
+      ],
+      steps: [{ kind: "activate-provider", name: "deepseek" }],
+    },
+    { DEEPSEEK_API_KEY: "sk-test" },
+  );
+
+  const probes = result.cacheProbes!;
+  assert.ok(probes[0].found, "deepseek mode should be built when DEEPSEEK_API_KEY is set");
+  assert.equal(probes[0].result, 80, "flat prompt_cache_hit_tokens used as the cached count");
+  assert.equal(probes[1].result, undefined, "deepseek hook ignores the OpenAI-standard shape");
 });

--- a/tests/agent/system-prompt-frontend.test.ts
+++ b/tests/agent/system-prompt-frontend.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCore } from "../../src/core/index.js";
+import agentBackend from "../../src/agent/index.js";
+import activateShellContext from "../../src/shell/shell-context.js";
+import type { AppConfig, ExtensionContext } from "../../src/shell/host-types.js";
+import type { AgentSurface } from "../../src/agent/host-types.js";
+
+process.env.AGENT_SH_HOME = mkdtempSync(join(tmpdir(), "agent-sh-sp-"));
+process.env.AGENT_SH_SKIP_SHELL_ENV = "1";
+
+/** Boot a core with the ash backend active, the way a frontend launcher does. */
+async function activeAgentCtx(): Promise<ExtensionContext> {
+  const core = createCore({} as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  agentBackend(ctx);
+  const agent = (ctx as ExtensionContext & { agent: AgentSurface }).agent;
+  agent.providers.register({ id: "test", apiKey: "k", baseURL: "http://localhost", defaultModel: "m", models: [{ id: "m" }] });
+  core.bus.emit("core:extensions-loaded", { names: [] });
+  await core.activateBackend("ash");
+  await new Promise((r) => setImmediate(r));
+  return ctx;
+}
+
+test("with no frontend advised, the prompt is identity + guide and carries no surface section", async () => {
+  const ctx = await activeAgentCtx();
+  const p = ctx.call("system-prompt:build") as string;
+  assert.ok(p.startsWith("You are ash"), "identity is paragraph one");
+  assert.ok(p.includes("agent-sh source and documentation"), "code/tools guide present");
+  assert.ok(!p.includes("terminal shell") && !p.includes("ashi, an interactive"), "no surface section is invented");
+});
+
+test("an advised frontend surface sits between the identity and the guide", async () => {
+  const ctx = await activeAgentCtx();
+  ctx.advise("system-prompt:frontend", () => "MARKER_SURFACE");
+  const p = ctx.call("system-prompt:build") as string;
+  const identity = p.indexOf("You are ash");
+  const surface = p.indexOf("MARKER_SURFACE");
+  const guide = p.indexOf("agent-sh source and documentation");
+  assert.ok(identity < surface && surface < guide, `expected identity < surface < guide, got ${identity}, ${surface}, ${guide}`);
+});
+
+test("companion frontend (no ctx.shell): shell_events explained, but no cwd-drift note", async () => {
+  const ctx = await activeAgentCtx();
+  activateShellContext(ctx);
+  const p = ctx.call("system-prompt:build") as string;
+  assert.ok(p.includes("<shell_events>"), "shell_events is explained when shell-context is active");
+  assert.ok(p.includes("standing preferences"), "preference-learning guidance travels with the emitter");
+  assert.ok(!p.includes("tool calls run in"), "no cwd-drift guidance when the agent owns its own fixed cwd");
+});
+
+test("shell frontend (ctx.shell present): <cwd> is explained as following the user's cd", async () => {
+  const ctx = await activeAgentCtx();
+  (ctx as { shell?: unknown }).shell = {};
+  activateShellContext(ctx);
+  const p = ctx.call("system-prompt:build") as string;
+  assert.ok(p.includes("tool calls run in"), "cwd-drift guidance present under the shell frontend");
+});

--- a/tests/cli/install-dev.test.ts
+++ b/tests/cli/install-dev.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = fileURLToPath(new URL("../../dist/cli/index.js", import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+
+function runOnce(args: string[], home: string, timeoutMs: number): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("node", [CLI, ...args], {
+      env: { PATH: process.env.PATH, HOME: home, AGENT_SH_HOME: home, AGENT_SH_SKIP_SHELL_ENV: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout!.on("data", (c) => { stdout += c.toString(); });
+    child.stderr!.on("data", (c) => { stderr += c.toString(); });
+    const timer = setTimeout(() => child.kill("SIGTERM"), timeoutMs);
+    child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+  });
+}
+
+/** A minimal extension whose only dependency is agent-sh, so that under --dev
+ *  npm install is offline via the file: link and there is no build step. */
+function makeExtension(): { ext: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "agent-sh-devext-"));
+  const ext = join(root, "dev-test-ext");
+  mkdirSync(ext);
+  writeFileSync(join(ext, "package.json"), JSON.stringify({
+    name: "dev-test-ext",
+    version: "0.0.0",
+    type: "module",
+    dependencies: { "agent-sh": "^0.14.11" },
+  }, null, 2));
+  writeFileSync(join(ext, "index.js"), "export default function activate() {}\n");
+  return { ext, root };
+}
+
+test("install --dev repoints the extension's agent-sh dep at the host core", { timeout: 120000 }, async () => {
+  const home = mkdtempSync(join(tmpdir(), "agent-sh-devhome-"));
+  const { ext, root } = makeExtension();
+  try {
+    const res = await runOnce(["install", `file:${ext}`, "--dev"], home, 90000);
+    assert.equal(res.code, 0, `install failed:\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+
+    // AGENT_SH_HOME is the config dir directly, so extensions land in <home>/extensions.
+    const installed = join(home, "extensions", "dev-test-ext");
+    const pkg = JSON.parse(readFileSync(join(installed, "package.json"), "utf-8"));
+    assert.ok(
+      typeof pkg.dependencies["agent-sh"] === "string" && pkg.dependencies["agent-sh"].startsWith("file:"),
+      `agent-sh dep should be a file: link, got ${pkg.dependencies["agent-sh"]}`,
+    );
+
+    // npm links the file: dep — the installed copy resolves to the host repo.
+    const linked = realpathSync(join(installed, "node_modules", "agent-sh"));
+    assert.equal(linked, realpathSync(REPO_ROOT), "node_modules/agent-sh resolves to the host repo");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/fixtures/provider-mode-driver.ts
+++ b/tests/fixtures/provider-mode-driver.ts
@@ -9,14 +9,22 @@ interface Scenario {
   config?: Partial<AppConfig>;
   capture: string[];
   dumpModes?: boolean;
+  probeCacheTokens?: Array<{ model: string; usage: Record<string, unknown> }>;
   steps: Array<
     | { kind: "providers.register"; payload: ProviderRegistration }
     | { kind: "providers.unregister"; id: string }
+    | { kind: "activate-provider"; name: keyof typeof PROVIDER_MODULES }
     | { kind: "core:extensions-loaded"; names?: string[] }
     | { kind: "activate-backend"; name: string }
     | { kind: "wait" }
   >;
 }
+
+const PROVIDER_MODULES = {
+  deepseek: () => import("../../src/agent/providers/deepseek.js"),
+  openrouter: () => import("../../src/agent/providers/openrouter.js"),
+  openai: () => import("../../src/agent/providers/openai.js"),
+} as const;
 
 async function main() {
   const raw = process.argv[2];
@@ -44,6 +52,9 @@ async function main() {
       agent.providers.register(step.payload);
     } else if (step.kind === "providers.unregister") {
       agent.providers.unregister(step.id);
+    } else if (step.kind === "activate-provider") {
+      const mod = await PROVIDER_MODULES[step.name]();
+      mod.default(ctx as ExtensionContext & { agent: AgentSurface });
     } else if (step.kind === "core:extensions-loaded") {
       core.bus.emit("core:extensions-loaded", { names: step.names ?? [] });
     } else if (step.kind === "activate-backend") {
@@ -55,14 +66,27 @@ async function main() {
 
   await new Promise((r) => setImmediate(r));
   let modes: AgentMode[] | undefined;
-  if (scenario.dumpModes) {
+  if (scenario.dumpModes || scenario.probeCacheTokens) {
     try {
       modes = ctx.call("agent:get-modes") as AgentMode[];
     } catch {
       modes = undefined;
     }
   }
-  process.stdout.write(JSON.stringify({ events: captured, modes: stripFns(modes) }) + "\n");
+
+  let cacheProbes: Array<{ model: string; result: number | undefined; found: boolean }> | undefined;
+  if (scenario.probeCacheTokens) {
+    cacheProbes = scenario.probeCacheTokens.map(({ model, usage }) => {
+      const mode = modes?.find((m) => m.model === model);
+      return { model, found: !!mode, result: mode?.extractCachedTokens?.(usage) };
+    });
+  }
+
+  process.stdout.write(JSON.stringify({
+    events: captured,
+    modes: scenario.dumpModes ? stripFns(modes) : undefined,
+    cacheProbes,
+  }) + "\n");
   process.exit(0);
 }
 

--- a/tests/shell/shell-context.test.ts
+++ b/tests/shell/shell-context.test.ts
@@ -6,6 +6,7 @@ import activateShellContext from "../../src/shell/shell-context.js";
 function setup(): { core: ReturnType<typeof createCore> } {
   const core = createCore({});
   const ctx = core.extensionContext({ quit: () => {} });
+  (ctx as { shell?: unknown }).shell = {}; // shell frontend: the agent shares the user's cwd
   activateShellContext(ctx);
   return { core };
 }
@@ -13,6 +14,19 @@ function setup(): { core: ReturnType<typeof createCore> } {
 function captureQueryContext(core: ReturnType<typeof createCore>): string {
   return String(core.handlers.call("query-context:build") ?? "");
 }
+
+test("<cwd> is emitted only under the shell frontend (ctx.shell present)", () => {
+  const peer = createCore({});
+  const peerCtx = peer.extensionContext({ quit: () => {} });
+  (peerCtx as { shell?: unknown }).shell = {};
+  activateShellContext(peerCtx);
+  assert.match(captureQueryContext(peer), /<cwd>/);
+
+  const companion = createCore({});
+  const compCtx = companion.extensionContext({ quit: () => {} });
+  activateShellContext(compCtx); // no ctx.shell → agent keeps its own fixed cwd
+  assert.doesNotMatch(captureQueryContext(companion), /<cwd>/);
+});
 
 test("user shell command lands in <shell_events> on next query-context", () => {
   const { core } = setup();


### PR DESCRIPTION
This PR bundles surface-aware system prompts, a provider-shaped cache-hit ratio, an `install --dev` flag for developing extensions against an unreleased local core, and a small ashi `/fork` picker fix.

## 1. Per-frontend surface description and cwd model

The default backend's system prompt baked in shell-peer assumptions — "you may be paired with a terminal shell… check shell history" — which are false under non-shell frontends like ashi. This makes the prompt surface-aware without the backend knowing about any specific surface.

- **`system-prompt:frontend` slot** — a core handler the active frontend advises to describe its surface. The backend renders it right after the identity (so it frames everything below) and omits it when nothing advises (bridge/headless). Each surface explains itself; the backend stays modality-free.
- **Neutralized static prompt** — split into a surface-agnostic identity and the code/tools/envelope guide; dropped the shell-specific framing and the shell-history "Preference Learning" block.
- **Envelope ownership** — shell-context now contributes the `<cwd>`/`<shell_events>` explanation it emits, present only when it is active.
- **Surface-specific cwd model** — shell-context shares the agent's working directory (follows the user's `cd`) only under the shell frontend (the one that installs `ctx.shell`). Other frontends keep a fixed workspace cwd: a user `cd` is shell context, not a relocation of the agent's tools.
- **ashi** describes itself as an interactive coding-agent TUI with a stable workspace, points the agent at its own source, and notes that `!` shell commands run in a separate shell.

### Surfaces

- **shell** (installs `ctx.shell`): unchanged — shares cwd, `<cwd>` follows `cd`, shell-history preferences.
- **ashi** (no `ctx.shell`): fixed workspace stated in its surface; `!` commands show up as `<shell_events>` context, not a cwd change.

## 2. Provider-shaped cache-hit ratio

The core read `prompt_tokens` off each usage-bearing chunk but dropped the cache fields, so any frontend wanting a cache-hit ratio had to tap `llm:chunk` and reconstruct it with its own knowledge of each provider's usage shape.

- **`cacheTokens` provider hook** — mirrors the existing `reasoningParams` hook. A core default reads the OpenAI-standard `prompt_tokens_details.cached_tokens` (covers OpenRouter/OpenAI and arbitrary OpenAI-compatible providers); native DeepSeek overrides it for its flat `prompt_cache_hit_tokens`. `buildModes` bakes the resolved extractor onto each `AgentMode`. Provider-shape knowledge stays in the provider file; the loop and frontends stay agnostic.
- **`agent:usage` carries `cached_prompt_tokens`** — the agent loop attaches the canonical cached-prompt-token count. The cache-hit ratio is then `cached_prompt_tokens / prompt_tokens` at the consumer.
- **ashi footer chip** — a `cache N.N%` chip in the status footer, colored by hit ratio (green ≥80%, yellow ≥40%, muted below), cleared on turns where the provider reports no caching.

A web/bridge frontend that currently reconstructs cache stats from `llm:chunk` can now drop that in favor of the enriched `agent:usage`.

## 3. `install --dev` for local-core development

`agent-sh install <ext>` resolves the extension's `agent-sh` pin from the npm registry, so a bundled extension that depends on an unreleased local core can't be installed against it — npm lands the published version and the extension's build either fails (it references newer APIs) or runs stale. Installing the latest ashi (which now needs `cached_prompt_tokens`) against a dev checkout otherwise required hand-editing `package.json`.

- **`--dev`** rewrites the copied extension's `agent-sh` dependency to the running host's package root before `npm install`, so it links the local checkout instead of the registry. npm symlinks the `file:` path, so later core rebuilds flow through without reinstalling. Generalizes to every bundled extension (the bridges, hub). Documented in the ashi README's "Install from source".

## 4. ashi `/fork` picker hint

The `/fork` branch picker rendered as a bare list in the footer with no header, so it blended into the transcript. pi-tui's `SelectList` has no border of its own — `/resume` is distinguishable only because it shows a muted hint line above its picker. Mirror that for `/fork`: a `↑↓ move · enter: select · esc: cancel` hint above the branch tree.

## 5. ashi startup: loaded-extensions line

On launch, ashi emits a muted line naming the built-in and user/installed extensions that loaded (`extensions: slash-commands · …`). Shown only for a new session — skipped on resume/`--continue` so a restored transcript isn't prefixed with it. Also drops a no-op `["rolling-history"]` arg to `loadBuiltinExtensions` (that param is the *disabled* list; rolling-history isn't a registered built-in, so it read as if it loaded something it didn't).

## Tests

- `tests/agent/system-prompt-frontend.test.ts` — slot ordering (surface sits between identity and guide; omitted when none) and the per-surface envelope/cwd split.
- `tests/shell/shell-context.test.ts` — `<cwd>` emitted only under the shell frontend.
- `tests/agent/provider-modes.test.ts` — the baked mode extractor reads OpenAI-standard `cached_tokens` (and returns nothing when absent), and DeepSeek's flat-field override takes precedence over the default. The driver fixture grew an `activate-provider` step and a `probeCacheTokens` probe to exercise the real hook end-to-end.
- `tests/cli/install-dev.test.ts` — `install --dev` repoints the extension's `agent-sh` dep at the host checkout and links it (offline, via a minimal fixture extension).

## Notes

The core changes (surface slot, neutral prompt, shell-context, cache hook) take effect on a core release; the ashi pieces (surface description, footer chip) land on reinstall. Both ashi additions degrade safely against an older published core: the surface advise is a no-op, and `agent:usage` simply lacks `cached_prompt_tokens` so the footer chip never populates. Installs don't break in the interim.



