### PR TITLE
Wrap long diff lines and keep their inline emphasis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- Diff rendering (edit/write previews) now wraps long lines across rows instead
+  of truncating them with an ellipsis, so the full changed line is always
+  visible. `wrapLine` also hard-breaks an over-long token (long identifier, URL)
+  that first appears mid-line, which previously overflowed the wrap width.
+
 ## [0.15.5] - 2026-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Releases before this file are recorded in the git tags and GitHub releases.
   of truncating them with an ellipsis, so the full changed line is always
   visible. `wrapLine` also hard-breaks an over-long token (long identifier, URL)
   that first appears mid-line, which previously overflowed the wrap width.
+- Inline word-level emphasis in diffs now applies to long (paragraph-length)
+  lines too. The token-LCS that highlights changed words was skipped past a
+  ~220-token-per-side cost guard, leaving the whole line a flat tint; it now
+  anchors the shared prefix/suffix and diffs only the changed middle, so long
+  edits still show what actually changed.
 
 ## [0.15.5] - 2026-06-04
 

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -141,6 +141,39 @@ function tokenLcs(
 }
 
 /**
+ * Anchors the shared prefix/suffix as unchanged and runs the O(m·n) LCS only on
+ * the differing middle. Null when that middle exceeds maxProduct.
+ */
+function inlineMatches(
+  a: Token[],
+  b: Token[],
+  maxProduct: number,
+): { oldMatch: boolean[]; newMatch: boolean[] } | null {
+  const m = a.length;
+  const n = b.length;
+  let pre = 0;
+  while (pre < m && pre < n && a[pre].text === b[pre].text) pre++;
+  let suf = 0;
+  while (suf < m - pre && suf < n - pre && a[m - 1 - suf].text === b[n - 1 - suf].text) suf++;
+
+  const midM = m - pre - suf;
+  const midN = n - pre - suf;
+  if (midM * midN > maxProduct) return null;
+
+  const oldMatch = new Array<boolean>(m).fill(false);
+  const newMatch = new Array<boolean>(n).fill(false);
+  for (let i = 0; i < pre; i++) { oldMatch[i] = true; newMatch[i] = true; }
+  for (let i = 0; i < suf; i++) { oldMatch[m - 1 - i] = true; newMatch[n - 1 - i] = true; }
+
+  if (midM > 0 && midN > 0) {
+    const mid = tokenLcs(a.slice(pre, m - suf), b.slice(pre, n - suf));
+    for (let i = 0; i < midM; i++) oldMatch[pre + i] = mid.oldMatch[i];
+    for (let j = 0; j < midN; j++) newMatch[pre + j] = mid.newMatch[j];
+  }
+  return { oldMatch, newMatch };
+}
+
+/**
  * Rewrite full ANSI resets (\x1b[0m) to foreground-only resets,
  * preserving the given background color across the line.
  */
@@ -193,15 +226,14 @@ function highlightInlineChanges(
     };
   }
 
-  // Safety guard: skip if LCS matrix would be too large
-  if (oldTokens.length * newTokens.length > 50000) {
+  const matches = inlineMatches(oldTokens, newTokens, 1_000_000);
+  if (!matches) {
     return {
       old: language ? highlightLine(oldLine, language) : oldLine,
       new: language ? highlightLine(newLine, language) : newLine,
     };
   }
-
-  const { oldMatch, newMatch } = tokenLcs(oldTokens, newTokens);
+  const { oldMatch, newMatch } = matches;
 
   const buildHighlighted = (
     tokens: Token[],
@@ -342,9 +374,7 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
 
   const continuationNo = " ".repeat(noW);
 
-  // Long lines wrap across rows rather than truncating: the first row carries
-  // the line number and sigil; continuation rows blank both but keep the
-  // gutter, row background, and alignment.
+  // Wrapped rows after the first blank the line number and sigil.
   const change = (no: string, sigil: string, bg: string, fg: string, text: string): string[] => {
     return wrapLine(text, lineTextW).map((seg, r) => {
       const n = r === 0 ? no : continuationNo;

--- a/src/utils/diff-renderer.ts
+++ b/src/utils/diff-renderer.ts
@@ -340,12 +340,21 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
   const bgWidth = Math.max(1, textWidth - noW - 3);
   const gutter = (n: string): string => `${p.dim}${n} │${p.reset} `;
 
-  const change = (no: string, sigil: string, bg: string, fg: string, text: string): string => {
-    if (!gutterLine) {
-      return `${bg}${padToWidth(`${fg}${no} ${sigil}${p.diffText} ${preserveBg(text, bg)}`, textWidth)}${p.reset}`;
-    }
-    if (useTrueColor) return gutter(no) + padToWidth(`${bg}${fg}${sigil}${p.diffText} ${preserveBg(text, bg)}`, bgWidth) + p.reset;
-    return `${gutter(no)}${fg}${sigil} ${text}${p.reset}`;
+  const continuationNo = " ".repeat(noW);
+
+  // Long lines wrap across rows rather than truncating: the first row carries
+  // the line number and sigil; continuation rows blank both but keep the
+  // gutter, row background, and alignment.
+  const change = (no: string, sigil: string, bg: string, fg: string, text: string): string[] => {
+    return wrapLine(text, lineTextW).map((seg, r) => {
+      const n = r === 0 ? no : continuationNo;
+      const sg = r === 0 ? sigil : " ";
+      if (!gutterLine) {
+        return `${bg}${padToWidth(`${fg}${n} ${sg}${p.diffText} ${preserveBg(seg, bg)}`, textWidth)}${p.reset}`;
+      }
+      if (useTrueColor) return gutter(n) + padToWidth(`${bg}${fg}${sg}${p.diffText} ${preserveBg(seg, bg)}`, bgWidth) + p.reset;
+      return `${gutter(n)}${fg}${sg} ${seg}${p.reset}`;
+    });
   };
 
   const hlCache = new Map<ChangePair, { old: string; new: string }>();
@@ -367,31 +376,25 @@ function renderUnifiedHunk(hunk: DiffHunk, layout: UnifiedLayout): string[] {
     ).padStart(noW);
 
     if (line.type === "context") {
-      const raw = truncateText(line.text, lineTextW);
-      const text = lang ? highlightLine(raw, lang) : raw;
-      out.push(!gutterLine ? `${p.dim}${no}${p.reset}   ${text}` : `${gutter(no)}  ${p.dim}${text}${p.reset}`);
+      const text = lang ? highlightLine(line.text, lang) : line.text;
+      wrapLine(text, lineTextW).forEach((seg, r) => {
+        const n = r === 0 ? no : continuationNo;
+        out.push(!gutterLine ? `${p.dim}${n}${p.reset}   ${seg}` : `${gutter(n)}  ${p.dim}${seg}${p.reset}`);
+      });
       continue;
     }
 
     const pair = pairs.get(i);
     if (line.type === "removed") {
-      let removedText: string;
-      if (pair) {
-        removedText = truncateText(highlightedPair(pair).old, lineTextW);
-      } else {
-        const raw = truncateText(line.text, lineTextW);
-        removedText = lang ? highlightLine(raw, lang) : raw;
-      }
-      out.push(change(no, "-", p.errorBg, p.error, removedText));
+      const removedText = pair
+        ? highlightedPair(pair).old
+        : (lang ? highlightLine(line.text, lang) : line.text);
+      out.push(...change(no, "-", p.errorBg, p.error, removedText));
     } else {
-      let addedText: string;
-      if (pair) {
-        addedText = truncateText(highlightedPair(pair).new, lineTextW);
-      } else {
-        const raw = truncateText(line.text, lineTextW);
-        addedText = lang ? highlightLine(raw, lang) : raw;
-      }
-      out.push(change(no, "+", p.successBg, p.success, addedText));
+      const addedText = pair
+        ? highlightedPair(pair).new
+        : (lang ? highlightLine(line.text, lang) : line.text);
+      out.push(...change(no, "+", p.successBg, p.success, addedText));
     }
   }
   return out;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -79,6 +79,34 @@ export function wrapLine(text: string, maxWidth: number): string[] {
     lastVisibleIdx = -1;
   };
 
+  // Break a token too wide for the remaining space across rows, char by char.
+  // Honors the current lineWidth so it works whether the line is empty or
+  // already holds carried tokens.
+  const hardBreak = (token: string): void => {
+    let remaining = token;
+    while (remaining.length > 0) {
+      let fitLen = 0, fitWidth = 0;
+      for (const ch of remaining) {
+        const cw = charWidth(ch.codePointAt(0) ?? 0);
+        if (fitWidth + cw > maxWidth - lineWidth) break;
+        fitWidth += cw;
+        fitLen += ch.length;
+      }
+      if (fitLen === 0) {
+        // Nothing fits in what's left of the line; flush and retry on a fresh
+        // one. On an already-empty line, force one char so we always progress.
+        if (lineWidth > 0) { commit(); continue; }
+        fitLen = remaining[0]?.length ?? 1;
+      }
+      const chunk = remaining.slice(0, fitLen);
+      remaining = remaining.slice(fitLen);
+      lineTokens.push(chunk);
+      lineWidth += visibleLen(chunk);
+      lastVisibleIdx = lineTokens.length - 1;
+      if (remaining.length > 0) commit();
+    }
+  };
+
   for (const seg of segments) {
     if (seg.startsWith("\x1b[")) {
       lineTokens.push(seg);
@@ -103,23 +131,7 @@ export function wrapLine(text: string, maxWidth: number): string[] {
 
       if (lineWidth === 0) {
         // Token longer than the entire line — hard-break by char width.
-        let remaining = token;
-        while (remaining.length > 0) {
-          let fitLen = 0, fitWidth = 0;
-          for (const ch of remaining) {
-            const cw = charWidth(ch.codePointAt(0) ?? 0);
-            if (fitWidth + cw > maxWidth) break;
-            fitWidth += cw;
-            fitLen += ch.length;
-          }
-          if (fitLen === 0) fitLen = remaining[0]?.length ?? 1;
-          const chunk = remaining.slice(0, fitLen);
-          remaining = remaining.slice(fitLen);
-          lineTokens.push(chunk);
-          lineWidth += visibleLen(chunk);
-          lastVisibleIdx = lineTokens.length - 1;
-          if (remaining.length > 0) commit();
-        }
+        hardBreak(token);
         continue;
       }
 
@@ -147,9 +159,13 @@ export function wrapLine(text: string, maxWidth: number): string[] {
         lineTokens.push(t);
         lineWidth += visibleLen(t);
       }
-      lineTokens.push(token);
-      lineWidth += tokenWidth;
-      lastVisibleIdx = lineTokens.length - 1;
+      if (lineWidth + tokenWidth <= maxWidth) {
+        lineTokens.push(token);
+        lineWidth += tokenWidth;
+        lastVisibleIdx = lineTokens.length - 1;
+      } else {
+        hardBreak(token);
+      }
     }
   }
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -79,9 +79,6 @@ export function wrapLine(text: string, maxWidth: number): string[] {
     lastVisibleIdx = -1;
   };
 
-  // Break a token too wide for the remaining space across rows, char by char.
-  // Honors the current lineWidth so it works whether the line is empty or
-  // already holds carried tokens.
   const hardBreak = (token: string): void => {
     let remaining = token;
     while (remaining.length > 0) {
@@ -93,8 +90,7 @@ export function wrapLine(text: string, maxWidth: number): string[] {
         fitLen += ch.length;
       }
       if (fitLen === 0) {
-        // Nothing fits in what's left of the line; flush and retry on a fresh
-        // one. On an already-empty line, force one char so we always progress.
+        // Force one char on an empty line so an over-wide char can't loop forever.
         if (lineWidth > 0) { commit(); continue; }
         fitLen = remaining[0]?.length ?? 1;
       }

--- a/tests/core/diff-renderer.test.ts
+++ b/tests/core/diff-renderer.test.ts
@@ -24,3 +24,29 @@ test("gutterLine defaults true: keeps the │ rule (pi-tui look unchanged)", () 
   }).map(strip);
   assert.ok(lines.some((l) => l.includes("│")), "default keeps the pipe rule");
 });
+
+test("unified wraps long lines instead of truncating, staying within width", () => {
+  const longA = "x = " + "a".repeat(200);
+  const longB = "x = " + "b".repeat(200);
+  const width = 60;
+  const lines = renderDiff(computeDiff(`p\n${longA}\nq\n`, `p\n${longB}\nq\n`), {
+    width, filePath: "x.txt", mode: "unified", gutterLine: false, maxLines: Number.MAX_SAFE_INTEGER,
+  }).map(strip);
+  assert.ok(!lines.some((l) => l.includes("…")), "no truncation ellipsis");
+  assert.ok(lines.filter((l) => /aa/.test(l)).length >= 2, "removed line wrapped across ≥2 rows");
+  assert.ok(lines.filter((l) => /bb/.test(l)).length >= 2, "added line wrapped across ≥2 rows");
+  for (const l of lines) assert.ok(l.length <= width, `row exceeds width ${width}: "${l}"`);
+});
+
+test("wrapped continuation rows omit the line number and sigil", () => {
+  const longA = "y = " + "a".repeat(120);
+  const lines = renderDiff(computeDiff("p\nkeep\nq\n", `p\n${longA}\nq\n`), {
+    width: 40, filePath: "x.txt", mode: "unified", gutterLine: false, maxLines: Number.MAX_SAFE_INTEGER,
+  }).map(strip);
+  assert.ok(lines.some((l) => /^\s*\d+ \+ y =/.test(l)), "added line's first row keeps `<n> +`");
+  const contRows = lines.filter((l) => /aa/.test(l));
+  assert.ok(contRows.length >= 2, "long line wrapped across continuation rows");
+  for (const cont of contRows) {
+    assert.doesNotMatch(cont, /^\s*\d+ [-+]/, "continuation row has no line number/sigil");
+  }
+});

--- a/tests/core/diff-renderer.test.ts
+++ b/tests/core/diff-renderer.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 const { computeDiff } = await import("../../src/utils/diff.js");
 const { renderDiff } = await import("../../src/utils/diff-renderer.js");
+const { palette } = await import("../../src/utils/palette.js");
 
 const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
 const old = "def add(a, b):\n    return a + b\n\nprint(add(1, 2))\n";
@@ -49,4 +50,15 @@ test("wrapped continuation rows omit the line number and sigil", () => {
   for (const cont of contRows) {
     assert.doesNotMatch(cont, /^\s*\d+ [-+]/, "continuation row has no line number/sigil");
   }
+});
+
+test("inline emphasis still applies on long lines (prefix/suffix-anchored)", () => {
+  // ~400 tokens/side: well past the old 50000 token-product guard that used to
+  // drop inline emphasis on long paragraphs.
+  const shared = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(20);
+  const lines = renderDiff(computeDiff(`${shared}value was ten\n`, `${shared}value was twelve\n`), {
+    width: 80, filePath: "x.txt", mode: "unified", gutterLine: false, trueColor: true, maxLines: Number.MAX_SAFE_INTEGER,
+  });
+  assert.ok(lines.some((l) => l.includes(palette.errorBgEmph)), "removed line keeps inline emphasis");
+  assert.ok(lines.some((l) => l.includes(palette.successBgEmph)), "added line keeps inline emphasis");
 });


### PR DESCRIPTION
## Summary

Two fixes to unified diff rendering (edit/write previews) for long lines.

### Wrap instead of truncate

Unified diffs truncated every line to a single terminal row with an ellipsis, so long lines (e.g. prose in LaTeX/Markdown edits) were unreadable — defeating the point of showing the diff. They now wrap: the first row keeps the line number and sigil; continuation rows blank both but keep the gutter, row background, and alignment. Context and changed lines wrap in unified mode; split (side-by-side) mode still truncates.

Wiring in the previously-imported-but-unused `wrapLine` surfaced a latent bug: a token wider than the wrap width that first appears mid-line was committed to the next row without breaking, overflowing the width. Hard-break is now factored into a helper and applied in that case too, so no rendered row exceeds the target width (also improves markdown/TUI wrapping).

### Keep inline emphasis on long lines

`highlightInlineChanges` skipped the token-LCS word-level emphasis once a changed line exceeded a 50000 token-product guard (~220 tokens/side), so paragraph-length edits rendered as a flat add/remove tint with no indication of what changed. It now anchors the shared leading/trailing token runs as unchanged and runs the O(m·n) LCS only on the differing middle, with the guard applied to that middle and a higher ceiling. This keeps realistic long lines cheap to diff and tightens emphasis to the changed region instead of speckling shared words across the line. Genuinely unrelated long lines (no shared prefix/suffix) still fall back to the solid tint.

## Testing

- New diff-renderer tests: long lines wrap with no ellipsis and stay within width; continuation rows omit the line number/sigil; inline emphasis still applies on long lines.
- Full test suite: 261/261.

CHANGELOG entries added under `[Unreleased]`.
