### PR TITLE
fix: subagent returns only final message, not full transcript

### DIFF
--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -96,7 +96,7 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
   const conversation = new LiveView();
   conversation.addUserMessage(task);
 
-  let fullResponseText = "";
+  let lastResponseText = "";
   let iterations = 0;
   let tokensConsumed = 0;
   let budgetExhausted = false;
@@ -117,7 +117,7 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
       onUsage?.(usage);
     }
 
-    fullResponseText += text;
+    if (text) lastResponseText = text;
 
     conversation.addAssistantMessage(assistantContent, assistantToolCalls, extras);
 
@@ -183,10 +183,10 @@ export async function runSubagent(opts: SubagentOptions): Promise<string> {
 
   if (budgetExhausted) {
     const note = `\n\n[Subagent terminated: completion-token budget (${budgetTokens}) exhausted after ${tokensConsumed} completion tokens. Returning partial progress.]`;
-    return fullResponseText + note;
+    return lastResponseText + note;
   }
 
-  return fullResponseText;
+  return lastResponseText;
 }
 
 /** Stream a single LLM response. */


### PR DESCRIPTION
## Problem

`runSubagent` accumulated assistant text from **every** iteration (`fullResponseText += text`) and returned the whole transcript. The parent appends that as a single `tool_result`, so a long subagent run bloats the parent's context.

On DeepSeek (automatic prefix caching), appending a large tool_result doesn't invalidate the existing cached prefix by itself — but it tips the parent over the **auto-compaction** threshold, and compaction rewrites the cached prompt prefix (`cachedSystemPrompt = undefined` in the agent loop), cold-starting the provider prompt cache. This surfaces as a subagent "overriding" the main agent's cache — and only happens when subagents are used.

## Fix

Return only the **last assistant message with content**, not the accumulated transcript. This matches the parent's tool_result contract (the parent only needs the subagent's conclusion) and how other agent runtimes surface subagent output.

- `fullResponseText += text` → `if (text) lastResponseText = text`
- both return sites updated; budget-exhausted note still appended
- Live tool events on the bus are unchanged, so intermediate steps still render in the UI — only the returned string shrinks.

## Notes

- Behavior change for consumers of `runSubagent`'s return value: any caller relying on the full transcript now gets only the final message. No internal caller depends on the transcript; flagging since it's re-exported from `core`/`agent` index.
- Does not address capacity-limited/local inference endpoints (vLLM/SGLang radix cache), where a subagent's own iterations can evict the parent prefix during the run — that needs subagents pinned to a separate endpoint.