### PR TITLE
Add startup update notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ### Added
 
+- Startup update notice. agent-sh checks npm once a day in the background and,
+  on the next launch, prints a notice to stderr when a newer release is
+  available. Disable with `"updateCheck": false` in settings.
 - `LICENSE` file (MIT) — matches the license declared in `package.json` and the
   README badge, which previously linked to a missing file.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { anyProviderConfigured } from "./auth/keys.js";
 import { clearOpost } from "../utils/tty.js";
 import { parseArgs } from "./args.js";
 import { captureShellEnvAsync, mergeShellEnv } from "./shell-env.js";
+import { getPendingUpdate, checkForUpdate } from "../utils/update-check.js";
 
 declare module "../core/event-bus.js" {
   interface BusEvents {
@@ -160,6 +161,16 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // ── Update notification (cache-driven; result from a prior run) ─
+  const pending = settings.updateCheck !== false ? getPendingUpdate() : null;
+  if (pending) {
+    process.stderr.write(
+      `\n${p.warning}⚠${p.reset}  ${p.bold}agent-sh ${pending.latest}${p.reset} is available ` +
+      `${p.muted}(you have ${pending.current})${p.reset}\n` +
+      `   ${p.muted}Run: ${p.reset}npm update -g agent-sh\n`,
+    );
+  }
+
   if (settings.startupBanner !== false) {
     const termW = process.stdout.columns || 80;
     const bannerW = Math.min(termW, 60);
@@ -213,6 +224,9 @@ async function main(): Promise<void> {
     },
   });
   bus.off("ui:error", bootUiError);
+
+  // Fire async update check — result is cached for next startup.
+  if (settings.updateCheck !== false) void checkForUpdate();
 
   bus.emit("input-mode:register", {
     id: "agent",

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -132,6 +132,8 @@ export interface Settings {
   startupBanner?: boolean;
   /** Show a subtle agent-sh indicator in the shell prompt. */
   promptIndicator?: boolean;
+  /** Check npm for a newer release and notify at startup. */
+  updateCheck?: boolean;
 
   // ── Built-in extensions ──────────────────────────────────
   /** Names of built-in extensions to disable (e.g. ["command-suggest"]). */
@@ -172,6 +174,7 @@ const DEFAULTS: Required<Settings> = {
   diagnose: false,
   startupBanner: true,
   promptIndicator: true,
+  updateCheck: true,
   disabledBuiltins: [],
   disabledExtensions: [],
 };

--- a/src/utils/update-check.ts
+++ b/src/utils/update-check.ts
@@ -1,0 +1,90 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CONFIG_DIR } from "../core/settings.js";
+import { PACKAGE_VERSION } from "./package-version.js";
+
+const CACHE_PATH = path.join(CONFIG_DIR, "update-check.json");
+
+interface UpdateCache {
+  latest: string;
+  checkedAt: number;
+}
+
+/**
+ * Read cached update info. Returns { latest, current } if a newer version
+ * was found within the last 7 days. Returns null otherwise.
+ *
+ * Designed for synchronous startup display — no network I/O.
+ */
+export function getPendingUpdate(): { latest: string; current: string } | null {
+  try {
+    const raw = fs.readFileSync(CACHE_PATH, "utf-8");
+    const cache = JSON.parse(raw) as UpdateCache;
+    if (!cache.latest || !cache.checkedAt) return null;
+
+    // Stale cache — don't nag about old news.
+    if (Date.now() - cache.checkedAt > 7 * 24 * 60 * 60 * 1000) return null;
+
+    if (compareVersions(cache.latest, PACKAGE_VERSION) > 0) {
+      return { latest: cache.latest, current: PACKAGE_VERSION };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Async check of the npm registry for the latest published version.
+ * Writes result to cache file for next startup. Rate-limited to one
+ * check per 24 hours. Network failures are silent no-ops.
+ *
+ * Call this after the shell is up — never await it at startup.
+ */
+export async function checkForUpdate(): Promise<void> {
+  // Don't re-check if we already checked within 24 hours.
+  try {
+    const raw = fs.readFileSync(CACHE_PATH, "utf-8");
+    const cache = JSON.parse(raw) as UpdateCache;
+    if (Date.now() - cache.checkedAt < 24 * 60 * 60 * 1000) return;
+  } catch {
+    // No cache — proceed.
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch("https://registry.npmjs.org/agent-sh/latest", {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+
+    if (!res.ok) return;
+    const data = (await res.json()) as { version?: string };
+    if (!data.version) return;
+
+    const cache: UpdateCache = {
+      latest: data.version,
+      checkedAt: Date.now(),
+    };
+
+    fs.mkdirSync(path.dirname(CACHE_PATH), { recursive: true });
+    fs.writeFileSync(CACHE_PATH, JSON.stringify(cache, null, 2) + "\n");
+  } catch {
+    // Network error, DNS failure, timeout — all silent.
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** Compare semver strings. Positive if a > b, negative if a < b, 0 if equal. */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va !== vb) return va - vb;
+  }
+  return 0;
+}


### PR DESCRIPTION
## What

Adds a startup notice when a newer `agent-sh` release is available on npm.

- **Cache-driven, no network on the hot path.** `getPendingUpdate()` reads a cached result synchronously at startup; `checkForUpdate()` refreshes the cache in the background after the shell is up, throttled to one registry hit per 24h with a 5s timeout. Network/parse failures are silent no-ops, and a cached result older than 7 days isn't shown.
- **Prints to stderr** so it can't corrupt redirected stdout.
- **Gated behind a new `updateCheck` setting** (default `true`) — set `"updateCheck": false` to disable the notice and the background check entirely (CI/offline/scripted use).

## Scope

The notice runs only in the `agent-sh` shell frontend (`cli/index.ts`). It's hardcoded to the `agent-sh` package (registry URL, version compare, `npm update -g agent-sh`). ashi (`@guanyilun/ashi`) and other `createCore` frontends ship as separate packages with their own entry points and do not run this path — by design, since the package name and update command differ.

## Files

- `src/utils/update-check.ts` — cache read + async registry check
- `src/cli/index.ts` — wire notice (stderr) and background check, both gated
- `src/core/settings.ts` — add `updateCheck?: boolean` (default `true`)
- `CHANGELOG.md` — `[Unreleased] / Added`

## Notes / follow-ups

- Version compare is numeric-segment based; it silently no-ops on prerelease tags (`x.y.z-rc.1`). Fine for the stable `latest` dist-tag today; a guard could be added if prereleases ever ship on `latest`.
- The cache file (`update-check.json`) has no package key. If ashi ever wants its own check, `update-check.ts` should be parameterized (registry name + cache key + update command) so the two don't clobber each other's cache.