### PR TITLE
fix: refresh settingsProviders on every providers:changed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- The settings provider overlay is now rebuilt on every `agent:providers:changed`
+  event, so a host `reloadSettings()` picks up `apiKey` / `baseURL` edits (and
+  added or removed providers) without a process restart. Previously it was read
+  once at load and went stale, so a changed key took effect only after a restart.
+
 ## [0.15.2] - 2026-06-02
 
 ### Added

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -116,10 +116,14 @@ export default function agentBackend(ctx: ExtensionContext): void {
 
   // Settings overlay — fields here win over contributing extensions' payloads.
   const settingsProviders = new Map<string, ResolvedProvider>();
-  for (const name of getProviderNames()) {
-    const p = resolveProvider(name);
-    if (p) settingsProviders.set(name, p);
-  }
+  const refreshSettingsProviders = () => {
+    settingsProviders.clear();
+    for (const name of getProviderNames()) {
+      const p = resolveProvider(name);
+      if (p) settingsProviders.set(name, p);
+    }
+  };
+  refreshSettingsProviders();
 
   const providerHooks = new Map<string, {
     reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
@@ -368,6 +372,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
   let loadedExtensionNames: string[] = [];
 
   bus.on("agent:providers:changed", () => {
+    refreshSettingsProviders();
     resolvedProviders = computeResolvedProviders();
     if (!resolved) return;
     bus.emit("agent:models-changed", {});

--- a/tests/agent/provider-refresh.test.ts
+++ b/tests/agent/provider-refresh.test.ts
@@ -1,0 +1,64 @@
+/** Settings provider overlay refresh on agent:providers:changed. */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DRIVER = fileURLToPath(new URL("../fixtures/provider-refresh-driver.ts", import.meta.url));
+
+interface DriverResult {
+  before?: string;
+  afterEdit?: string;
+  afterRemove?: string;
+}
+
+async function run(settings: Record<string, unknown>): Promise<DriverResult> {
+  const home = mkdtempSync(join(tmpdir(), "agent-sh-prf-"));
+  writeFileSync(join(home, "settings.json"), JSON.stringify(settings));
+  try {
+    return await new Promise<DriverResult>((resolve, reject) => {
+      const child = spawn("node", ["--import", "tsx", DRIVER], {
+        env: {
+          PATH: process.env.PATH,
+          HOME: home,
+          AGENT_SH_HOME: home,
+          AGENT_SH_SKIP_SHELL_ENV: "1",
+          OPENROUTER_API_KEY: "",
+          OPENAI_API_KEY: "",
+          DEEPSEEK_API_KEY: "",
+          OPENAI_BASE_URL: "",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout!.on("data", (c) => { stdout += c.toString(); });
+      child.stderr!.on("data", (c) => { stderr += c.toString(); });
+      const timer = setTimeout(() => child.kill("SIGKILL"), 15000);
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        try {
+          const line = stdout.trim().split(/\r?\n/).pop() ?? "";
+          resolve(JSON.parse(line) as DriverResult);
+        } catch (err) {
+          reject(new Error(`driver output not JSON. exit=${code} stdout=${stdout} stderr=${stderr} err=${(err as Error).message}`));
+        }
+      });
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test("settings provider overlay refreshes on agent:providers:changed", async () => {
+  const result = await run({
+    defaultProvider: "myproxy",
+    providers: { myproxy: { apiKey: "sk-old", baseURL: "https://proxy.local/v1", defaultModel: "m1" } },
+  });
+  assert.equal(result.before, "sk-old", "initial key should resolve");
+  assert.equal(result.afterEdit, "sk-new", "edited key should take effect after reload + providers:changed");
+  assert.equal(result.afterRemove, undefined, "removed provider should drop out of the overlay");
+});

--- a/tests/fixtures/provider-refresh-driver.ts
+++ b/tests/fixtures/provider-refresh-driver.ts
@@ -1,0 +1,49 @@
+/** Subprocess driver for tests/agent/provider-refresh.test.ts. Reports the
+ *  apiKey agent:resolve-endpoint returns before a settings edit, after the edit
+ *  (with reloadSettings + agent:providers:changed), and after the provider is
+ *  removed from settings. */
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createCore } from "../../src/core/index.js";
+import { activateAgent } from "../../src/agent/index.js";
+import { reloadSettings } from "../../src/core/settings.js";
+import type { AppConfig } from "../../src/shell/host-types.js";
+
+function settings(providers: Record<string, unknown>) {
+  return JSON.stringify({ defaultProvider: "myproxy", providers });
+}
+
+async function main() {
+  const settingsPath = join(process.env.AGENT_SH_HOME!, "settings.json");
+
+  const core = createCore({} as AppConfig);
+  const ctx = core.extensionContext({ quit: () => {} });
+  activateAgent(ctx);
+  core.bus.emit("core:extensions-loaded", { names: [] });
+  await new Promise((r) => setImmediate(r));
+
+  const key = () =>
+    (ctx.call("agent:resolve-endpoint", { provider: "myproxy", id: "m1" }) as { apiKey?: string } | undefined)?.apiKey;
+
+  const reload = (providers: Record<string, unknown>) => {
+    writeFileSync(settingsPath, settings(providers));
+    reloadSettings();
+    core.bus.emit("agent:providers:changed", {});
+  };
+
+  const before = key();
+  reload({ myproxy: { apiKey: "sk-new", baseURL: "https://proxy.local/v1", defaultModel: "m1" } });
+  const afterEdit = key();
+  reload({});
+  const afterRemove = key();
+
+  process.stdout.write(JSON.stringify({ before, afterEdit, afterRemove }) + "\n");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("driver error:", err);
+  process.exit(1);
+});
+
+process.on("unhandledRejection", () => {});


### PR DESCRIPTION
## Problem

`settingsProviders` Map (populated from `settings.json` at module load) was never refreshed after `reloadSettings()`. This means:

- `computeResolvedProviders()` → `resolveWithSettings()` reads stale `apiKey`/`baseURL` from `settingsProviders`
- Changing the API key in settings and reloading has no effect on existing sessions
- Only a full process restart picks up the new key

## Fix

On every `agent:providers:changed` event (fired when providers are registered/unregistered, or when host calls `reloadProviders`), refresh the `settingsProviders` map by re-reading from `settings.json` via `resolveProvider()`.

This ensures `computeResolvedProviders()` → `resolveWithSettings(p?.apiKey ?? s?.apiKey)` picks up the fresh key.

## Related

Downstream issue in asHub: firslov/asHub#64