### PR TITLE
fix: use shell builtin host vars in OSC 7 instead of hostname(1)

### DIFF
--- a/src/shell/strategies/bash.ts
+++ b/src/shell/strategies/bash.ts
@@ -2,7 +2,9 @@ import * as fs from "fs";
 import * as path from "path";
 import type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
 
-const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
+// $HOSTNAME is a bash builtin — avoids shelling out to hostname(1), which
+// isn't installed everywhere (e.g. Arch without inetutils).
+const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$HOSTNAME" "$PWD"';
 const TITLE_CMD = 'printf "\\e]0;⚡ agent-sh: %s\\a" "${PWD/#$HOME/~}"';
 
 export const bashStrategy: ShellStrategy = {

--- a/src/shell/strategies/fish.ts
+++ b/src/shell/strategies/fish.ts
@@ -2,7 +2,9 @@ import * as fs from "fs";
 import * as path from "path";
 import type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
 
-const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" (hostname) "$PWD"';
+// $hostname is set by fish itself — avoids shelling out to hostname(1), which
+// isn't installed everywhere (e.g. Arch without inetutils).
+const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$hostname" "$PWD"';
 const TITLE_CMD =
   'printf "\\e]0;⚡ agent-sh: %s\\a" (string replace -- "$HOME" "~" "$PWD")';
 

--- a/src/shell/strategies/zsh.ts
+++ b/src/shell/strategies/zsh.ts
@@ -2,7 +2,9 @@ import * as fs from "fs";
 import * as path from "path";
 import type { ShellStrategy, PrepareSpawnOpts, ShellSpawnConfig } from "./types.js";
 
-const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$(hostname)" "$PWD"';
+// $HOST is a zsh builtin — avoids shelling out to hostname(1), which isn't
+// installed everywhere (e.g. Arch without inetutils).
+const OSC7_CMD = 'printf "\\e]7;file://%s%s\\a" "$HOST" "$PWD"';
 const TITLE_CMD = 'printf "\\e]0;⚡ agent-sh: %s\\a" "${PWD/#$HOME/~}"';
 
 export const zshStrategy: ShellStrategy = {


### PR DESCRIPTION
The OSC 7 cwd sequence shells out to `hostname`, which is not installed on every system — Arch ships it in the optional `inetutils` package. When it is missing, every prompt prints:

```
__agent_sh_precmd:1: command not found: hostname
```

This replaces the subprocess with each shell's own host variable:

| shell | before | after |
|---|---|---|
| zsh  | `$(hostname)` | `$HOST` |
| bash | `$(hostname)` | `$HOSTNAME` |
| fish | `(hostname)`  | `$hostname` |

Also saves a fork/exec on every prompt.

### Safety

The host portion of OSC 7 is advisory. `output-parser.ts` matches it with `file://[^/]*` and consumes only the path, so cwd tracking is unaffected even if a shell leaves the variable empty.

### Testing

Verified on Arch (zsh, no `inetutils`): the error is gone, OSC 7 emits `file://carbon/home/yguan`, and cwd tracking follows `cd /tmp` correctly.