### PR TITLE
Isolate event-bus listener faults and surface them on ui:error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ### Changed
 
+- Event bus now isolates listener faults. A throwing subscriber or transform no
+  longer propagates out of `emit` (which could abort an in-flight turn) or stop
+  sibling listeners — each callback site (fire-and-forget listeners, the `onAny`
+  tap, and the sync/async transform pipes) is wrapped individually. Faults route
+  through a host-installable reporter; the kernel surfaces them on the universal
+  `ui:error` channel (and to stderr under `DEBUG`) instead of throwing or
+  silently swallowing.
+
 - Floating panel (overlay extensions): Up/Down arrows and the scroll wheel now
   scroll the transcript in the input/idle phase, matching their behavior while
   the agent is working. Previously they navigated input history, so after a

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from "node:events";
-
 export interface BackendRegistration {
   name: string;
   kill: () => void;
@@ -49,6 +47,15 @@ export interface BusMeta {
 
 export type AnyListener = (name: string, payload: unknown, meta: BusMeta) => void;
 
+/** A listener fault routed to the error reporter; `phase` is the callback site. */
+export interface BusFault {
+  phase: "on" | "any" | "pipe" | "pipe-async";
+  event: string;
+  err: unknown;
+}
+
+export type ErrorReporter = (fault: BusFault) => void;
+
 /**
  * Typed event bus with two modes:
  * - emit/on/off: fire-and-forget notifications
@@ -56,16 +63,52 @@ export type AnyListener = (name: string, payload: unknown, meta: BusMeta) => voi
  *   can modify the payload before passing to the next
  */
 export class EventBus {
-  private emitter = new EventEmitter().setMaxListeners(0);
+  private listeners = new Map<string, Listener<any>[]>();
   private pipeListeners = new Map<string, PipeListener<any>[]>();
   private asyncPipeListeners = new Map<string, AsyncPipeListener<any>[]>();
   private source = "0000";
   private nextSeq = 0;
   private anyListeners: AnyListener[] = [];
 
+  /** Default fault sink, overridable via setErrorReporter: silent unless DEBUG. */
+  private reportError: ErrorReporter = ({ phase, event, err }) => {
+    if (process.env.DEBUG) {
+      const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      process.stderr.write(`[event-bus] ${phase} fault on "${event}": ${msg}\n`);
+    }
+  };
+
   /** Set the source id stamped onto every emitted event. */
   setSource(src: string): void {
     this.source = src;
+  }
+
+  /** Install a fault reporter. */
+  setErrorReporter(fn: ErrorReporter): void {
+    this.reportError = fn;
+  }
+
+  /** Report a fault; guarded so a broken reporter can't break dispatch. */
+  private fault(phase: BusFault["phase"], event: string, err: unknown): void {
+    try {
+      this.reportError({ phase, event, err });
+    } catch {
+      /* swallow */
+    }
+  }
+
+  /** Fire every listener for `name`, isolating faults. */
+  private notify(name: string, payload: unknown): void {
+    const arr = this.listeners.get(name);
+    if (!arr || arr.length === 0) return;
+    // snapshot so a listener that (un)subscribes mid-dispatch can't shift iteration
+    if (arr.length === 1) {
+      try { arr[0](payload); } catch (err) { this.fault("on", name, err); }
+      return;
+    }
+    for (const fn of arr.slice()) {
+      try { fn(payload); } catch (err) { this.fault("on", name, err); }
+    }
   }
 
   /** Subscribe to every emitted event with full envelope. Returns unsubscribe. */
@@ -87,10 +130,10 @@ export class EventBus {
         name,
       };
       for (const fn of this.anyListeners) {
-        try { fn(name, payload, meta); } catch { /* swallow */ }
+        try { fn(name, payload, meta); } catch (err) { this.fault("any", name, err); }
       }
     }
-    this.emitter.emit(name, payload);
+    this.notify(name, payload);
   }
 
   /** Subscribe to a fire-and-forget event. */
@@ -98,7 +141,12 @@ export class EventBus {
     event: K,
     fn: Listener<BusEvents[K]>,
   ): void {
-    this.emitter.on(event, fn);
+    let arr = this.listeners.get(event);
+    if (!arr) {
+      arr = [];
+      this.listeners.set(event, arr);
+    }
+    arr.push(fn);
   }
 
   /** Unsubscribe from a fire-and-forget event. */
@@ -106,7 +154,10 @@ export class EventBus {
     event: K,
     fn: Listener<BusEvents[K]>,
   ): void {
-    this.emitter.off(event, fn);
+    const arr = this.listeners.get(event);
+    if (!arr) return;
+    const idx = arr.indexOf(fn);
+    if (idx !== -1) arr.splice(idx, 1);
   }
 
   /** Emit a fire-and-forget event. */
@@ -123,10 +174,10 @@ export class EventBus {
   relay(meta: BusMeta, payload: unknown): void {
     if (this.anyListeners.length > 0) {
       for (const fn of this.anyListeners) {
-        try { fn(meta.name, payload, meta); } catch { /* swallow */ }
+        try { fn(meta.name, payload, meta); } catch (err) { this.fault("any", meta.name, err); }
       }
     }
-    this.emitter.emit(meta.name, payload);
+    this.notify(meta.name, payload);
   }
 
   /**
@@ -191,12 +242,12 @@ export class EventBus {
       try {
         const out = fn(result);
         if (out && typeof (out as any).then === "function") {
-          console.error(`[event-bus] Warning: async handler in sync pipe "${String(event)}" — use onPipeAsync instead`);
+          this.fault("pipe", String(event), new Error("async handler in sync pipe — use onPipeAsync instead"));
           continue;
         }
         result = out;
       } catch (err) {
-        console.error(`[event-bus] Pipe handler error in "${String(event)}":`, err instanceof Error ? err.message : err);
+        this.fault("pipe", String(event), err);
       }
     }
     return result;
@@ -245,7 +296,11 @@ export class EventBus {
     if (!listeners) return payload;
     let result = payload;
     for (const fn of listeners) {
-      result = await fn(result);
+      try {
+        result = await fn(result);
+      } catch (err) {
+        this.fault("pipe-async", String(event), err);
+      }
     }
     return result;
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -48,6 +48,24 @@ export function createCore(config: AppConfig): AgentShellCore {
   // should accept ≥6 hex chars.
   const instanceId = crypto.randomBytes(3).toString("hex");
   bus.setSource(instanceId);
+
+  // Surface faults on ui:error; `surfacing` stops a faulting renderer from looping.
+  let surfacing = false;
+  bus.setErrorReporter(({ phase, event, err }) => {
+    const detail = err instanceof Error ? err.message : String(err);
+    if (process.env.DEBUG) {
+      const full = err instanceof Error ? (err.stack ?? err.message) : detail;
+      process.stderr.write(`[event-bus] ${phase} fault on "${event}": ${full}\n`);
+    }
+    if (surfacing) return;
+    surfacing = true;
+    try {
+      bus.emit("ui:error", { message: `Handler error on "${event}": ${detail}` });
+    } finally {
+      surfacing = false;
+    }
+  });
+
   handlers.define("config:get-app-config", () => config);
   handlers.define("cwd", () => process.cwd());
 

--- a/tests/core/error-surfacing.test.ts
+++ b/tests/core/error-surfacing.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AppConfig } from "../../src/shell/host-types.js";
+
+process.env.AGENT_SH_HOME = mkdtempSync(join(tmpdir(), "agent-sh-core-test-"));
+
+const { createCore } = await import("../../src/core/index.js");
+
+test("a faulting listener is surfaced on ui:error", () => {
+  const core = createCore({} as AppConfig);
+  const errors: string[] = [];
+  core.bus.on("ui:error", (e) => errors.push(e.message));
+
+  core.bus.on("ui:info", () => { throw new Error("kaboom"); });
+  core.bus.emit("ui:info", { message: "x" });
+
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /ui:info/);
+  assert.match(errors[0], /kaboom/);
+});
+
+test("a faulting ui:error renderer does not loop back through the reporter", () => {
+  const core = createCore({} as AppConfig);
+  let renders = 0;
+  core.bus.on("ui:error", () => { renders++; throw new Error("renderer down"); });
+
+  core.bus.on("ui:info", () => { throw new Error("kaboom"); });
+  assert.doesNotThrow(() => core.bus.emit("ui:info", { message: "x" }));
+  assert.equal(renders, 1);
+});

--- a/tests/core/event-bus.test.ts
+++ b/tests/core/event-bus.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EventBus, type BusFault } from "../../src/core/event-bus.js";
+
+test("a throwing on-listener does not stop a sibling or throw out of emit", () => {
+  const bus = new EventBus();
+  const seen: string[] = [];
+
+  bus.on("ui:info", () => { throw new Error("boom"); });
+  bus.on("ui:info", (p) => { seen.push(p.message); });
+
+  assert.doesNotThrow(() => bus.emit("ui:info", { message: "hello" }));
+  assert.deepEqual(seen, ["hello"]);
+});
+
+test("listener faults are surfaced to the installed reporter with phase/event", () => {
+  const bus = new EventBus();
+  const faults: BusFault[] = [];
+  bus.setErrorReporter((f) => faults.push(f));
+
+  const boom = new Error("boom");
+  bus.on("ui:info", () => { throw boom; });
+  bus.emit("ui:info", { message: "x" });
+
+  assert.equal(faults.length, 1);
+  assert.equal(faults[0].phase, "on");
+  assert.equal(faults[0].event, "ui:info");
+  assert.equal(faults[0].err, boom);
+});
+
+test("a broken reporter cannot break dispatch", () => {
+  const bus = new EventBus();
+  const seen: string[] = [];
+  bus.setErrorReporter(() => { throw new Error("reporter is broken too"); });
+
+  bus.on("ui:info", () => { throw new Error("boom"); });
+  bus.on("ui:info", (p) => { seen.push(p.message); });
+
+  assert.doesNotThrow(() => bus.emit("ui:info", { message: "hi" }));
+  assert.deepEqual(seen, ["hi"]);
+});
+
+test("a rejecting async-pipe transform is isolated and the chain continues", async () => {
+  const bus = new EventBus();
+  const faults: BusFault[] = [];
+  bus.setErrorReporter((f) => faults.push(f));
+
+  bus.onPipeAsync("config:switch-backend", () => { throw new Error("nope"); });
+  bus.onPipeAsync("config:switch-backend", async (p) => ({ name: p.name + "!" }));
+
+  const out = await bus.emitPipeAsync("config:switch-backend", { name: "ash" });
+
+  assert.equal(out.name, "ash!");
+  assert.equal(faults.length, 1);
+  assert.equal(faults[0].phase, "pipe-async");
+});
+
+test("a throwing sync-pipe transform is a no-op, keeping the last good payload", () => {
+  const bus = new EventBus();
+  const faults: BusFault[] = [];
+  bus.setErrorReporter((f) => faults.push(f));
+
+  bus.onPipe("config:switch-backend", (p) => ({ name: p.name + "-a" }));
+  bus.onPipe("config:switch-backend", () => { throw new Error("nope"); });
+  bus.onPipe("config:switch-backend", (p) => ({ name: p.name + "-c" }));
+
+  const out = bus.emitPipe("config:switch-backend", { name: "x" });
+
+  assert.equal(out.name, "x-a-c");
+  assert.equal(faults.length, 1);
+  assert.equal(faults[0].phase, "pipe");
+});
+
+test("on/off/emit deliver in subscription order and off unsubscribes", () => {
+  const bus = new EventBus();
+  const order: number[] = [];
+  const second = () => order.push(2);
+
+  bus.on("ui:info", () => order.push(1));
+  bus.on("ui:info", second);
+  bus.on("ui:info", () => order.push(3));
+
+  bus.emit("ui:info", { message: "" });
+  assert.deepEqual(order, [1, 2, 3]);
+
+  bus.off("ui:info", second);
+  order.length = 0;
+  bus.emit("ui:info", { message: "" });
+  assert.deepEqual(order, [1, 3]);
+});
+
+test("a listener that subscribes mid-dispatch does not receive the in-flight event", () => {
+  const bus = new EventBus();
+  let lateCalls = 0;
+
+  bus.on("ui:info", () => {
+    bus.on("ui:info", () => { lateCalls++; });
+  });
+
+  bus.emit("ui:info", { message: "" });
+  assert.equal(lateCalls, 0);
+
+  bus.emit("ui:info", { message: "" });
+  assert.equal(lateCalls, 1);
+});


### PR DESCRIPTION
## Why

The event bus is the substrate every backend and extension wires into, so its robustness sets a floor for the whole system. Two callback sites weren't isolated:

- **`on`-listeners** went through Node's `EventEmitter`, whose `emit` throws synchronously if any listener throws — so a single buggy subscriber could throw out of `emit` mid-stream and abort an in-flight turn, and stop sibling listeners from running.
- **`emitPipeAsync`** awaited each transform unguarded, so one rejecting async transform rejected the whole emit.

(`emitPipe` and `onAny` already isolated per-call, but reported inconsistently — `console.error` vs. silent swallow.)

## What

- Replace the bus's internal `EventEmitter` with an explicit `Map<string, Listener[]>`. Every callback site now wraps each call individually. Listener order is preserved; a listener that (un)subscribes mid-dispatch can't shift iteration or receive the in-flight event (single-listener fast path is allocation-free).
- A throwing subscriber can no longer throw out of `emit` or starve siblings; a rejecting async transform becomes a no-op that keeps the last good payload and lets the chain continue (matching the existing sync-pipe semantics).
- All four sites route through one seam: `setErrorReporter(fn)`. The host decides how faults surface. Default is silent except under `DEBUG` (full stack to stderr).
- `createCore` installs a reporter that surfaces faults on the universal `ui:error` channel — the same channel core already uses for backend errors — with a reentrancy guard so a `ui:error` renderer that itself faults can't loop.

## Behavior change

`emitPipe` faults previously `console.error`'d unconditionally; they now route through the reporter (DEBUG-only by default, plus `ui:error` under the host). This is the consistency win — the host opts into surfacing — but anything relying on those always printing to stderr will see them move.

A transform that faults on a hot path (e.g. a broken per-chunk `agent:response-chunk` pipe) will surface `ui:error` per chunk. Surfacing is faithful rather than throttled; if that proves noisy, a dedup/rate-limit in the host reporter is the follow-up.

## Tests

- `tests/core/event-bus.test.ts` — fault isolation across `on`/sync-pipe/async-pipe, the reporter contract (phase/event/err), a broken reporter can't break dispatch, plus regressions for the `EventEmitter` → map swap (subscription-order delivery, `off`, no in-flight delivery to a mid-dispatch subscriber).
- `tests/core/error-surfacing.test.ts` — faults reach `ui:error`; a faulting `ui:error` renderer doesn't loop.

Full suite: 270/270.