### PR TITLE
Match shell-mode markdown theme to the ashi frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Releases before this file are recorded in the git tags and GitHub releases.
   `ui:error` channel (and to stderr under `DEBUG`) instead of throwing or
   silently swallowing.
 
+- Shell-mode markdown now uses a truecolor theme matching the ashi frontend
+  (gold headings, teal inline code and list bullets, blue underlined links, gray
+  blockquote bars and horizontal rules) instead of the terminal's 16-color
+  palette, so it reads consistently across terminal profiles. Adds dedicated
+  `md*` slots to the color palette.
 - Floating panel (overlay extensions): Up/Down arrows and the scroll wheel now
   scroll the transcript in the input/idle phase, matching their behavior while
   the agent is working. Previously they navigated input history, so after a

--- a/examples/extensions/solarized-theme.ts
+++ b/examples/extensions/solarized-theme.ts
@@ -23,5 +23,16 @@ export default function activate(ctx: ShellContext) {
     errorBg:       "\x1b[48;2;42;30;30m",   // base03 with red tint
     successBgEmph: "\x1b[48;2;20;70;50m",   // stronger green tint
     errorBgEmph:   "\x1b[48;2;70;30;30m",   // stronger red tint
+
+    mdHeading:         "\x1b[38;2;181;137;0m",  // yellow (#b58900)
+    mdLink:            "\x1b[38;2;38;139;210m", // blue (#268bd2)
+    mdLinkUrl:         "\x1b[38;2;88;110;117m", // base01 (#586e75)
+    mdCode:            "\x1b[38;2;42;161;152m", // cyan (#2aa198)
+    mdCodeBlock:       "\x1b[38;2;133;153;0m",  // green (#859900)
+    mdCodeBlockBorder: "\x1b[38;2;88;110;117m", // base01 (#586e75)
+    mdQuote:           "\x1b[38;2;88;110;117m", // base01 (#586e75)
+    mdQuoteBorder:     "\x1b[38;2;88;110;117m", // base01 (#586e75)
+    mdHr:              "\x1b[38;2;88;110;117m", // base01 (#586e75)
+    mdListBullet:      "\x1b[38;2;38;139;210m", // blue (#268bd2)
   });
 }

--- a/src/shell/tui-renderer.ts
+++ b/src/shell/tui-renderer.ts
@@ -613,7 +613,7 @@ export default function activate(ctx: ExtensionContext): void {
     flushForRaw();
     contentGap("code");
     if (language) {
-      s.renderer!.writeLine(`${p.dim}${language}${p.reset}`);
+      s.renderer!.writeLine(`${p.mdCodeBlockBorder}${language}${p.reset}`);
     }
     let highlighted: string;
     try {
@@ -633,7 +633,10 @@ export default function activate(ctx: ExtensionContext): void {
         console.error = origError;
       }
     } catch {
-      highlighted = code;
+      highlighted = code
+        .split("\n")
+        .map((l) => `${p.mdCodeBlock}${l}${p.reset}`)
+        .join("\n");
     }
     const contentWidth = Math.min(90, width - 2);
     for (const line of highlighted.split("\n")) {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -352,27 +352,24 @@ export class MarkdownRenderer {
   private renderLine(line: string): string {
     if (line.trim() === "") return "";
 
-    // Headings
-    const h1 = line.match(/^# (.+)/);
-    if (h1) return `${p.bold}${p.warning}${h1[1]}${p.reset}`;
+    // Headings — H3+ keep the `###` marker; H1/H2 don't
+    const heading = line.match(/^(#{1,6}) (.+)/);
+    if (heading) {
+      const level = heading[1]!.length;
+      const text = heading[2]!;
+      if (level === 1) return `${p.bold}${p.underline}${p.mdHeading}${text}${p.reset}`;
+      if (level === 2) return `${p.bold}${p.mdHeading}${text}${p.reset}`;
+      return `${p.bold}${p.mdHeading}${"#".repeat(level)} ${text}${p.reset}`;
+    }
 
-    const h2 = line.match(/^## (.+)/);
-    if (h2) return `${p.bold}${p.accent}${h2[1]}${p.reset}`;
-
-    const h3 = line.match(/^### (.+)/);
-    if (h3) return `${p.bold}${h3[1]}${p.reset}`;
-
-    const h4 = line.match(/^#{4,} (.+)/);
-    if (h4) return `${p.bold}${h4[1]}${p.reset}`;
-
-    // Horizontal rule — subtle short separator, not full-width
+    // Horizontal rule
     if (/^(-{3,}|_{3,}|\*{3,})\s*$/.test(line)) {
-      return "";
+      return `${p.mdHr}${"─".repeat(Math.min(this.contentWidth, 80))}${p.reset}`;
     }
 
     // Blockquote
     const bq = line.match(/^>\s?(.*)/);
-    if (bq) return `${p.muted}│${p.reset} ${p.dim}${p.italic}${this.renderInline(bq[1] || "")}${p.reset}`;
+    if (bq) return `${p.mdQuoteBorder}│${p.reset} ${p.mdQuote}${p.italic}${this.renderInline(bq[1] || "")}${p.reset}`;
 
     // Task list (checkbox items) — must come before generic unordered list
     const task = line.match(/^(\s*)[*\-+]\s+\[([ xX])\]\s+(.*)/);
@@ -389,14 +386,14 @@ export class MarkdownRenderer {
     const ul = line.match(/^(\s*)[*\-+]\s+(.*)/);
     if (ul) {
       const indent = ul[1] || "";
-      return `${indent}  ${p.accent}*${p.reset} ${this.renderInline(ul[2] || "")}`;
+      return `${indent}  ${p.mdListBullet}-${p.reset} ${this.renderInline(ul[2] || "")}`;
     }
 
     // Ordered list
     const ol = line.match(/^(\s*)(\d+)[.)]\s+(.*)/);
     if (ol) {
       const indent = ol[1] || "";
-      return `${indent}  ${p.accent}${ol[2]}.${p.reset} ${this.renderInline(ol[3] || "")}`;
+      return `${indent}  ${p.mdListBullet}${ol[2]}.${p.reset} ${this.renderInline(ol[3] || "")}`;
     }
 
     return this.renderInline(line);
@@ -406,10 +403,10 @@ export class MarkdownRenderer {
     // Links first — later subs inject `\x1b[…m` whose `[` would be eaten here.
     text = text.replace(
       /\[([^\]]+)\]\(([^)]+)\)/g,
-      `$1 ${p.muted}${p.underline}($2)${p.reset}`
+      `${p.mdLink}${p.underline}$1${p.reset} ${p.mdLinkUrl}($2)${p.reset}`
     );
     // Inline code
-    text = text.replace(/`([^`]+)`/g, `${p.accent}$1${p.reset}`);
+    text = text.replace(/`([^`]+)`/g, `${p.mdCode}$1${p.reset}`);
     // Bold + italic
     text = text.replace(/\*\*\*(.+?)\*\*\*/g, `${p.bold}${p.italic}$1${p.reset}`);
     // Bold
@@ -419,7 +416,7 @@ export class MarkdownRenderer {
     text = text.replace(/\*(.+?)\*/g, `${p.italic}$1${p.reset}`);
     text = text.replace(/(?<!\w)_(.+?)_(?!\w)/g, `${p.italic}$1${p.reset}`);
     // Strikethrough
-    text = text.replace(/~~(.+?)~~/g, `${p.dim}$1${p.reset}`);
+    text = text.replace(/~~(.+?)~~/g, `${p.strikethrough}$1${p.reset}`);
     return text;
   }
 

--- a/src/utils/palette.ts
+++ b/src/utils/palette.ts
@@ -29,7 +29,20 @@ export interface ColorPalette {
   dim: string;
   italic: string;
   underline: string;
+  strikethrough: string;
   reset: string;
+
+  // ── Markdown element colors ───────────────────────────────
+  mdHeading: string;       // headings (all levels)
+  mdLink: string;          // link text
+  mdLinkUrl: string;       // link URL
+  mdCode: string;          // inline code span
+  mdCodeBlock: string;     // fenced code fallback (no highlight)
+  mdCodeBlockBorder: string; // code fence / language label
+  mdQuote: string;         // blockquote text
+  mdQuoteBorder: string;   // blockquote left bar
+  mdHr: string;            // horizontal rule
+  mdListBullet: string;    // list bullet / ordinal
 }
 
 const defaultPalette: ColorPalette = {
@@ -45,11 +58,23 @@ const defaultPalette: ColorPalette = {
   errorBgEmph:   "\x1b[48;2;124;50;64m",
   diffText:      "\x1b[97m",   // bright white — readable on the red/green tints
 
-  bold:      "\x1b[1m",
-  dim:       "\x1b[2m",
-  italic:    "\x1b[3m",
-  underline: "\x1b[4m",
-  reset:     "\x1b[0m",
+  bold:          "\x1b[1m",
+  dim:           "\x1b[2m",
+  italic:        "\x1b[3m",
+  underline:     "\x1b[4m",
+  strikethrough: "\x1b[9m",
+  reset:         "\x1b[0m",
+
+  mdHeading:         "\x1b[38;2;240;198;116m", // #f0c674 gold
+  mdLink:            "\x1b[38;2;129;162;190m", // #81a2be blue
+  mdLinkUrl:         "\x1b[38;2;102;102;102m", // #666666 dim gray
+  mdCode:            "\x1b[38;2;138;190;183m", // #8abeb7 teal
+  mdCodeBlock:       "\x1b[38;2;181;189;104m", // #b5bd68 green
+  mdCodeBlockBorder: "\x1b[38;2;128;128;128m", // #808080 gray
+  mdQuote:           "\x1b[38;2;128;128;128m", // #808080 gray
+  mdQuoteBorder:     "\x1b[38;2;128;128;128m", // #808080 gray
+  mdHr:              "\x1b[38;2;128;128;128m", // #808080 gray
+  mdListBullet:      "\x1b[38;2;138;190;183m", // #8abeb7 teal
 };
 
 /** Active palette — import and use directly in components. */


### PR DESCRIPTION
## What

Shell-mode markdown rendering used the 16-color ANSI semantic roles (`accent`/`warning`/`muted`), so its colors changed with each terminal profile and looked different from the ashi frontend, which pins a truecolor palette. This aligns the two.

## Changes

- **`src/utils/palette.ts`** — add a `strikethrough` modifier and ten `md*` slots with truecolor defaults mirroring ashi's bundled `dark.json`.
- **`src/utils/markdown.ts`** — point each markdown element at the new slots and match ashi's behavior:
  - headings are one gold color (H1 underlined, H2 plain, H3+ keep the `###` marker)
  - inline code and list bullets in teal; bullets render `-`
  - links: blue underlined text + dim-gray URL
  - blockquote bar / horizontal rule in gray; HRs now **draw** a line instead of collapsing to blank
  - strikethrough uses a real SGR code instead of dim
- **`src/shell/tui-renderer.ts`** — code-fence language label and the highlight fallback use the `md*` slots.
- **`examples/extensions/solarized-theme.ts`** — set the `md*` slots so the bundled theme keeps coloring markdown.

## Compatibility note

Markdown now reads its own `md*` slots instead of the shared semantic roles. A theme that overrides only the 5 semantic roles will no longer affect markdown — it must set the `md*` slots too (as the updated Solarized example demonstrates). This mirrors the two-tier structure the ashi theme already uses.

## Testing

- `npm test` — 261 pass
- `tsc --noEmit` clean
- Rendered sample markdown through `MarkdownRenderer` with both the default and Solarized palettes to confirm each element picks up the expected color.