### PR TITLE
Scroll the overlay transcript with arrows, move history to Ctrl+P/N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ## [Unreleased]
 
+### Changed
+
+- Floating panel (overlay extensions): Up/Down arrows and the scroll wheel now
+  scroll the transcript in the input/idle phase, matching their behavior while
+  the agent is working. Previously they navigated input history, so after a
+  reply there was no way to scroll back through it (the panel owns its alt
+  screen, where terminals route the wheel through arrow keys). Input history
+  moved to Ctrl+P / Ctrl+N; PageUp/PageDown still page-scroll.
+
 ## [0.15.6] - 2026-06-04
 
 ### Added

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -823,6 +823,13 @@ export class FloatingPanel {
     this.autocompleteIndex = 0;
   }
 
+  private moveAutocomplete(delta: number): void {
+    const n = this.autocompleteItems.length;
+    if (n === 0) return;
+    this.autocompleteIndex = (this.autocompleteIndex + delta + n) % n;
+    this.render();
+  }
+
   // ── Input handling ──────────────────────────────────────────
 
   private handleIntercept(payload: { data: string; consumed: boolean }): { data: string; consumed: boolean } {
@@ -913,6 +920,16 @@ export class FloatingPanel {
 
     if (this.handleScroll(data, false)) return;
 
+    if (data === "\x10" || data === "\x0e") {
+      const forward = data === "\x0e";
+      if (this.autocompleteActive) {
+        this.moveAutocomplete(forward ? 1 : -1);
+      } else if (forward ? this.editor.historyForward() : this.editor.historyBack()) {
+        this.render();
+      }
+      return;
+    }
+
     const actions = this.editor.feed(data);
     for (const action of actions) {
       switch (action.action) {
@@ -924,6 +941,7 @@ export class FloatingPanel {
           this.editor.pushHistory(query);
           this.editor.clear();
           this.clearAutocomplete();
+          this.userScrolled = false;
           // Phase change is the submit handler's call — sync slash commands
           // (e.g. /model, /help) keep the user in input mode.
           this.handlers.call(`${this.prefix}:submit`, query);
@@ -945,30 +963,14 @@ export class FloatingPanel {
         case "shift+tab":
           this.render();
           break;
-        case "arrow-up": {
-          if (this.autocompleteActive) {
-            this.autocompleteIndex = this.autocompleteIndex === 0
-              ? this.autocompleteItems.length - 1
-              : this.autocompleteIndex - 1;
-            this.render();
-          } else {
-            const hist = this.editor.historyBack();
-            if (hist) this.render();
-          }
+        case "arrow-up":
+          if (this.autocompleteActive) this.moveAutocomplete(-1);
+          else this.scrollUp(1);
           break;
-        }
-        case "arrow-down": {
-          if (this.autocompleteActive) {
-            this.autocompleteIndex = this.autocompleteIndex === this.autocompleteItems.length - 1
-              ? 0
-              : this.autocompleteIndex + 1;
-            this.render();
-          } else {
-            const hist = this.editor.historyForward();
-            if (hist) this.render();
-          }
+        case "arrow-down":
+          if (this.autocompleteActive) this.moveAutocomplete(1);
+          else this.scrollDown(1);
           break;
-        }
         case "changed":
         case "delete-empty":
           this.updateAutocomplete();


### PR DESCRIPTION
## Problem

In the [`overlay-agent`](examples/extensions/overlay-agent.ts) floating panel, Up/Down arrows and the scroll wheel couldn't scroll the transcript in the input/idle phase — they rotated input history instead, showing previous inputs in the editor.

The panel runs in its own alt screen (`\x1b[?1049h`) but never enables mouse reporting, so terminals degrade the scroll wheel into Up/Down arrow keys. In the input phase those arrows were fed to the line editor's history navigation rather than scroll. Since the input phase is also where you land *after* a reply finishes (`setDone()` flips the phase back to `input`), there was no way to scroll back through a long response. During the `active` phase arrows already scrolled, so the gap was only visible while reading a finished reply.

## Change

- **Up/Down + scroll wheel** now scroll the transcript in the input/idle phase, consistent with the active phase.
- **Input history** moves to **Ctrl+P** (previous) / **Ctrl+N** (next).
- **PageUp/PageDown** still page-scroll in every phase (unchanged).
- The **autocomplete dropdown** still navigates with Up/Down (and Ctrl+P/N) while it's open.
- Submitting a query clears the scroll lock so the new turn snaps into view even if you'd scrolled up while composing.

All changes are contained in the shared `src/utils/floating-panel.ts`, so any overlay extension built on `FloatingPanel` gets the new behavior.

## Test plan

Interactive (needs a real terminal): load the extension with `agent-sh -e examples/extensions/overlay-agent.ts`, press Ctrl+\, ask something with a long answer, then:
- scroll back with ↑/↓ and the wheel after the reply finishes
- recall previous inputs with Ctrl+P / Ctrl+N
- confirm PageUp/PageDown still page-scroll and `/`-command completion still navigates with the arrows

`tsc --noEmit` passes.