### PR TITLE
feat: export skills discovery API as agent-sh/skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
       "types": "./dist/agent/types.d.ts",
       "default": "./dist/agent/types.js"
     },
+    "./skills": {
+      "types": "./dist/agent/skills.d.ts",
+      "default": "./dist/agent/skills.js"
+    },
     "./store": {
       "types": "./dist/agent/store.d.ts",
       "default": "./dist/agent/store.js"


### PR DESCRIPTION
Expose `discoverGlobalSkills()` and `invalidateGlobalSkillsCache()` as a public module entry point.

**Motivation**: Downstream tools (e.g. asHub) need to discover installed skills and invalidate the discovery cache after install/uninstall. Currently these functions are internal-only, forcing downstream to duplicate the filesystem scan logic.

**Changes**: Add `"./skills"` to `package.json` exports map pointing to `dist/agent/skills`.