### PR TITLE
Send OpenRouter x-session-id for sticky cache routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ## [Unreleased]
 
+### Added
+
+- OpenRouter requests now send an `x-session-id` header keyed on the frontend's
+  resume-stable session id, pinning sticky provider routing so prompt caches stay
+  warm across turns — including after compaction rewrites the opening messages,
+  the case OpenRouter's default message-hash routing misses. Wired through a new
+  per-provider `requestHeaders` endpoint hook (scoped to OpenRouter only) and a
+  `session:current-id` handler the frontend supplies; absent that handler no
+  header is sent.
+
 ### Fixed
 
 - ashi user shell: the command label shown above each `!` command's output could

--- a/examples/extensions/ashi/src/cli.ts
+++ b/examples/extensions/ashi/src/cli.ts
@@ -177,6 +177,8 @@ async function main(): Promise<void> {
 
   const ctx = core.extensionContext({ quit: cleanup });
 
+  ctx.define("session:current-id", () => store.current().id);
+
   activateAgent(ctx);
   activateShellContext(ctx);
   await loadBuiltinExtensions(ctx);

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -462,6 +462,17 @@ export class AgentLoop implements AgentBackend {
   }
 
 
+  /** Resume-stable conversation id from the frontend (e.g. ashi); undefined
+   *  when the frontend tracks no session. */
+  private currentSessionId(): string | undefined {
+    try {
+      const id = this.handlers.call("session:current-id");
+      return typeof id === "string" && id ? id : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private resolveEndpoint(m: Model): ModelEndpoint | undefined {
     try {
       return this.handlers.call("agent:resolve-endpoint", { provider: m.provider, id: m.id }) as ModelEndpoint | undefined;
@@ -1439,7 +1450,12 @@ export class AgentLoop implements AgentBackend {
     };
     this.bus.emit("llm:request", requestParams);
 
-    const stream = await this.llmClient.stream({ ...requestParams, signal });
+    const headers = this.activeEndpoint?.buildRequestHeaders?.({ sessionId: this.currentSessionId() });
+    const stream = await this.llmClient.stream({
+      ...requestParams,
+      signal,
+      ...(headers && Object.keys(headers).length ? { headers } : {}),
+    });
 
     try {
     for await (const chunk of stream) {

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -22,6 +22,7 @@ declare module "../core/event-bus.js" {
       id: string;
       reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
       cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
+      requestHeaders?: (info: { sessionId?: string }) => Record<string, string>;
     };
 
     "agent:models-changed": Record<string, never>;

--- a/src/agent/host-types.ts
+++ b/src/agent/host-types.ts
@@ -93,6 +93,7 @@ export interface ModelEndpoint {
   baseURL?: string;
   buildReasoningParams?: (level: string) => Record<string, unknown>;
   extractCachedTokens?: (usage: Record<string, unknown>) => number | undefined;
+  buildRequestHeaders?: (info: { sessionId?: string }) => Record<string, string>;
 }
 
 // ── Agent-host extension surface ─────────────────────────────────
@@ -111,6 +112,7 @@ export interface AgentSurface {
     configure: (id: string, opts: {
       reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
       cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
+      requestHeaders?: (info: { sessionId?: string }) => Record<string, string>;
     }) => void;
   };
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -128,6 +128,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
   const providerHooks = new Map<string, {
     reasoningParams?: (level: string, model?: string) => Record<string, unknown>;
     cacheTokens?: (usage: Record<string, unknown>) => number | undefined;
+    requestHeaders?: (info: { sessionId?: string }) => Record<string, string>;
   }>();
 
   // Bakes model id so ModelEndpoint.buildReasoningParams keeps its (level) signature.
@@ -138,6 +139,9 @@ export default function agentBackend(ctx: ExtensionContext): void {
 
   const bindCacheTokens = (shapeId: string) =>
     providerHooks.get(shapeId)?.cacheTokens ?? defaultCacheTokens;
+
+  const bindRequestHeaders = (shapeId: string) =>
+    providerHooks.get(shapeId)?.requestHeaders;
 
   const agentSurface: AgentSurface = {
     llm: createLlmFacade({ list: ctx.list, call: ctx.call }),
@@ -345,6 +349,7 @@ export default function agentBackend(ctx: ExtensionContext): void {
       baseURL: p.baseURL,
       buildReasoningParams: bindReasoning(shapeId, modelId),
       extractCachedTokens: bindCacheTokens(shapeId),
+      buildRequestHeaders: bindRequestHeaders(shapeId),
     };
   };
 
@@ -388,10 +393,11 @@ export default function agentBackend(ctx: ExtensionContext): void {
     }
   });
 
-  bus.on("provider:configure", ({ id, reasoningParams, cacheTokens }) => {
+  bus.on("provider:configure", ({ id, reasoningParams, cacheTokens, requestHeaders }) => {
     const prev = providerHooks.get(id) ?? {};
     if (reasoningParams !== undefined) prev.reasoningParams = reasoningParams;
     if (cacheTokens !== undefined) prev.cacheTokens = cacheTokens;
+    if (requestHeaders !== undefined) prev.requestHeaders = requestHeaders;
     providerHooks.set(id, prev);
   });
 

--- a/src/agent/llm-client.ts
+++ b/src/agent/llm-client.ts
@@ -68,7 +68,7 @@ export class LlmClient {
   }
 
   stream(opts: StreamOpts) {
-    const { signal, messages, tools, model, max_tokens, ...rest } = opts;
+    const { signal, headers, messages, tools, model, max_tokens, ...rest } = opts;
     const body = {
       ...rest,
       model: model ?? this.model,
@@ -78,7 +78,7 @@ export class LlmClient {
       stream: true as const,
       stream_options: { include_usage: true },
     };
-    return this.client.chat.completions.create(body as ChatCompletionCreateParamsStreaming, { signal });
+    return this.client.chat.completions.create(body as ChatCompletionCreateParamsStreaming, { signal, headers });
   }
 
   async complete(opts: CompleteOpts): Promise<string> {
@@ -102,6 +102,8 @@ export type StreamOpts = {
   model?: string;
   max_tokens?: number;
   signal?: AbortSignal;
+  /** Per-request transport headers, forwarded to the SDK (not request body). */
+  headers?: Record<string, string>;
 } & Record<string, unknown>;
 
 export type CompleteOpts = {

--- a/src/agent/providers/openrouter.ts
+++ b/src/agent/providers/openrouter.ts
@@ -42,7 +42,16 @@ function toModalities(input?: string[]): ("text" | "image")[] | undefined {
 
 export default function activate(ctx: AgentContext): void {
   const apiKey = resolveApiKey("openrouter").key;
-  ctx.agent.providers.configure("openrouter", { reasoningParams: buildReasoningParams });
+  ctx.agent.providers.configure("openrouter", {
+    reasoningParams: buildReasoningParams,
+    // x-session-id pins sticky provider routing across turns so prompt caches
+    // stay warm even when compaction rewrites the opening messages.
+    requestHeaders: ({ sessionId }) => {
+      const headers: Record<string, string> = {};
+      if (sessionId) headers["x-session-id"] = sessionId;
+      return headers;
+    },
+  });
   ctx.agent.providers.register({
     id: "openrouter",
     apiKey: apiKey ?? undefined,

--- a/tests/agent/llm-client-headers.test.ts
+++ b/tests/agent/llm-client-headers.test.ts
@@ -1,0 +1,38 @@
+/** LlmClient forwards per-request headers (e.g. OpenRouter x-session-id) to the
+ *  SDK request options, not into the request body. */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LlmClient } from "../../src/agent/llm-client.js";
+
+/** Replace the SDK call with a spy and return what stream() passed it. */
+function captureStream(client: LlmClient, opts: Record<string, unknown>): { body: any; reqOpts: any } {
+  let captured: { body: any; reqOpts: any } | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (client as any).client.chat.completions = {
+    create: (body: any, reqOpts: any) => {
+      captured = { body, reqOpts };
+      return (async function* () { /* empty stream */ })();
+    },
+  };
+  client.stream(opts as never);
+  return captured!;
+}
+
+test("stream() forwards headers to the SDK request options, not the body", () => {
+  const client = new LlmClient({ apiKey: "x", model: "m" });
+  const { body, reqOpts } = captureStream(client, {
+    messages: [],
+    headers: { "x-session-id": "sess-abc" },
+  });
+
+  assert.equal(reqOpts.headers["x-session-id"], "sess-abc", "header reaches the transport layer");
+  assert.ok(!("headers" in body), "headers must not leak into the request body");
+});
+
+test("stream() omits the headers option when none are supplied", () => {
+  const client = new LlmClient({ apiKey: "x", model: "m" });
+  const { body, reqOpts } = captureStream(client, { messages: [] });
+
+  assert.equal(reqOpts.headers, undefined, "no headers passed → undefined, SDK uses defaults only");
+  assert.ok(!("headers" in body));
+});

--- a/tests/agent/provider-modes.test.ts
+++ b/tests/agent/provider-modes.test.ts
@@ -21,10 +21,17 @@ interface CacheProbe {
   found: boolean;
 }
 
+interface HeaderProbe {
+  model: string;
+  found: boolean;
+  headers: Record<string, string> | undefined;
+}
+
 interface DriverResult {
   events: CapturedEvent[];
   models?: any[];
   cacheProbes?: CacheProbe[];
+  headerProbes?: HeaderProbe[];
   stderr: string;
   stdout: string;
   exitCode: number | null;
@@ -32,7 +39,7 @@ interface DriverResult {
 
 async function runDriver(
   settings: Record<string, unknown>,
-  scenario: { config?: Record<string, unknown>; capture: string[]; dumpModels?: boolean; probeCacheTokens?: unknown[]; steps: unknown[] },
+  scenario: { config?: Record<string, unknown>; capture: string[]; dumpModels?: boolean; probeCacheTokens?: unknown[]; probeRequestHeaders?: unknown[]; steps: unknown[] },
   envOverride: Record<string, string> = {},
 ): Promise<DriverResult> {
   const home = mkdtempSync(join(tmpdir(), "agent-sh-pmodes-"));
@@ -66,8 +73,8 @@ async function runDriver(
         clearTimeout(timer);
         try {
           const line = stdout.trim().split(/\r?\n/).pop() ?? "";
-          const parsed = JSON.parse(line) as { events: CapturedEvent[]; models?: any[]; cacheProbes?: CacheProbe[] };
-          resolve({ events: parsed.events, models: parsed.models, cacheProbes: parsed.cacheProbes, stderr, stdout, exitCode: code });
+          const parsed = JSON.parse(line) as { events: CapturedEvent[]; models?: any[]; cacheProbes?: CacheProbe[]; headerProbes?: HeaderProbe[] };
+          resolve({ events: parsed.events, models: parsed.models, cacheProbes: parsed.cacheProbes, headerProbes: parsed.headerProbes, stderr, stdout, exitCode: code });
         } catch (err) {
           reject(new Error(`driver output not JSON.\nexit=${code}\nstdout:\n${stdout}\nstderr:\n${stderr}\nparse error: ${(err as Error).message}`));
         }
@@ -261,4 +268,42 @@ test("native DeepSeek's flat hit count overrides the default cache extractor", a
   assert.ok(probes[0].found, "deepseek mode should be built when DEEPSEEK_API_KEY is set");
   assert.equal(probes[0].result, 80, "flat prompt_cache_hit_tokens used as the cached count");
   assert.equal(probes[1].result, undefined, "deepseek hook ignores the OpenAI-standard shape");
+});
+
+test("openrouter attaches x-session-id only when a session id is present", async () => {
+  // activate-provider installs the requestHeaders configure hook (keyed on the
+  // "openrouter" provider id, independent of catalog registration); the explicit
+  // register gives the model an apiKey so it surfaces in agent:get-models.
+  const result = await runDriver({}, {
+    capture: [],
+    probeRequestHeaders: [
+      { model: "or/m", sessionId: "sess-abc" },
+      { model: "or/m" },
+    ],
+    steps: [
+      { kind: "activate-provider", name: "openrouter" },
+      { kind: "providers.register", payload: { id: "openrouter", apiKey: "x", baseURL: "https://openrouter.ai/api/v1", defaultModel: "or/m", models: ["or/m"] } },
+    ],
+  });
+
+  const probes = result.headerProbes!;
+  assert.ok(probes[0].found, "registered openrouter model should exist");
+  assert.deepEqual(probes[0].headers, { "x-session-id": "sess-abc" }, "session id flows into the sticky-routing header");
+  assert.deepEqual(probes[1].headers, {}, "no session id → no header attached");
+});
+
+test("non-openrouter providers register no request-headers hook", async () => {
+  const result = await runDriver(
+    {},
+    {
+      capture: [],
+      probeRequestHeaders: [{ model: "deepseek-v4-flash", sessionId: "sess-abc" }],
+      steps: [{ kind: "activate-provider", name: "deepseek" }],
+    },
+    { DEEPSEEK_API_KEY: "sk-test" },
+  );
+
+  const probes = result.headerProbes!;
+  assert.ok(probes[0].found, "deepseek model should exist");
+  assert.equal(probes[0].headers, undefined, "deepseek configures no requestHeaders hook, so no header is built");
 });

--- a/tests/fixtures/provider-mode-driver.ts
+++ b/tests/fixtures/provider-mode-driver.ts
@@ -10,6 +10,7 @@ interface Scenario {
   capture: string[];
   dumpModels?: boolean;
   probeCacheTokens?: Array<{ model: string; usage: Record<string, unknown> }>;
+  probeRequestHeaders?: Array<{ model: string; sessionId?: string }>;
   steps: Array<
     | { kind: "providers.register"; payload: ProviderRegistration }
     | { kind: "providers.unregister"; id: string }
@@ -74,7 +75,7 @@ async function main() {
   };
 
   let models: Model[] | undefined;
-  if (scenario.dumpModels || scenario.probeCacheTokens) {
+  if (scenario.dumpModels || scenario.probeCacheTokens || scenario.probeRequestHeaders) {
     try {
       models = ctx.call("agent:get-models") as Model[];
     } catch {
@@ -91,12 +92,22 @@ async function main() {
     });
   }
 
+  let headerProbes: Array<{ model: string; found: boolean; headers: Record<string, string> | undefined }> | undefined;
+  if (scenario.probeRequestHeaders) {
+    headerProbes = scenario.probeRequestHeaders.map(({ model, sessionId }) => {
+      const m = models?.find((x) => x.id === model);
+      const ep = m ? endpointFor(m) : undefined;
+      return { model, found: !!m, headers: ep?.buildRequestHeaders?.({ sessionId }) };
+    });
+  }
+
   const dumped = models?.map((m) => ({ ...m, endpoint: endpointFor(m) }));
 
   process.stdout.write(JSON.stringify({
     events: captured,
     models: scenario.dumpModels ? stripFns(dumped) : undefined,
     cacheProbes,
+    headerProbes,
   }) + "\n");
   process.exit(0);
 }


### PR DESCRIPTION
## Problem

OpenRouter keeps prompt caches warm by routing a conversation back to the provider that served it. We were sending **no** session identifier, so OpenRouter fell back to hashing the opening messages to recognize a conversation. That hash changes the moment compaction rewrites the early messages — re-routing to a cold provider exactly when a warm cache matters most. (DeepSeek and the other OpenRouter models we use cache automatically, so this is purely about *routing stickiness*, not `cache_control` breakpoints.)

## Change

Send an `x-session-id` header keyed on the frontend's **resume-stable** session id, pinning sticky routing across turns and across compaction. Three seams:

- **Value** — the resume-stable id lives in the frontend's session store (not core; core's `instanceId` is minted fresh per process). ashi exposes it via a new `session:current-id` handler. Absent that handler (non-ashi frontend), no header is sent.
- **Scope** — a new per-provider `requestHeaders` endpoint hook, threaded through `provider:configure` → `agent:resolve-endpoint`, mirroring `buildReasoningParams` / `extractCachedTokens`. Only `openrouter.ts` registers it; every other provider's `buildRequestHeaders` is `undefined`, so nothing is attached. No `baseURL` sniffing.
- **Transport** — `AgentLoop.stream()` reads the id best-effort and passes the resulting headers to `LlmClient.stream()`, which forwards them to the SDK request options (a header, not a body field, so a stricter backend can't 400 on it).

## Scope / follow-up

Main agent loop only. Subagent streams (`subagent.ts`) still use default routing — a follow-up if we want them pinned to the parent's provider.

## Testing

- `tsc --noEmit` clean
- `tests/agent` suite passes (111/111), including new coverage:
  - `provider-modes`: the OpenRouter endpoint attaches `x-session-id` only when a session id is present, and non-OpenRouter providers register no request-headers hook — exercised through the real `provider:configure` → `agent:resolve-endpoint` chain (new `probeRequestHeaders` driver probe).
  - `llm-client-headers`: `LlmClient.stream` forwards per-request headers to the SDK request options, not into the request body.
