### PR TITLE
Add a UI-surface protocol for ashi extensions

### DIFF
--- a/examples/extensions/ashi-ui-demo.ts
+++ b/examples/extensions/ashi-ui-demo.ts
@@ -1,0 +1,63 @@
+/**
+ * ashi UI-surface demo — exercises every surface via the typed `@guanyilun/ashi/ui` helper.
+ *
+ * Usage:  ashi -e ashi-ui-demo        (or -e examples/extensions/ashi-ui-demo.ts)
+ *
+ * Adds a pinned dock line and a status segment, plus commands:
+ *   /ui-demo        walk the dialogs (select → confirm → input) + notify
+ *   /ui-demo-bump   bump the status segment and re-pull the footer
+ *   /ui-demo-dock   toggle the dock widget and re-pull the dock
+ */
+import { createUi } from "@guanyilun/ashi/ui";
+import type { ExtensionContext } from "agent-sh/types";
+
+export default function activate(ctx: ExtensionContext): void {
+  const ui = createUi(ctx);
+  let bumps = 0;
+  let dockOn = true;
+
+  const status = ui.status(() => ({ id: "demo", text: `✦ demo ${bumps}`, color: "accent" }));
+  const dock = ui.dock((nodes) => {
+    if (!dockOn) return null;
+    const line = nodes.text({ paddingX: 1 });
+    line.setText("📌 ui-demo: a pinned dock widget");
+    return line.node;
+  });
+
+  ctx.registerCommand("ui-demo-bump", "Bump the demo status segment", () => {
+    bumps++;
+    status.refresh();
+  });
+
+  ctx.registerCommand("ui-demo-dock", "Toggle the demo dock widget", () => {
+    dockOn = !dockOn;
+    dock.refresh();
+  });
+
+  ctx.registerCommand("ui-demo", "Walk the ashi UI dialogs (select/confirm/input)", async () => {
+    ui.notify("ui-demo: starting…");
+
+    const fruit = await ui.select({
+      title: "Pick a fruit",
+      items: [
+        { value: "apple", label: "Apple", description: "crisp" },
+        { value: "banana", label: "Banana", description: "soft" },
+        { value: "cherry", label: "Cherry" },
+      ],
+    });
+    if (!fruit) {
+      ui.notify("ui-demo: cancelled", "warn");
+      return;
+    }
+
+    if (!(await ui.confirm({ title: `Really pick ${fruit}?` }))) {
+      ui.notify("ui-demo: not confirmed", "warn");
+      return;
+    }
+
+    const note = await ui.input({ title: "Add a note — enter to submit, esc to skip" });
+    const summary = `picked ${fruit}${note ? ` — ${note}` : ""}`;
+    ui.setEditorText(`/* ${summary} */`);
+    ui.notify(`ui-demo: ${summary}`, "success");
+  });
+}

--- a/examples/extensions/ashi/EXTENDING.md
+++ b/examples/extensions/ashi/EXTENDING.md
@@ -2,6 +2,8 @@
 
 Other extensions can customize how chat entries and tool results render — and even swap the whole TUI renderer — without forking ashi. For non-render concerns (commands, settings, tools, providers) use the standard `agent-sh` extension API; see the [agent-sh extension docs](https://github.com/guanyilun/agent-sh/blob/main/docs/extensions.md).
 
+To **drive** the UI from an extension — post a notice, add a status segment, pin a dock widget, or open a select/confirm/input dialog — use the UI-surface protocol (bus events + named handlers, no `ctx.ui` object); see [`docs/ui-surface-protocol.md`](docs/ui-surface-protocol.md) and the worked example `examples/extensions/ashi-ui-demo.ts`.
+
 ## Chat hooks
 
 These return a renderer-agnostic chat-entry view built from the active renderer's

--- a/examples/extensions/ashi/docs/ui-surface-protocol.md
+++ b/examples/extensions/ashi/docs/ui-surface-protocol.md
@@ -1,0 +1,163 @@
+# ashi UI surfaces
+
+How an extension drives ashi's terminal UI — post a notice, add a status-bar segment, pin a
+widget above the input, or ask the user a question.
+
+ashi doesn't hand extensions a `ui` object. Instead it answers a small set of **bus events**
+and **named handlers**, so the same extension degrades gracefully under a frontend that doesn't
+implement a given surface (and under headless/RPC use). There are three shapes:
+
+- **Notices** are fire-and-forget bus events (`ctx.bus.emit`).
+- **Status segments and docks** are *pull* pipes (`ctx.bus.onPipe`): ashi asks for contributions
+  while it repaints and you append yours — ashi owns the layout.
+- **Dialogs** are request/response calls (`await ctx.call(...)`) that resolve when the user answers.
+
+## Setup
+
+For typed events, import the augmentation once (types only — no runtime cost):
+
+```ts
+import "@guanyilun/ashi/events";
+```
+
+`ui:*` names are meant to work under any ashi-compatible frontend; `ashi:*` names are specific to
+ashi's terminal UI. Before a `ctx.call(...)` that must return a value, feature-detect:
+
+```ts
+if (ctx.list().includes("ui:select")) { /* … */ }
+```
+
+Bus emits (`ui:notify`, the `*:invalidate` nudges) need no detection — they're no-ops when nothing
+is listening.
+
+## Timing
+
+Extensions load before ashi mounts, so the surfaces aren't all live at `activate()` time:
+
+- **Pull contributors (`status`, `dock`, any `onPipe`) can be registered any time** — ashi reads them
+  on its next repaint, so registering during `activate()` is fine; the first paint picks them up.
+- **Imperative surfaces (notify, dialogs, editor) are ready once ashi has mounted.** From a command
+  or key handler they're always ready. To use one at startup, wait for the `ashi:ready` event:
+
+  ```ts
+  ctx.bus.on("ashi:ready", () => createUi(ctx).notify("loaded"));
+  ```
+
+The helper degrades (`select`/`input` → `undefined`, `confirm` → `false`) if called before a frontend
+answers, so a premature call can't throw; a premature `notify` is simply dropped.
+
+## Post a notice
+
+```ts
+ctx.bus.emit("ui:notify", { message: "Saved.", level: "success" });
+// level: "info" (default) | "warn" | "error" | "success"
+```
+
+Appends a themed line to the transcript.
+
+## Add a status-bar segment
+
+Contribute to the footer; ashi appends your segment and owns placement:
+
+```ts
+ctx.bus.onPipe("ui:status", (p) => ({
+  segments: [...p.segments, { id: "build", text: "✓ build ok", color: "success" }],
+}));
+```
+
+A segment is `{ id: string; text: string; color?: ThemeColor }`, where `ThemeColor` is a theme name
+such as `"accent"`, `"success"`, `"warning"`, `"error"`, or `"muted"`. When your data changes
+outside a repaint, ask ashi to re-pull:
+
+```ts
+ctx.bus.emit("ui:status:invalidate", {});
+```
+
+## Pin a widget above the input
+
+Same pull model, but you build the view from the renderer's node factory (so you never import a
+TUI library):
+
+```ts
+ctx.bus.onPipe("ashi:dock:above-input", (p) => {
+  const line = p.nodes.text({ paddingX: 1 });
+  line.setText("📌 2 todos remaining");
+  return { ...p, views: [...p.views, line.node] };
+});
+
+// after a change:
+ctx.bus.emit("ashi:dock:invalidate", {});
+```
+
+`p.nodes` offers `text`, `markdown`, `container`, `spacer`, and `image`. Return the payload
+unchanged to contribute nothing — the dock takes zero space when empty.
+
+## Ask the user
+
+```ts
+const fruit = await ctx.call("ui:select", {
+  title: "Pick a fruit",
+  items: [
+    { value: "apple", label: "Apple", description: "crisp" },
+    { value: "banana", label: "Banana" },
+  ],
+});                      // → the chosen value, or undefined if cancelled
+
+const ok = await ctx.call("ui:confirm", { title: "Delete it?" });   // → boolean
+
+const name = await ctx.call("ui:input", {
+  title: "Name?",        // hint shown above the input
+  prefill: "untitled",   // optional starting text
+});                      // → the text, or undefined if cancelled (Esc)
+```
+
+Only one dialog (or built-in picker) is open at a time; a call made while one is open resolves
+`undefined`.
+
+## Read or seed the input
+
+```ts
+const draft = ctx.call("ui:editor:get-text") as string;
+ctx.call("ui:editor:set-text", "/commit ");
+```
+
+## Typed helper
+
+If you're willing to depend on `@guanyilun/ashi`, `createUi(ctx)` wraps everything above with
+full types and no magic strings. Request/response surfaces also degrade on their own — `select`
+and `input` resolve `undefined`, `confirm` resolves `false` — when no frontend answers:
+
+```ts
+import { createUi } from "@guanyilun/ashi/ui";
+
+const ui = createUi(ctx);
+ui.notify("Saved.", "success");
+const fruit = await ui.select({ title: "Pick", items: [{ value: "a", label: "Apple" }] });
+const seg = ui.status(() => ({ id: "build", text: "✓ ok", color: "success" })); // seg.refresh() / seg.remove()
+const widget = ui.dock((nodes) => {
+  const t = nodes.text({ paddingX: 1 });
+  t.setText("📌 note");
+  return t.node;
+});
+```
+
+The raw events and calls above carry no build-time dependency on ashi — reach for them if you
+want a dependency-free extension. The helper is the same protocol with types and degradation
+bolted on.
+
+## Not yet available
+
+Floating/overlay panels and fully custom interactive components aren't exposed — the renderer
+contract has no free-placement layer yet. Use the dock, dialogs, and notices above.
+
+## Working example
+
+[`ashi-ui-demo.ts`](../../ashi-ui-demo.ts) exercises every surface through the typed helper. Load
+it and try the commands:
+
+```
+ashi -e ashi-ui-demo
+/ui-demo        # select → confirm → input, then a notice
+/ui-demo-bump   # update the status segment
+/ui-demo-dock   # toggle the pinned widget
+```

--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -16,6 +16,14 @@
     "./renderer": {
       "types": "./dist/renderer.d.ts",
       "import": "./dist/renderer.js"
+    },
+    "./events": {
+      "types": "./dist/events.d.ts",
+      "import": "./dist/events.js"
+    },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "import": "./dist/ui.js"
     }
   },
   "files": [

--- a/examples/extensions/ashi/src/chat/lines.ts
+++ b/examples/extensions/ashi/src/chat/lines.ts
@@ -1,5 +1,5 @@
 import type { RenderNode, RenderNodes } from "../renderer.js";
-import { theme } from "../theme.js";
+import { theme, type ThemeColor } from "../theme.js";
 
 export class InfoLine {
   readonly node: RenderNode;
@@ -15,6 +15,25 @@ export class ErrorLine {
   constructor(nodes: RenderNodes, message: string) {
     const t = nodes.text({ paddingX: 1 });
     t.setText(`${theme.fg("error", "✗")} ${theme.fg("error", message)}`);
+    this.node = t.node;
+  }
+}
+
+export type NoticeLevel = "info" | "warn" | "error" | "success";
+
+const NOTICE: Record<NoticeLevel, { color: ThemeColor; prefix: string }> = {
+  info: { color: "muted", prefix: "" },
+  success: { color: "success", prefix: "✓ " },
+  warn: { color: "warning", prefix: "! " },
+  error: { color: "error", prefix: "✗ " },
+};
+
+export class NoticeLine {
+  readonly node: RenderNode;
+  constructor(nodes: RenderNodes, message: string, level: NoticeLevel = "info") {
+    const { color, prefix } = NOTICE[level];
+    const t = nodes.text({ paddingX: 1 });
+    t.setText(`${theme.fg(color, prefix)}${theme.fg(color, message)}`);
     this.node = t.node;
   }
 }

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -24,6 +24,7 @@ function headlessTerminal(): Terminal {
   };
 }
 
+import "./events.js";
 import { mountAshi } from "./frontend.js";
 import { MultiSessionStore } from "./multi-session-store.js";
 import { registerForkCommands, applyBranchMessages } from "./commands.js";
@@ -246,7 +247,7 @@ async function main(): Promise<void> {
   const handle = mountAshi(ctx, getStore, capture, renderer);
   stopFrontend = handle.stop;
 
-  (core.bus.emit as (event: string, payload: unknown) => void)("ashi:ready", {});
+  core.bus.emit("ashi:ready", {});
 
   registerForkCommands(ctx, getStore, handle.openTreePicker, handle.rebuildChat, capture);
   registerSessionCommands(ctx, getStore, capture, {

--- a/examples/extensions/ashi/src/dialogs.ts
+++ b/examples/extensions/ashi/src/dialogs.ts
@@ -1,0 +1,67 @@
+import type { App, Renderer } from "./renderer.js";
+import { InfoLine } from "./chat/lines.js";
+
+export interface SelectChoice {
+  value: string;
+  label: string;
+  description?: string;
+}
+export interface SelectOpts {
+  title?: string;
+  items: SelectChoice[];
+}
+export interface ConfirmOpts {
+  title: string;
+}
+
+export interface DialogGuard {
+  isOpen(): boolean;
+  setOpen(open: boolean): void;
+}
+
+export interface Dialogs {
+  select(opts: SelectOpts): Promise<string | undefined>;
+  confirm(opts: ConfirmOpts): Promise<boolean>;
+}
+
+export function createDialogs(app: App, renderer: Renderer, guard: DialogGuard): Dialogs {
+  const select = (opts: SelectOpts): Promise<string | undefined> => {
+    if (guard.isOpen() || opts.items.length === 0) return Promise.resolve(undefined);
+    return new Promise((resolve) => {
+      const hint = new InfoLine(renderer, opts.title ?? "↑↓ move · enter: select · esc: cancel");
+      const picker = app.createSelectList(
+        opts.items.map((c) => ({ value: c.value, label: c.label, description: c.description })),
+        { visibleRows: Math.min(15, Math.max(1, opts.items.length)) },
+      );
+      let settled = false;
+      const close = (result?: string): void => {
+        if (settled) return;
+        settled = true;
+        guard.setOpen(false);
+        app.footerSlot.removeChild(picker.node);
+        app.footerSlot.removeChild(hint.node);
+        app.focusInput();
+        app.requestRender();
+        resolve(result);
+      };
+      picker.onSelect((item) => close(item.value));
+      picker.onCancel(() => close());
+      guard.setOpen(true);
+      app.footerSlot.addChild(hint.node);
+      app.footerSlot.addChild(picker.node);
+      app.setFocus(picker.node);
+      app.requestRender();
+    });
+  };
+
+  const confirm = (opts: ConfirmOpts): Promise<boolean> =>
+    select({
+      title: opts.title,
+      items: [
+        { value: "yes", label: "Yes" },
+        { value: "no", label: "No" },
+      ],
+    }).then((v) => v === "yes");
+
+  return { select, confirm };
+}

--- a/examples/extensions/ashi/src/docks.ts
+++ b/examples/extensions/ashi/src/docks.ts
@@ -1,0 +1,31 @@
+import type { EventBus } from "agent-sh/event-bus";
+import type { App, Renderer } from "./renderer.js";
+
+export interface Dock {
+  refresh(): void;
+}
+
+export function createDock(app: App, renderer: Renderer, bus: EventBus): Dock {
+  const container = renderer.container();
+  let mounted = false;
+
+  const refresh = (): void => {
+    container.clear();
+    const { views } = bus.emitPipe("ashi:dock:above-input", { nodes: renderer, views: [] });
+    for (const view of views) container.addChild(view);
+    // Mount only when non-empty: an always-present footer child (even empty) defeats the
+    // footer slot's blank-line spacing above the input.
+    if (views.length > 0 && !mounted) {
+      app.footerSlot.addChild(container.node);
+      mounted = true;
+    } else if (views.length === 0 && mounted) {
+      app.footerSlot.removeChild(container.node);
+      mounted = false;
+    }
+    app.requestRender();
+  };
+
+  bus.on("ashi:dock:invalidate", refresh);
+  refresh();
+  return { refresh };
+}

--- a/examples/extensions/ashi/src/events.ts
+++ b/examples/extensions/ashi/src/events.ts
@@ -1,0 +1,16 @@
+// ui:* names are neutral by intent but declared HERE in ashi, not core, on purpose: a name
+// graduates to core's BusEvents only when a second frontend outside ashi speaks it
+// (see docs/ui-surface-protocol.md). ashi:* names carry TUI vocabulary and stay ashi-owned.
+import type { RenderNode, RenderNodes } from "./renderer.js";
+import type { StatusSegment } from "./status-footer.js";
+
+declare module "agent-sh/event-bus" {
+  interface BusEvents {
+    "ui:notify": { message: string; level?: "info" | "warn" | "error" | "success" };
+    "ui:status": { segments: StatusSegment[] };
+    "ui:status:invalidate": Record<string, never>;
+    "ashi:dock:above-input": { nodes: RenderNodes; views: RenderNode[] };
+    "ashi:dock:invalidate": Record<string, never>;
+    "ashi:ready": Record<string, never>;
+  }
+}

--- a/examples/extensions/ashi/src/frontend.ts
+++ b/examples/extensions/ashi/src/frontend.ts
@@ -11,7 +11,10 @@ import type {
   ToolCallView,
   ToolResultView,
 } from "./renderer.js";
-import { ErrorLine, InfoLine } from "./chat/lines.js";
+import { ErrorLine, InfoLine, NoticeLine } from "./chat/lines.js";
+import { createDock } from "./docks.js";
+import { createDialogs, type ConfirmOpts, type SelectOpts } from "./dialogs.js";
+import { createInputPrompt, type InputOpts } from "./input-prompt.js";
 import { AssistantMessage } from "./chat/assistant.js";
 import { ThinkingBlock } from "./chat/thinking.js";
 import { UserMessage } from "./chat/user-message.js";
@@ -198,15 +201,31 @@ export function mountAshi(
   const app = renderer.mount();
   const input = app.input;
 
-  const statusFooter = new StatusFooter(app.status, renderer.measureWidth);
+  const statusFooter = new StatusFooter(
+    app.status,
+    renderer.measureWidth,
+    () => bus.emitPipe("ui:status", { segments: [] }).segments,
+  );
+  createDock(app, renderer, bus);
 
   let shellMode = false;
   let pendingPrivate = false;
+  let pickerOpen = false;
+
+  const modalGuard = { isOpen: () => pickerOpen, setOpen: (open: boolean) => { pickerOpen = open; } };
+  const inputPrompt = createInputPrompt(app, renderer, input, modalGuard);
+  const dialogs = createDialogs(app, renderer, modalGuard);
+  ctx.define("ui:select", (opts: SelectOpts) => dialogs.select(opts));
+  ctx.define("ui:confirm", (opts: ConfirmOpts) => dialogs.confirm(opts));
+  ctx.define("ui:input", (opts: InputOpts) => inputPrompt.prompt(opts));
+  ctx.define("ui:editor:get-text", () => input.getText());
+  ctx.define("ui:editor:set-text", (text: string) => { input.setText(text); });
+
   const autocomplete = createAutocompleteController({
     app,
     input,
     provider: new BusAutocompleteProvider(bus),
-    suppressed: () => shellMode,
+    suppressed: () => shellMode || inputPrompt.isActive(),
   });
 
   const defaultBorderColor = input.defaultBorderColor;
@@ -235,6 +254,7 @@ export function mountAshi(
   };
 
   input.onChange((text) => {
+    if (inputPrompt.isActive()) return;
     const r = deriveChangeHandlerResult(shellMode, pendingPrivate, text);
     // setText fires onChange synchronously; set mode/private before setText or the recursive call clobbers it.
     if (r.mode !== shellMode) setShellMode(r.mode);
@@ -244,6 +264,7 @@ export function mountAshi(
   });
 
   input.onSubmit((text) => {
+    if (inputPrompt.handleSubmit(text)) return;
     const action = classifySubmit(text, shellMode, pendingPrivate);
     if (action.kind === "noop") return;
     input.setText("");
@@ -862,6 +883,16 @@ export function mountAshi(
     app.requestRender();
   });
 
+  bus.on("ui:notify", ({ message, level }) => {
+    appendEntry(new NoticeLine(renderer, message, level).node, { t: "plain" });
+    app.requestRender();
+  });
+
+  bus.on("ui:status:invalidate", () => {
+    statusFooter.refresh();
+    app.requestRender();
+  });
+
   bus.on("agent:info", (info) => {
     statusFooter.update({
       model: info.model,
@@ -886,7 +917,6 @@ export function mountAshi(
 
   refreshFooterStats();
 
-  let pickerOpen = false;
   let activeSessionPicker: SelectView | null = null;
   let activeSessionRepopulate: ((keepIndex?: number) => boolean) | null = null;
   let activeSessionClose: (() => void) | null = null;

--- a/examples/extensions/ashi/src/input-prompt.ts
+++ b/examples/extensions/ashi/src/input-prompt.ts
@@ -1,0 +1,64 @@
+import type { App, InputView, RenderNode, Renderer } from "./renderer.js";
+import { InfoLine } from "./chat/lines.js";
+
+export interface InputOpts {
+  title?: string;
+  prefill?: string;
+}
+
+export interface InputPrompt {
+  prompt(opts?: InputOpts): Promise<string | undefined>;
+  isActive(): boolean;
+  handleSubmit(text: string): boolean;
+}
+
+export function createInputPrompt(
+  app: App,
+  renderer: Renderer,
+  input: InputView,
+  guard: { isOpen(): boolean; setOpen(open: boolean): void },
+): InputPrompt {
+  let active: { resolve: (value?: string) => void; hint: RenderNode } | null = null;
+
+  const end = (value?: string): void => {
+    if (!active) return;
+    const { resolve, hint } = active;
+    active = null;
+    guard.setOpen(false);
+    app.footerSlot.removeChild(hint);
+    input.setText("");
+    app.requestRender();
+    resolve(value);
+  };
+
+  app.onKey((key) => {
+    if (!active || key.isRelease()) return;
+    if (key.matches("escape")) {
+      end(undefined);
+      return { consume: true };
+    }
+  });
+
+  return {
+    prompt(opts = {}) {
+      if (active || guard.isOpen()) return Promise.resolve(undefined);
+      return new Promise<string | undefined>((resolve) => {
+        const hint = new InfoLine(renderer, opts.title ?? "type · enter: submit · esc: cancel");
+        app.footerSlot.addChild(hint.node);
+        // Set active before setText: the editor fires onChange synchronously, and the prompt
+        // must suppress the normal onChange path (shell-mode derivation / autocomplete).
+        active = { resolve, hint: hint.node };
+        guard.setOpen(true); // share the pickers' modal flag — a prompt and a picker exclude each other
+        input.setText(opts.prefill ?? "");
+        app.focusInput();
+        app.requestRender();
+      });
+    },
+    isActive: () => active !== null,
+    handleSubmit(text) {
+      if (!active) return false;
+      end(text);
+      return true;
+    },
+  };
+}

--- a/examples/extensions/ashi/src/status-footer.ts
+++ b/examples/extensions/ashi/src/status-footer.ts
@@ -1,6 +1,12 @@
 import { basename } from "node:path";
 import type { TextView } from "./renderer.js";
-import { theme } from "./theme.js";
+import { theme, type ThemeColor } from "./theme.js";
+
+export interface StatusSegment {
+  id: string;
+  text: string;
+  color?: ThemeColor;
+}
 
 interface StatusFields {
   model?: string;
@@ -18,10 +24,12 @@ interface StatusFields {
 
 export class StatusFooter {
   private fields: StatusFields = {};
+  private extSegments: StatusSegment[] = [];
 
   constructor(
     private view: TextView,
     private measure: (text: string) => number,
+    private pull?: () => StatusSegment[],
   ) {
     this.refresh();
   }
@@ -31,7 +39,8 @@ export class StatusFooter {
     this.refresh();
   }
 
-  private refresh(): void {
+  refresh(): void {
+    this.extSegments = this.pull?.() ?? [];
     this.view.setRenderFn((width) => [this.buildFooter(width)]);
   }
 
@@ -77,6 +86,9 @@ export class StatusFooter {
       parts.push(`${theme.fg("muted", "cache ")}${theme.fg(color, `${cachePct.toFixed(1)}%`)}`);
     }
     if (compactions && compactions > 0) parts.push(theme.fg("muted", `⊟ ${compactions}`));
+    for (const seg of this.extSegments) {
+      parts.push(seg.color ? theme.fg(seg.color, seg.text) : seg.text);
+    }
     return parts.length === 0 ? "" : parts.join(sep);
   }
 }

--- a/examples/extensions/ashi/src/ui.ts
+++ b/examples/extensions/ashi/src/ui.ts
@@ -1,0 +1,88 @@
+import type { ExtensionContext } from "agent-sh/types";
+import type { RenderNode, RenderNodes } from "./renderer.js";
+import type { StatusSegment } from "./status-footer.js";
+import type { SelectOpts, ConfirmOpts } from "./dialogs.js";
+import type { InputOpts } from "./input-prompt.js";
+
+export type { SelectChoice, SelectOpts, ConfirmOpts } from "./dialogs.js";
+export type { InputOpts } from "./input-prompt.js";
+export type { StatusSegment } from "./status-footer.js";
+
+export type NoticeLevel = "info" | "warn" | "error" | "success";
+
+export interface Contribution {
+  /** Re-pull this surface (call after the content it depends on changes). */
+  refresh(): void;
+  remove(): void;
+}
+
+/**
+ * Typed sugar over ashi's UI protocol. Wraps the bus events and named handlers so call
+ * sites read like a UI object, with real types and no magic strings — without a `ui` field
+ * on the kernel context. Request/response surfaces degrade when no frontend answers them
+ * (select/input → undefined, confirm → false, getEditorText → "").
+ */
+export interface Ui {
+  notify(message: string, level?: NoticeLevel): void;
+  select(opts: SelectOpts): Promise<string | undefined>;
+  confirm(opts: ConfirmOpts): Promise<boolean>;
+  input(opts?: InputOpts): Promise<string | undefined>;
+  getEditorText(): string;
+  setEditorText(text: string): void;
+  /** Contribute a status-bar segment. `get` runs on each repaint; return null to show nothing. */
+  status(get: () => StatusSegment | null): Contribution;
+  /** Contribute a pinned widget above the input, built from the renderer's node factory. */
+  dock(build: (nodes: RenderNodes) => RenderNode | null): Contribution;
+}
+
+export function createUi(ctx: ExtensionContext): Ui {
+  const has = (name: string): boolean => ctx.list().includes(name);
+
+  return {
+    notify(message, level) {
+      ctx.bus.emit("ui:notify", { message, level });
+    },
+    select(opts) {
+      if (!has("ui:select")) return Promise.resolve(undefined);
+      return ctx.call("ui:select", opts) as Promise<string | undefined>;
+    },
+    confirm(opts) {
+      if (!has("ui:confirm")) return Promise.resolve(false);
+      return ctx.call("ui:confirm", opts) as Promise<boolean>;
+    },
+    input(opts = {}) {
+      if (!has("ui:input")) return Promise.resolve(undefined);
+      return ctx.call("ui:input", opts) as Promise<string | undefined>;
+    },
+    getEditorText() {
+      return has("ui:editor:get-text") ? (ctx.call("ui:editor:get-text") as string) : "";
+    },
+    setEditorText(text) {
+      if (has("ui:editor:set-text")) ctx.call("ui:editor:set-text", text);
+    },
+    status(get) {
+      const contribute = (p: { segments: StatusSegment[] }): { segments: StatusSegment[] } => {
+        const seg = get();
+        return seg ? { segments: [...p.segments, seg] } : p;
+      };
+      ctx.bus.onPipe("ui:status", contribute);
+      return {
+        refresh: () => ctx.bus.emit("ui:status:invalidate", {}),
+        remove: () => ctx.bus.offPipe("ui:status", contribute),
+      };
+    },
+    dock(build) {
+      const contribute = (
+        p: { nodes: RenderNodes; views: RenderNode[] },
+      ): { nodes: RenderNodes; views: RenderNode[] } => {
+        const view = build(p.nodes);
+        return view ? { ...p, views: [...p.views, view] } : p;
+      };
+      ctx.bus.onPipe("ashi:dock:above-input", contribute);
+      return {
+        refresh: () => ctx.bus.emit("ashi:dock:invalidate", {}),
+        remove: () => ctx.bus.offPipe("ashi:dock:above-input", contribute),
+      };
+    },
+  };
+}

--- a/examples/extensions/ashi/tests/ui-dialogs.test.ts
+++ b/examples/extensions/ashi/tests/ui-dialogs.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createDialogs } from "../src/dialogs.js";
+import type { App, RenderNode, Renderer, SelectItem, SelectView } from "../src/renderer.js";
+
+const node = (tag: string): RenderNode => ({ tag }) as unknown as RenderNode;
+
+function harness() {
+  const footer: RenderNode[] = [];
+  let onSelect: ((i: SelectItem) => void) | null = null;
+  let onCancel: (() => void) | null = null;
+  let focusInput = 0;
+  const app = {
+    footerSlot: {
+      node: node("footer"),
+      addChild: (c: RenderNode) => { footer.push(c); },
+      removeChild: (c: RenderNode) => { const i = footer.indexOf(c); if (i >= 0) footer.splice(i, 1); },
+      clear: () => {},
+    },
+    createSelectList: (_items: SelectItem[]): SelectView => ({
+      node: node("picker"),
+      setSelectedIndex: () => {},
+      getSelectedItem: () => undefined,
+      onSelect: (fn: (i: SelectItem) => void) => { onSelect = fn; },
+      onCancel: (fn: () => void) => { onCancel = fn; },
+    }),
+    setFocus: () => {},
+    focusInput: () => { focusInput++; },
+    requestRender: () => {},
+  } as unknown as App;
+  const renderer = {
+    text: () => ({ node: node("text"), setText() {}, setLines() {}, setRenderFn() {} }),
+  } as unknown as Renderer;
+  let open = false;
+  const dialogs = createDialogs(app, renderer, { isOpen: () => open, setOpen: (v) => { open = v; } });
+  return {
+    dialogs,
+    choose: (item: SelectItem) => onSelect?.(item),
+    cancel: () => onCancel?.(),
+    footerCount: () => footer.length,
+    isOpen: () => open,
+    focusInputCount: () => focusInput,
+  };
+}
+
+test("ui:select resolves with the chosen value and cleans up", async () => {
+  const h = harness();
+  const p = h.dialogs.select({ items: [{ value: "a", label: "A" }, { value: "b", label: "B" }] });
+  assert.equal(h.isOpen(), true, "guard set while open");
+  assert.equal(h.footerCount(), 2, "hint + picker mounted");
+
+  h.choose({ value: "b", label: "B" });
+  assert.equal(await p, "b");
+  assert.equal(h.isOpen(), false, "guard cleared");
+  assert.equal(h.footerCount(), 0, "footer cleaned up");
+  assert.equal(h.focusInputCount(), 1, "input refocused");
+});
+
+test("ui:select cancel resolves undefined", async () => {
+  const h = harness();
+  const p = h.dialogs.select({ items: [{ value: "a", label: "A" }] });
+  h.cancel();
+  assert.equal(await p, undefined);
+  assert.equal(h.isOpen(), false);
+});
+
+test("ui:select returns undefined while a picker is already open", async () => {
+  const h = harness();
+  const first = h.dialogs.select({ items: [{ value: "a", label: "A" }] });
+  const blocked = await h.dialogs.select({ items: [{ value: "x", label: "X" }] });
+  assert.equal(blocked, undefined, "second call blocked by the guard");
+  h.choose({ value: "a", label: "A" });
+  assert.equal(await first, "a");
+});
+
+test("ui:select returns undefined for an empty item list", async () => {
+  const h = harness();
+  assert.equal(await h.dialogs.select({ items: [] }), undefined);
+  assert.equal(h.isOpen(), false, "no picker opened");
+});
+
+test("ui:confirm maps Yes→true and No→false", async () => {
+  const yes = harness();
+  const py = yes.dialogs.confirm({ title: "Sure?" });
+  yes.choose({ value: "yes", label: "Yes" });
+  assert.equal(await py, true);
+
+  const no = harness();
+  const pn = no.dialogs.confirm({ title: "Sure?" });
+  no.choose({ value: "no", label: "No" });
+  assert.equal(await pn, false);
+});

--- a/examples/extensions/ashi/tests/ui-dock-render.test.ts
+++ b/examples/extensions/ashi/tests/ui-dock-render.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventBus } from "agent-sh/event-bus";
+import { createNodes, footerContainer } from "../src/renderers/pi-tui/nodes.js";
+import { createDock } from "../src/docks.js";
+import type { App, Renderer } from "../src/renderer.js";
+
+// Uses the REAL pi-tui renderer (not fakes), unlike ui-dock.test.ts: verifies actual paint
+// and the footer-spacing interaction, which fakes can't catch.
+
+const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+const render = (node: unknown, width = 80): string[] =>
+  (node as { render(width: number): string[] }).render(width).map(strip);
+
+function harness(hasContentAbove: () => boolean) {
+  const nodes = createNodes();
+  const footer = footerContainer(hasContentAbove);
+  const app = { footerSlot: footer, requestRender() {} } as unknown as App;
+  return { app, renderer: nodes as unknown as Renderer, footer };
+}
+
+test("real render: empty dock keeps the footer's blank-line spacing above the input", () => {
+  const bus = new EventBus();
+  const h = harness(() => true);
+  createDock(h.app, h.renderer, bus);
+  assert.deepEqual(render(h.footer.node), [""], "spacer line preserved when the dock is empty");
+});
+
+test("real render: no content above + empty dock → footer renders nothing", () => {
+  const bus = new EventBus();
+  const h = harness(() => false);
+  createDock(h.app, h.renderer, bus);
+  assert.deepEqual(render(h.footer.node), [], "no spacer before any conversation starts");
+});
+
+test("real render: a dock contributor's text actually paints in the footer", () => {
+  const bus = new EventBus();
+  bus.onPipe("ashi:dock:above-input", (p) => {
+    const t = p.nodes.text({ paddingX: 1 });
+    t.setText("📌 pinned");
+    return { ...p, views: [...p.views, t.node] };
+  });
+  const h = harness(() => true);
+  createDock(h.app, h.renderer, bus);
+  const lines = render(h.footer.node);
+  assert.ok(lines.some((l) => l.includes("📌 pinned")), `painted: ${JSON.stringify(lines)}`);
+});

--- a/examples/extensions/ashi/tests/ui-dock.test.ts
+++ b/examples/extensions/ashi/tests/ui-dock.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventBus } from "agent-sh/event-bus";
+import { createDock } from "../src/docks.js";
+import type { App, ContainerView, RenderNode, Renderer } from "../src/renderer.js";
+
+const node = (tag: string): RenderNode => ({ tag }) as unknown as RenderNode;
+
+function fakeContainer(): ContainerView & { children: RenderNode[] } {
+  const children: RenderNode[] = [];
+  return {
+    node: node("container"),
+    children,
+    addChild(c) { children.push(c); },
+    removeChild(c) { const i = children.indexOf(c); if (i >= 0) children.splice(i, 1); },
+    clear() { children.length = 0; },
+  };
+}
+
+function harness() {
+  const dock = fakeContainer();
+  const footer = fakeContainer();
+  const renderer = {
+    container: () => dock,
+    text: () => ({ node: node("text"), setText() {}, setLines() {}, setRenderFn() {} }),
+  } as unknown as Renderer;
+  const app = { footerSlot: footer, requestRender() {} } as unknown as App;
+  return { app, renderer, dockChildren: () => dock.children, footerChildren: () => footer.children };
+}
+
+test("ashi:dock pull pipe: a contributor's view lands in the dock and mounts", () => {
+  const bus = new EventBus();
+  bus.onPipe("ashi:dock:above-input", (p) => ({ ...p, views: [...p.views, p.nodes.text().node] }));
+
+  const h = harness();
+  createDock(h.app, h.renderer, bus);
+
+  assert.equal(h.dockChildren().length, 1, "one contributed view");
+  assert.equal(h.footerChildren().length, 1, "dock mounted into footerSlot when non-empty");
+});
+
+test("ashi:dock: no contributors → dock not mounted (preserves footer spacing)", () => {
+  const bus = new EventBus();
+  const h = harness();
+  createDock(h.app, h.renderer, bus);
+  assert.equal(h.dockChildren().length, 0);
+  assert.equal(h.footerChildren().length, 0, "empty dock must not occupy footerSlot");
+});
+
+test("ashi:dock:invalidate mounts/unmounts as contributions appear and vanish", () => {
+  const bus = new EventBus();
+  let count = 0;
+  bus.onPipe("ashi:dock:above-input", (p) => {
+    const views = [...p.views];
+    for (let i = 0; i < count; i++) views.push(p.nodes.text().node);
+    return { ...p, views };
+  });
+
+  const h = harness();
+  createDock(h.app, h.renderer, bus);
+  assert.equal(h.footerChildren().length, 0, "not mounted while empty");
+
+  count = 2;
+  bus.emit("ashi:dock:invalidate", {});
+  assert.equal(h.dockChildren().length, 2, "re-pulled after invalidate");
+  assert.equal(h.footerChildren().length, 1, "mounted once non-empty");
+
+  count = 0;
+  bus.emit("ashi:dock:invalidate", {});
+  assert.equal(h.dockChildren().length, 0);
+  assert.equal(h.footerChildren().length, 0, "unmounted when contributions vanish");
+});

--- a/examples/extensions/ashi/tests/ui-helper.test.ts
+++ b/examples/extensions/ashi/tests/ui-helper.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventBus } from "agent-sh/event-bus";
+import { createUi } from "../src/ui.js";
+import type { ExtensionContext } from "agent-sh/types";
+
+function fakeCtx(handlers: Record<string, (...args: unknown[]) => unknown> = {}) {
+  const bus = new EventBus();
+  const ctx = {
+    bus,
+    list: () => Object.keys(handlers),
+    call: (name: string, ...args: unknown[]) => handlers[name]?.(...args),
+  } as unknown as ExtensionContext;
+  return { ctx, bus };
+}
+
+test("notify emits ui:notify with the level", () => {
+  const { ctx, bus } = fakeCtx();
+  let got: unknown = null;
+  bus.on("ui:notify", (e) => { got = e; });
+  createUi(ctx).notify("hi", "success");
+  assert.deepEqual(got, { message: "hi", level: "success" });
+});
+
+test("select forwards to ctx.call and returns its value (typed string | undefined)", async () => {
+  const { ctx } = fakeCtx({ "ui:select": () => Promise.resolve("apple") });
+  const chosen: string | undefined = await createUi(ctx).select({ items: [{ value: "apple", label: "A" }] });
+  assert.equal(chosen, "apple");
+});
+
+test("select degrades to undefined when no frontend answers", async () => {
+  const { ctx } = fakeCtx(); // ui:select not registered
+  assert.equal(await createUi(ctx).select({ items: [] }), undefined);
+});
+
+test("confirm degrades to false when no frontend answers", async () => {
+  const { ctx } = fakeCtx();
+  const ok: boolean = await createUi(ctx).confirm({ title: "?" });
+  assert.equal(ok, false);
+});
+
+test("getEditorText degrades to empty string", () => {
+  const { ctx } = fakeCtx();
+  assert.equal(createUi(ctx).getEditorText(), "");
+});
+
+test("status contributes a segment via the ui:status pipe", () => {
+  const { ctx, bus } = fakeCtx();
+  createUi(ctx).status(() => ({ id: "x", text: "seg", color: "accent" }));
+  const { segments } = bus.emitPipe("ui:status", { segments: [] });
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0]?.text, "seg");
+});
+
+test("status get returning null contributes nothing", () => {
+  const { ctx, bus } = fakeCtx();
+  createUi(ctx).status(() => null);
+  assert.equal(bus.emitPipe("ui:status", { segments: [] }).segments.length, 0);
+});
+
+test("status: refresh emits invalidate, remove unsubscribes", () => {
+  const { ctx, bus } = fakeCtx();
+  let invalidated = 0;
+  bus.on("ui:status:invalidate", () => { invalidated++; });
+  const h = createUi(ctx).status(() => ({ id: "x", text: "seg" }));
+  h.refresh();
+  assert.equal(invalidated, 1);
+  h.remove();
+  assert.equal(bus.emitPipe("ui:status", { segments: [] }).segments.length, 0);
+});
+
+test("dock builds a view from the node factory", () => {
+  const { ctx, bus } = fakeCtx();
+  createUi(ctx).dock((nodes) => nodes.text().node);
+  const nodes = { text: () => ({ node: { t: "text" }, setText() {} }) } as never;
+  const { views } = bus.emitPipe("ashi:dock:above-input", { nodes, views: [] });
+  assert.equal(views.length, 1);
+});

--- a/examples/extensions/ashi/tests/ui-input.test.ts
+++ b/examples/extensions/ashi/tests/ui-input.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createInputPrompt } from "../src/input-prompt.js";
+import type { App, InputView, KeyEvent, RenderNode, Renderer } from "../src/renderer.js";
+
+const node = (tag: string): RenderNode => ({ tag }) as unknown as RenderNode;
+const esc = (): KeyEvent => ({ matches: (n) => n === "escape", isRelease: () => false, isRepeat: () => false });
+
+function harness() {
+  const footer: RenderNode[] = [];
+  let onKey: ((k: KeyEvent) => { consume: boolean } | void) | null = null;
+  let text = "";
+  let focusInput = 0;
+  const app = {
+    footerSlot: {
+      node: node("footer"),
+      addChild: (c: RenderNode) => { footer.push(c); },
+      removeChild: (c: RenderNode) => { const i = footer.indexOf(c); if (i >= 0) footer.splice(i, 1); },
+      clear: () => {},
+    },
+    onKey: (h: (k: KeyEvent) => { consume: boolean } | void) => { onKey = h; },
+    focusInput: () => { focusInput++; },
+    requestRender: () => {},
+  } as unknown as App;
+  const input = {
+    node: node("input"),
+    getText: () => text,
+    setText: (t: string) => { text = t; },
+  } as unknown as InputView;
+  const renderer = {
+    text: () => ({ node: node("text"), setText() {}, setLines() {}, setRenderFn() {} }),
+  } as unknown as Renderer;
+  let open = false;
+  const ip = createInputPrompt(app, renderer, input, { isOpen: () => open, setOpen: (v) => { open = v; } });
+  return {
+    ip,
+    pressEsc: () => onKey?.(esc()),
+    footerCount: () => footer.length,
+    text: () => text,
+    setGuardOpen: (v: boolean) => { open = v; },
+    guardOpen: () => open,
+    focusInputCount: () => focusInput,
+  };
+}
+
+test("ui:input resolves with submitted text and cleans up", async () => {
+  const h = harness();
+  const p = h.ip.prompt({ title: "Name?" });
+  assert.equal(h.ip.isActive(), true);
+  assert.equal(h.guardOpen(), true, "holds the shared modal guard (blocks pickers)");
+  assert.equal(h.footerCount(), 1, "hint mounted");
+  assert.equal(h.focusInputCount(), 1, "input focused");
+
+  assert.equal(h.ip.handleSubmit("ada"), true, "submit consumed while active");
+  assert.equal(await p, "ada");
+  assert.equal(h.ip.isActive(), false);
+  assert.equal(h.guardOpen(), false, "releases the guard");
+  assert.equal(h.footerCount(), 0, "hint removed");
+  assert.equal(h.text(), "", "input cleared");
+});
+
+test("ui:input prefill seeds the input", async () => {
+  const h = harness();
+  const p = h.ip.prompt({ prefill: "draft" });
+  assert.equal(h.text(), "draft");
+  h.ip.handleSubmit("draft edited");
+  assert.equal(await p, "draft edited");
+});
+
+test("ui:input Esc cancels with undefined", async () => {
+  const h = harness();
+  const p = h.ip.prompt();
+  assert.deepEqual(h.pressEsc(), { consume: true }, "escape consumed while active");
+  assert.equal(await p, undefined);
+  assert.equal(h.ip.isActive(), false);
+  assert.equal(h.guardOpen(), false, "guard released on cancel");
+});
+
+test("ui:input handleSubmit is a no-op when inactive", () => {
+  const h = harness();
+  assert.equal(h.ip.handleSubmit("ignored"), false);
+  assert.equal(h.pressEsc(), undefined, "escape passes through when inactive");
+});
+
+test("ui:input is blocked while a picker is open", async () => {
+  const h = harness();
+  h.setGuardOpen(true);
+  assert.equal(await h.ip.prompt(), undefined);
+  assert.equal(h.ip.isActive(), false);
+});

--- a/examples/extensions/ashi/tests/ui-status-pull.test.ts
+++ b/examples/extensions/ashi/tests/ui-status-pull.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventBus } from "agent-sh/event-bus";
+import { StatusFooter, type StatusSegment } from "../src/status-footer.js";
+import type { TextView } from "../src/renderer.js";
+
+const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+function fakeView(): { view: TextView; line: (w?: number) => string } {
+  let fn: ((width: number) => string[]) | null = null;
+  const view = {
+    setRenderFn(f: ((width: number) => string[]) | null) { fn = f; },
+  } as unknown as TextView;
+  return { view, line: (w = 80) => strip((fn?.(w) ?? [""])[0] ?? "") };
+}
+
+const pullFrom = (bus: EventBus) => (): StatusSegment[] =>
+  bus.emitPipe("ui:status", { segments: [] as StatusSegment[] }).segments;
+
+test("ui:status pull pipe: an extension's segment lands in the footer", () => {
+  const bus = new EventBus();
+  bus.onPipe("ui:status", (p) => ({ segments: [...p.segments, { id: "demo", text: "★ demo" }] }));
+
+  const { view, line } = fakeView();
+  const footer = new StatusFooter(view, (s) => s.length, pullFrom(bus));
+  footer.update({ model: "opus" });
+
+  const out = line();
+  assert.ok(out.includes("opus"), `built-in segment present: ${out}`);
+  assert.ok(out.includes("★ demo"), `extension segment present: ${out}`);
+});
+
+test("ui:status: no contributors → footer is unchanged", () => {
+  const bus = new EventBus();
+  const { view, line } = fakeView();
+  const footer = new StatusFooter(view, (s) => s.length, pullFrom(bus));
+  footer.update({ model: "opus" });
+  assert.equal(line().includes("|"), false, "no extra separators when nothing contributes");
+  assert.ok(line().includes("opus"));
+});
+
+test("ui:status:invalidate re-pulls the contributor's current value", () => {
+  const bus = new EventBus();
+  let label = "v1";
+  bus.onPipe("ui:status", (p) => ({ segments: [...p.segments, { id: "demo", text: label }] }));
+
+  const { view, line } = fakeView();
+  const footer = new StatusFooter(view, (s) => s.length, pullFrom(bus));
+  footer.update({ model: "opus" });
+  assert.ok(line().includes("v1"));
+
+  label = "v2";
+  footer.refresh();
+  assert.ok(line().includes("v2"), `re-pulled after invalidate: ${line()}`);
+});


### PR DESCRIPTION
## What

Extensions can now drive ashi's terminal UI through a small protocol of **bus events** and **named handlers** — without a `ctx.ui` object on the kernel context. The same extension degrades gracefully under a frontend that doesn't implement a surface (and under headless/RPC).

Surfaces:
- **Notices** — `ui:notify` (`bus.emit`)
- **Status-bar segments** — `ui:status` pull pipe (+ `ui:status:invalidate`)
- **Pinned widget above the input** — `ashi:dock:above-input` pull pipe (+ `ashi:dock:invalidate`)
- **Dialogs / editor** — `ui:select` / `ui:confirm` / `ui:input` / `ui:editor:get-text` / `ui:editor:set-text` (`ctx.call`)

## Why

ashi previously exposed only declarative render hooks and a whole-renderer swap — there was no way for an extension to post a notice, add a status segment, pin a widget, or ask the user something. This adds that middle tier while keeping the kernel modality-free: ashi *answers* a protocol, and `ctx.ui`-style ergonomics return as an optional library over it rather than a kernel field.

## Naming & timing

- `ui:*` names are neutral (any ashi-compatible frontend could answer them); `ashi:*` names carry terminal-specific vocabulary.
- Pull contributors (status/dock) can register any time — ashi reads them on its next repaint. Imperative surfaces are ready once ashi has mounted; for startup use, gate on the `ashi:ready` event.

## API surface

- Typed `BusEvents` augmentation exported as `@guanyilun/ashi/events`.
- `createUi(ctx)` helper exported as `@guanyilun/ashi/ui` — typed wrappers over the protocol with graceful degradation (`select`/`input` → `undefined`, `confirm` → `false` when no frontend answers). It encapsulates the bus, so consumers using it don't need the events import.

## Docs & example

- Guide: `examples/extensions/ashi/docs/ui-surface-protocol.md`
- Worked example exercising every surface: `examples/extensions/ashi-ui-demo.ts` — `ashi -e ashi-ui-demo`, then `/ui-demo`, `/ui-demo-bump`, `/ui-demo-dock`

## Testing

- 82 unit/integration tests, including a real-renderer test that drives the dock through the actual pi-tui `FooterSlot`/`Container`/`Text` (catches the footer-spacing interaction fakes can't).
- Verified live in a terminal: notices, status segment, pinned dock, and the full select → confirm → input flow render correctly.