### PR TITLE
Fix multi-line query submit: slash-command misparse and history corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Releases before this file are recorded in the git tags and GitHub releases.
 - Shell frontend: multi-line queries no longer corrupt the input history
   file. Entries are stored with newlines escaped, so a multi-line paste
   recalls as one history entry instead of splitting into several bogus ones.
+- Shell frontend: multi-line bracketed pastes keep their line breaks on
+  terminals that send pasted newlines as `\r` (xterm convention — iTerm2,
+  Terminal.app). The paste accumulator deleted `\r` instead of normalizing
+  it to `\n`, silently joining the paste into one line. Ghostty/kitty
+  (verbatim `\n`) were unaffected.
 
 ## [0.15.8] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Releases before this file are recorded in the git tags and GitHub releases.
   characters into `�` when the paste spans multiple stdin chunks. The stdin
   reader decoded each chunk independently, tearing UTF-8 sequences at chunk
   boundaries; it now decodes statefully across chunks.
+- Shell frontend: a pasted multi-line query starting with `/` (e.g. a file
+  path) is now sent to the agent instead of being misparsed as a slash
+  command. Only single-line queries dispatch as commands.
+- Shell frontend: multi-line queries no longer corrupt the input history
+  file. Entries are stored with newlines escaped, so a multi-line paste
+  recalls as one history entry instead of splitting into several bogus ones.
 
 ## [0.15.8] - 2026-06-10
 

--- a/src/shell/input-handler.ts
+++ b/src/shell/input-handler.ts
@@ -88,7 +88,8 @@ export class InputHandler {
   private loadHistory(): void {
     try {
       const data = fs.readFileSync(HISTORY_FILE, "utf-8");
-      this.history = data.split("\n").filter(Boolean);
+      this.history = data.split("\n").filter(Boolean)
+        .map((l) => l.replace(/\\([\\n])/g, (_, c: string) => c === "n" ? "\n" : "\\"));
     } catch {
     }
   }
@@ -97,7 +98,8 @@ export class InputHandler {
     try {
       const { historySize } = getSettings();
       fs.mkdirSync(path.dirname(HISTORY_FILE), { recursive: true });
-      const lines = this.history.slice(-historySize);
+      const lines = this.history.slice(-historySize)
+        .map((l) => l.replace(/\\/g, "\\\\").replace(/\n/g, "\\n"));
       fs.writeFileSync(HISTORY_FILE, lines.join("\n") + "\n");
     } catch {
     }
@@ -392,7 +394,7 @@ export class InputHandler {
           this.editor.clear();
           this.view.resetCursor();
           this.dismissAutocomplete();
-          if (query && query.startsWith("/")) {
+          if (query && query.startsWith("/") && !query.includes("\n")) {
             const spaceIdx = query.indexOf(" ");
             const name = spaceIdx === -1 ? query : query.slice(0, spaceIdx);
             const args = spaceIdx === -1 ? "" : query.slice(spaceIdx + 1).trim();

--- a/src/utils/line-editor.ts
+++ b/src/utils/line-editor.ts
@@ -152,7 +152,7 @@ export class LineEditor {
     // paste, since typed input arrives one keystroke per chunk in raw mode.
     if (!this.inPaste && data.length > 1 && /[\r\n]/.test(data)
         && data.indexOf("\x1b[200~") === -1) {
-      this.pasteAccum = data.replace(/\r\n?/g, "\n");
+      this.pasteAccum = data;
       actions.push(...this.commitPaste());
       return actions;
     }
@@ -263,7 +263,7 @@ export class LineEditor {
   private consumePasteChunk(data: string): number {
     const endIdx = data.indexOf(PASTE_END);
     if (endIdx !== -1) {
-      this.pasteAccum += data.slice(0, endIdx).replace(/\r/g, "");
+      this.pasteAccum += data.slice(0, endIdx);
       return endIdx;
     }
     let suffixLen = 0;
@@ -271,14 +271,17 @@ export class LineEditor {
       if (data.endsWith(PASTE_END.slice(0, p))) { suffixLen = p; break; }
     }
     const safeEnd = data.length - suffixLen;
-    this.pasteAccum += data.slice(0, safeEnd).replace(/\r/g, "");
+    this.pasteAccum += data.slice(0, safeEnd);
     if (suffixLen > 0) this.pendingSeq = data.slice(safeEnd);
     return -1;
   }
 
   private commitPaste(): LineEditAction[] {
     this.inPaste = false;
-    const accum = this.pasteAccum;
+    // Pasted line separators arrive as \n, \r (xterm convention), or \r\n
+    // depending on terminal; normalize on the full accumulation so a \r\n
+    // pair split across chunks still collapses to one newline.
+    const accum = this.pasteAccum.replace(/\r\n?/g, "\n");
     this.pasteAccum = "";
     if (!accum) return [];
     if (accum.indexOf("\n") === -1) {

--- a/tests/shell/input-handler.test.ts
+++ b/tests/shell/input-handler.test.ts
@@ -76,6 +76,31 @@ test("multi-line bracketed paste submits resolved content", () => {
   assert.deepEqual(h.submitted, ["line one\nline two"]);
 });
 
+test("bracketed paste with \\r separators (xterm convention) keeps line breaks", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  h.handler.handleInput("\x1b[200~line one\rline two\rline three\x1b[201~");
+  h.handler.handleInput("\r");
+  assert.deepEqual(h.submitted, ["line one\nline two\nline three"]);
+});
+
+test("bracketed paste with \\r\\n separators keeps line breaks", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  h.handler.handleInput("\x1b[200~line one\r\nline two\x1b[201~");
+  h.handler.handleInput("\r");
+  assert.deepEqual(h.submitted, ["line one\nline two"]);
+});
+
+test("\\r\\n pair split across stdin chunks collapses to one newline", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  h.handler.handleInput("\x1b[200~line one\r");
+  h.handler.handleInput("\nline two\x1b[201~");
+  h.handler.handleInput("\r");
+  assert.deepEqual(h.submitted, ["line one\nline two"]);
+});
+
 test("multi-line paste starting with / goes to the agent, not command dispatch", () => {
   const h = makeHarness();
   h.handler.handleInput(">");

--- a/tests/shell/input-handler.test.ts
+++ b/tests/shell/input-handler.test.ts
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), "agent-sh-input-handler-test-"));
+process.env.AGENT_SH_HOME = TEST_HOME;
+
+const { InputHandler } = await import("../../src/shell/input-handler.js");
+const { TuiInputView } = await import("../../src/shell/tui-input-view.js");
+const { EventBus } = await import("../../src/core/event-bus.js");
+const HISTORY_FILE = join(TEST_HOME, "input-history");
+
+interface Harness {
+  handler: InstanceType<typeof InputHandler>;
+  bus: InstanceType<typeof EventBus>;
+  submitted: string[];
+  commands: { name: string; args: string }[];
+}
+
+function makeHarness(): Harness {
+  const bus = new EventBus();
+  const handlerMap = new Map<string, (...a: unknown[]) => unknown>();
+  const surface = {
+    write: () => {},
+    writeLine: () => {},
+    columns: 80,
+    rows: 24,
+    onResize: () => () => {},
+  };
+  const handler = new InputHandler({
+    ctx: {
+      isForegroundBusy: () => false,
+      getCwd: () => "/tmp",
+      isAgentActive: () => false,
+      writeToPty: () => {},
+      onCommandEntered: () => {},
+      redrawPrompt: () => {},
+      freshPrompt: () => {},
+    },
+    bus,
+    handlers: {
+      define: (name, fn) => { handlerMap.set(name, fn); },
+      call: (name, ...a) => handlerMap.get(name)?.(...a),
+    },
+    onShowAgentInfo: () => ({ info: "" }),
+    view: new TuiInputView(surface),
+  });
+
+  const submitted: string[] = [];
+  const commands: { name: string; args: string }[] = [];
+  bus.on("agent:submit", (e) => submitted.push(e.query));
+  bus.on("command:execute", (e) => commands.push(e));
+  bus.emit("input-mode:register", {
+    id: "agent",
+    trigger: ">",
+    label: "agent",
+    promptIcon: "❯",
+    indicator: "●",
+    onSubmit(query, b) { b.emit("agent:submit", { query }); },
+    returnToSelf: true,
+  });
+  return { handler, bus, submitted, commands };
+}
+
+test.afterEach(() => {
+  try { rmSync(HISTORY_FILE); } catch { /* noop */ }
+});
+
+test("multi-line bracketed paste submits resolved content", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  h.handler.handleInput("\x1b[200~line one\nline two\x1b[201~");
+  h.handler.handleInput("\r");
+  assert.deepEqual(h.submitted, ["line one\nline two"]);
+});
+
+test("multi-line paste starting with / goes to the agent, not command dispatch", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  h.handler.handleInput("\x1b[200~/usr/bin/env node\nsecond line\x1b[201~");
+  h.handler.handleInput("\r");
+  assert.deepEqual(h.commands, []);
+  assert.deepEqual(h.submitted, ["/usr/bin/env node\nsecond line"]);
+});
+
+test("single-line slash query still dispatches as a command", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  for (const ch of "/model gpt-test") h.handler.handleInput(ch);
+  h.handler.handleInput("\r");
+  assert.deepEqual(h.commands, [{ name: "/model", args: "gpt-test" }]);
+  assert.deepEqual(h.submitted, []);
+});
+
+test("multi-line history entries survive save/load round-trip", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  h.handler.handleInput("\x1b[200~with \\backslash\nand second line\x1b[201~");
+  h.handler.handleInput("\r");
+
+  const onDisk = readFileSync(HISTORY_FILE, "utf-8");
+  assert.equal(onDisk, "with \\\\backslash\\nand second line\n");
+
+  const h2 = makeHarness();
+  h2.handler.handleInput(">");
+  h2.handler.handleInput("\x1b[A"); // arrow-up: recall most recent entry
+  h2.handler.handleInput("\r");
+  assert.deepEqual(h2.submitted, ["with \\backslash\nand second line"]);
+});
+
+test("legacy unescaped history lines load as-is", () => {
+  const h = makeHarness();
+  h.handler.handleInput(">");
+  for (const ch of "plain old entry") h.handler.handleInput(ch);
+  h.handler.handleInput("\r");
+  assert.equal(readFileSync(HISTORY_FILE, "utf-8"), "plain old entry\n");
+
+  const h2 = makeHarness();
+  h2.handler.handleInput(">");
+  h2.handler.handleInput("\x1b[A");
+  h2.handler.handleInput("\r");
+  assert.deepEqual(h2.submitted, ["plain old entry"]);
+});


### PR DESCRIPTION
Three bugs around multi-line queries in the shell-mode input box (bracketed pastes collapsed to a `[paste +N lines]` placeholder):

- A query starting with `/` was dispatched as a slash command with the entire multi-line text as the command name. Slash commands are single-line; multi-line queries now go to the agent. A pasted file path like `/usr/bin/...` followed by more lines previously vanished into `command:execute` with a garbage name.
- The input-history file is one entry per line, but multi-line queries were written with raw newlines, so each line came back as a separate bogus entry on the next session. Entries are now stored with `\n` and `\\` backslash-escaped and unescaped on load; legacy plain lines load unchanged.
- Terminals following the xterm convention (iTerm2, Terminal.app) send pasted newlines as `\r` inside the bracketed-paste envelope; the paste accumulator deleted `\r` (written for CRLF pairs), silently joining such pastes into one line. All three separator forms (`\n`, `\r`, `\r\n`) now normalize to `\n`, on the full accumulation so a `\r\n` pair split across stdin chunks still collapses to one newline. Ghostty/kitty (verbatim `\n`) were unaffected.

Adds an InputHandler test harness covering paste→submit resolution for all three separator forms, chunk-split CRLF, both slash cases, the history round-trip, and legacy history lines.