### PR TITLE
Bump bundled extensions to agent-sh ^0.15.0

### DIFF
--- a/examples/extensions/ash-scheme/package.json
+++ b/examples/extensions/ash-scheme/package.json
@@ -6,6 +6,6 @@
   "main": "index.ts",
   "dependencies": {
     "@jcubic/lips": "1.0.0-beta.20",
-    "agent-sh": "^0.14.0"
+    "agent-sh": "^0.15.0"
   }
 }

--- a/examples/extensions/ashi-ink/package.json
+++ b/examples/extensions/ashi-ink/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
     "@guanyilun/ashi": "^0.2.0",
-    "agent-sh": "^0.14.0",
+    "agent-sh": "^0.15.0",
     "cli-table3": "^0.6.0",
     "ink": "^5.0.0",
     "ink-spinner": "^5.0.0",

--- a/examples/extensions/ashi/package.json
+++ b/examples/extensions/ashi/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
-    "agent-sh": "^0.14.11",
+    "agent-sh": "^0.15.0",
     "chalk": "^5.5.0",
     "cli-highlight": "^2.1.11"
   },

--- a/examples/extensions/claude-code-bridge/package.json
+++ b/examples/extensions/claude-code-bridge/package.json
@@ -6,7 +6,7 @@
   "main": "index.ts",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
-    "agent-sh": "^0.14.0",
+    "agent-sh": "^0.15.0",
     "zod": "^4.0.0"
   }
 }

--- a/examples/extensions/opencode-bridge/package.json
+++ b/examples/extensions/opencode-bridge/package.json
@@ -6,6 +6,6 @@
   "main": "index.ts",
   "dependencies": {
     "@opencode-ai/sdk": "^1.14.41",
-    "agent-sh": "^0.14.0"
+    "agent-sh": "^0.15.0"
   }
 }


### PR DESCRIPTION
Now that `agent-sh@0.15.0` is published, point the bundled extensions that pin a published `agent-sh` at the new minor. `^0.14.x` is a caret that excludes `0.15.0`, so they were stuck on `0.14.x` until this.

**Safe — no code changes.** None of these consume the renamed model-selection surface (verified by sweep), so this is a pure "track latest", not a migration.

| Extension | `agent-sh` |
| --- | --- |
| opencode-bridge | `^0.14.0` → `^0.15.0` |
| claude-code-bridge | `^0.14.0` → `^0.15.0` |
| ash-scheme | `^0.14.0` → `^0.15.0` |
| ashi-ink | `^0.14.0` → `^0.15.0` |
| `@guanyilun/ashi` | `^0.14.11` → `^0.15.0` |

Not touched:
- `ash-acp-bridge` — `file:../../..` (tracks repo source; already on the new API)
- `pi-bridge` — declares no `agent-sh` dep (built in-repo; already migrated)

**Note on `@guanyilun/ashi`:** this only changes the declared dependency. ashi still ships on `agent-sh@0.14.11` until it's re-released (an `ashi-v*` tag); this just makes the next ashi release build against `0.15.0`.