### PR TITLE
Strip cursor-control bytes from floating panel rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Releases before this file are recorded in the git tags and GitHub releases.
 
 ### Fixed
 
+- Floating panel (overlay agent): tool output with CRLF line endings (e.g.
+  ssh's stderr warnings) no longer renders as staircased, left-truncated
+  lines inside the panel. The trailing `\r` survived into panel content
+  rows and repainted each composited row from column 0; panel rows now
+  strip cursor-moving control bytes (keeping colors), and the TUI's
+  command-output splitter treats `\r\n` as a line break.
 - Shell frontend: pasting multibyte text (e.g. Chinese) no longer corrupts
   characters into `�` when the paste spans multiple stdin chunks. The stdin
   reader decoded each chunk independently, tearing UTF-8 sequences at chunk

--- a/src/shell/tui-renderer.ts
+++ b/src/shell/tui-renderer.ts
@@ -939,7 +939,7 @@ export default function activate(ctx: ExtensionContext): void {
       ? getSettings().readOutputMaxLines
       : getSettings().maxCommandOutputLines;
     s.commandOutputBuffer += chunk;
-    const lines = s.commandOutputBuffer.split("\n");
+    const lines = s.commandOutputBuffer.split(/\r?\n/);
     s.commandOutputBuffer = lines.pop()!;
     for (const line of lines) {
       if (s.commandOutputLineCount < maxLines) {

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -138,3 +138,24 @@ export function padEndToWidth(str: string, targetWidth: number): string {
 export function stripAnsi(str: string): string {
   return stripAnsiPkg(str).replace(/\r/g, "");
 }
+
+/**
+ * Sanitize text for painting at a fixed screen position: SGR (color/style)
+ * passes through; anything else that would move the cursor or mutate
+ * terminal state mid-row is dropped. Tabs become a single space so painted
+ * width matches `stripAnsi`-based measurement.
+ */
+export function stripCursorControls(str: string): string {
+  // Park SGR behind NUL placeholders so the strips below can't eat their ESC bytes.
+  const sgr: string[] = [];
+  const cleaned = str
+    .replace(/\x00/g, "")
+    .replace(/\x1b\[[0-9;:]*m/g, (m) => { sgr.push(m); return "\x00"; })
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, "")
+    .replace(/\x1b\[[0-9;:?]*[ -/]*[@-~]/g, "")
+    .replace(/\x1b./g, "")
+    .replace(/\t/g, " ")
+    .replace(/[\x01-\x08\x0a-\x1f\x7f]/g, "");
+  let i = 0;
+  return cleaned.replace(/\x00/g, () => sgr[i++] ?? "");
+}

--- a/src/utils/floating-panel.ts
+++ b/src/utils/floating-panel.ts
@@ -30,7 +30,7 @@
  * Usage from extensions:
  *   import { FloatingPanel } from "agent-sh/utils/floating-panel.js";
  */
-import { stripAnsi } from "./ansi.js";
+import { stripAnsi, stripCursorControls } from "./ansi.js";
 import { wrapLine } from "./markdown.js";
 import { LineEditor } from "./line-editor.js";
 import { TerminalBuffer } from "./terminal-buffer.js";
@@ -408,10 +408,11 @@ export class FloatingPanel {
 
     // Default row builder: truncate and pad
     this.handlers.define(`${p}:build-row`, (content: string, width: number): string => {
-      const plain = stripAnsi(content);
+      const clean = stripCursorControls(content);
+      const plain = stripAnsi(clean);
       const display = plain.length > width
-        ? content.slice(0, width - 1) + "\u2026"
-        : content;
+        ? clean.slice(0, width - 1) + "\u2026"
+        : clean;
       const pad = Math.max(0, width - stripAnsi(display).length);
       return display + " ".repeat(pad);
     });

--- a/tests/core/floating-panel-rows.test.ts
+++ b/tests/core/floating-panel-rows.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EventBus } from "../../src/core/event-bus.js";
+import { FloatingPanel } from "../../src/utils/floating-panel.js";
+import { stripCursorControls } from "../../src/utils/ansi.js";
+
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+test("stripCursorControls keeps SGR, drops cursor-moving bytes", () => {
+  assert.equal(stripCursorControls(`${DIM}hello${RESET}`), `${DIM}hello${RESET}`);
+  assert.equal(stripCursorControls("line\r"), "line");
+  assert.equal(stripCursorControls("a\x1b[3Ab"), "ab");
+  assert.equal(stripCursorControls("a\x1b[2Kb"), "ab");
+  assert.equal(stripCursorControls("a\x1b]0;title\x07b"), "ab");
+  assert.equal(stripCursorControls("a\x1b7b\x1b8c"), "abc");
+  assert.equal(stripCursorControls("a\tb"), "a b");
+  assert.equal(stripCursorControls("a\bb\x00c"), "abc");
+});
+
+test("build-row paints a CRLF-derived line without a stray carriage return", () => {
+  const panel = new FloatingPanel(new EventBus(), {
+    trigger: "\x1c",
+    dimBackground: false,
+  });
+
+  // What tui:render-command-output produces for an ssh warning whose
+  // trailing \r survived a split("\n") on CRLF output.
+  const line = `${DIM}  ** WARNING: connection is not using a post-quantum key exchange algorithm.\r${RESET}`;
+  const row: string = panel.handlers.call("panel:build-row", line, 96);
+
+  assert.ok(!row.includes("\r"), "row must not contain a carriage return");
+  assert.ok(row.includes("** WARNING: connection"));
+  assert.equal(stripAnsiLen(row), 96);
+});
+
+test("build-row width math matches painted width when controls are stripped", () => {
+  const panel = new FloatingPanel(new EventBus(), {
+    trigger: "\x1c",
+    dimBackground: false,
+  });
+
+  const row: string = panel.handlers.call("panel:build-row", "ok\r\x1b[5D", 10);
+  assert.equal(row, "ok" + " ".repeat(8));
+});
+
+function stripAnsiLen(s: string): number {
+  return s.replace(/\x1b\[[^m]*m/g, "").length;
+}


### PR DESCRIPTION
## Problem

Tool output with CRLF line endings renders corrupted inside the floating panel (overlay agent): lines appear staircased to the right with their left portion chopped off. ssh is the common trigger — OpenSSH terminates its stderr log lines (e.g. the post-quantum KEX warnings) with `\r\n` even when stderr is a pipe.

## Cause

`writeCommandOutput` split tool-output chunks on `"\n"` only, so each line kept a trailing `\r`. In the normal scrolling TUI that's invisible (the `\r` lands right before the newline). But `FloatingPanel` paints content rows at fixed screen positions: the embedded `\r` jumps the cursor back to column 0 mid-row, and the padding + right border + dimmed background tail then overwrite the left of the row. Shorter lines get more padding, so the overwrite reaches further right each line — hence the staircase. `build-row` measures width with `stripAnsi`, which drops `\r`, so the width math hid the problem while the painted string kept it.

## Fix

Two layers:

- New `stripCursorControls` helper in `utils/ansi.ts`: SGR (color/style) passes through; OSC, non-SGR CSI (cursor movement, erase), bare ESC sequences, and C0 controls are dropped; tabs become a single space so painted width matches `stripAnsi`-based measurement. `FloatingPanel`'s default `build-row` runs content through it, so any producer feeding a panel is safe — the panel no longer trusts content strings to only advance the cursor.
- `writeCommandOutput` splits on `/\r?\n/`, fixing the CRLF source for every render surface.

Lone-`\r` progress redraws (curl-style) in tool output still don't animate inside the panel — the `\r` is dropped, so redraws append instead of overwriting — same as before, just no longer frame-corrupting.

## Testing

- `tests/core/floating-panel-rows.test.ts`: sanitizer unit cases plus `build-row` painting a CRLF-derived line (no `\r` in the row, content intact, exact width).
- Verified end-to-end by feeding the ssh warning lines through `build-row` and a cursor-emulating paint: reproduced the exact staircase before the fix, clean aligned rows after.
- Full suite green (310/310).