### PR TITLE
Replace AgentMode with a concrete Model and ModelEndpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Releases before this file are recorded in the git tags and GitHub releases.
+
+## [Unreleased]
+
+### Changed
+
+- **Breaking — model-selection surface renamed.** `AgentMode` is now `Model`: a
+  serializable identity + capabilities, with `provider` required and the `model`
+  field renamed to `id`. The credentials (`apiKey`/`baseURL`) and the
+  reasoning/cache closures moved out of the model into a new internal
+  `ModelEndpoint`, resolved by `(provider, id)` via `agent:resolve-endpoint`.
+  - Handlers: `agent:get-modes` → `agent:get-models`, `agent:get-mode` → `agent:get-model`.
+  - Events: `agent:modes-changed` → `agent:models-changed`; `config:switch-model`
+    payload `{ model }` → `{ id, provider }`; `config:get-models` entries are now
+    full `Model[]` (`.model` → `.id`, plus capability fields).
+  - Silent-breaking at runtime for unmigrated extensions (string-keyed handlers /
+    loose bus payloads); no end-user behavior change. Warrants a minor bump.
+    Migration guide: [#234](https://github.com/guanyilun/agent-sh/pull/234).

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -249,7 +249,7 @@ The agent supports configurable thinking/reasoning levels for models that suppor
 
 DeepSeek-family models require their previous-turn `reasoning_content` / `reasoning_details` to be echoed back on the next assistant message. Most other reasoning models do **not** want that — feeding prior chain-of-thought back through lenient OpenAI-compatible shims can register as out-of-distribution input and degrade quality.
 
-agent-sh gates this behavior per-mode via the `AgentMode.echoReasoning` flag (default `false`). Reasoning extras are only attached to assistant messages when the active mode opts in.
+agent-sh gates this behavior per-model via the `Model.echoReasoning` flag (default `false`). Reasoning extras are only attached to assistant messages when the active model opts in.
 
 For OpenRouter, the flag is set automatically: model ids matching the built-in pattern `/deepseek/i` (V3, V3.2, V4, rebadges) get `echoReasoning: true`. You can extend or override this in `settings.json`:
 
@@ -361,23 +361,26 @@ The user can also trigger compaction manually with `/compact`.
 
 ash supports multiple models and providers, switchable at runtime.
 
-### Modes
+### Models
 
-Each mode is a model + optional provider configuration:
+Each entry is a `(provider, model)` target — a serializable identity plus capabilities:
 
 ```typescript
-interface AgentMode {
-  model: string;
-  provider?: string;
-  providerConfig?: {        // reconfigure LLM client on switch
-    apiKey: string;
-    baseURL?: string;
-  };
+interface Model {
+  id: string;               // model id, e.g. "openai/gpt-5"
+  provider: string;         // identity is the (provider, id) pair
   contextWindow?: number;   // per-model override for the auto-compact threshold
+  maxTokens?: number;
+  reasoning?: boolean;
+  supportsReasoningEffort?: boolean;
+  echoReasoning?: boolean;
+  modalities?: ("text" | "image")[];
 }
 ```
 
-When all modes share the same provider, switching just changes the model name. When modes span providers (e.g. OpenAI + Anthropic via OpenRouter), switching also reconfigures the LLM client with different credentials and base URL.
+The credentials and provider-shape transforms needed to actually call a model — `apiKey`/`baseURL` plus the reasoning/cache encoders — live in a separate `ModelEndpoint`, resolved internally by `(provider, id)`. It never travels on a frontend-facing event, so `Model` stays secret-free and serializable.
+
+`agent:get-models` returns the catalog; `agent:models-changed` fires when it changes. When all models share the same provider, switching just changes the model. When they span providers (e.g. OpenAI + Anthropic via OpenRouter), switching also reconfigures the LLM client with the new endpoint's credentials and base URL.
 
 ### Switching
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,8 +142,8 @@ agent-sh/
 │   │
 │   ├── agent/                # Agent host — ash backend, providers, tools, skills
 │   │   ├── index.ts          # activateAgent — attaches ctx.agent, registers core tools + ash backend
-│   │   ├── events.ts         # BusEvents augmentation (agent:providers, agent:modes-changed, ...)
-│   │   ├── host-types.ts     # AgentSurface, AgentContext, ProviderRegistration, AgentMode
+│   │   ├── events.ts         # BusEvents augmentation (agent:providers, agent:models-changed, ...)
+│   │   ├── host-types.ts     # AgentSurface, AgentContext, ProviderRegistration, Model, ModelEndpoint
 │   │   ├── types.ts          # AgentBackend, ToolDefinition, ToolResult
 │   │   ├── agent-loop.ts     # ash AgentLoop (constructed lazily in start())
 │   │   ├── llm-client.ts, llm-facade.ts  # ash LLM transport + ctx.agent.llm facade

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -498,7 +498,7 @@ export default function activate(ctx: AgentContext): void {
 
 Settings overlay registered providers: `providers.<id>.apiKey/baseURL/defaultModel/models/modelCapabilities` in `~/.agent-sh/settings.json` wins over the extension's payload, so users can pin keys, endpoints, and per-model overrides without touching extension code.
 
-Re-register to refresh (e.g. after fetching a catalog asynchronously); listeners are notified via `agent:providers:changed` and `agent:modes-changed`. To configure provider hooks like custom reasoning-effort encoding, use `ctx.agent.providers.configure(id, { reasoningParams })`.
+Re-register to refresh (e.g. after fetching a catalog asynchronously); listeners are notified via `agent:providers:changed` and `agent:models-changed`. To configure provider hooks like custom reasoning-effort encoding, use `ctx.agent.providers.configure(id, { reasoningParams })`.
 
 ## Named Handlers (Advice System)
 

--- a/examples/extensions/ash-acp-bridge/src/index.ts
+++ b/examples/extensions/ash-acp-bridge/src/index.ts
@@ -434,10 +434,10 @@ function waitForModelsToSettle(
       timer = setTimeout(done, Math.max(0, Math.min(quietMs, remaining)));
     };
     const done = () => {
-      core.bus.off("agent:modes-changed", arm);
+      core.bus.off("agent:models-changed", arm);
       resolve();
     };
-    core.bus.on("agent:modes-changed", arm);
+    core.bus.on("agent:models-changed", arm);
     arm();
   });
 }
@@ -446,15 +446,14 @@ function getModelsPayload(): Record<string, unknown> | undefined {
   if (!core) return undefined;
   const info = core.bus.emitPipe("config:get-models", { models: [], active: null });
   if (!info.models.length) return undefined;
-  const idFor = (m: { model: string; provider: string }) =>
-    m.provider ? `${m.model}@${m.provider}` : m.model;
+  const idFor = (m: { id: string; provider: string }) => `${m.id}@${m.provider}`;
   const current = info.active ?? info.models[0]!;
   return {
     currentModelId: idFor(current),
     availableModels: info.models.map((m) => ({
       modelId: idFor(m),
-      name: m.provider ? `${m.provider}/${m.model}` : m.model,
-      description: m.provider ? `Provider: ${m.provider}` : "",
+      name: `${m.provider}/${m.id}`,
+      description: `Provider: ${m.provider}`,
     })),
   };
 }
@@ -601,7 +600,12 @@ function dispatch(msg: JsonRpcRequest): void {
       break;
     case "session/set_model":
       if (core && params?.modelId) {
-        core.bus.emit("config:switch-model", { model: params.modelId as string });
+        const raw = params.modelId as string;
+        const at = raw.lastIndexOf("@");
+        core.bus.emit("config:switch-model", {
+          id: at > 0 ? raw.slice(0, at) : raw,
+          provider: at > 0 ? raw.slice(at + 1) : "",
+        });
       }
       sendResult(id!, {
         models: getModelsPayload() ?? {},

--- a/examples/extensions/pi-bridge/index.ts
+++ b/examples/extensions/pi-bridge/index.ts
@@ -331,34 +331,29 @@ export default function activate(ctx: ExtensionContext): void {
       const all = modelRegistry.getAvailable() as Array<{ id: string; provider: string }>;
       const cur = session.model;
       return {
-        models: all.map((m) => ({ model: m.id, provider: m.provider })),
-        active: cur ? { model: cur.id, provider: cur.provider } : null,
+        models: all.map((m) => ({ id: m.id, provider: m.provider })),
+        active: cur ? { id: cur.id, provider: cur.provider } : null,
       };
     };
 
-    // Slash command emits `model@provider` for disambiguation; pi looks up by (provider, id).
-    const onSwitchModel = async ({ model: target }: { model: string }) => {
+    const onSwitchModel = async ({ id, provider }: { id: string; provider: string }) => {
       if (!session || !modelRegistry) return;
-      const atIdx = target.lastIndexOf("@");
-      const modelId = atIdx > 0 ? target.slice(0, atIdx) : target;
-      const providerHint = atIdx > 0 ? target.slice(atIdx + 1) : undefined;
-
       const candidates = (modelRegistry.getAvailable() as Array<{ id: string; provider: string }>)
-        .filter((m) => m.id === modelId && (!providerHint || m.provider === providerHint));
+        .filter((m) => m.id === id && (!provider || m.provider === provider));
 
       if (candidates.length === 0) {
-        bus.emit("ui:error", { message: `Unknown model: ${target}` });
+        bus.emit("ui:error", { message: `Unknown model: ${provider}:${id}` });
         return;
       }
       if (candidates.length > 1) {
         const opts = candidates.map((m) => `${m.id}@${m.provider}`).join(", ");
-        bus.emit("ui:error", { message: `Ambiguous model "${modelId}". Use one of: ${opts}` });
+        bus.emit("ui:error", { message: `Ambiguous model "${id}". Use one of: ${opts}` });
         return;
       }
       const picked = candidates[0]!;
       const full = modelRegistry.find(picked.provider, picked.id);
       if (!full) {
-        bus.emit("ui:error", { message: `Model not found: ${target}` });
+        bus.emit("ui:error", { message: `Model not found: ${picked.provider}:${picked.id}` });
         return;
       }
       try {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -4,7 +4,7 @@
  * and the loop emits the agent:* progress/response/tool event stream.
  */
 import type { EventBus, BusEvents } from "../core/event-bus.js";
-import type { AgentMode } from "./host-types.js";
+import type { Model, ModelEndpoint } from "./host-types.js";
 import type { LlmClient } from "./llm-client.js";
 import type { HandlerFunctions } from "../utils/handler-registry.js";
 import { setMaxListeners } from "node:events";
@@ -56,7 +56,7 @@ export interface AgentLoopConfig {
   bus: EventBus;
   llmClient: LlmClient;
   handlers: HandlerFunctions;
-  initialMode?: AgentMode;
+  initialModel?: Model;
   compositor?: Compositor;
   /** Instance ID from core — ensures history entries match the ID in prompts. */
   instanceId?: string;
@@ -67,7 +67,8 @@ export class AgentLoop implements AgentBackend {
   private toolRegistry: ToolRegistry;
   private conversation: LiveView;
   private fileReadCache: FileReadCache;
-  private activeMode: AgentMode;
+  private activeModel: Model;
+  private activeEndpoint: ModelEndpoint | undefined;
   private boundListeners: Array<{ event: string; fn: (...args: any[]) => void }> = [];
   private boundPipeListeners: Array<{ event: string; fn: (...args: any[]) => any; async: boolean }> = [];
   private lastProjectSkillNames = new Set<string>();
@@ -111,7 +112,8 @@ export class AgentLoop implements AgentBackend {
 
     this.conversation = new LiveView(this.handlers, this.instanceId);
 
-    this.activeMode = config.initialMode ?? { model: config.llmClient.model };
+    this.activeModel = config.initialModel ?? { id: config.llmClient.model, provider: "custom" };
+    this.activeEndpoint = this.resolveEndpoint(this.activeModel);
 
     // Tool protocol — controls how tools are presented to the LLM
     const { names: fromExtensions } = this.bus.emitPipe("agent:core-tools:collect", { names: [] });
@@ -186,86 +188,75 @@ export class AgentLoop implements AgentBackend {
       this.conversation.appendUserMessage(text);
       this.bus.emit("conversation:message-appended", { role: "user", content: text });
     });
-    on("config:switch-model", ({ model: target }) => {
-      const atIdx = target.lastIndexOf("@");
-      const modelId = atIdx > 0 ? target.slice(0, atIdx) : target;
-      const providerHint = atIdx > 0 ? target.slice(atIdx + 1) : undefined;
-      const modes = this.pullModes();
-      const found = modes.find((m) =>
-        m.model === modelId && (!providerHint || m.provider === providerHint),
-      );
+    on("config:switch-model", ({ id, provider }) => {
+      const found = this.pullModels().find((m) => m.id === id && m.provider === provider);
       if (!found) {
-        this.bus.emit("ui:error", { message: `Unknown model: ${target}` });
+        this.bus.emit("ui:error", { message: `Unknown model: ${provider}:${id}` });
         return;
       }
-      this.activeMode = found;
-      if (found.providerConfig) {
-        this.llmClient.reconfigure({ ...found.providerConfig, model: found.model });
+      this.activeModel = found;
+      this.activeEndpoint = this.resolveEndpoint(found);
+      if (this.activeEndpoint) {
+        this.llmClient.reconfigure({ apiKey: this.activeEndpoint.apiKey, baseURL: this.activeEndpoint.baseURL, model: found.id });
       } else {
-        this.llmClient.model = found.model;
+        this.llmClient.model = found.id;
       }
-      const label = found.provider ? `${found.provider}: ${found.model}` : found.model;
       this.emitIdentity();
 
-      // Persist as the new default — selection survives restart.
-      // Safe even for dynamic providers: agent-backend defers mode
-      // resolution to `core:extensions-loaded`, so the extension gets
-      // to re-register before the persisted default is looked up.
-      if (found.provider) {
-        updateSettings({
-          defaultProvider: found.provider,
-          providers: { [found.provider]: { defaultModel: found.model } },
-        });
-        this.bus.emit("ui:info", { message: `Model: ${label} (saved as default)` });
-      } else {
-        this.bus.emit("ui:info", { message: `Model: ${label}` });
-      }
+      // Persist as the new default — selection survives restart. Safe even for
+      // dynamic providers: agent-backend defers model resolution to
+      // core:extensions-loaded, so the extension re-registers before the
+      // persisted default is looked up.
+      updateSettings({
+        defaultProvider: found.provider,
+        providers: { [found.provider]: { defaultModel: found.id } },
+      });
+      this.bus.emit("ui:info", { message: `Model: ${found.provider}: ${found.id} (saved as default)` });
       this.bus.emit("config:changed", {});
     });
-    on("agent:modes-changed", () => {
-      const modes = this.pullModes();
-      const prev = this.activeMode;
-      const fresh = modes.find((m) => m.model === prev.model && m.provider === prev.provider);
+    on("agent:models-changed", () => {
+      const models = this.pullModels();
+      const prev = this.activeModel;
+      const fresh = models.find((m) => m.id === prev.id && m.provider === prev.provider);
       let identityChanged = false;
       if (fresh) {
-        this.activeMode = fresh;
-        if (fresh.providerConfig && fresh.providerConfig !== prev.providerConfig) {
-          this.llmClient.reconfigure({ ...fresh.providerConfig, model: fresh.model });
+        this.activeModel = fresh;
+        const ep = this.resolveEndpoint(fresh);
+        if (ep && (ep.apiKey !== this.activeEndpoint?.apiKey || ep.baseURL !== this.activeEndpoint?.baseURL)) {
+          this.llmClient.reconfigure({ apiKey: ep.apiKey, baseURL: ep.baseURL, model: fresh.id });
         }
-        identityChanged = fresh.model !== prev.model
-          || fresh.provider !== prev.provider
-          || fresh.contextWindow !== prev.contextWindow;
-      } else if (prev.provider) {
+        this.activeEndpoint = ep;
+        identityChanged = fresh.contextWindow !== prev.contextWindow;
+      } else {
         // Ghost: keep prev active so mid-turn stream() doesn't switch models.
         this.bus.emit("ui:info", {
-          message: `${prev.provider}:${prev.model} is not in the refreshed catalog — keeping it active until you /model to another.`,
+          message: `${prev.provider}:${prev.id} is not in the refreshed catalog — keeping it active until you /model to another.`,
         });
       }
       if (identityChanged) this.emitIdentity();
       this.bus.emit("config:changed", {});
     });
     onPipe("config:get-models", () => {
-      const modes = this.pullModes();
-      const models = modes.map((m) => ({ model: m.model, provider: m.provider ?? "" }));
-      // Surface a ghost active mode so /model still shows it.
-      if (!modes.some((m) => m.model === this.activeMode.model && m.provider === this.activeMode.provider)) {
-        models.push({ model: this.activeMode.model, provider: this.activeMode.provider ?? "" });
+      const models = this.pullModels();
+      const list = [...models];
+      // Surface a ghost active model so /model still shows it.
+      if (!models.some((m) => m.id === this.activeModel.id && m.provider === this.activeModel.provider)) {
+        list.push(this.activeModel);
       }
-      const active = { model: this.activeMode.model, provider: this.activeMode.provider ?? "" };
-      return { models, active };
+      return { models: list, active: this.activeModel };
     });
     on("config:set-thinking", ({ level }) => {
       if (!AgentLoop.THINKING_LEVELS.includes(level)) {
         this.bus.emit("ui:error", { message: `Unknown thinking level: ${level}. Use: ${AgentLoop.THINKING_LEVELS.join(", ")}` });
         return;
       }
-      const mode = this.currentMode;
+      const mode = this.activeModel;
       if (level !== "off" && mode.reasoning === false) {
-        this.bus.emit("ui:error", { message: `Model ${mode.model} does not support thinking.` });
+        this.bus.emit("ui:error", { message: `Model ${mode.id} does not support thinking.` });
         return;
       }
       if (level !== "off" && mode.supportsReasoningEffort === false) {
-        this.bus.emit("ui:error", { message: `Provider ${mode.provider ?? "unknown"} does not support reasoning_effort.` });
+        this.bus.emit("ui:error", { message: `Provider ${mode.provider} does not support reasoning_effort.` });
         return;
       }
       this.thinkingLevel = level;
@@ -273,7 +264,7 @@ export class AgentLoop implements AgentBackend {
       this.bus.emit("config:changed", {});
     });
     onPipe("config:get-thinking", () => {
-      const mode = this.currentMode;
+      const mode = this.activeModel;
       const supported = mode.reasoning !== false && mode.supportsReasoningEffort !== false;
       return { level: this.thinkingLevel, levels: AgentLoop.THINKING_LEVELS, supported };
     });
@@ -296,12 +287,12 @@ export class AgentLoop implements AgentBackend {
     onPipe("context:get-stats", () => ({
       activeTokens: this.conversation.estimateTokens(),
       totalTokens: this.conversation.estimatePromptTokens(),
-      budgetTokens: this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+      budgetTokens: this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     }));
 
     onPipe("context:snapshot", (payload) => {
       payload.messages = this.conversation.get();
-      payload.contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      payload.contextWindow = this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       payload.activeTokens = this.conversation.estimateTokens();
       return payload;
     });
@@ -460,41 +451,42 @@ export class AgentLoop implements AgentBackend {
   }
 
   private reasoningParams(): Record<string, unknown> {
-    const mode = this.currentMode;
-    if (mode.reasoning === false) return {};
-    if (mode.supportsReasoningEffort === false) return {};
-    if (mode.buildReasoningParams) return mode.buildReasoningParams(this.thinkingLevel);
+    const model = this.activeModel;
+    if (model.reasoning === false) return {};
+    if (model.supportsReasoningEffort === false) return {};
+    const build = this.activeEndpoint?.buildReasoningParams;
+    if (build) return build(this.thinkingLevel);
     if (this.thinkingLevel === "off") return {};
     const effort = this.thinkingLevel === "xhigh" ? "high" : this.thinkingLevel;
     return { reasoning_effort: effort };
   }
 
 
-  private get currentMode(): AgentMode {
-    return this.activeMode;
+  private resolveEndpoint(m: Model): ModelEndpoint | undefined {
+    try {
+      return this.handlers.call("agent:resolve-endpoint", { provider: m.provider, id: m.id }) as ModelEndpoint | undefined;
+    } catch {
+      return undefined;
+    }
   }
 
-  private pullModes(): AgentMode[] {
+  private pullModels(): Model[] {
     try {
-      return (this.handlers.call("agent:get-modes") as AgentMode[]) ?? [];
+      return (this.handlers.call("agent:get-models") as Model[]) ?? [];
     } catch {
       return [];
     }
   }
 
   private emitIdentity(): void {
-    const m = this.activeMode;
+    const m = this.activeModel;
     this.bus.emit("agent:info", {
       name: "ash",
       version: PACKAGE_VERSION,
-      model: m.model,
+      model: m.id,
       provider: m.provider,
       contextWindow: m.contextWindow,
     });
-  }
-
-  private get currentModel(): string {
-    return this.activeMode.model;
   }
 
   /**
@@ -584,9 +576,9 @@ export class AgentLoop implements AgentBackend {
   private formatError(e: unknown): string {
     const raw = e instanceof Error ? e.message : String(e);
     const status = (e as any).status;
-    const model = this.currentModel;
+    const model = this.activeModel.id;
     const baseURL = (this.llmClient as any).config?.baseURL;
-    const provider = this.currentMode.provider;
+    const provider = this.activeModel.provider;
 
     // Connection errors — most likely misconfigured provider
     if (raw.includes("ECONNREFUSED") || raw.includes("ECONNRESET") ||
@@ -663,7 +655,7 @@ export class AgentLoop implements AgentBackend {
         parts.push("# Extension Instructions\n\n" + extensionSections.join("\n\n"));
       }
 
-      if (this.currentMode.modalities?.includes("image")) {
+      if (this.activeModel.modalities?.includes("image")) {
         parts.push(
           "# Image Support\n\n"
           + "This model supports image input. When you need visual information, "
@@ -683,15 +675,15 @@ export class AgentLoop implements AgentBackend {
     // only happen for state the core genuinely owns (not state that
     // an extension could track by listening to events).
 
-    h.define("agent:get-mode", () => ({
-      model: this.currentMode.model,
-      provider: this.currentMode.provider ?? "",
+    h.define("agent:get-model", () => ({
+      model: this.activeModel.id,
+      provider: this.activeModel.provider,
       thinkingLevel: this.thinkingLevel,
-      contextWindow: this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+      contextWindow: this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     }));
 
     h.define("agent:get-tokens", () => {
-      const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      const contextWindow = this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       const promptTokens = this.conversation.estimatePromptTokens();
       return {
         active: this.conversation.estimateTokens(),
@@ -742,7 +734,7 @@ export class AgentLoop implements AgentBackend {
     }));
 
     h.define("agent:get-compaction-state", () => {
-      const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      const contextWindow = this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       const ratio = getSettings().autoCompactThreshold ?? 0.5;
       return {
         count: this.compactionCount,
@@ -914,7 +906,7 @@ export class AgentLoop implements AgentBackend {
       // Fail closed: an image sent to a non-vision model errors and leaves an
       // unsendable message poisoning history, so require declared image support.
       let userImages = images?.length ? images : undefined;
-      if (userImages && !this.currentMode.modalities?.includes("image")) {
+      if (userImages && !this.activeModel.modalities?.includes("image")) {
         this.bus.emit("ui:info", { message: `Current model has no declared image support — ${userImages.length} image(s) dropped.` });
         userImages = undefined;
       }
@@ -968,7 +960,7 @@ export class AgentLoop implements AgentBackend {
     while (!signal.aborted) {
       // Auto-compact when total context approaches the window limit.
       const totalEstimate = this.conversation.estimatePromptTokens();
-      const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      const contextWindow = this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       const s = getSettings();
       const threshold = Math.floor(
         (contextWindow - RESPONSE_RESERVE) * s.autoCompactThreshold,
@@ -1355,7 +1347,7 @@ export class AgentLoop implements AgentBackend {
 
         // Context overflow — aggressively compact and retry
         if (this.isContextOverflow(e)) {
-          const contextWindow = this.currentMode.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+          const contextWindow = this.activeModel.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
           const target = Math.floor((contextWindow - RESPONSE_RESERVE) * 0.6);
           const stats = await this.compactWithHooks(target, 1);
           // If compaction freed nothing, retrying will hit the same error.
@@ -1441,8 +1433,8 @@ export class AgentLoop implements AgentBackend {
     const requestParams = {
       messages,
       tools: apiTools,
-      model: this.currentModel,
-      max_tokens: this.currentMode.maxTokens ?? 65536,
+      model: this.activeModel.id,
+      max_tokens: this.activeModel.maxTokens ?? 65536,
       ...this.reasoningParams(),
     };
     this.bus.emit("llm:request", requestParams);
@@ -1458,7 +1450,7 @@ export class AgentLoop implements AgentBackend {
       if ((chunk as any).usage) {
         const u = (chunk as any).usage;
         const promptTokens = u.prompt_tokens ?? 0;
-        const cachedPromptTokens = this.currentMode.extractCachedTokens?.(u);
+        const cachedPromptTokens = this.activeEndpoint?.extractCachedTokens?.(u);
         this.bus.emit("agent:usage", {
           prompt_tokens: promptTokens,
           completion_tokens: u.completion_tokens ?? 0,
@@ -1555,7 +1547,7 @@ export class AgentLoop implements AgentBackend {
 
     // Echo reasoning only for modes that opt in (e.g. DeepSeek-R1).
     const extras: Record<string, unknown> = {};
-    if (this.currentMode.echoReasoning) {
+    if (this.activeModel.echoReasoning) {
       if (reasoning && reasoningField) extras[reasoningField] = reasoning;
       if (reasoningDetailsByIndex.size > 0) {
         extras.reasoning_details = [...reasoningDetailsByIndex.entries()]

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -1,6 +1,6 @@
 /** Agent-protocol events. Speak this to be a backend; consume it to be a frontend. */
 import type { ContentBlock } from "../core/event-bus.js";
-import type { ProviderRegistration } from "./host-types.js";
+import type { Model, ProviderRegistration } from "./host-types.js";
 import type { ImageContent, ToolDefinition, ToolResultDisplay } from "./types.js";
 
 export interface AgentIdentity {
@@ -24,7 +24,7 @@ declare module "../core/event-bus.js" {
       cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
     };
 
-    "agent:modes-changed": Record<string, never>;
+    "agent:models-changed": Record<string, never>;
     "config:switch-provider": { provider: string };
 
     "agent:info": AgentIdentity;
@@ -132,8 +132,8 @@ declare module "../core/event-bus.js" {
       stats?: { before: number; after: number; evictedCount: number };
     };
 
-    "config:switch-model": { model: string };
-    "config:get-models": { models: { model: string; provider: string }[]; active: { model: string; provider: string } | null };
+    "config:switch-model": { id: string; provider: string };
+    "config:get-models": { models: Model[]; active: Model | null };
     "config:set-thinking": { level: string };
     "config:get-thinking": { level: string; levels: string[]; supported: boolean };
 

--- a/src/agent/host-types.ts
+++ b/src/agent/host-types.ts
@@ -63,16 +63,16 @@ export interface ProviderRegistration {
   noAuth?: boolean;
 }
 
-/** A model entry in the cycling list, optionally tied to a provider. */
-export interface AgentMode {
-  model: string;
-  /** Provider id — when cycling changes provider, LlmClient is reconfigured. */
-  provider?: string;
-  /** Provider-specific config for reconfiguring LlmClient on switch. */
-  providerConfig?: { apiKey: string; baseURL?: string };
+/** A selectable (provider, model) target the frontend lists and switches.
+ *  Serializable — identity + capabilities only; the secret + closures needed to
+ *  invoke it live in ModelEndpoint, so this can safely cross to frontends and
+ *  out-of-process bridges. */
+export interface Model {
+  id: string;
+  provider: string;
   /** Context window size in tokens (for usage display). */
   contextWindow?: number;
-  /** Max output tokens for this mode. */
+  /** Max output tokens. */
   maxTokens?: number;
   /** Model supports reasoning/thinking tokens. */
   reasoning?: boolean;
@@ -83,6 +83,14 @@ export interface AgentMode {
   echoReasoning?: boolean;
   /** Input modalities the model supports. Defaults to ["text"]. */
   modalities?: ("text" | "image")[];
+}
+
+/** Credentials + provider-shape transforms for invoking a Model, resolved by
+ *  (provider, id). Internal: holds a secret (apiKey) and non-serializable
+ *  closures, so it must never ride a bus event. */
+export interface ModelEndpoint {
+  apiKey: string;
+  baseURL?: string;
   buildReasoningParams?: (level: string) => Record<string, unknown>;
   extractCachedTokens?: (usage: Record<string, unknown>) => number | undefined;
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -4,7 +4,7 @@
  */
 import "./events.js";
 import type { ExtensionContext } from "../shell/host-types.js";
-import type { AgentContext, AgentMode, AgentSurface, ProviderRegistration } from "../agent/host-types.js";
+import type { AgentContext, Model, ModelEndpoint, AgentSurface, ProviderRegistration } from "../agent/host-types.js";
 import type { AppConfig } from "../shell/host-types.js";
 import { AgentLoop } from "./agent-loop.js";
 import { LlmClient } from "./llm-client.js";
@@ -126,7 +126,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
     cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
   }>();
 
-  // Bakes model id so AgentMode.buildReasoningParams keeps its (level) signature.
+  // Bakes model id so ModelEndpoint.buildReasoningParams keeps its (level) signature.
   const bindReasoning = (shapeId: string, model: string) => {
     const hook = providerHooks.get(shapeId)?.reasoningParams;
     return hook ? (level: string) => hook(level, model) : defaultReasoningBuilder;
@@ -310,33 +310,42 @@ export default function agentBackend(ctx: ExtensionContext): void {
     return out;
   };
 
-  const buildModes = (): AgentMode[] => {
-    const out: AgentMode[] = [];
+  const buildModels = (): Model[] => {
+    const out: Model[] = [];
     for (const [id, p] of resolvedProviders) {
       if (!p.apiKey) continue;
       if (!usableProvider(p)) continue;
-      const shapeId = p.reasoningShape ?? id;
       for (const model of p.models) {
         const mc = p.modelCapabilities?.get(model);
         out.push({
-          model,
+          id: model,
           provider: id,
-          providerConfig: { apiKey: p.apiKey, baseURL: p.baseURL },
           contextWindow: mc?.contextWindow ?? p.contextWindow,
           maxTokens: mc?.maxTokens ?? (mc?.contextWindow ? Math.min(Math.floor(mc.contextWindow * 0.4), 65536) : undefined),
           reasoning: mc?.reasoning,
           supportsReasoningEffort: p.supportsReasoningEffort,
           echoReasoning: mc?.echoReasoning,
           modalities: mc?.modalities,
-          buildReasoningParams: bindReasoning(shapeId, model),
-          extractCachedTokens: bindCacheTokens(shapeId),
         });
       }
     }
     return out;
   };
 
-  ctx.define("agent:get-modes", () => buildModes());
+  const resolveEndpoint = (providerId: string, modelId: string): ModelEndpoint | undefined => {
+    const p = resolvedProviders.get(providerId);
+    if (!p?.apiKey) return undefined;
+    const shapeId = p.reasoningShape ?? providerId;
+    return {
+      apiKey: p.apiKey,
+      baseURL: p.baseURL,
+      buildReasoningParams: bindReasoning(shapeId, modelId),
+      extractCachedTokens: bindCacheTokens(shapeId),
+    };
+  };
+
+  ctx.define("agent:get-models", () => buildModels());
+  ctx.define("agent:resolve-endpoint", ({ provider, id }: { provider: string; id: string }) => resolveEndpoint(provider, id));
 
   // Reconfigured at core:extensions-loaded; start() gates on `resolved`.
   const llmClient = new LlmClient({ apiKey: "not-configured", model: "not-configured" });
@@ -361,16 +370,16 @@ export default function agentBackend(ctx: ExtensionContext): void {
   bus.on("agent:providers:changed", () => {
     resolvedProviders = computeResolvedProviders();
     if (!resolved) return;
-    bus.emit("agent:modes-changed", {});
+    bus.emit("agent:models-changed", {});
     if (!ashActive) return;
-    if (buildModes().some((m) => m.model === llmClient.model)) return;
+    if (buildModels().some((m) => m.id === llmClient.model)) return;
     const pendingProvider = getSettings().defaultProvider;
     if (!pendingProvider) return;
     const p = resolvedProviders.get(pendingProvider);
     if (!p) return;
     const pendingModel = persistedModelFor(pendingProvider);
     if (pendingModel && p.models.includes(pendingModel) && llmClient.model !== pendingModel) {
-      bus.emit("config:switch-model", { model: pendingModel });
+      bus.emit("config:switch-model", { id: pendingModel, provider: pendingProvider });
     }
   });
 
@@ -421,17 +430,16 @@ export default function agentBackend(ctx: ExtensionContext): void {
     // No provider → don't register ash; let another backend own activation.
     if (!effectiveApiKey || !effectiveModel) return;
 
-    const foundInModes = buildModes().find(
-      (m) => m.model === effectiveModel && (!activeProvider || m.provider === activeProvider.id),
+    const foundModel = buildModels().find(
+      (m) => m.id === effectiveModel && (!activeProvider || m.provider === activeProvider.id),
     );
     // Stub when openrouter's async catalog hasn't returned yet; reconciled
     // later via agent:providers:changed → config:switch-model.
-    const initialMode: AgentMode = foundInModes ?? (activeProvider ? {
-      model: effectiveModel,
-      provider: activeProvider.id,
-      providerConfig: { apiKey: effectiveApiKey, baseURL: effectiveBaseURL },
-      supportsReasoningEffort: activeProvider.supportsReasoningEffort,
-    } : { model: effectiveModel });
+    const initialModel: Model = foundModel ?? {
+      id: effectiveModel,
+      provider: activeProvider?.id ?? providerName ?? "custom",
+      supportsReasoningEffort: activeProvider?.supportsReasoningEffort,
+    };
 
     llmClient.reconfigure({ apiKey: effectiveApiKey, baseURL: effectiveBaseURL, model: effectiveModel });
     resolved = true;
@@ -450,7 +458,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
           bus,
           llmClient,
           handlers: { define: ctx.define, advise: ctx.advise, call: ctx.call, list: ctx.list },
-          initialMode,
+          initialModel,
           compositor: ctx.shell?.compositor,
           instanceId: ctx.instanceId,
         });
@@ -544,8 +552,8 @@ export default function agentBackend(ctx: ExtensionContext): void {
       return;
     }
     llmClient.reconfigure({ apiKey: p.apiKey, baseURL: p.baseURL, model: switchModel });
-    bus.emit("agent:modes-changed", {});
-    bus.emit("config:switch-model", { model: switchModel });
+    bus.emit("agent:models-changed", {});
+    bus.emit("config:switch-model", { id: switchModel, provider: name });
     bus.emit("ui:info", { message: `Switched to ${name} (${switchModel})` });
   });
 
@@ -569,7 +577,7 @@ export { ToolRegistry } from "./tool-registry.js";
 export { runSubagent, type SubagentOptions } from "./subagent.js";
 
 /** Built-in providers register unconditionally so `auth list` can
- *  enumerate them; buildModes() skips entries without an apiKey. */
+ *  enumerate them; buildModels() skips entries without an apiKey. */
 export function activateAgent(ctx: ExtensionContext): void {
   agentBackend(ctx);
   const agentCtx = ctx as AgentContext;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,7 +20,7 @@ import { CONFIG_DIR } from "./settings.js";
 export { EventBus } from "./event-bus.js";
 export type { BusEvents, ContentBlock, BackendRegistration } from "./event-bus.js";
 export type { CoreContext, CoreConfig } from "./types.js";
-export type { AgentContext, AgentConfig, AgentSurface, AgentConfigSurface, AgentMode, LlmInterface, LlmMessage, LlmSession } from "../agent/host-types.js";
+export type { AgentContext, AgentConfig, AgentSurface, AgentConfigSurface, Model, LlmInterface, LlmMessage, LlmSession } from "../agent/host-types.js";
 export type { ShellContext, ShellConfig, ShellSurface, ShellConfigSurface, ExtensionContext, RemoteSession, RemoteSessionOptions, RenderSurface, InputModeConfig, TerminalSession, BlockTransformOptions, FencedBlockTransformOptions, AppConfig } from "../shell/host-types.js";
 export { palette, setPalette, resetPalette } from "../utils/palette.js";
 export type { ColorPalette } from "../utils/palette.js";

--- a/src/extensions/slash-commands/index.ts
+++ b/src/extensions/slash-commands/index.ts
@@ -55,15 +55,21 @@ export default function activate(ctx: ExtensionContext): void {
     description: "Cycle to next model, or switch to a specific one",
     handler: (args) => {
       const name = args.trim();
+      const { models, active } = bus.emitPipe("config:get-models", { models: [], active: null });
       if (!name) {
-        const { active } = bus.emitPipe("config:get-models", { models: [], active: null });
-        const label = active
-          ? `${active.model}${active.provider ? ` [${active.provider}]` : ""}`
-          : "none";
+        const label = active ? `${active.id} [${active.provider}]` : "none";
         bus.emit("ui:info", { message: `Model: ${label}` });
-      } else {
-        bus.emit("config:switch-model", { model: name });
+        return;
       }
+      const atIdx = name.lastIndexOf("@");
+      const id = atIdx > 0 ? name.slice(0, atIdx) : name;
+      const providerHint = atIdx > 0 ? name.slice(atIdx + 1) : undefined;
+      const found = models.find((m) => m.id === id && (!providerHint || m.provider === providerHint));
+      if (!found) {
+        bus.emit("ui:error", { message: `Unknown model: ${name}` });
+        return;
+      }
+      bus.emit("config:switch-model", { id: found.id, provider: found.provider });
     },
   });
 
@@ -187,16 +193,16 @@ export default function activate(ctx: ExtensionContext): void {
     const partial = (payload.commandArgs ?? "").toLowerCase();
     const { models, active } = bus.emitPipe("config:get-models", { models: [], active: null });
     const counts = new Map<string, number>();
-    for (const m of models) counts.set(m.model, (counts.get(m.model) ?? 0) + 1);
+    for (const m of models) counts.set(m.id, (counts.get(m.id) ?? 0) + 1);
     const items = models
-      .filter((m) => m.model.toLowerCase().includes(partial))
+      .filter((m) => m.id.toLowerCase().includes(partial))
       .slice(0, 15)
       .map((m) => {
-        const ambiguous = (counts.get(m.model) ?? 0) > 1 && m.provider;
-        const qualified = ambiguous ? `${m.model}@${m.provider}` : m.model;
+        const ambiguous = (counts.get(m.id) ?? 0) > 1;
+        const qualified = ambiguous ? `${m.id}@${m.provider}` : m.id;
         return {
           name: `/model ${qualified}`,
-          description: `${m.provider ? `[${m.provider}]` : ""}${active && m.model === active.model && m.provider === active.provider ? " (active)" : ""}`,
+          description: `[${m.provider}]${active && m.id === active.id && m.provider === active.provider ? " (active)" : ""}`,
         };
       });
     if (items.length === 0) return payload;

--- a/tests/agent/provider-modes.test.ts
+++ b/tests/agent/provider-modes.test.ts
@@ -23,7 +23,7 @@ interface CacheProbe {
 
 interface DriverResult {
   events: CapturedEvent[];
-  modes?: any[];
+  models?: any[];
   cacheProbes?: CacheProbe[];
   stderr: string;
   stdout: string;
@@ -32,7 +32,7 @@ interface DriverResult {
 
 async function runDriver(
   settings: Record<string, unknown>,
-  scenario: { config?: Record<string, unknown>; capture: string[]; dumpModes?: boolean; probeCacheTokens?: unknown[]; steps: unknown[] },
+  scenario: { config?: Record<string, unknown>; capture: string[]; dumpModels?: boolean; probeCacheTokens?: unknown[]; steps: unknown[] },
   envOverride: Record<string, string> = {},
 ): Promise<DriverResult> {
   const home = mkdtempSync(join(tmpdir(), "agent-sh-pmodes-"));
@@ -66,8 +66,8 @@ async function runDriver(
         clearTimeout(timer);
         try {
           const line = stdout.trim().split(/\r?\n/).pop() ?? "";
-          const parsed = JSON.parse(line) as { events: CapturedEvent[]; modes?: any[]; cacheProbes?: CacheProbe[] };
-          resolve({ events: parsed.events, modes: parsed.modes, cacheProbes: parsed.cacheProbes, stderr, stdout, exitCode: code });
+          const parsed = JSON.parse(line) as { events: CapturedEvent[]; models?: any[]; cacheProbes?: CacheProbe[] };
+          resolve({ events: parsed.events, models: parsed.models, cacheProbes: parsed.cacheProbes, stderr, stdout, exitCode: code });
         } catch (err) {
           reject(new Error(`driver output not JSON.\nexit=${code}\nstdout:\n${stdout}\nstderr:\n${stderr}\nparse error: ${(err as Error).message}`));
         }
@@ -99,8 +99,8 @@ test("settings.json apiKey/baseURL/defaultModel and modelsExplicit override regi
   };
 
   const result = await runDriver(settings, {
-    dumpModes: true,
-    capture: ["agent:modes-changed"],
+    dumpModels: true,
+    capture: ["agent:models-changed"],
     steps: [
       {
         kind: "providers.register",
@@ -115,22 +115,22 @@ test("settings.json apiKey/baseURL/defaultModel and modelsExplicit override regi
     ],
   });
 
-  const modes = result.modes!;
+  const models = result.models!;
   assert.deepEqual(
-    modes.map((m) => m.model),
+    models.map((m) => m.id),
     ["settings/m1", "settings/m2"],
     "settings.models replaces payload models when modelsExplicit",
   );
 
-  for (const m of modes) {
+  for (const m of models) {
     assert.equal(m.provider, "openrouter");
-    assert.equal(m.providerConfig.apiKey, "sk-from-settings", `apiKey override on mode ${m.model}`);
-    assert.equal(m.providerConfig.baseURL, "https://settings.example", `baseURL override on mode ${m.model}`);
+    assert.equal(m.endpoint.apiKey, "sk-from-settings", `apiKey override on model ${m.id}`);
+    assert.equal(m.endpoint.baseURL, "https://settings.example", `baseURL override on model ${m.id}`);
   }
 
-  const m2 = modes.find((m) => m.model === "settings/m2")!;
+  const m2 = models.find((m) => m.id === "settings/m2")!;
   assert.equal(m2.contextWindow, 99999, "settings modelCapabilities overlay");
-  const m1 = modes.find((m) => m.model === "settings/m1")!;
+  const m1 = models.find((m) => m.id === "settings/m1")!;
   assert.equal(m1.contextWindow, undefined, "no caps when neither settings nor payload supply them");
 });
 
@@ -143,8 +143,8 @@ test("active mode missing from refreshed catalog stays as ghost + emits ui:info 
   };
 
   const result = await runDriver(settings, {
-    dumpModes: true,
-    capture: ["agent:info", "ui:info", "agent:modes-changed"],
+    dumpModels: true,
+    capture: ["agent:info", "ui:info", "agent:models-changed"],
     steps: [
       { kind: "providers.register", payload: { id: "openrouter", apiKey: "x", defaultModel: "m-a", models: ["m-a", "m-b"] } },
       { kind: "core:extensions-loaded" },
@@ -165,9 +165,9 @@ test("active mode missing from refreshed catalog stays as ghost + emits ui:info 
   assert.equal(infos[infos.length - 1].model, "m-b", "active model preserved across refresh");
 
   assert.deepEqual(
-    result.modes!.map((m) => m.model),
+    result.models!.map((m) => m.id),
     ["m-a", "m-c"],
-    "agent:get-modes reflects the refreshed catalog (ghost lives in AgentLoop)",
+    "agent:get-models reflects the refreshed catalog (ghost lives in AgentLoop)",
   );
 });
 
@@ -178,7 +178,7 @@ test("persisted default not in initial catalog → stub used as initial active m
   };
 
   const result = await runDriver(settings, {
-    dumpModes: true,
+    dumpModels: true,
     capture: ["agent:info"],
     steps: [
       { kind: "providers.register", payload: { id: "openrouter", apiKey: "x", defaultModel: "existing/default", models: ["existing/m1"] } },
@@ -193,7 +193,7 @@ test("persisted default not in initial catalog → stub used as initial active m
   assert.equal(infos[0].provider, "openrouter");
   assert.equal(infos[0].contextWindow, undefined, "stub has no contextWindow");
 
-  assert.deepEqual(result.modes!.map((m) => m.model), ["existing/m1"], "registry has only the real catalog");
+  assert.deepEqual(result.models!.map((m) => m.id), ["existing/m1"], "registry has only the real catalog");
 });
 
 test("late catalog containing persisted default does not switch away from active override", async () => {

--- a/tests/fixtures/provider-mode-driver.ts
+++ b/tests/fixtures/provider-mode-driver.ts
@@ -3,12 +3,12 @@
 import { createCore } from "../../src/core/index.js";
 import agentBackend from "../../src/agent/index.js";
 import type { AppConfig, ExtensionContext } from "../../src/shell/host-types.js";
-import type { AgentMode, AgentSurface, ProviderRegistration } from "../../src/agent/host-types.js";
+import type { Model, ModelEndpoint, AgentSurface, ProviderRegistration } from "../../src/agent/host-types.js";
 
 interface Scenario {
   config?: Partial<AppConfig>;
   capture: string[];
-  dumpModes?: boolean;
+  dumpModels?: boolean;
   probeCacheTokens?: Array<{ model: string; usage: Record<string, unknown> }>;
   steps: Array<
     | { kind: "providers.register"; payload: ProviderRegistration }
@@ -65,26 +65,37 @@ async function main() {
   }
 
   await new Promise((r) => setImmediate(r));
-  let modes: AgentMode[] | undefined;
-  if (scenario.dumpModes || scenario.probeCacheTokens) {
+  const endpointFor = (m: Model): ModelEndpoint | undefined => {
     try {
-      modes = ctx.call("agent:get-modes") as AgentMode[];
+      return ctx.call("agent:resolve-endpoint", { provider: m.provider, id: m.id }) as ModelEndpoint | undefined;
     } catch {
-      modes = undefined;
+      return undefined;
+    }
+  };
+
+  let models: Model[] | undefined;
+  if (scenario.dumpModels || scenario.probeCacheTokens) {
+    try {
+      models = ctx.call("agent:get-models") as Model[];
+    } catch {
+      models = undefined;
     }
   }
 
   let cacheProbes: Array<{ model: string; result: number | undefined; found: boolean }> | undefined;
   if (scenario.probeCacheTokens) {
     cacheProbes = scenario.probeCacheTokens.map(({ model, usage }) => {
-      const mode = modes?.find((m) => m.model === model);
-      return { model, found: !!mode, result: mode?.extractCachedTokens?.(usage) };
+      const m = models?.find((x) => x.id === model);
+      const ep = m ? endpointFor(m) : undefined;
+      return { model, found: !!m, result: ep?.extractCachedTokens?.(usage) };
     });
   }
 
+  const dumped = models?.map((m) => ({ ...m, endpoint: endpointFor(m) }));
+
   process.stdout.write(JSON.stringify({
     events: captured,
-    modes: scenario.dumpModes ? stripFns(modes) : undefined,
+    models: scenario.dumpModels ? stripFns(dumped) : undefined,
     cacheProbes,
   }) + "\n");
   process.exit(0);


### PR DESCRIPTION
## Why

`AgentMode` conflated two things: the selectable `(provider, model)` identity that frontends list and switch between, and the credentials + provider-shape closures needed to actually call the model. It was also misnamed — each entry is a `(provider, model)` target, not a behavioral mode — and `provider` was optional despite identity always keying on it, which forced `?? ""` coalescing and an `@`-encoded model string threaded through `config:switch-model`.

## What

Split the one struct into two:

- **`Model`** — serializable identity + capabilities, `provider` now required. What `agent:get-models` returns and what the frontend lists/switches. This is the `config:get-models` payload, so it must stay secret-free and serializable (the ACP bridge forwards it out-of-process).
- **`ModelEndpoint`** — `apiKey`/`baseURL` + the reasoning/cache transforms, resolved by `(provider, id)` via the new internal `agent:resolve-endpoint` handler. Holds a secret and non-serializable closures, so it never rides a bus event.

`config:switch-model` now carries a structured `{ id, provider }` instead of an `@`-encoded string. The `/model` frontend resolves the typed string to a concrete pair; the ACP bridge flattens to its own flat `modelId` only at the protocol edge. The `?? ""` provider coalescing is gone — the pair is total, with inline credentials synthesizing a `"custom"` provider name.

## Breaking changes & migration

All changes are in the extension/event surface. **No end-user behavior change** — `/model` and switching work identically (verified by manual cross-provider switch).

These are **silent-breaking at runtime**: handler names are string keys and bus payloads are loose at the call boundary, so an unmigrated consumer won't fail to compile — it'll return an empty model list or no-op the switch. Publish as a **minor bump, not a patch**.

### Types (exported from `agent-sh`)

| Old | New |
| --- | --- |
| `AgentMode` | `Model` (no deprecated alias) |
| — | `ModelEndpoint` (new; internal — not for frontend events) |

- `AgentMode.model` → `Model.id`; `Model.provider` is now **required** (was optional).
- `AgentMode.providerConfig` (`apiKey`/`baseURL`) and the `buildReasoningParams`/`extractCachedTokens` closures moved out of the model into `ModelEndpoint`.

### Handlers (`ctx.handlers.call` / `ctx.call`)

| Old | New | Returns |
| --- | --- | --- |
| `agent:get-modes` | `agent:get-models` | `Model[]` (entries keyed by `id`, not `model`) |
| `agent:get-mode` | `agent:get-model` | unchanged shape `{ model, provider, thinkingLevel, contextWindow }` |
| — | `agent:resolve-endpoint` | `ModelEndpoint` — **internal only** (returns closures; do not serialize / forward across a process) |

### Bus events

| Event | Change |
| --- | --- |
| `agent:modes-changed` | renamed → `agent:models-changed` |
| `config:switch-model` | payload `{ model: string }` → `{ id: string; provider: string }` |
| `config:get-models` | entries `{ model, provider }` → full `Model[]` (`.model` → `.id`, plus capability fields) |

### Migrating a consumer

1. `AgentMode` → `Model`; read `.id` not `.model`; drop `.providerConfig` (resolve creds via `agent:resolve-endpoint` only if you truly need them — most consumers don't).
2. `agent:get-modes` / `agent:get-mode` / `agent:modes-changed` → `agent:get-models` / `agent:get-model` / `agent:models-changed`.
3. Before emitting `config:switch-model`, resolve your model string to `{ id, provider }` (split `id@provider`, look it up in `config:get-models`). Reference: the `/model` handler in `src/extensions/slash-commands/index.ts`.
4. Reading `config:get-models`: use `m.id`; you now also get `contextWindow` / `modalities` / etc. for free.

### Consumer status

- **Migrated in this PR:** agent-loop, index, events, host-types, core, slash-commands, ash-acp-bridge, pi-bridge, tests, docs.
- **Not affected (verified by full-repo sweep):** ashi, ashi-ink, claude-code-bridge, opencode-bridge, ash-mcp-bridge — none consume the changed surface; they read model identity via `agent:info`, which is unchanged.
- **asHub (separate repo):** migrated on branch `migrate-model-api`, typecheck-verified against this API. It pins published `agent-sh`, so **bump asHub's `agent-sh` dependency to this release and merge that branch together** — bumping without the branch (or merging the branch on old core) breaks model listing/switching.

## Verification

- `tsc --noEmit` clean (root + the `ash-acp-bridge` example, which links core via `file:`).
- Full suite **254/254**, including the 6 provider/model integration tests (settings overlay, ghost preservation, persisted-default stub, late reconcile, both cache extractors — the latter now probed through the resolved endpoint).
- Manual `/model` switch (incl. cross-provider) confirmed working.