### PR TITLE
Decode stdin statefully to fix UTF-8 tearing in pastes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases before this file are recorded in the git tags and GitHub releases.
 
+## [Unreleased]
+
+### Fixed
+
+- Shell frontend: pasting multibyte text (e.g. Chinese) no longer corrupts
+  characters into `�` when the paste spans multiple stdin chunks. The stdin
+  reader decoded each chunk independently, tearing UTF-8 sequences at chunk
+  boundaries; it now decodes statefully across chunks.
+
 ## [0.15.8] - 2026-06-10
 
 ### Added

--- a/src/shell/terminal.ts
+++ b/src/shell/terminal.ts
@@ -7,6 +7,7 @@
  * factory wires it to process.stdin/stdout for the CLI; headless hosts
  * (multi-session web hubs, tests) supply their own.
  */
+import { StringDecoder } from "node:string_decoder";
 import type { RenderSurface } from "../utils/compositor.js";
 
 export interface Terminal {
@@ -23,40 +24,50 @@ export interface Terminal {
   suspendInput?(): { resume(): void };
 }
 
-/** Default Terminal: wraps process.stdin/stdout. */
-export function processTerminal(): Terminal {
+/** Default Terminal: wraps process.stdin/stdout (injectable for tests). */
+export function processTerminal(
+  stdin: NodeJS.ReadStream = process.stdin,
+  stdout: NodeJS.WriteStream = process.stdout,
+): Terminal {
   return {
     write(data) {
-      if (process.stdout.writable) {
-        try { process.stdout.write(data); } catch { /* ignore */ }
+      if (stdout.writable) {
+        try { stdout.write(data); } catch { /* ignore */ }
       }
     },
     onInput(cb) {
-      const handler = (b: Buffer) => cb(b.toString("utf-8"));
-      process.stdin.on("data", handler);
-      return () => { process.stdin.off("data", handler); };
+      // Stateful decode: tty chunk boundaries can land mid-way through a
+      // multibyte UTF-8 sequence (large pastes), so per-chunk toString()
+      // would emit U+FFFD for the torn halves.
+      const decoder = new StringDecoder("utf-8");
+      const handler = (b: Buffer) => {
+        const text = decoder.write(b);
+        if (text) cb(text);
+      };
+      stdin.on("data", handler);
+      return () => { stdin.off("data", handler); };
     },
     onResize(cb) {
-      const handler = () => cb(process.stdout.columns || 80, process.stdout.rows || 24);
-      process.stdout.on("resize", handler);
-      return () => { process.stdout.off("resize", handler); };
+      const handler = () => cb(stdout.columns || 80, stdout.rows || 24);
+      stdout.on("resize", handler);
+      return () => { stdout.off("resize", handler); };
     },
-    cols() { return process.stdout.columns || 80; },
-    rows() { return process.stdout.rows || 24; },
+    cols() { return stdout.columns || 80; },
+    rows() { return stdout.rows || 24; },
     suspendInput() {
-      const wasRaw = process.stdin.isTTY && (process.stdin as { isRaw?: boolean }).isRaw;
-      if (process.stdin.isTTY) {
+      const wasRaw = stdin.isTTY && (stdin as { isRaw?: boolean }).isRaw;
+      if (stdin.isTTY) {
         try {
-          process.stdin.setRawMode(false);
-          process.stdin.pause();
+          stdin.setRawMode(false);
+          stdin.pause();
         } catch { /* ignore */ }
       }
       return {
         resume() {
-          if (process.stdin.isTTY) {
+          if (stdin.isTTY) {
             try {
-              process.stdin.resume();
-              if (wasRaw) process.stdin.setRawMode(true);
+              stdin.resume();
+              if (wasRaw) stdin.setRawMode(true);
             } catch { /* ignore */ }
           }
         },

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -6,7 +6,8 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { surfaceFromTerminal, type Terminal } from "../../src/shell/terminal.js";
+import { EventEmitter } from "node:events";
+import { processTerminal, surfaceFromTerminal, type Terminal } from "../../src/shell/terminal.js";
 
 interface Recording {
   writes: string[];
@@ -76,6 +77,60 @@ test("surfaceFromTerminal: columns/rows reflect terminal state at access time", 
   t._rows = 50;
   assert.equal(surface.columns, 132);
   assert.equal(surface.rows, 50);
+});
+
+// processTerminal.onInput is a plain "data" listener, so a bare
+// EventEmitter posing as stdin lets us drive byte chunks directly.
+function makeFakeStdin(): NodeJS.ReadStream {
+  return new EventEmitter() as unknown as NodeJS.ReadStream;
+}
+
+function collectInput(run: (emit: (b: Buffer) => void) => void): string[] {
+  const stdin = makeFakeStdin();
+  const seen: string[] = [];
+  processTerminal(stdin).onInput((s) => seen.push(s));
+  run((b) => stdin.emit("data", b));
+  return seen;
+}
+
+test("processTerminal: onInput decodes a whole-chunk multibyte paste", () => {
+  const seen = collectInput((emit) => emit(Buffer.from("测试显著性", "utf-8")));
+  assert.deepEqual(seen, ["测试显著性"]);
+});
+
+test("processTerminal: onInput survives a chunk boundary mid UTF-8 sequence", () => {
+  const buf = Buffer.from("测试显著性", "utf-8");
+  // Split inside the second character's 3-byte sequence — per-chunk
+  // toString() would yield U+FFFD replacement characters here.
+  const seen = collectInput((emit) => {
+    emit(buf.subarray(0, 4));
+    emit(buf.subarray(4));
+  });
+  assert.equal(seen.join(""), "测试显著性");
+  assert.ok(!seen.join("").includes("�"));
+});
+
+test("processTerminal: onInput holds back a fully-partial chunk instead of emitting garbage", () => {
+  const buf = Buffer.from("中", "utf-8"); // 3 bytes
+  const all = collectInput((emit) => {
+    emit(buf.subarray(0, 1));
+    emit(buf.subarray(1, 2));
+    emit(buf.subarray(2));
+  });
+  assert.deepEqual(all, ["中"]);
+});
+
+test("processTerminal: onInput decoder state is per-subscriber", () => {
+  const stdin = makeFakeStdin();
+  const buf = Buffer.from("好", "utf-8");
+  const a: string[] = [];
+  const b: string[] = [];
+  processTerminal(stdin).onInput((s) => a.push(s));
+  processTerminal(stdin).onInput((s) => b.push(s));
+  stdin.emit("data", buf.subarray(0, 1));
+  stdin.emit("data", buf.subarray(1));
+  assert.deepEqual(a, ["好"]);
+  assert.deepEqual(b, ["好"]);
 });
 
 test("surfaceFromTerminal: onResize wires through to the underlying terminal", () => {


### PR DESCRIPTION
## Problem

Pasting multibyte text (e.g. Chinese) into the shell frontend corrupts characters into `�` once the paste is large enough to span multiple stdin chunks.

A tty delivers paste input in fixed-size chunks (typically 1024 bytes on macOS), and `processTerminal().onInput` decoded each chunk independently with `Buffer.toString("utf-8")`. Chinese characters are 3 bytes each, so a chunk boundary tears a character roughly 2 out of 3 times; each torn half decodes to U+FFFD. Everything downstream — PTY forwarding to the child shell and the agent-input LineEditor — consumes the already-decoded string, so the corruption shows up in both contexts.

```
per-chunk toString : 测���显著性
StringDecoder      : 测试显著性
```

The ashi frontend is unaffected: pi-tui calls `process.stdin.setEncoding("utf8")`, which decodes statefully across chunks.

## Fix

Decode with a per-subscriber `StringDecoder` (same approach `src/utils/executor.ts` already uses for child stdout/stderr): it holds back a trailing partial sequence and completes it with the next chunk. Empty decodes (a chunk that is entirely a partial sequence) are skipped rather than delivered as `""`.

Also makes `processTerminal`'s streams injectable (defaulting to `process.stdin`/`process.stdout`) so the tests can drive chunked input through a fake `EventEmitter` — attaching a `data` listener to the real stdin puts it into flowing mode and keeps the test process alive after the run.

## Tests

- whole-chunk multibyte paste decodes intact
- chunk boundary mid UTF-8 sequence produces no replacement characters
- a fully-partial chunk is held back, not emitted as garbage
- decoder state is per-subscriber

Full suite: 299/299 pass.